### PR TITLE
Update logging for follower growth

### DIFF
--- a/src/utils/calculateFollowerGrowthRate.ts
+++ b/src/utils/calculateFollowerGrowthRate.ts
@@ -49,7 +49,7 @@ async function calculateFollowerGrowthRate(
     ]);
 
     if (!latestSnapshot || typeof latestSnapshot.followersCount !== 'number') {
-      logger.warn(`No recent AccountInsight or valid followersCount for userId: ${resolvedUserId} up to ${endDate.toISOString()}`);
+      logger.debug(`No recent AccountInsight or valid followersCount for userId: ${resolvedUserId} up to ${endDate.toISOString()}`);
       return initialResult;
     }
     initialResult.currentFollowers = latestSnapshot.followersCount;


### PR DESCRIPTION
## Summary
- use `logger.debug` when `AccountInsight` is missing in `calculateFollowerGrowthRate`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e49be0ec832e9443d43088e640d1