### PR TITLE
Fix groupBy param in user engagement route

### DIFF
--- a/src/app/api/v1/users/[userId]/performance/average-engagement/route.test.ts
+++ b/src/app/api/v1/users/[userId]/performance/average-engagement/route.test.ts
@@ -1,0 +1,49 @@
+import { GET } from './route';
+import getAverageEngagementByGrouping from '@/utils/getAverageEngagementByGrouping';
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+
+jest.mock('@/utils/getAverageEngagementByGrouping', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockGetAverage = getAverageEngagementByGrouping as jest.Mock;
+
+const createRequest = (userId: string, search: string = ''): NextRequest => {
+  const url = `http://localhost/api/v1/users/${userId}/performance/average-engagement${search}`;
+  return new NextRequest(url);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/v1/users/[userId]/performance/average-engagement', () => {
+  const userId = new Types.ObjectId().toString();
+
+  it('calls helper with provided parameters', async () => {
+    mockGetAverage.mockResolvedValueOnce([]);
+    const req = createRequest(
+      userId,
+      '?timePeriod=last_7_days&engagementMetricField=stats.views&groupBy=context'
+    );
+    const res = await GET(req, { params: { userId } });
+    expect(mockGetAverage).toHaveBeenCalledWith(
+      userId,
+      'last_7_days',
+      'stats.views',
+      'context'
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 for invalid groupBy', async () => {
+    const req = createRequest(userId, '?groupBy=invalid');
+    const res = await GET(req, { params: { userId } });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('groupBy inválido');
+    expect(mockGetAverage).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/users/[userId]/performance/average-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/average-engagement/route.ts
@@ -78,25 +78,25 @@ export async function GET(
   }
 
   // Determinar groupBy (padrão format)
+  const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context'];
   const groupBy: GroupingType =
-    groupByParam === 'context' ? 'context' : 'format';
+    groupByParam && ALLOWED_GROUPINGS.includes(groupByParam)
+      ? groupByParam
+      : 'format';
+  if (groupByParam && !ALLOWED_GROUPINGS.includes(groupByParam)) {
+    return NextResponse.json(
+      { error: `groupBy inválido. Permitidos: ${ALLOWED_GROUPINGS.join(', ')}` },
+      { status: 400 }
+    );
+  }
 
   try {
-    // Mapear timePeriod para número de dias
-    const timePeriodToDays: Record<TimePeriod, number> = {
-      last_7_days: 7,
-      last_30_days: 30,
-      last_90_days: 90,
-      last_6_months: 180,
-      last_12_months: 365,
-      all_time: 0 // ou outro valor que represente "todos os tempos"
-    };
-
-    // Chama utilitário com 3 parâmetros
+    // Chama utilitário com 4 parâmetros conforme assinatura
     const results = await getAverageEngagementByGrouping(
       userId,
-      timePeriodToDays[timePeriod],
-      [engagementMetric]
+      timePeriod,
+      engagementMetric,
+      groupBy
     );
 
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- validate groupBy in average engagement route
- forward original timePeriod, metric and groupBy to helper
- add test for route using jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851da511840832e8c8cfeb52dec5501