### PR TITLE
Add creator support for Top Movers

### DIFF
--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -343,6 +343,9 @@ export default function TopMoversWidget() {
                   <tr key={item.entityId}>
                     <td className="px-3 py-2 whitespace-nowrap font-medium text-gray-800 dark:text-gray-100">
                       <div className="flex items-center">
+                        {entityType === 'creator' && item.profilePictureUrl && (
+                           <img src={item.profilePictureUrl} alt={item.entityName} className="h-6 w-6 rounded-full mr-2 object-cover" width={24} height={24} />
+                        )}
                         {entityType === 'creator' && !item.profilePictureUrl && (
                            <div className="h-6 w-6 rounded-full bg-gray-200 mr-2 flex items-center justify-center text-xs">{item.entityName?.substring(0,1).toUpperCase()}</div>
                         )}

--- a/src/app/api/admin/dashboard/top-movers/route.test.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.test.ts
@@ -96,14 +96,14 @@ describe('API Route: /api/admin/dashboard/top-movers', () => {
     }));
   });
 
-  it('should log a warning but proceed for entityType "creator"', async () => {
-    mockFetchTopMoversData.mockResolvedValue([]); // Service will return [] for creator
+  it('should handle entityType "creator" without warning', async () => {
+    mockFetchTopMoversData.mockResolvedValue([]);
     const creatorPayload = { ...validPayloadBase, entityType: 'creator' };
     const req = createMockRequest(creatorPayload);
     const response = await POST(req);
 
-    expect(response.status).toBe(200); // API should still succeed
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Processing request for 'creator' entity type, which is not fully implemented"));
+    expect(response.status).toBe(200);
+    expect(logger.warn).not.toHaveBeenCalled();
     expect(fetchTopMoversData).toHaveBeenCalledWith(expect.objectContaining({ entityType: 'creator' }));
   });
 

--- a/src/app/api/admin/dashboard/top-movers/route.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.ts
@@ -123,11 +123,6 @@ export async function POST(req: NextRequest) {
 
     const validatedArgs = validationResult.data as IFetchTopMoversArgs; // Cast after successful validation
 
-    // Removed logger.warn as creator entity type logic is now implemented in the service.
-    // if (validatedArgs.entityType === 'creator') {
-    //   logger.warn(`${TAG} Processing request for 'creator' entity type...`);
-    // }
-
     logger.info(`${TAG} Calling fetchTopMoversData with validated args: ${JSON.stringify(validatedArgs)}`);
     const results: ITopMoverResult[] = await fetchTopMoversData(validatedArgs);
 


### PR DESCRIPTION
## Summary
- implement aggregation for creator top movers
- return creator results without warnings in API route
- show creator avatars when available
- update tests for new behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852319d5f8c832eb879e98c024d288c