### PR TITLE
Use segment stats in radar chart

### DIFF
--- a/src/app/models/SegmentRadar.ts
+++ b/src/app/models/SegmentRadar.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models, Document } from 'mongoose';
+
+export interface ISegmentRadar extends Document {
+  segmentId: string;
+  metrics: Record<string, number | null>;
+}
+
+const segmentRadarSchema = new Schema<ISegmentRadar>({
+  segmentId: { type: String, required: true, index: true },
+  metrics: { type: Schema.Types.Mixed, required: true },
+});
+
+export default models.SegmentRadar || model<ISegmentRadar>('SegmentRadar', segmentRadarSchema);

--- a/src/lib/services/segmentRadarService.ts
+++ b/src/lib/services/segmentRadarService.ts
@@ -1,0 +1,19 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import SegmentRadarModel from '@/app/models/SegmentRadar';
+
+export async function fetchSegmentRadarStats(segmentId: string): Promise<Record<string, number | null>> {
+  const TAG = '[segmentRadarService][fetchSegmentRadarStats]';
+  try {
+    await connectToDatabase();
+    const doc = await SegmentRadarModel.findOne({ segmentId }).lean();
+    if (!doc) {
+      logger.warn(`${TAG} No stats found for segment ${segmentId}`);
+      return {};
+    }
+    return doc.metrics || {};
+  } catch (error: any) {
+    logger.error(`${TAG} Error fetching stats for segment ${segmentId}:`, error);
+    throw new Error(`Failed to fetch radar stats for segment ${segmentId}: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- create `SegmentRadar` model and service
- use `fetchSegmentRadarStats` when comparing to a segment
- add tests for user vs user and user vs segment with real service data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685243690310832e9582fc34e5314937