### PR TITLE
Add platform summary KPIs section

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, { useState, useEffect, memo } from 'react';
+import PlatformKpiCard from '../PlatformKpiCard';
+
+interface PlatformSummaryData {
+  totalCreators: number;
+  pendingCreators: number;
+  activeCreatorsInPeriod: number;
+  averageEngagementRateInPeriod: number;
+  averageReachInPeriod: number;
+}
+
+const PlatformSummaryKpis: React.FC = () => {
+  const [data, setData] = useState<PlatformSummaryData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/admin/dashboard/platform-summary');
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        }
+        const result: PlatformSummaryData = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const formatPercentage = (num?: number | null) => {
+    if (num === null || typeof num === 'undefined') return null;
+    return `${(num * 100).toFixed(1)}%`;
+  };
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 md:gap-6">
+      <PlatformKpiCard
+        title="Criadores Totais"
+        value={data?.totalCreators ?? null}
+        isLoading={loading}
+        error={error}
+        tooltip="Número total de criadores cadastrados."
+      />
+      <PlatformKpiCard
+        title="Pendentes"
+        value={data?.pendingCreators ?? null}
+        isLoading={loading}
+        error={error}
+        tooltip="Criadores aguardando aprovação."
+      />
+      <PlatformKpiCard
+        title="Ativos no Período"
+        value={data?.activeCreatorsInPeriod ?? null}
+        isLoading={loading}
+        error={error}
+        tooltip="Criadores que postaram no período informado."
+      />
+      <PlatformKpiCard
+        title="Engajamento Médio"
+        value={formatPercentage(data?.averageEngagementRateInPeriod)}
+        isLoading={loading}
+        error={error}
+        tooltip="Taxa média de engajamento sobre alcance no período."
+      />
+      <PlatformKpiCard
+        title="Alcance Médio"
+        value={data?.averageReachInPeriod ?? null}
+        isLoading={loading}
+        error={error}
+        tooltip="Alcance médio das postagens no período."
+      />
+    </div>
+  );
+};
+
+export default memo(PlatformSummaryKpis);
+

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -12,6 +12,7 @@ import PlatformReachEngagementTrendChart from './components/PlatformReachEngagem
 import PlatformMovingAverageEngagementChart from './components/PlatformMovingAverageEngagementChart';
 import TotalActiveCreatorsKpi from './components/kpis/TotalActiveCreatorsKpi';
 import PlatformComparativeKpi from './components/kpis/PlatformComparativeKpi';
+import PlatformSummaryKpis from './components/kpis/PlatformSummaryKpis';
 
 // Componentes da Plataforma - Módulo 2 (Análise de Conteúdo)
 import PlatformAverageEngagementChart from './components/PlatformAverageEngagementChart';
@@ -69,6 +70,10 @@ const AdminCreatorDashboardPage: React.FC = () => {
           />
         </div>
       </header>
+
+      <section id="platform-summary" className="mb-8">
+        <PlatformSummaryKpis />
+      </section>
 
       <section id="creator-selection-simulation" className="mb-8 p-4 bg-white rounded-lg shadow">
         <h2 className="text-lg font-semibold text-gray-700 mb-3">Simular Seleção de Criador Detalhado:</h2>


### PR DESCRIPTION
## Summary
- show platform dashboard KPIs in a new `PlatformSummaryKpis` component
- render this summary near the top of the admin creator dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521f7db000832e85736abcef30ca70