### PR TITLE
Add reach interaction trend fallback

### DIFF
--- a/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import getReachEngagementTrendChartData from '@/charts/getReachEngagementTrendChartData'; // Ajuste o caminho
+import getReachEngagementTrendChartData from '@/charts/getReachEngagementTrendChartData';
+import getReachInteractionTrendChartData from '@/charts/getReachInteractionTrendChartData';
 import { Types } from 'mongoose';
 
 type ReachEngagementChartResponse = any;
@@ -39,11 +40,18 @@ export async function GET(
   }
 
   try {
-    const data: ReachEngagementChartResponse = await getReachEngagementTrendChartData(
+    let data: ReachEngagementChartResponse = await getReachEngagementTrendChartData(
       userId,
       timePeriod,
       granularity
     );
+
+    const noInsightData =
+      !data.chartData || data.chartData.every(p => p.reach === null && p.engagedUsers === null);
+
+    if (noInsightData) {
+      data = await getReachInteractionTrendChartData(userId, timePeriod, granularity);
+    }
 
     if (!data.chartData || data.chartData.length === 0) {
       data.insightSummary =

--- a/src/charts/getReachInteractionTrendChartData.test.ts
+++ b/src/charts/getReachInteractionTrendChartData.test.ts
@@ -1,0 +1,107 @@
+import { Types } from 'mongoose';
+import getReachInteractionTrendChartData from './getReachInteractionTrendChartData';
+import MetricModel from '@/app/models/Metric';
+
+jest.mock('@/app/models/Metric', () => ({
+  find: jest.fn(),
+}));
+
+function formatDateYYYYMMDD(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+function getYearWeek(date: Date): string {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return d.getUTCFullYear() + '-' + String(weekNo).padStart(2, '0');
+}
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+describe('getReachInteractionTrendChartData', () => {
+  const userId = new Types.ObjectId().toString();
+  let baseDate: Date;
+
+  beforeEach(() => {
+    (MetricModel.find as jest.Mock).mockReset();
+    baseDate = new Date(2023, 10, 15, 12, 0, 0, 0); // 15 Nov 2023
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  function mockMetric(postDate: Date, reach?: number | null, interactions?: number | null) {
+    return {
+      _id: new Types.ObjectId(),
+      user: new Types.ObjectId(userId),
+      postDate,
+      stats: {
+        ...(reach !== null ? { reach } : {}),
+        ...(interactions !== null ? { total_interactions: interactions } : {}),
+      },
+    } as any;
+  }
+
+  test('Agrega posts diários e preenche gaps', async () => {
+    const posts = [
+      mockMetric(addDays(baseDate, -6), 100, 10), // Nov 9
+      mockMetric(addDays(baseDate, -4), 120, 12), // Nov 11
+      mockMetric(addDays(baseDate, 0), 150, 15),  // Nov 15
+    ];
+    (MetricModel.find as jest.Mock).mockReturnValue({ sort: jest.fn().mockReturnThis(), lean: () => Promise.resolve(posts) });
+
+    const result = await getReachInteractionTrendChartData(userId, 'last_7_days', 'daily');
+
+    expect(result.chartData.length).toBe(7);
+    expect(result.chartData[0]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -6)), reach: 100, engagedUsers: 10 });
+    expect(result.chartData[1]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -5)), reach: null, engagedUsers: null });
+    expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -4)), reach: 120, engagedUsers: 12 });
+    expect(result.chartData[6]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, 0)), reach: 150, engagedUsers: 15 });
+  });
+
+  test('Agrega posts semanais e preenche gaps', async () => {
+    const posts = [
+      mockMetric(addDays(baseDate, -28), 200, 20),
+      mockMetric(addDays(baseDate, -14), 300, 30),
+      mockMetric(addDays(baseDate, 0), 400, 40),
+    ];
+    (MetricModel.find as jest.Mock).mockReturnValue({ sort: jest.fn().mockReturnThis(), lean: () => Promise.resolve(posts) });
+
+    const result = await getReachInteractionTrendChartData(userId, 'last_30_days', 'weekly');
+
+    const week1 = getYearWeek(addDays(baseDate, -28));
+    const week2 = getYearWeek(addDays(baseDate, -21)); // gap
+    const week3 = getYearWeek(addDays(baseDate, -14));
+    const week4 = getYearWeek(addDays(baseDate, -7));  // gap
+    const week5 = getYearWeek(addDays(baseDate, 0));
+
+    expect(result.chartData.find(p => p.date === week1)?.reach).toBe(200);
+    expect(result.chartData.find(p => p.date === week2)?.reach).toBeNull();
+    expect(result.chartData.find(p => p.date === week3)?.engagedUsers).toBe(30);
+    expect(result.chartData.find(p => p.date === week4)?.reach).toBeNull();
+    expect(result.chartData.find(p => p.date === week5)?.engagedUsers).toBe(40);
+  });
+
+  test('Nenhum post retorna todos nulos', async () => {
+    (MetricModel.find as jest.Mock).mockReturnValue({ sort: jest.fn().mockReturnThis(), lean: () => Promise.resolve([]) });
+    const result = await getReachInteractionTrendChartData(userId, 'last_3_days', 'daily');
+    expect(result.chartData.length).toBe(3);
+    result.chartData.forEach(p => {
+      expect(p.reach).toBeNull();
+      expect(p.engagedUsers).toBeNull();
+    });
+  });
+
+  test('Erro no DB', async () => {
+    (MetricModel.find as jest.Mock).mockReturnValue({ sort: jest.fn().mockReturnThis(), lean: () => Promise.reject(new Error('DB Error')) });
+    const result = await getReachInteractionTrendChartData(userId, 'last_7_days', 'daily');
+    expect(result.chartData.length).toBe(7);
+    expect(result.insightSummary).toBe('Erro ao buscar dados de alcance e interações.');
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/charts/getReachInteractionTrendChartData.ts
+++ b/src/charts/getReachInteractionTrendChartData.ts
@@ -1,0 +1,101 @@
+// src/charts/getReachInteractionTrendChartData.ts
+
+import { Types } from 'mongoose';
+import MetricModel, { IMetric } from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import {
+  addDays,
+  formatDateYYYYMMDD,
+  getStartDateFromTimePeriod,
+  getYearWeek,
+} from '@/utils/dateHelpers';
+
+interface ReachInteractionDataPoint {
+  date: string;
+  reach: number | null;
+  engagedUsers: number | null; // represents total_interactions
+}
+
+interface ReachInteractionChartResponse {
+  chartData: ReachInteractionDataPoint[];
+  insightSummary?: string;
+}
+
+async function getReachInteractionTrendChartData(
+  userId: string | Types.ObjectId,
+  timePeriod: 'last_7_days' | 'last_30_days' | 'last_90_days' | 'last_6_months' | 'last_12_months' | 'all_time' | string,
+  granularity: 'daily' | 'weekly',
+): Promise<ReachInteractionChartResponse> {
+  const resolvedUserId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
+
+  const today = new Date();
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+  const response: ReachInteractionChartResponse = {
+    chartData: [],
+    insightSummary: 'Nenhum dado de alcance ou interações encontrado para o período.',
+  };
+
+  try {
+    await connectToDatabase();
+
+    const posts: Pick<IMetric, 'postDate' | 'stats'>[] = await MetricModel.find({
+      user: resolvedUserId,
+      postDate: { $gte: startDate, $lte: endDate },
+    })
+      .sort({ postDate: 1 })
+      .lean();
+
+    const dataMap = new Map<string, { reach: number; engagedUsers: number }>();
+    for (const post of posts) {
+      const stats = post.stats || {};
+      const reach = typeof stats.reach === 'number' ? stats.reach : 0;
+      const interactions = typeof stats.total_interactions === 'number' ? stats.total_interactions : 0;
+      if (reach === 0 && interactions === 0) continue;
+
+      const key = granularity === 'daily'
+        ? formatDateYYYYMMDD(post.postDate)
+        : getYearWeek(post.postDate);
+
+      const agg = dataMap.get(key) || { reach: 0, engagedUsers: 0 };
+      agg.reach += reach;
+      agg.engagedUsers += interactions;
+      dataMap.set(key, agg);
+    }
+
+    let cursor = new Date(startDate);
+    while (cursor <= endDate) {
+      const key = granularity === 'daily'
+        ? formatDateYYYYMMDD(cursor)
+        : getYearWeek(cursor);
+      const entry = dataMap.get(key);
+      response.chartData.push({
+        date: key,
+        reach: entry ? entry.reach : null,
+        engagedUsers: entry ? entry.engagedUsers : null,
+      });
+      cursor = granularity === 'daily' ? addDays(cursor, 1) : addDays(cursor, 7);
+    }
+
+    const valid = response.chartData.filter(p => p.reach !== null || p.engagedUsers !== null);
+    if (valid.length) {
+      const totalReach = valid.reduce((s, p) => s + (p.reach ?? 0), 0);
+      const totalInter = valid.reduce((s, p) => s + (p.engagedUsers ?? 0), 0);
+      const periodText = timePeriod === 'all_time'
+        ? 'todo o período'
+        : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months', ' meses');
+      response.insightSummary =
+        `Média de alcance: ${(totalReach / valid.length).toFixed(0)}, interações: ${(totalInter / valid.length).toFixed(0)} por ${granularity === 'daily' ? 'dia' : 'semana'} nos ${periodText}.`;
+    }
+
+    return response;
+  } catch (err) {
+    logger.error(`Erro em getReachInteractionTrendChartData (${resolvedUserId}):`, err);
+    response.insightSummary = 'Erro ao buscar dados de alcance e interações.';
+    return response;
+  }
+}
+
+export default getReachInteractionTrendChartData;


### PR DESCRIPTION
## Summary
- add helper to sum post reach and interactions
- switch API endpoints to fall back to post metrics if insight records absent
- include tests for new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685249626274832eb8484a8b51b4be55