### PR TITLE
Fix admin dashboard date range handling

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
@@ -11,7 +11,12 @@ interface PlatformSummaryData {
   averageReachInPeriod: number;
 }
 
-const PlatformSummaryKpis: React.FC = () => {
+interface PlatformSummaryKpisProps {
+  startDate: string;
+  endDate: string;
+}
+
+const PlatformSummaryKpis: React.FC<PlatformSummaryKpisProps> = ({ startDate, endDate }) => {
   const [data, setData] = useState<PlatformSummaryData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -21,7 +26,8 @@ const PlatformSummaryKpis: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        const response = await fetch('/api/admin/dashboard/platform-summary');
+        const params = new URLSearchParams({ startDate, endDate });
+        const response = await fetch(`/api/admin/dashboard/platform-summary?${params.toString()}`);
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
@@ -37,7 +43,7 @@ const PlatformSummaryKpis: React.FC = () => {
     };
 
     fetchData();
-  }, []);
+  }, [startDate, endDate]);
 
   const formatPercentage = (num?: number | null) => {
     if (num === null || typeof num === 'undefined') return null;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -49,8 +49,9 @@ const AdminCreatorDashboardPage: React.FC = () => {
   const [marketProposal, setMarketProposal] = useState<string>(proposalOptions[0]!);
 
   const today = new Date();
-  const startDate = formatDateYYYYMMDD(getStartDateFromTimePeriod(today, globalTimePeriod));
-  const endDate = formatDateYYYYMMDD(today);
+  const startDateObj = getStartDateFromTimePeriod(today, globalTimePeriod);
+  const startDate = startDateObj.toISOString();
+  const endDate = today.toISOString();
   const rankingDateRange = { startDate, endDate };
 
 
@@ -85,7 +86,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
       </header>
 
       <section id="platform-summary" className="mb-8">
-        <PlatformSummaryKpis />
+        <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
       </section>
 
       <section id="creator-selection-simulation" className="mb-8 p-4 bg-white rounded-lg shadow">


### PR DESCRIPTION
## Summary
- pass ISO date range to admin dashboard components
- support date range props on `PlatformSummaryKpis`
- propagate selected range from dashboard page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523b177910832e93a9edf030212ef2