### PR TITLE
Add contexts API and dynamic dropdowns

### DIFF
--- a/src/app/admin/creator-dashboard/ContentSegmentComparison.tsx
+++ b/src/app/admin/creator-dashboard/ContentSegmentComparison.tsx
@@ -51,7 +51,7 @@ interface ContentSegmentComparisonProps {
 
 const FORMAT_OPTIONS = ["", "Reel", "Post Estático", "Carrossel", "Story", "Video Longo"];
 const PROPOSAL_OPTIONS = ["", "Educativo", "Humor", "Notícia", "Review", "Tutorial", "Desafio", "Vlog"];
-const CONTEXT_OPTIONS = ["", "Finanças", "Tecnologia", "Moda", "Saúde", "Educação", "Entretenimento", "Viagem", "Gastronomia"];
+const DEFAULT_CONTEXTS = [""];
 
 // --- Funções Utilitárias ---
 const formatDisplayNumber = (num?: number): string => {
@@ -82,6 +82,22 @@ export default function ContentSegmentComparison({ dateRangeFilter }: ContentSeg
   const [comparisonResults, setComparisonResults] = useState<SegmentComparisonResultItem[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [contextOptions, setContextOptions] = useState<string[]>(DEFAULT_CONTEXTS);
+
+  useEffect(() => {
+    async function loadContexts() {
+      try {
+        const res = await fetch('/api/admin/dashboard/contexts');
+        if (res.ok) {
+          const data = await res.json();
+          setContextOptions(['', ...data.contexts]);
+        }
+      } catch (e) {
+        console.error('Failed to load contexts', e);
+      }
+    }
+    loadContexts();
+  }, []);
 
   const handleSegmentChange = (id: string, field: 'name' | keyof ISegmentDefinition, value: string) => {
     setSegmentsToCompare(prevSegments =>
@@ -243,7 +259,7 @@ export default function ContentSegmentComparison({ dateRangeFilter }: ContentSeg
                     onChange={(e) => handleSegmentChange(segment.id, 'context', e.target.value)}
                     className="mt-0.5 w-full px-2.5 py-1.5 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 >
-                    {CONTEXT_OPTIONS.map(opt => <option key={opt} value={opt}>{opt === "" ? "Qualquer Contexto" : opt}</option>)}
+                    {contextOptions.map(opt => <option key={opt} value={opt}>{opt === "" ? "Qualquer Contexto" : opt}</option>)}
                 </select>
                 </div>
             </div>

--- a/src/app/admin/creator-dashboard/GlobalPostsExplorer.tsx
+++ b/src/app/admin/creator-dashboard/GlobalPostsExplorer.tsx
@@ -65,10 +65,25 @@ const GlobalPostsExplorer = memo(function GlobalPostsExplorer({ dateRangeFilter 
   const [isTrendChartOpen, setIsTrendChartOpen] = useState(false);
   const [selectedPostIdForTrend, setSelectedPostIdForTrend] = useState<string | null>(null);
 
-  // Predefined options for dropdowns
-  const contextOptions = ["all", "Finanças", "Tecnologia", "Moda", "Saúde", "Educação", "Entretenimento"];
+  // Options for dropdowns loaded from API
+  const [contextOptions, setContextOptions] = useState<string[]>(["all"]);
   const proposalOptions = ["all", "Educativo", "Humor", "Notícia", "Review", "Tutorial"];
   const formatOptions = ["all", "Reel", "Post Estático", "Carrossel", "Story"];
+
+  useEffect(() => {
+    async function loadContexts() {
+      try {
+        const res = await fetch('/api/admin/dashboard/contexts');
+        if (res.ok) {
+          const data = await res.json();
+          setContextOptions(['all', ...data.contexts]);
+        }
+      } catch (e) {
+        console.error('Failed to load contexts', e);
+      }
+    }
+    loadContexts();
+  }, []);
 
   // Modal Handlers
   const handleOpenPostDetailModal = useCallback((postId: string) => {

--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -74,7 +74,9 @@ const SORT_BY_OPTIONS: { value: TopMoverSortBy; label: string }[] = [
 ];
 
 const FORMAT_OPTIONS_TOP_MOVERS = ["", "Reel", "Post Estático", "Carrossel", "Story", "Video Longo"];
-const CONTEXT_OPTIONS_TOP_MOVERS = ["", "Finanças", "Tecnologia", "Moda", "Saúde", "Educação", "Entretenimento"];
+
+// Context options loaded from API
+const DEFAULT_CONTEXTS = [""];
 
 
 // --- Funções Utilitárias ---
@@ -98,11 +100,27 @@ export default function TopMoversWidget() {
   const [sortBy, setSortBy] = useState<TopMoverSortBy>('absoluteChange_decrease');
 
   const [contentFilters, setContentFilters] = useState<ISegmentDefinition>({});
+  const [contextOptions, setContextOptions] = useState<string[]>(DEFAULT_CONTEXTS);
   
   const [results, setResults] = useState<ITopMoverResult[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadContexts() {
+      try {
+        const res = await fetch('/api/admin/dashboard/contexts');
+        if (res.ok) {
+          const data = await res.json();
+          setContextOptions(['', ...data.contexts]);
+        }
+      } catch (e) {
+        console.error('Failed to load contexts', e);
+      }
+    }
+    loadContexts();
+  }, []);
 
   const handleContentFilterChange = (field: keyof ISegmentDefinition, value: string) => {
     // CORREÇÃO: A atualização do estado com `prev` está correta, mas clarificamos que o valor vazio se torna `undefined`.
@@ -283,7 +301,7 @@ export default function TopMoversWidget() {
             <div>
               <label htmlFor="tm-contentContext" className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">Contexto (Conteúdo)</label>
               <select id="tm-contentContext" value={contentFilters.context || ""} onChange={e => handleContentFilterChange('context', e.target.value)} className="w-full px-3 py-1.5 border-gray-300 dark:border-gray-500 rounded-md h-[38px] sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100">
-                {CONTEXT_OPTIONS_TOP_MOVERS.map(c => <option key={c} value={c}>{c === "" ? "Todos Contextos" : c}</option>)}
+                {contextOptions.map(c => <option key={c} value={c}>{c === "" ? "Todos Contextos" : c}</option>)}
               </select>
             </div>
           </>

--- a/src/app/api/admin/dashboard/contexts/route.test.ts
+++ b/src/app/api/admin/dashboard/contexts/route.test.ts
@@ -1,0 +1,52 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
+import { logger } from '@/app/lib/logger';
+import { DatabaseError } from '@/app/lib/errors';
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@/app/lib/dataService/marketAnalysis/cohortsService', () => ({
+  getAvailableContexts: jest.fn(),
+}));
+
+const mockGetAvailableContexts = getAvailableContexts as jest.Mock;
+
+describe('API Route: /api/admin/dashboard/contexts', () => {
+  const createRequest = () => new NextRequest('http://localhost/api/admin/dashboard/contexts');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 with contexts list', async () => {
+    mockGetAvailableContexts.mockResolvedValue(['Finanças', 'Tecnologia']);
+    const res = await GET(createRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ contexts: ['Finanças', 'Tecnologia'] });
+  });
+
+  it('returns 500 on DatabaseError', async () => {
+    mockGetAvailableContexts.mockRejectedValue(new DatabaseError('db fail'));
+    const res = await GET(createRequest());
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Erro de banco de dados: db fail');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetAvailableContexts.mockRejectedValue(new Error('boom'));
+    const res = await GET(createRequest());
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Ocorreu um erro interno no servidor.');
+  });
+});

--- a/src/app/api/admin/dashboard/contexts/route.ts
+++ b/src/app/api/admin/dashboard/contexts/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/app/lib/logger';
+import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
+import { DatabaseError } from '@/app/lib/errors';
+
+const SERVICE_TAG = '[api/admin/dashboard/contexts]';
+
+async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
+  const session = { user: { name: 'Admin User' } };
+  const isAdmin = true;
+  if (!session || !isAdmin) {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request for available contexts.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado. Sessão de administrador inválida.', 401);
+    }
+    logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
+
+    const contexts = await getAvailableContexts();
+    logger.info(`${TAG} Retrieved ${contexts.length} contexts.`);
+    return NextResponse.json({ contexts }, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(`Erro de banco de dados: ${error.message}`, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/admin/dashboard/contexts` endpoint backed by `getAvailableContexts`
- load context options from the API in GlobalPostsExplorer, TopMoversWidget, and ContentSegmentComparison
- test new contexts endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852234f4ce4832e9af3a6ba354f1ea6