### PR TITLE
Add proposal ranking service and dashboard card

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
@@ -9,6 +9,7 @@ jest.mock('./CreatorTable', () => jest.fn(() => <div data-testid="creator-table-
 jest.mock('./ContentStatsWidgets', () => jest.fn(() => <div data-testid="content-stats-mock">ContentStatsWidgets</div>));
 jest.mock('./GlobalPostsExplorer', () => jest.fn(() => <div data-testid="global-posts-mock">GlobalPostsExplorer</div>));
 jest.mock('./StandaloneChatInterface', () => jest.fn(() => <div data-testid="chat-interface-mock">StandaloneChatInterface</div>));
+jest.mock('./ProposalRankingCard', () => jest.fn(() => <div data-testid="proposal-ranking-mock">ProposalRankingCard</div>));
 
 // Mock Heroicons
 jest.mock('@heroicons/react/24/solid', () => ({

--- a/src/app/admin/creator-dashboard/ProposalRankingCard.tsx
+++ b/src/app/admin/creator-dashboard/ProposalRankingCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { IProposalMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+import SkeletonBlock from './SkeletonBlock';
+
+interface ProposalRankingCardProps {
+  title: string;
+  apiEndpoint: string;
+  dateRangeFilter?: {
+    startDate?: string;
+    endDate?: string;
+  };
+  metricLabel?: string;
+  limit?: number;
+}
+
+const ProposalRankingCard: React.FC<ProposalRankingCardProps> = ({
+  title,
+  apiEndpoint,
+  dateRangeFilter,
+  metricLabel = '',
+  limit = 5,
+}) => {
+  const [rankingData, setRankingData] = useState<IProposalMetricRankItem[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!dateRangeFilter?.startDate || !dateRangeFilter?.endDate) {
+      setRankingData(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({ limit: String(limit) });
+
+    if (dateRangeFilter.startDate) {
+      const localStart = new Date(dateRangeFilter.startDate);
+      const utcStart = new Date(Date.UTC(localStart.getFullYear(), localStart.getMonth(), localStart.getDate(), 0, 0, 0, 0));
+      params.append('startDate', utcStart.toISOString());
+    }
+    if (dateRangeFilter.endDate) {
+      const localEnd = new Date(dateRangeFilter.endDate);
+      const utcEnd = new Date(Date.UTC(localEnd.getFullYear(), localEnd.getMonth(), localEnd.getDate(), 23, 59, 59, 999));
+      params.append('endDate', utcEnd.toISOString());
+    }
+
+    try {
+      const response = await fetch(`${apiEndpoint}?${params.toString()}`);
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Failed to fetch ${title}`);
+      }
+      const data: IProposalMetricRankItem[] = await response.json();
+      setRankingData(data);
+    } catch (e: any) {
+      setError(e.message);
+      setRankingData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiEndpoint, dateRangeFilter, limit, title]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const formatMetricValue = (value: number): string => {
+    if (Number.isInteger(value)) {
+      return value.toLocaleString('pt-BR');
+    }
+    return parseFloat(value.toFixed(2)).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  };
+
+  const renderSkeleton = () => (
+    <ul className="space-y-2.5 animate-pulse">
+      {Array.from({ length: limit }).map((_, i) => (
+        <li key={i} className="flex items-center space-x-3">
+          <SkeletonBlock width="w-3/4" height="h-3" />
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow border border-gray-200 h-full flex flex-col">
+      <h4 className="text-md font-semibold text-gray-700 mb-3 truncate" title={title}>{title}</h4>
+      {isLoading && renderSkeleton()}
+      {!isLoading && error && (
+        <div className="text-center py-4 flex-grow flex flex-col justify-center items-center">
+          <p className="text-xs text-red-500 px-2">Erro: {error}</p>
+          <button onClick={fetchData} className="mt-2 px-3 py-1 text-xs bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200">
+            Tentar Novamente
+          </button>
+        </div>
+      )}
+      {!isLoading && !error && rankingData && rankingData.length > 0 && (
+        <ol className="space-y-2 text-sm flex-grow">
+          {rankingData.map((item, index) => (
+            <li key={item.proposal + index} className="flex items-center justify-between py-1">
+              <span className="text-xs font-medium text-gray-500 w-5 text-center">{index + 1}.</span>
+              <span className="flex-1 truncate text-gray-800" title={item.proposal}>{item.proposal}</span>
+              <span className="text-xs text-indigo-600 font-semibold whitespace-nowrap">
+                {formatMetricValue(item.metricValue)}{metricLabel && ` ${metricLabel}`}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+      {!isLoading && !error && (!rankingData || rankingData.length === 0) && (
+        <div className="text-center py-4 text-xs text-gray-400 flex-grow flex flex-col justify-center items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8 mb-1">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h7.5M8.25 12h7.5m-7.5 5.25h7.5M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+          </svg>
+          Nenhum dado disponível para o período selecionado.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProposalRankingCard;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -20,6 +20,8 @@ import PlatformEngagementDistributionByFormatChart from './components/PlatformEn
 import PlatformVideoPerformanceMetrics from './components/PlatformVideoPerformanceMetrics';
 import PlatformMonthlyEngagementStackedChart from './components/PlatformMonthlyEngagementStackedChart';
 import PlatformPerformanceHighlights from './components/PlatformPerformanceHighlights';
+import ProposalRankingCard from './ProposalRankingCard';
+import { getStartDateFromTimePeriod, formatDateYYYYMMDD } from '@/utils/dateHelpers';
 
 // View de Detalhe do Criador (Módulo 3 e partes do Módulo 2 para usuário)
 import UserDetailView from './components/views/UserDetailView';
@@ -31,6 +33,11 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
   const selectedComparisonPeriodForPlatformKPIs = "month_vs_previous";
   const [isSelectorOpen, setIsSelectorOpen] = useState(false);
+
+  const today = new Date();
+  const startDate = formatDateYYYYMMDD(getStartDateFromTimePeriod(today, globalTimePeriod));
+  const endDate = formatDateYYYYMMDD(today);
+  const proposalDateRange = { startDate, endDate };
 
 
   const handleUserSelect = (userId: string) => {
@@ -140,6 +147,18 @@ const AdminCreatorDashboardPage: React.FC = () => {
                 <PlatformMonthlyEngagementStackedChart timePeriod={globalTimePeriod} />
                 <PlatformEngagementDistributionByFormatChart timePeriod={globalTimePeriod} /> {/* Adicionado aqui */}
             </div>
+          </section>
+
+          <section id="proposal-ranking" className="mb-10">
+            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+              Ranking por Proposta
+            </h2>
+            <ProposalRankingCard
+              title="Propostas com Mais Interações"
+              apiEndpoint="/api/admin/dashboard/rankings/proposals?metric=total_interactions"
+              dateRangeFilter={proposalDateRange}
+              limit={5}
+            />
           </section>
 
           <section id="creator-highlights-and-scatter-plot" className="mb-10">

--- a/src/app/api/admin/dashboard/rankings/proposals/route.ts
+++ b/src/app/api/admin/dashboard/rankings/proposals/route.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview API Endpoint for fetching proposal rankings.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopProposals, ProposalRankingMetric } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/proposals]';
+
+const querySchema = z.object({
+  metric: z.enum(['avg_views', 'total_interactions']).transform(val => val as ProposalRankingMetric),
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
+  const session = { user: { name: 'Admin User' } };
+  const isAdmin = true;
+  if (!session || !isAdmin) {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { metric, startDate, endDate, limit } = validationResult.data;
+
+    const results = await fetchTopProposals({
+      dateRange: { startDate, endDate },
+      metric,
+      limit,
+    });
+
+    return NextResponse.json(results, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/lib/dataService/marketAnalysis/rankingsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/rankingsService.ts
@@ -8,7 +8,7 @@ import { logger } from '@/app/lib/logger';
 import MetricModel from '@/app/models/Metric';
 import { connectToDatabase } from '../connection';
 import { DatabaseError } from '@/app/lib/errors';
-import { IFetchCreatorRankingParams, ICreatorMetricRankItem } from './types';
+import { IFetchCreatorRankingParams, ICreatorMetricRankItem, IProposalMetricRankItem, ProposalRankingMetric } from './types';
 
 const SERVICE_TAG = '[dataService][rankingsService]';
 
@@ -233,5 +233,42 @@ export async function fetchTopSharingCreators(
   } catch (error: any) {
     logger.error(`${TAG} Error:`, error);
     throw new DatabaseError(`Failed to fetch top sharing creators: ${error.message}`);
+  }
+}
+
+export async function fetchTopProposals(params: {
+  dateRange: { startDate: Date; endDate: Date };
+  metric: ProposalRankingMetric;
+  limit?: number;
+}): Promise<IProposalMetricRankItem[]> {
+  const TAG = `${SERVICE_TAG}[fetchTopProposals]`;
+  const { dateRange, metric, limit = 5 } = params;
+  logger.info(`${TAG} Fetching metric ${metric} for period: ${dateRange.startDate} - ${dateRange.endDate}`);
+
+  try {
+    await connectToDatabase();
+    const metricField = metric === 'avg_views' ? '$stats.views' : '$stats.total_interactions';
+    const accumulator = metric === 'avg_views' ? '$avg' : '$sum';
+
+    const matchStage: PipelineStage.Match['$match'] = {
+      postDate: { $gte: dateRange.startDate, $lte: dateRange.endDate },
+      proposal: { $exists: true, $ne: null },
+    };
+    matchStage[metricField.substring(1)] = { $exists: true, $ne: null };
+
+    const pipeline: PipelineStage[] = [
+      { $match: matchStage },
+      { $group: { _id: '$proposal', metricValue: { [accumulator]: metricField } } },
+      { $sort: { metricValue: -1 } },
+      { $limit: limit },
+      { $project: { _id: 0, proposal: '$_id', metricValue: metric === 'avg_views' ? { $round: ['$metricValue', 2] } : '$metricValue' } }
+    ];
+
+    const results = await MetricModel.aggregate(pipeline);
+    logger.info(`${TAG} Found ${results.length} proposals.`);
+    return results as IProposalMetricRankItem[];
+  } catch (error: any) {
+    logger.error(`${TAG} Error:`, error);
+    throw new DatabaseError(`Failed to fetch top proposals: ${error.message}`);
   }
 }

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -17,6 +17,12 @@ export const TopCreatorMetricEnum = z.enum([
 ]);
 export type TopCreatorMetric = z.infer<typeof TopCreatorMetricEnum>;
 
+export const ProposalRankingMetricEnum = z.enum([
+  'avg_views',
+  'total_interactions'
+]);
+export type ProposalRankingMetric = z.infer<typeof ProposalRankingMetricEnum>;
+
 // --- Interfaces de Contrato ---
 
 export interface IMarketPerformanceResult {
@@ -164,6 +170,11 @@ export interface IRankingCreatorInfo {
 }
 
 export interface ICreatorMetricRankItem extends IRankingCreatorInfo {
+  metricValue: number;
+}
+
+export interface IProposalMetricRankItem {
+  proposal: string;
   metricValue: number;
 }
 


### PR DESCRIPTION
## Summary
- introduce enum `ProposalRankingMetricEnum` and ranking result interface
- add new `fetchTopProposals` function to rankings service
- expose `/api/admin/dashboard/rankings/proposals` endpoint
- implement `ProposalRankingCard` component
- show new ranking in Creator Dashboard
- update page tests to mock the new component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852169881f4832eb95d5367c6054afe