### PR TITLE
Add follower daily change analytics

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface ApiChangePoint {
+  date: string;
+  change: number | null;
+}
+
+interface PlatformFollowerChangeResponse {
+  chartData: ApiChangePoint[];
+  insightSummary?: string;
+}
+
+interface PlatformFollowerChangeChartProps {
+  timePeriod: string;
+}
+
+const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = ({
+  timePeriod
+}) => {
+  const [data, setData] = useState<PlatformFollowerChangeResponse['chartData']>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const apiUrl = `/api/v1/platform/trends/follower-change?timePeriod=${timePeriod}`;
+      const response = await fetch(apiUrl);
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+      }
+      const result: PlatformFollowerChangeResponse = await response.json();
+      setData(result.chartData);
+      setInsightSummary(result.insightSummary);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setData([]);
+      setInsightSummary(undefined);
+    } finally {
+      setLoading(false);
+    }
+  }, [timePeriod]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const tooltipFormatter = (value: number | null) => (value !== null ? value.toLocaleString() : 'N/A');
+
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
+      <div className="flex flex-col sm:flex-row justify-between sm:items-center mb-4">
+        <h2 className="text-lg md:text-xl font-semibold text-gray-700 mb-2 sm:mb-0">
+          Variação Diária de Seguidores da Plataforma
+        </h2>
+      </div>
+      <div style={{ width: '100%', height: 300 }}>
+        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
+        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+        {!loading && !error && data.length > 0 && (
+          <ResponsiveContainer>
+            <BarChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+              <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
+              <YAxis stroke="#666" tick={{ fontSize: 12 }} />
+              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <Bar dataKey="change" name="Variação" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+        {!loading && !error && data.length === 0 && (
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
+        )}
+      </div>
+      {insightSummary && !loading && !error && (
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+      )}
+    </div>
+  );
+};
+
+export default memo(PlatformFollowerChangeChart);

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface ApiChangePoint {
+  date: string;
+  change: number | null;
+}
+
+interface UserFollowerChangeResponse {
+  chartData: ApiChangePoint[];
+  insightSummary?: string;
+}
+
+const TIME_PERIOD_OPTIONS = [
+  { value: 'last_7_days', label: 'Últimos 7 dias' },
+  { value: 'last_30_days', label: 'Últimos 30 dias' },
+  { value: 'last_90_days', label: 'Últimos 90 dias' },
+  { value: 'last_6_months', label: 'Últimos 6 meses' },
+  { value: 'last_12_months', label: 'Últimos 12 meses' },
+  { value: 'all_time', label: 'Todo o período' },
+];
+
+interface UserFollowerChangeChartProps {
+  userId: string | null;
+  chartTitle?: string;
+  initialTimePeriod?: string;
+}
+
+const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
+  userId,
+  chartTitle = 'Variação Diária de Seguidores',
+  initialTimePeriod,
+}) => {
+  const [data, setData] = useState<UserFollowerChangeResponse['chartData']>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [timePeriod, setTimePeriod] = useState<string>(
+    initialTimePeriod || TIME_PERIOD_OPTIONS[1]?.value || 'last_30_days'
+  );
+
+  useEffect(() => {
+    if (initialTimePeriod) setTimePeriod(initialTimePeriod);
+  }, [initialTimePeriod]);
+
+  const fetchData = useCallback(async () => {
+    if (!userId) {
+      setData([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const apiUrl = `/api/v1/users/${userId}/trends/follower-change?timePeriod=${timePeriod}`;
+      const response = await fetch(apiUrl);
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+      }
+      const result: UserFollowerChangeResponse = await response.json();
+      setData(result.chartData);
+      setInsightSummary(result.insightSummary);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setData([]);
+      setInsightSummary(undefined);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, timePeriod]);
+
+  useEffect(() => {
+    if (userId) {
+      fetchData();
+    } else {
+      setData([]);
+      setLoading(false);
+    }
+  }, [userId, fetchData]);
+
+  const handleTimePeriodChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setTimePeriod(e.target.value);
+  };
+
+  const tooltipFormatter = (value: number | null) => (value !== null ? value.toLocaleString() : 'N/A');
+
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      {userId && (
+        <div className="mb-4">
+          <label htmlFor={`timePeriodUserFollowerChange-${userId}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <select
+            id={`timePeriodUserFollowerChange-${userId}`}
+            value={timePeriod}
+            onChange={handleTimePeriodChange}
+            disabled={loading}
+            className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+          >
+            {TIME_PERIOD_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+      <div style={{ width: '100%', height: 300 }}>
+        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
+        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+        {!loading && !error && data.length > 0 && (
+          <ResponsiveContainer>
+            <BarChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+              <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
+              <YAxis stroke="#666" tick={{ fontSize: 12 }} />
+              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <Bar dataKey="change" name="Variação" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+        {!loading && !error && data.length === 0 && (
+          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
+        )}
+      </div>
+      {insightSummary && !loading && !error && (
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(UserFollowerChangeChart);

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 // User-specific charts & metrics
 import UserFollowerTrendChart from '../UserFollowerTrendChart';
+import UserFollowerChangeChart from '../UserFollowerChangeChart';
 import UserReachEngagementTrendChart from '../UserReachEngagementTrendChart';
 import UserMovingAverageEngagementChart from '../UserMovingAverageEngagementChart';
 import UserAverageEngagementChart from '../UserAverageEngagementChart';
@@ -115,10 +116,10 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
         </h3>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
           <UserFollowerTrendChart userId={userId} chartTitle="Evolução de Seguidores" initialTimePeriod={initialChartsTimePeriod} />
-          <UserReachEngagementTrendChart userId={userId} chartTitle="Alcance e Contas Engajadas" initialTimePeriod={initialChartsTimePeriod} />
+          <UserFollowerChangeChart userId={userId} chartTitle="Variação Diária de Seguidores" initialTimePeriod={initialChartsTimePeriod} />
         </div>
-        <div className="grid grid-cols-1 gap-6">
-          {/* UserMovingAverageEngagementChart precisa de initialDataWindow e initialAvgWindow */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          <UserReachEngagementTrendChart userId={userId} chartTitle="Alcance e Contas Engajadas" initialTimePeriod={initialChartsTimePeriod} />
           <UserMovingAverageEngagementChart userId={userId} chartTitle="Média Móvel de Engajamento Diário" initialTimePeriod={initialChartsTimePeriod} />
         </div>
       </section>

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -8,6 +8,7 @@ import GlobalTimePeriodFilter from './components/filters/GlobalTimePeriodFilter'
 
 // Componentes da Plataforma - Módulo 1 (Visão Geral)
 import PlatformFollowerTrendChart from './components/PlatformFollowerTrendChart';
+import PlatformFollowerChangeChart from './components/PlatformFollowerChangeChart';
 import PlatformReachEngagementTrendChart from './components/PlatformReachEngagementTrendChart';
 import PlatformMovingAverageEngagementChart from './components/PlatformMovingAverageEngagementChart';
 import TotalActiveCreatorsKpi from './components/kpis/TotalActiveCreatorsKpi';
@@ -139,9 +140,10 @@ const AdminCreatorDashboardPage: React.FC = () => {
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
               <PlatformFollowerTrendChart timePeriod={globalTimePeriod} />
-              <PlatformReachEngagementTrendChart timePeriod={globalTimePeriod} />
+              <PlatformFollowerChangeChart timePeriod={globalTimePeriod} />
             </div>
-            <div className="grid grid-cols-1 gap-6">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
+              <PlatformReachEngagementTrendChart timePeriod={globalTimePeriod} />
               <PlatformMovingAverageEngagementChart timePeriod={globalTimePeriod} />
             </div>
           </section>

--- a/src/app/api/v1/platform/trends/follower-change/route.ts
+++ b/src/app/api/v1/platform/trends/follower-change/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import getFollowerDailyChangeData from '@/charts/getFollowerDailyChangeData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+
+const ALLOWED_TIME_PERIODS = [
+  'last_7_days',
+  'last_30_days',
+  'last_90_days',
+  'last_6_months',
+  'last_12_months',
+  'all_time'
+];
+
+interface ApiChangePoint {
+  date: string;
+  change: number | null;
+}
+
+interface FollowerChangeResponse {
+  chartData: ApiChangePoint[];
+  insightSummary: string;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod = timePeriodParam && ALLOWED_TIME_PERIODS.includes(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+
+  if (timePeriodParam && !ALLOWED_TIME_PERIODS.includes(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    await connectToDatabase();
+    const platformUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    if (!platformUsers || platformUsers.length === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum usuário encontrado na plataforma para agregar dados.' }, { status: 200 });
+    }
+
+    const userIds = platformUsers.map(u => u._id);
+    const BATCH_SIZE = 50;
+    const results: PromiseSettledResult<FollowerChangeResponse>[] = [];
+
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batchIds.map(id => getFollowerDailyChangeData(id.toString(), timePeriod));
+      const batchRes = await Promise.allSettled(batchPromises);
+      results.push(...batchRes);
+    }
+
+    const aggregatedByDate = new Map<string, number>();
+    results.forEach(r => {
+      if (r.status === 'fulfilled') {
+        r.value.chartData.forEach(p => {
+          if (p.change !== null) {
+            const curr = aggregatedByDate.get(p.date) || 0;
+            aggregatedByDate.set(p.date, curr + p.change);
+          }
+        });
+      } else {
+        logger.error('Erro ao buscar mudança de seguidores para um usuário:', r.reason);
+      }
+    });
+
+    if (aggregatedByDate.size === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum dado de seguidores encontrado para os usuários da plataforma no período.' }, { status: 200 });
+    }
+
+    const chartData: ApiChangePoint[] = Array.from(aggregatedByDate.entries())
+      .map(([date, change]) => ({ date, change }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let insight = 'Dados de variação diária de seguidores da plataforma.';
+    if (chartData.length > 0) {
+      const totalChange = chartData.reduce((acc, p) => acc + (p.change ?? 0), 0);
+      const periodText = timePeriod === 'all_time'
+        ? 'todo o período'
+        : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months', ' meses');
+      if (totalChange > 0) {
+        insight = `A plataforma ganhou ${totalChange.toLocaleString()} seguidores nos ${periodText}.`;
+      } else if (totalChange < 0) {
+        insight = `A plataforma perdeu ${Math.abs(totalChange).toLocaleString()} seguidores nos ${periodText}.`;
+      } else {
+        insight = `Sem mudança no total de seguidores da plataforma nos ${periodText}.`;
+      }
+    }
+
+    return NextResponse.json({ chartData, insightSummary: insight }, { status: 200 });
+  } catch (error) {
+    logger.error('[API PLATFORM/TRENDS/FOLLOWER-CHANGE] Error aggregating platform follower change:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/users/[userId]/trends/follower-change/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/follower-change/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import getFollowerDailyChangeData from '@/charts/getFollowerDailyChangeData';
+import { Types } from 'mongoose';
+
+const ALLOWED_TIME_PERIODS = [
+  'last_7_days',
+  'last_30_days',
+  'last_90_days',
+  'last_6_months',
+  'last_12_months',
+  'all_time'
+];
+
+export async function GET(
+  request: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json({ error: 'User ID inválido ou ausente.' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod = timePeriodParam && ALLOWED_TIME_PERIODS.includes(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+
+  if (timePeriodParam && !ALLOWED_TIME_PERIODS.includes(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    const data = await getFollowerDailyChangeData(userId, timePeriod);
+    if (!data.chartData || data.chartData.length === 0) {
+      data.insightSummary = data.insightSummary || 'Sem dados no período selecionado.';
+    }
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/charts/getFollowerDailyChangeData.test.ts
+++ b/src/charts/getFollowerDailyChangeData.test.ts
@@ -1,0 +1,103 @@
+import { Types } from 'mongoose';
+import getFollowerDailyChangeData from './getFollowerDailyChangeData';
+import AccountInsightModel, { IAccountInsight } from '@/app/models/AccountInsight';
+
+jest.mock('@/app/models/AccountInsight', () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+function formatDateYYYYMMDD(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function createDate(daysAgo: number, baseDate?: Date): Date {
+  const date = baseDate ? new Date(baseDate) : new Date();
+  date.setDate(date.getDate() - daysAgo);
+  date.setHours(12,0,0,0);
+  return date;
+}
+
+describe('getFollowerDailyChangeData', () => {
+  const userId = new Types.ObjectId().toString();
+  let baseTestDate: Date;
+
+  beforeEach(() => {
+    (AccountInsightModel.find as jest.Mock).mockReset();
+    (AccountInsightModel.findOne as jest.Mock).mockReset();
+    baseTestDate = new Date();
+    baseTestDate.setHours(12,0,0,0);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  const mockInsight = (followersCount: number, date: Date): IAccountInsight => ({
+    _id: new Types.ObjectId(),
+    user: new Types.ObjectId(userId),
+    followersCount,
+    recordedAt: date,
+    accountInsightsPeriod: {}
+  } as IAccountInsight);
+
+  test('last_30_days com dados e carry-forward', async () => {
+    const period = 'last_30_days';
+    const numDays = 30;
+    (AccountInsightModel.findOne as jest.Mock).mockResolvedValueOnce(
+      mockInsight(100, createDate(numDays, baseTestDate))
+    );
+
+    const snapshotsInPeriod = [
+      mockInsight(105, createDate(numDays - 5, baseTestDate)),
+      mockInsight(110, createDate(numDays - 15, baseTestDate)),
+      mockInsight(110, createDate(numDays - 15, baseTestDate)),
+      mockInsight(120, createDate(numDays - 25, baseTestDate)),
+    ];
+    (AccountInsightModel.find as jest.Mock).mockResolvedValue(snapshotsInPeriod);
+
+    const result = await getFollowerDailyChangeData(userId, period);
+
+    expect(result.chartData.length).toBe(numDays + 1);
+    const changeMap = new Map(result.chartData.map(p => [p.date, p.change]));
+
+    const dayKeySnapshot1 = formatDateYYYYMMDD(createDate(numDays - 5, baseTestDate));
+    expect(changeMap.get(dayKeySnapshot1)).toBe(5); // 105 - 100
+
+    const dayAfterSnapshot1 = formatDateYYYYMMDD(createDate(numDays - 4, baseTestDate));
+    expect(changeMap.get(dayAfterSnapshot1)).toBe(0);
+
+    const dayKeySnapshot2 = formatDateYYYYMMDD(createDate(numDays - 15, baseTestDate));
+    expect(changeMap.get(dayKeySnapshot2)).toBe(5); // 110 - 105
+
+    const dayKeySnapshot3 = formatDateYYYYMMDD(createDate(numDays - 25, baseTestDate));
+    expect(changeMap.get(dayKeySnapshot3)).toBe(10); // 120 - 110
+
+    const lastPoint = result.chartData[result.chartData.length -1];
+    expect(lastPoint.change).toBe(0);
+    expect(result.insightSummary).toContain('Ganho de 20 seguidores');
+  });
+
+  test('Sem snapshots no período, mas com snapshot anterior', async () => {
+    (AccountInsightModel.findOne as jest.Mock).mockResolvedValueOnce(
+      mockInsight(90, createDate(30, baseTestDate))
+    );
+    (AccountInsightModel.find as jest.Mock).mockResolvedValue([]);
+
+    const result = await getFollowerDailyChangeData(userId, 'last_30_days');
+    expect(result.chartData.length).toBe(31);
+    result.chartData.forEach(p => expect(p.change).toBe(0));
+    expect(result.insightSummary).toContain('Sem mudança');
+  });
+
+  test('Sem nenhum snapshot', async () => {
+    (AccountInsightModel.findOne as jest.Mock).mockResolvedValueOnce(null);
+    (AccountInsightModel.find as jest.Mock).mockResolvedValue([]);
+
+    const result = await getFollowerDailyChangeData(userId, 'last_30_days');
+    expect(result.chartData.length).toBe(31);
+    result.chartData.forEach(p => expect(p.change).toBeNull());
+    expect(result.insightSummary).toBe('Nenhum dado encontrado para o período.');
+  });
+});

--- a/src/charts/getFollowerDailyChangeData.ts
+++ b/src/charts/getFollowerDailyChangeData.ts
@@ -1,0 +1,125 @@
+import AccountInsightModel, { IAccountInsight } from "@/app/models/AccountInsight";
+import { Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import {
+  addDays,
+  formatDateYYYYMMDD,
+  getStartDateFromTimePeriod
+} from "@/utils/dateHelpers";
+
+interface DailyChangePoint {
+  date: string;
+  change: number | null;
+}
+
+interface FollowerDailyChangeResponse {
+  chartData: DailyChangePoint[];
+  insightSummary?: string;
+}
+
+async function getFollowerDailyChangeData(
+  userId: string | Types.ObjectId,
+  timePeriod: string
+): Promise<FollowerDailyChangeResponse> {
+  const resolvedUserId = typeof userId === "string" ? new Types.ObjectId(userId) : userId;
+
+  const today = new Date();
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+  const baseResponse: FollowerDailyChangeResponse = {
+    chartData: [],
+    insightSummary: "Nenhum dado encontrado para o período.",
+  };
+
+  try {
+    await connectToDatabase();
+
+    const snapshots: IAccountInsight[] = await AccountInsightModel.find({
+      user: resolvedUserId,
+      recordedAt: { $gte: startDate, $lte: endDate },
+    })
+      .sort({ recordedAt: 1 })
+      .lean();
+
+    const dailyDataMap = new Map<string, number>();
+    for (const snap of snapshots) {
+      if (typeof snap.followersCount === "number") {
+        dailyDataMap.set(formatDateYYYYMMDD(snap.recordedAt), snap.followersCount);
+      }
+    }
+
+    let lastKnownFollowers: number | null = null;
+    const snapshotBeforeStart = await AccountInsightModel.findOne({
+      user: resolvedUserId,
+      recordedAt: { $lt: startDate },
+    })
+      .sort({ recordedAt: -1 })
+      .lean();
+
+    if (snapshotBeforeStart && typeof snapshotBeforeStart.followersCount === "number") {
+      lastKnownFollowers = snapshotBeforeStart.followersCount;
+    }
+
+    let previousFollowers: number | null = lastKnownFollowers;
+    let currentDate = new Date(startDate);
+    const loopEndDate = new Date(endDate);
+
+    const followerCounts: { date: string; value: number | null }[] = [];
+
+    while (currentDate <= loopEndDate) {
+      const dayKey = formatDateYYYYMMDD(currentDate);
+      if (dailyDataMap.has(dayKey)) {
+        lastKnownFollowers = dailyDataMap.get(dayKey)!;
+      }
+      followerCounts.push({ date: dayKey, value: lastKnownFollowers });
+      currentDate = addDays(currentDate, 1);
+    }
+
+    const changeData: DailyChangePoint[] = [];
+    for (const point of followerCounts) {
+      let change: number | null = null;
+      if (point.value !== null && previousFollowers !== null) {
+        change = point.value - previousFollowers;
+      }
+      changeData.push({ date: point.date, change });
+      if (point.value !== null) {
+        previousFollowers = point.value;
+      }
+    }
+
+    baseResponse.chartData = changeData;
+
+    const firstValuePoint = followerCounts.find(p => p.value !== null);
+    const lastValuePoint = [...followerCounts].filter(p => p.value !== null).pop();
+
+    if (firstValuePoint && lastValuePoint && firstValuePoint.value !== null && lastValuePoint.value !== null) {
+      const absoluteGrowth = lastValuePoint.value - firstValuePoint.value;
+      let periodText = timePeriod.replace("last_", "últimos ").replace("_days", " dias").replace("_months", " meses");
+      if (timePeriod === "all_time") periodText = "todo o período";
+
+      if (absoluteGrowth > 0) {
+        baseResponse.insightSummary = `Ganho de ${absoluteGrowth.toLocaleString()} seguidores nos ${periodText}.`;
+      } else if (absoluteGrowth < 0) {
+        baseResponse.insightSummary = `Perda de ${Math.abs(absoluteGrowth).toLocaleString()} seguidores nos ${periodText}.`;
+      } else {
+        baseResponse.insightSummary = `Sem mudança no número de seguidores nos ${periodText}.`;
+      }
+    } else if (lastValuePoint && lastValuePoint.value !== null) {
+      baseResponse.insightSummary = `Atualmente com ${lastValuePoint.value.toLocaleString()} seguidores.`;
+    } else {
+      baseResponse.insightSummary = "Não há dados de seguidores suficientes para gerar um resumo.";
+    }
+
+    return baseResponse;
+  } catch (error) {
+    logger.error(`Error in getFollowerDailyChangeData for userId ${resolvedUserId}:`, error);
+    return {
+      chartData: [],
+      insightSummary: "Erro ao buscar dados de mudança diária de seguidores.",
+    };
+  }
+}
+
+export default getFollowerDailyChangeData;


### PR DESCRIPTION
## Summary
- add new chart util `getFollowerDailyChangeData` with tests
- expose new API routes for follower-change trends
- add React components `UserFollowerChangeChart` and `PlatformFollowerChangeChart`
- display follower change charts beside follower trend charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852480eaeac832ebe91ea0e1655a67c