### PR TITLE
Add radar effectiveness insight hook

### DIFF
--- a/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
+++ b/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
@@ -173,7 +173,17 @@ const useIntelligenceChat = () => {
     }
   }, [isLoading, messages, processStream]);
 
-  return { messages, isLoading, error, visualizations, suggestions, startConversation, setMessages };
+  const askRadarEffectiveness = useCallback(
+    (alertType?: string, periodDays: number = 30) => {
+      const query = alertType
+        ? `Qual a eficácia do Radar Tuca para alertas do tipo '${alertType}' nos últimos ${periodDays} dias?`
+        : `Qual a eficácia do Radar Tuca nos últimos ${periodDays} dias?`;
+      startConversation(query);
+    },
+    [startConversation]
+  );
+
+  return { messages, isLoading, error, visualizations, suggestions, startConversation, askRadarEffectiveness, setMessages };
 };
 
 
@@ -338,7 +348,7 @@ const ChatInput: FC<{
 // --- INÍCIO DA CORREÇÃO 2: Alterar a assinatura do componente para aceitar props ---
 const StandaloneChatInterface: React.FC<StandaloneChatInterfaceProps> = ({ initialPrompt }) => {
 // --- FIM DA CORREÇÃO 2 ---
-  const { messages, isLoading, error, visualizations, suggestions, startConversation } = useIntelligenceChat();
+  const { messages, isLoading, error, visualizations, suggestions, startConversation, askRadarEffectiveness } = useIntelligenceChat();
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -374,6 +384,12 @@ const StandaloneChatInterface: React.FC<StandaloneChatInterfaceProps> = ({ initi
             <div className="mx-auto bg-white dark:bg-gray-700 border dark:border-gray-600 w-12 h-12 rounded-full flex items-center justify-center text-2xl mb-3">💡</div>
             <p className="text-md font-semibold text-gray-700 dark:text-gray-300">Como posso ajudar?</p>
             <p className="text-xs mt-1">Faça perguntas sobre criadores, conteúdo ou tendências.</p>
+            <button
+              onClick={() => askRadarEffectiveness()}
+              className="mt-4 inline-flex items-center px-3 py-1.5 rounded-md bg-indigo-600 text-white text-xs font-medium hover:bg-indigo-700"
+            >
+              Radar Tuca
+            </button>
           </div>
         )}
         {messages.map((m) => <MessageBubble key={m.id} message={m} />)}

--- a/src/app/admin/intelligence-hub/page.tsx
+++ b/src/app/admin/intelligence-hub/page.tsx
@@ -169,7 +169,17 @@ const useIntelligenceChat = () => {
     }
   }, [isLoading, messages, processStream]);
 
-  return { messages, isLoading, error, visualizations, suggestions, startConversation, setMessages };
+  const askRadarEffectiveness = useCallback(
+    (alertType?: string, periodDays: number = 30) => {
+      const query = alertType
+        ? `Qual a eficácia do Radar Tuca para alertas do tipo '${alertType}' nos últimos ${periodDays} dias?`
+        : `Qual a eficácia do Radar Tuca nos últimos ${periodDays} dias?`;
+      startConversation(query);
+    },
+    [startConversation]
+  );
+
+  return { messages, isLoading, error, visualizations, suggestions, startConversation, askRadarEffectiveness, setMessages };
 };
 
 // ============================================================================
@@ -335,7 +345,7 @@ const ChatInput: FC<{
 // ============================================================================
 
 export default function IntelligenceHubPage() {
-  const { messages, isLoading, error, visualizations, suggestions, startConversation } = useIntelligenceChat();
+  const { messages, isLoading, error, visualizations, suggestions, startConversation, askRadarEffectiveness } = useIntelligenceChat();
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -358,6 +368,12 @@ export default function IntelligenceHubPage() {
         <header className="mb-10">
           <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">Central de Inteligência</h1>
           <p className="text-md text-gray-600 dark:text-gray-400 mt-2">Pergunte, analise e obtenha insights estratégicos sobre o seu mercado.</p>
+          <button
+            onClick={() => askRadarEffectiveness()}
+            className="mt-4 inline-flex items-center px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            Ver eficácia do Radar
+          </button>
         </header>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:gap-12">

--- a/src/app/lib/adminAiFunctions.test.ts
+++ b/src/app/lib/adminAiFunctions.test.ts
@@ -36,15 +36,17 @@ jest.mock('./logger', () => ({
   // --- Importações ---
   import { adminFunctionExecutors } from './adminAiFunctions';
   import {
-      fetchMarketPerformance, 
+      fetchMarketPerformance,
       fetchTopCreators,
-      getCreatorProfile
+      getCreatorProfile,
+      fetchTucaRadarEffectiveness
   } from './dataService/marketAnalysisService';
   
   // Tipando os mocks para facilitar o uso nos testes
   const mockedFetchTopCreators = fetchTopCreators as jest.Mock;
   const mockedFetchMarketPerformance = fetchMarketPerformance as jest.Mock;
   const mockedGetCreatorProfile = getCreatorProfile as jest.Mock;
+  const mockedFetchTucaRadarEffectiveness = fetchTucaRadarEffectiveness as jest.Mock;
   
   describe('Admin AI Function Executors', () => {
   
@@ -131,7 +133,24 @@ jest.mock('./logger', () => ({
           });
           expect(response.summary).toContain('Análise de 100 posts');
           expect(response.visualizations[0].type).toBe('kpi');
-          expect(response.visualizations[0].data.value).toBe('4.75');
+       expect(response.visualizations[0].data.value).toBe('4.75');
+       });
+    });
+
+    // --- Testes para getTucaRadarEffectiveness ---
+    describe('getTucaRadarEffectiveness', () => {
+       it('deve estar exportada como função', () => {
+          expect(typeof adminFunctionExecutors.getTucaRadarEffectiveness).toBe('function');
+       });
+
+       it('deve retornar sumário apropriado quando não há dados', async () => {
+          mockedFetchTucaRadarEffectiveness.mockResolvedValue([]);
+
+          const args = { periodDays: 30 };
+          const response = await adminFunctionExecutors.getTucaRadarEffectiveness(args) as any;
+
+          expect(mockedFetchTucaRadarEffectiveness).toHaveBeenCalledWith(args);
+          expect(response.summary).toContain('Não foram encontrados dados');
        });
     });
   });


### PR DESCRIPTION
## Summary
- expose function to query Radar Tuca alert effectiveness from the admin chat
- surface button for admins to trigger this insight
- allow creator dashboard chat to request Radar Tuca insight
- test that `getTucaRadarEffectiveness` executor is exported and works when no data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522a9cf660832e9f7c0b535422168e