### PR TITLE
Handle empty chart data better

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,32 @@ Selecione múltiplos criadores e defina as métricas dos eixos X e Y para gerar 
 
 O componente **UserMonthlyComparisonChart** exibe a evolução de uma métrica entre os três últimos meses para um criador específico.
 Ele consome o endpoint `/api/v1/users/{userId}/charts/monthly-comparison` e permite escolher a métrica a ser comparada (total de posts ou total de interações).
+
 Basta fornecer o `userId` ao componente e ele renderizará um gráfico de colunas com as diferenças mensais.
+
+### Populando o Banco para Testes
+
+Os gráficos dependem das coleções **AccountInsight** e **Metric**. Caso seu banco esteja vazio, os componentes exibirão a mensagem "Sem dados no período selecionado". Para experimentar localmente, insira alguns registros manualmente no MongoDB:
+
+```javascript
+use data2content
+db.accountinsights.insertOne({
+  user: ObjectId("<id do usuário>"),
+  instagramAccountId: "123",
+  recordedAt: new Date(),
+  followersCount: 1000
+})
+
+db.metrics.insertOne({
+  user: ObjectId("<id do usuário>"),
+  postDate: new Date(),
+  type: "REEL",
+  source: "manual",
+  stats: { reach: 500, likes: 70, comments: 5 }
+})
+```
+
+Crie alguns documentos com datas diferentes para que os gráficos possam calcular tendências e médias.
 
 
 ## Learn More

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
@@ -133,7 +133,7 @@ const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para o período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
@@ -102,7 +102,7 @@ const PlatformMonthlyEngagementStackedChart: React.FC<PlatformMonthlyEngagementS
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado de engajamento disponível para o período.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados de engajamento no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -135,7 +135,7 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para o período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
@@ -156,7 +156,7 @@ const PlatformReachEngagementTrendChart: React.FC<PlatformReachEngagementTrendCh
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para o período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
@@ -197,7 +197,7 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para o período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
@@ -151,7 +151,7 @@ const UserMonthlyEngagementStackedChart: React.FC<UserMonthlyEngagementStackedCh
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado de engajamento disponível para o período.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados de engajamento no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
@@ -217,7 +217,7 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para o período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
         )}
       </div>
       {insightSummary && !loading && !error && (

--- a/src/app/api/v1/users/[userId]/trends/followers/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/followers/route.ts
@@ -45,6 +45,11 @@ export async function GET(
       granularity
     );
 
+    if (!data.chartData || data.chartData.length === 0) {
+      data.insightSummary =
+        data.insightSummary || 'Sem dados no período selecionado.';
+    }
+
     return NextResponse.json(data, { status: 200 });
 
   } catch (error) {

--- a/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
@@ -45,6 +45,11 @@ export async function GET(
       granularity
     );
 
+    if (!data.chartData || data.chartData.length === 0) {
+      data.insightSummary =
+        data.insightSummary || 'Sem dados no período selecionado.';
+    }
+
     return NextResponse.json(data, { status: 200 });
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure follower and reach-engagement routes return an insight summary when no data is found
- show a clear "Sem dados no período selecionado" message in charts
- document how to populate AccountInsight and Metric data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852437f5ef0832ebdc7c26b6182b5c9