### PR TITLE
Add proposal-based engagement chart

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -5,7 +5,7 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
 
-type GroupingType = "format" | "context";
+type GroupingType = "format" | "context" | "proposal";
 
 interface ApiAverageEngagementDataPoint {
   name: string;
@@ -31,6 +31,7 @@ const ENGAGEMENT_METRIC_OPTIONS = [
 const GROUP_BY_OPTIONS = [ // Usado apenas se o seletor de groupBy fosse habilitado
   { value: "format", label: "Formato" },
   { value: "context", label: "Contexto" },
+  { value: "proposal", label: "Proposta" },
 ];
 
 interface PlatformAverageEngagementChartProps {

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -5,7 +5,7 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
 
-type GroupingType = "format" | "context";
+type GroupingType = "format" | "context" | "proposal";
 
 interface ApiUserAverageEngagementDataPoint {
   name: string;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -153,7 +153,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
             <div className="mb-6 md:mb-8">
                 <PlatformPerformanceHighlights timePeriod={globalTimePeriod}/>
             </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 md:mb-8">
               <PlatformAverageEngagementChart
                 initialGroupBy="format"
                 chartTitle="Engajamento Médio por Formato (Plataforma)"
@@ -162,6 +162,11 @@ const AdminCreatorDashboardPage: React.FC = () => {
               <PlatformAverageEngagementChart
                 initialGroupBy="context"
                 chartTitle="Engajamento Médio por Contexto (Plataforma)"
+                timePeriod={globalTimePeriod}
+              />
+              <PlatformAverageEngagementChart
+                initialGroupBy="proposal"
+                chartTitle="Engajamento Médio por Proposta (Plataforma)"
                 timePeriod={globalTimePeriod}
               />
             </div>

--- a/src/app/api/v1/platform/performance/average-engagement/route.test.ts
+++ b/src/app/api/v1/platform/performance/average-engagement/route.test.ts
@@ -58,6 +58,28 @@ describe('GET /api/v1/platform/performance/average-engagement', () => {
     expect(body.chartData[0].postsCount).toBe(1);
   });
 
+  it('aggregates engagement metrics by proposal', async () => {
+    const users = [{ _id: 'u1' }];
+    const userLean = jest.fn().mockResolvedValue(users);
+    const userSelect = jest.fn().mockReturnValue({ lean: userLean });
+    mockUserFind.mockReturnValue({ select: userSelect });
+
+    const posts = [
+      { proposal: 'Review', stats: { total_interactions: 100 } },
+      { proposal: 'Review', stats: { total_interactions: 50 } },
+      { proposal: 'News', stats: { total_interactions: 200 } },
+    ];
+    const metricLean = jest.fn().mockResolvedValue(posts);
+    mockMetricFind.mockReturnValue({ lean: metricLean });
+
+    const res = await GET(createRequest('?groupBy=proposal'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.groupBy).toBe('proposal');
+    expect(body.chartData.length).toBe(2);
+  });
+
   it('returns 400 for invalid groupBy', async () => {
     const res = await GET(createRequest('?groupBy=invalid'));
     expect(res.status).toBe(400);

--- a/src/app/api/v1/platform/performance/average-engagement/route.ts
+++ b/src/app/api/v1/platform/performance/average-engagement/route.ts
@@ -7,7 +7,7 @@ import { getNestedValue } from '@/utils/dataAccessHelpers';
 import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
 
 // Tipo local para agrupamento
-type GroupingType = 'format' | 'context';
+type GroupingType = 'format' | 'context' | 'proposal';
 
 // Constantes para validação e defaults
 const ALLOWED_TIME_PERIODS = ['all_time', 'last_7_days', 'last_30_days', 'last_90_days', 'last_6_months', 'last_12_months'] as const;
@@ -16,7 +16,7 @@ type TimePeriod = typeof ALLOWED_TIME_PERIODS[number];
 const ALLOWED_ENGAGEMENT_METRICS = ['stats.total_interactions', 'stats.views', 'stats.likes', 'stats.comments', 'stats.shares'] as const;
 type EngagementMetricField = typeof ALLOWED_ENGAGEMENT_METRICS[number];
 
-const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context'];
+const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context', 'proposal'];
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -70,7 +70,7 @@ export async function GET(request: Request) {
 
     const performanceByGroup: Record<string, { sumPerformance: number; count: number }> = {};
     for (const post of posts) {
-      const groupKey = groupBy === 'format' ? post.format : post.context;
+      const groupKey = groupBy === 'format' ? post.format : groupBy === 'context' ? post.context : post.proposal;
       const metricValue = getNestedValue(post, engagementMetric);
       if (groupKey && metricValue !== null) {
         const key = groupKey.toString();

--- a/src/app/api/v1/users/[userId]/performance/average-engagement/route.test.ts
+++ b/src/app/api/v1/users/[userId]/performance/average-engagement/route.test.ts
@@ -38,6 +38,19 @@ describe('GET /api/v1/users/[userId]/performance/average-engagement', () => {
     expect(res.status).toBe(200);
   });
 
+  it('handles groupBy proposal', async () => {
+    mockGetAverage.mockResolvedValueOnce([]);
+    const req = createRequest(userId, '?groupBy=proposal');
+    const res = await GET(req, { params: { userId } });
+    expect(mockGetAverage).toHaveBeenCalledWith(
+      userId,
+      'last_90_days',
+      'stats.total_interactions',
+      'proposal'
+    );
+    expect(res.status).toBe(200);
+  });
+
   it('returns 400 for invalid groupBy', async () => {
     const req = createRequest(userId, '?groupBy=invalid');
     const res = await GET(req, { params: { userId } });

--- a/src/app/api/v1/users/[userId]/performance/average-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/average-engagement/route.ts
@@ -3,7 +3,7 @@ import { Types } from 'mongoose';
 import getAverageEngagementByGrouping from '@/utils/getAverageEngagementByGrouping';
 
 // Tipo de agrupamento local (usado apenas na resposta)
-type GroupingType = 'format' | 'context';
+type GroupingType = 'format' | 'context' | 'proposal';
 
 // Constantes para validação de parâmetros
 type TimePeriod =
@@ -78,7 +78,7 @@ export async function GET(
   }
 
   // Determinar groupBy (padrão format)
-  const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context'];
+  const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context', 'proposal'];
   const groupBy: GroupingType =
     groupByParam && ALLOWED_GROUPINGS.includes(groupByParam)
       ? groupByParam

--- a/src/utils/getAverageEngagementByGrouping.ts
+++ b/src/utils/getAverageEngagementByGrouping.ts
@@ -5,7 +5,7 @@ import { Types } from 'mongoose';
 import { getNestedValue } from './dataAccessHelpers';
 import { getStartDateFromTimePeriod } from './dateHelpers';
 
-export type GroupingType = 'format' | 'context';
+export type GroupingType = 'format' | 'context' | 'proposal';
 
 interface AverageResult {
   name: string;
@@ -53,7 +53,9 @@ async function getAverageEngagementByGrouping(
       const key =
         groupBy === 'format'
           ? (post.format || '').toString()
-          : post.context ?? null;
+          : groupBy === 'context'
+            ? post.context ?? null
+            : post.proposal ?? null;
 
       if (groupBy === 'format') {
         if (!key) continue;


### PR DESCRIPTION
## Summary
- support `proposal` grouping for average engagement calculations
- expose proposal grouping in platform and user API routes
- add proposal option in average engagement chart components
- show "Engajamento Médio por Proposta" chart in the creator dashboard
- expand tests for new proposal grouping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685249469518832e89c189966acfe788