### PR TITLE
Add Jest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies and run the development server:
 
 ```bash
+# install dependencies
+npm install
+
+# start development server
 npm run dev
 # or
 yarn dev
@@ -19,6 +23,16 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Testing
+
+This project uses [Jest](https://jestjs.io/) for its test suite.
+Install dependencies if you haven't already and then run:
+
+```bash
+npm test
+```
+
 
 ## Learn More
 

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Simple setup script to install dependencies before running tests
+npm install


### PR DESCRIPTION
## Summary
- explain how to install dependencies before running the dev server
- add documentation about running Jest tests
- provide a `setup-tests.sh` script for installing dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d18d7a28832e8b6ec982c44e985e