### PR TITLE
Add top creators ranking widget and API

### DIFF
--- a/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
@@ -1,0 +1,143 @@
+'use client';
+import React, { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
+import SkeletonBlock from './SkeletonBlock';
+import { TopCreatorMetric } from '@/app/lib/dataService/marketAnalysisService';
+
+interface TopCreatorsWidgetProps {
+  title: string;
+  context?: string;
+  metric?: TopCreatorMetric;
+  days?: number;
+  limit?: number;
+  metricLabel?: string;
+}
+
+const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
+  title,
+  context,
+  metric = 'total_interactions',
+  days = 30,
+  limit = 5,
+  metricLabel = '',
+}) => {
+  const [rankingData, setRankingData] = useState<any[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({
+      metric,
+      days: String(days),
+      limit: String(limit),
+    });
+    if (context) params.append('context', context);
+
+    try {
+      const response = await fetch(`/api/admin/dashboard/rankings/top-creators?${params.toString()}`);
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to fetch rankings');
+      }
+      const data = await response.json();
+      setRankingData(data);
+    } catch (e: any) {
+      setError(e.message);
+      setRankingData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [context, metric, days, limit]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const formatMetricValue = (value: number): string => {
+    if (Number.isInteger(value)) {
+      return value.toLocaleString('pt-BR');
+    }
+    return parseFloat(value.toFixed(2)).toLocaleString('pt-BR', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  };
+
+  const renderSkeleton = () => (
+    <ul className="space-y-2.5 animate-pulse">
+      {Array.from({ length: limit }).map((_, i) => (
+        <li key={i} className="flex items-center space-x-3">
+          <SkeletonBlock variant="circle" width="w-8" height="h-8" />
+          <div className="flex-1 space-y-1.5">
+            <SkeletonBlock width="w-3/4" height="h-3" />
+            <SkeletonBlock width="w-1/2" height="h-2.5" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow border border-gray-200 h-full flex flex-col">
+      <h4 className="text-md font-semibold text-gray-700 mb-3 truncate" title={title}>
+        {title}
+      </h4>
+      {isLoading && renderSkeleton()}
+      {!isLoading && error && (
+        <div className="text-center py-4 flex-grow flex flex-col justify-center items-center">
+          <p className="text-xs text-red-500 px-2">Erro: {error}</p>
+          <button
+            onClick={fetchData}
+            className="mt-2 px-3 py-1 text-xs bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200"
+          >
+            Tentar Novamente
+          </button>
+        </div>
+      )}
+      {!isLoading && !error && rankingData && rankingData.length > 0 && (
+        <ol className="space-y-2 text-sm flex-grow">
+          {rankingData.map((item: any, index: number) => (
+            <li key={item.creatorId.toString()} className="flex items-center space-x-2.5 py-1">
+              <span className="text-xs font-medium text-gray-500 w-5 text-center">{index + 1}.</span>
+              {item.profilePictureUrl ? (
+                <Image
+                  src={item.profilePictureUrl}
+                  alt={item.creatorName || 'Creator'}
+                  width={32}
+                  height={32}
+                  className="w-8 h-8 rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-xs font-semibold text-gray-500">
+                  {item.creatorName?.substring(0, 1).toUpperCase() || '?'}
+                </div>
+              )}
+              <div className="flex-1 truncate">
+                <p className="text-gray-800 font-medium truncate" title={item.creatorName}>
+                  {item.creatorName || 'Desconhecido'}
+                </p>
+              </div>
+              <span className="text-xs text-indigo-600 font-semibold whitespace-nowrap">
+                {formatMetricValue(item.metricValue)}
+                {metricLabel && ` ${metricLabel}`}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+      {!isLoading && !error && (!rankingData || rankingData.length === 0) && (
+        <div className="text-center py-4 text-xs text-gray-400 flex-grow flex flex-col justify-center items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8 mb-1">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h7.5M8.25 12h7.5m-7.5 5.25h7.5M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+          </svg>
+          Nenhum dado disponível para o período selecionado.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopCreatorsWidget;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -23,6 +23,7 @@ import PlatformMonthlyEngagementStackedChart from './components/PlatformMonthlyE
 import PlatformPerformanceHighlights from './components/PlatformPerformanceHighlights';
 import ProposalRankingCard from './ProposalRankingCard';
 import CreatorRankingCard from './CreatorRankingCard';
+import TopCreatorsWidget from './TopCreatorsWidget';
 import { getStartDateFromTimePeriod, formatDateYYYYMMDD } from '@/utils/dateHelpers';
 
 // View de Detalhe do Criador (Módulo 3 e partes do Módulo 2 para usuário)
@@ -171,7 +172,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
             Rankings de Criadores
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
             <CreatorRankingCard
               title="Maior Engajamento"
               apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
@@ -191,14 +192,20 @@ const AdminCreatorDashboardPage: React.FC = () => {
               dateRangeFilter={rankingDateRange}
               limit={5}
             />
-            <CreatorRankingCard
-              title="Mais Compartilhamentos"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
-              dateRangeFilter={rankingDateRange}
-              limit={5}
-            />
-          </div>
-        </section>
+              <CreatorRankingCard
+                title="Mais Compartilhamentos"
+                apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
+                dateRangeFilter={rankingDateRange}
+                limit={5}
+              />
+              <TopCreatorsWidget
+                title="Top Criadores"
+                metric="total_interactions"
+                days={30}
+                limit={5}
+              />
+            </div>
+          </section>
 
           <section id="creator-highlights-and-scatter-plot" className="mb-10">
             <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">

--- a/src/app/api/admin/dashboard/rankings/top-creators/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/top-creators/route.test.ts
@@ -1,0 +1,50 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+import { fetchTopCreators } from '@/app/lib/dataService/marketAnalysis/profilesService';
+import { DatabaseError } from '@/app/lib/errors';
+
+jest.mock('@/app/lib/dataService/marketAnalysis/profilesService', () => ({
+  fetchTopCreators: jest.fn(),
+}));
+
+function mockRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/top-creators');
+  Object.entries(params).forEach(([k, v]) => url.searchParams.append(k, v));
+  return new NextRequest(url.toString());
+}
+
+const sampleData = [
+  { creatorId: '1', creatorName: 'Alice', metricValue: 100, totalInteractions: 200, postCount: 10 },
+];
+
+describe('API Route: top-creators', () => {
+  beforeEach(() => {
+    (fetchTopCreators as jest.Mock).mockReset();
+  });
+
+  it('returns ranking data with valid query', async () => {
+    (fetchTopCreators as jest.Mock).mockResolvedValueOnce(sampleData);
+    const req = mockRequest({ context: 'tech', metric: 'shares', days: '30', limit: '1' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(sampleData);
+    expect(fetchTopCreators).toHaveBeenCalledWith({ context: 'tech', metricToSortBy: 'shares', days: 30, limit: 1 });
+  });
+
+  it('returns 400 on invalid metric', async () => {
+    const req = mockRequest({ metric: 'invalid' });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(fetchTopCreators).not.toHaveBeenCalled();
+  });
+
+  it('handles DatabaseError with 500', async () => {
+    (fetchTopCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const req = mockRequest({ metric: 'shares', days: '30', limit: '1' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/top-creators/route.ts
+++ b/src/app/api/admin/dashboard/rankings/top-creators/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopCreators, TopCreatorMetricEnum } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/top-creators]';
+
+const querySchema = z.object({
+  context: z.string().optional(),
+  metric: TopCreatorMetricEnum.optional().default('total_interactions'),
+  days: z.coerce.number().int().positive().max(365).optional().default(30),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+});
+
+async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
+  const session = { user: { name: 'Admin User' } }; // Mock session
+  const isAdmin = true; // Mock admin check
+  if (!session || !isAdmin) {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors
+        .map(e => `${e.path.join('.')}?: ${e.message}`)
+        .join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { context, metric, days, limit } = validationResult.data;
+    const results = await fetchTopCreators({
+      context: context ?? 'geral',
+      metricToSortBy: metric,
+      days,
+      limit,
+    });
+
+    return NextResponse.json(results, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- expose new API route for top creators rankings
- create `TopCreatorsWidget` component
- show the widget in the creator rankings section
- add unit tests for the new API endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852234b9b30832e824e795fe62d5cc1