### PR TITLE
Fix moving average engagement for users

### DIFF
--- a/src/utils/calculateMovingAverageEngagement.test.ts
+++ b/src/utils/calculateMovingAverageEngagement.test.ts
@@ -1,8 +1,12 @@
 import { Types } from 'mongoose';
 import calculateMovingAverageEngagement, { MovingAverageDataPoint } from './calculateMovingAverageEngagement'; // Ajuste
 import DailyMetricSnapshotModel, { IDailyMetricSnapshot } from '@/app/models/DailyMetricSnapshot'; // Ajuste
+import MetricModel from '@/app/models/Metric';
 
 jest.mock('@/app/models/DailyMetricSnapshot', () => ({
+  find: jest.fn(),
+}));
+jest.mock('@/app/models/Metric', () => ({
   find: jest.fn(),
 }));
 
@@ -18,6 +22,12 @@ function createDate(daysAgo: number, baseDate?: Date): Date {
   return date;
 }
 
+const mockMetricIds = (ids: string[] = [new Types.ObjectId().toString()]) => {
+  (MetricModel.find as jest.Mock).mockReturnValue({
+    distinct: jest.fn().mockResolvedValue(ids.map(id => new Types.ObjectId(id)))
+  });
+};
+
 
 describe('calculateMovingAverageEngagement', () => {
   const userId = new Types.ObjectId().toString();
@@ -25,6 +35,8 @@ describe('calculateMovingAverageEngagement', () => {
 
   beforeEach(() => {
     (DailyMetricSnapshotModel.find as jest.Mock).mockReset();
+    (MetricModel.find as jest.Mock).mockReset();
+    mockMetricIds();
     baseTestEndDate = new Date(2023, 10, 15); // Ex: 15 de Novembro de 2023
   });
 

--- a/src/utils/calculateMovingAverageEngagement.ts
+++ b/src/utils/calculateMovingAverageEngagement.ts
@@ -1,4 +1,5 @@
 import DailyMetricSnapshotModel, { IDailyMetricSnapshot } from "@/app/models/DailyMetricSnapshot";
+import MetricModel from "@/app/models/Metric";
 import { Types } from "mongoose";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import { logger } from "@/app/lib/logger";
@@ -60,8 +61,10 @@ async function calculateMovingAverageEngagement(
   try {
     await connectToDatabase();
 
+    const metricIds: Types.ObjectId[] = await MetricModel.find({ user: resolvedUserId }).distinct('_id');
+
     const snapshots: IDailyMetricSnapshot[] = await DailyMetricSnapshotModel.find({
-      user: resolvedUserId,
+      metric: { $in: metricIds },
       date: { $gte: dataFullStartDate, $lte: dataEndDate },
     })
       .sort({ date: 1 })


### PR DESCRIPTION
## Summary
- get metric ids for the user when calculating moving averages
- fetch snapshots with those metric ids
- update moving average engagement tests accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e4a97880832e8a3eadea30f18ac8