### PR TITLE
Ensure DB connection for platform trend route

### DIFF
--- a/src/app/api/v1/platform/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/reach-engagement/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import UserModel from '@/app/models/User'; // Importar UserModel
 import getReachEngagementTrendChartData from '@/charts/getReachEngagementTrendChartData';
+import { connectToDatabase } from '@/app/lib/mongoose';
 
 interface ReachEngagementChartResponse {
   chartData: ApiReachEngagementDataPoint[];
@@ -41,6 +42,7 @@ export async function GET(
   }
 
   try {
+    await connectToDatabase();
     // 1. Buscar Usuários da Plataforma
     const platformUsers = await UserModel.find({
       // TODO: Adicionar critérios para usuários ativos


### PR DESCRIPTION
## Summary
- connect to MongoDB before querying in platform reach-engagement trend API route

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851df62bb4c832e8ba05ffd09eeb4e6