### PR TITLE
Import PipelineStage in chart util

### DIFF
--- a/src/charts/getEngagementDistributionByFormatChartData.ts
+++ b/src/charts/getEngagementDistributionByFormatChartData.ts
@@ -1,5 +1,5 @@
 import MetricModel from "@/app/models/Metric";
-import { Types } from "mongoose";
+import { Types, PipelineStage } from "mongoose";
 import { connectToDatabase } from "@/app/lib/mongoose"; // Added
 import { logger } from "@/app/lib/logger"; // Added
 import { getStartDateFromTimePeriod } from "@/utils/dateHelpers"; // Importar helper compartilhado
@@ -47,7 +47,7 @@ async function getEngagementDistributionByFormatChartData(
       matchStage.postDate = { $gte: startDate, $lte: endDate };
     }
 
-    const pipeline = [
+    const pipeline: PipelineStage[] = [
       { $match: matchStage },
       {
         $project: {


### PR DESCRIPTION
## Summary
- import `PipelineStage` from mongoose
- type `pipeline` as `PipelineStage[]`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685238680df8832ea482cef87b075107