### PR TITLE
Explicit DailySnapshot array type in ContentTrendChart

### DIFF
--- a/src/app/admin/creator-dashboard/ContentTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/ContentTrendChart.tsx
@@ -56,7 +56,7 @@ const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
       }
       const json: PostDetailResponse = await res.json();
       setMeta({ format: json.format, proposal: json.proposal, context: json.context });
-      const snapshots = (json.dailySnapshots || []).map((s, idx) => ({
+      const snapshots: DailySnapshot[] = (json.dailySnapshots || []).map((s, idx) => ({
         ...s,
         date: s.date ? new Date(s.date) : undefined,
         dayNumber: typeof s.dayNumber === 'number' ? s.dayNumber : idx + 1,


### PR DESCRIPTION
## Summary
- fix implicit any by declaring a `DailySnapshot[]` type when mapping post daily snapshots

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523866c674832e88404799f1db3a04