### PR TITLE
Initialize MongoDB connection in followers trend route

### DIFF
--- a/src/app/api/v1/platform/trends/followers/route.ts
+++ b/src/app/api/v1/platform/trends/followers/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import UserModel from '@/app/models/User'; // Importar UserModel
 import getFollowerTrendChartData from '@/charts/getFollowerTrendChartData'; // Ajuste o caminho
-import { connectToDatabase } from '@/app/lib/mongoose'; // Added
+import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger'; // Added
 import { Types } from 'mongoose'; // Para ObjectId, se necessário para UserModel
 
@@ -44,6 +44,7 @@ export async function GET(
   }
 
   try {
+    await connectToDatabase();
     // 1. Buscar apenas os usuários da plataforma que estejam ativos
     const platformUsers = await UserModel.find({
         planStatus: 'active',


### PR DESCRIPTION
## Summary
- connect to MongoDB in the platform followers trend endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851df654224832ea340ad5fdc29d2af