### PR TITLE
Add creator table with comparison/detail modals

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorComparisonModal.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorComparisonModal.test.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
   isOpen: true,
   onClose: jest.fn(),
   creatorIdsToCompare: ['id1', 'id2', 'id3'],
+  dateRangeFilter: { startDate: '2023-01-01', endDate: '2023-01-31' },
 };
 
 describe('CreatorComparisonModal Component', () => {
@@ -61,11 +62,14 @@ describe('CreatorComparisonModal Component', () => {
   test('fetches comparison data on mount if isOpen and creatorIds are provided', async () => {
     render(<CreatorComparisonModal {...defaultProps} />);
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-    expect(fetch).toHaveBeenCalledWith('/api/admin/dashboard/creators/compare', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ creatorIds: defaultProps.creatorIdsToCompare }),
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/admin/dashboard/creators/compare?startDate=2023-01-01&endDate=2023-01-31',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ creatorIds: defaultProps.creatorIdsToCompare }),
+      }
+    );
   });
 
   test('does not fetch if creatorIdsToCompare has less than 2 IDs', () => {
@@ -150,9 +154,12 @@ describe('CreatorComparisonModal Component', () => {
     rerender(<CreatorComparisonModal {...defaultProps} creatorIdsToCompare={newIds} />);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
-    expect(fetch).toHaveBeenLastCalledWith('/api/admin/dashboard/creators/compare', expect.objectContaining({
-      body: JSON.stringify({ creatorIds: newIds }),
-    }));
+    expect(fetch).toHaveBeenLastCalledWith(
+      '/api/admin/dashboard/creators/compare?startDate=2023-01-01&endDate=2023-01-31',
+      expect.objectContaining({
+        body: JSON.stringify({ creatorIds: newIds }),
+      })
+    );
     expect(await screen.findByText('Dave')).toBeInTheDocument();
     expect(screen.getByText('Eve')).toBeInTheDocument();
   });

--- a/src/app/admin/creator-dashboard/CreatorComparisonModal.tsx
+++ b/src/app/admin/creator-dashboard/CreatorComparisonModal.tsx
@@ -9,6 +9,10 @@ interface CreatorComparisonModalProps {
   isOpen: boolean;
   onClose: () => void;
   creatorIdsToCompare: string[];
+  dateRangeFilter?: {
+    startDate?: string;
+    endDate?: string;
+  };
 }
 
 // Helper to format numbers - can be expanded
@@ -32,6 +36,7 @@ export default function CreatorComparisonModal({
   isOpen,
   onClose,
   creatorIdsToCompare,
+  dateRangeFilter,
 }: CreatorComparisonModalProps) {
   const [comparisonData, setComparisonData] = useState<ICreatorProfile[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,7 +52,12 @@ export default function CreatorComparisonModal({
     setError(null);
 
     try {
-      const response = await fetch('/api/admin/dashboard/creators/compare', {
+      const params = new URLSearchParams();
+      if (dateRangeFilter?.startDate) params.append('startDate', dateRangeFilter.startDate);
+      if (dateRangeFilter?.endDate) params.append('endDate', dateRangeFilter.endDate);
+      const url = `/api/admin/dashboard/creators/compare${params.toString() ? `?${params.toString()}` : ''}`;
+
+      const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ creatorIds: creatorIdsToCompare }),
@@ -68,7 +78,7 @@ export default function CreatorComparisonModal({
     } finally {
       setIsLoading(false);
     }
-  }, [isOpen, creatorIdsToCompare]);
+  }, [isOpen, creatorIdsToCompare, dateRangeFilter]);
 
   useEffect(() => {
     if (isOpen) {
@@ -79,7 +89,7 @@ export default function CreatorComparisonModal({
       setError(null);
       setIsLoading(false);
     }
-  }, [isOpen, fetchComparisonData]); // fetchComparisonData depends on creatorIdsToCompare
+  }, [isOpen, fetchComparisonData]); // fetchComparisonData depends on creatorIdsToCompare and dateRangeFilter
 
   if (!isOpen) {
     return null;

--- a/src/app/admin/creator-dashboard/CreatorTable.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorTable.test.tsx
@@ -323,7 +323,8 @@ describe('CreatorTable Component', () => {
 
   describe('Creator Comparison Functionality', () => {
     test('checkbox interaction updates selectedForComparison state and respects MAX_CREATORS_TO_COMPARE', async () => {
-      render(<CreatorTable />);
+      const dateRange = { startDate: '2023-01-01', endDate: '2023-01-31' };
+      render(<CreatorTable dateRangeFilter={dateRange} />);
       await screen.findByText('Alice Wonderland'); // Wait for data
 
       const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
@@ -408,6 +409,7 @@ describe('CreatorTable Component', () => {
         expect.objectContaining({
           isOpen: true,
           creatorIdsToCompare: expectedIds,
+          dateRangeFilter: dateRange,
         }),
         {}
       );

--- a/src/app/admin/creator-dashboard/CreatorTable.tsx
+++ b/src/app/admin/creator-dashboard/CreatorTable.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
-import { UserGroupIcon, InformationCircleIcon, UsersIcon, XMarkIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { UserGroupIcon, InformationCircleIcon, UsersIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { FaSpinner, FaCheckCircle } from 'react-icons/fa';
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
@@ -15,6 +15,8 @@ import { SkeletonTable } from '../../components/SkeletonTable';
 import { UserAvatar } from '../../components/UserAvatar';
 import { StatusBadge } from '../../components/StatusBadge';
 import { SearchBar } from '../../components/SearchBar';
+import CreatorDetailModal from './CreatorDetailModal';
+import CreatorComparisonModal from './CreatorComparisonModal';
 
 
 // --- Definições de Componentes em Falta ---
@@ -65,47 +67,6 @@ const CREATOR_STATUS_MAPPINGS = {
 
 type UpdateStatusState = {
     [key: string]: 'approving' | 'idle';
-};
-
-
-// Modal de Detalhes do Criador (Versão Simples)
-const CreatorDetailModal = ({ isOpen, onClose, creator, dateRangeFilter }: { isOpen: boolean; onClose: () => void; creator: IDashboardCreator | null; dateRangeFilter: any }) => {
-  if (!isOpen || !creator) return null;
-
-  return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center">
-      <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-2xl m-4 max-h-[90vh] overflow-y-auto">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-bold text-gray-800">Detalhes de {creator.name}</h2>
-          <button onClick={onClose} className="p-1 rounded-full text-gray-400 hover:bg-gray-100">
-            <XMarkIcon className="w-6 h-6" />
-          </button>
-        </div>
-        {/* Conteúdo do modal mantido como antes */}
-      </div>
-    </div>
-  );
-};
-
-// Modal de Comparação de Criadores (Versão Simples)
-const CreatorComparisonModal = ({ isOpen, onClose, creatorIdsToCompare }: any) => {
-    if (!isOpen) return null;
-    return (
-        <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center">
-            <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-2xl m-4">
-                <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-xl font-bold text-gray-800">Comparando Criadores</h2>
-                    <button onClick={onClose} className="p-1 rounded-full text-gray-400 hover:bg-gray-100">
-                      <XMarkIcon className="w-6 h-6" />
-                    </button>
-                </div>
-                <div className="text-gray-700">
-                    <p>IDs a serem comparados: {creatorIdsToCompare.join(', ')}</p>
-                    <p className="mt-4"><i>(Gráficos de comparação viriam aqui)</i></p>
-                </div>
-            </div>
-        </div>
-    );
 };
 
 
@@ -388,7 +349,14 @@ const CreatorTable = memo(function CreatorTable({ planStatusFilter, expertiseLev
       </div>
 
       {isDetailModalOpen && <CreatorDetailModal isOpen={isDetailModalOpen} onClose={() => setIsDetailModalOpen(false)} creator={selectedCreatorForModal} dateRangeFilter={dateRangeFilter} />}
-      {isComparisonModalOpen && <CreatorComparisonModal isOpen={isComparisonModalOpen} onClose={() => setIsComparisonModalOpen(false)} creatorIdsToCompare={selectedForComparison} />}
+      {isComparisonModalOpen && (
+        <CreatorComparisonModal
+          isOpen={isComparisonModalOpen}
+          onClose={() => setIsComparisonModalOpen(false)}
+          creatorIdsToCompare={selectedForComparison}
+          dateRangeFilter={dateRangeFilter}
+        />
+      )}
     </>
   );
 });

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -25,6 +25,7 @@ import ProposalRankingCard from './ProposalRankingCard';
 import CreatorRankingCard from './CreatorRankingCard';
 import TopCreatorsWidget from './TopCreatorsWidget';
 import TopMoversWidget from './TopMoversWidget';
+import CreatorTable from './CreatorTable';
 import { getStartDateFromTimePeriod, formatDateYYYYMMDD } from '@/utils/dateHelpers';
 import CohortComparisonChart from './components/CohortComparisonChart';
 import MarketPerformanceChart from './components/MarketPerformanceChart';
@@ -272,17 +273,12 @@ const AdminCreatorDashboardPage: React.FC = () => {
           <MarketPerformanceChart format={marketFormat} proposal={marketProposal} />
         </section>
 
-        <section id="creator-highlights-and-scatter-plot" className="mb-10">
-            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Destaques e Análise Comparativa de Criadores
-            </h2>
-            <p className="text-sm text-gray-500 mb-4 italic">
-              (Em breve: Tabelas de Criadores com melhor performance)
-            </p>
-            <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
-                 {/* CreatorsScatterPlot was removed here */}
-            </div>
-          </section>
+        <section id="creator-list" className="mb-10">
+          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+            Lista de Criadores
+          </h2>
+          <CreatorTable dateRangeFilter={rankingDateRange} />
+        </section>
         </>
       )}
 


### PR DESCRIPTION
## Summary
- import real modal components into CreatorTable and pass date range
- expose CreatorTable in admin dashboard page
- include date range when fetching creator comparison data
- update tests for new date range prop

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852298b8590832eafa808e39fe082e2