### PR TITLE
Implement auth logic for daily metrics API

### DIFF
--- a/src/app/api/metrics/[metricId]/daily/route.test.ts
+++ b/src/app/api/metrics/[metricId]/daily/route.test.ts
@@ -1,0 +1,78 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import MetricModel from '@/app/models/Metric';
+import DailyMetricSnapshotModel from '@/app/models/DailyMetricSnapshot';
+import mongoose from 'mongoose';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/Metric', () => ({
+  findOne: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('@/app/models/DailyMetricSnapshot', () => ({
+  find: jest.fn(),
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockMetricFindOne = (MetricModel as any).findOne as jest.Mock;
+const mockMetricFindById = (MetricModel as any).findById as jest.Mock;
+const mockSnapshotFind = (DailyMetricSnapshotModel as any).find as jest.Mock;
+
+const createRequest = (metricId: string) =>
+  new NextRequest(`http://localhost/api/metrics/${metricId}/daily`);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe('GET /api/metrics/[metricId]/daily', () => {
+  it('returns 401 when user is not authenticated', async () => {
+    const metricId = new mongoose.Types.ObjectId().toString();
+    mockGetServerSession.mockResolvedValue(null);
+
+    const res = await GET(createRequest(metricId), { params: { metricId } });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns snapshots when authenticated', async () => {
+    const metricId = new mongoose.Types.ObjectId().toString();
+    const userId = new mongoose.Types.ObjectId().toString();
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    const findOneLean = jest.fn().mockResolvedValue({ _id: metricId });
+    const findOneSelect = jest.fn().mockReturnValue({ lean: findOneLean });
+    mockMetricFindOne.mockReturnValue({ select: findOneSelect });
+
+    const snapshotDocs = [
+      { date: new Date('2024-01-01'), dailyViews: 10, cumulativeViews: 10 },
+    ];
+    const snapLean = jest.fn().mockResolvedValue(snapshotDocs);
+    const snapSelect = jest.fn().mockReturnValue({ lean: snapLean });
+    const snapSort = jest.fn().mockReturnValue({ select: snapSelect });
+    mockSnapshotFind.mockReturnValue({ sort: snapSort });
+
+    const res = await GET(createRequest(metricId), { params: { metricId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0].date).toBe('2024-01-01');
+  });
+});

--- a/src/app/api/metrics/[metricId]/daily/route.ts
+++ b/src/app/api/metrics/[metricId]/daily/route.ts
@@ -6,27 +6,21 @@ import DailyMetricSnapshotModel from '@/app/models/DailyMetricSnapshot';
 import MetricModel from '@/app/models/Metric'; // Importar MetricModel para verificar propriedade
 import mongoose, { Types } from 'mongoose'; // <<< CORRIGIDO: Importa mongoose e Types
 import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
-// --- Placeholder para sua função de autenticação ---
-// Substitua pela sua lógica real para obter o ID do usuário logado a partir da requisição
-// Exemplo: pode vir de uma sessão, token JWT, etc.
 async function getUserIdFromRequest(request: Request): Promise<Types.ObjectId | null> {
-  // LÓGICA DE AUTENTICAÇÃO AQUI
-  // Exemplo (simulado):
-  // const session = await getServerSession(authOptions); // Exemplo com NextAuth
-  // if (!session?.user?.id) return null;
-  // return new Types.ObjectId(session.user.id);
-
-  // Retornando um ID fixo para fins de exemplo - SUBSTITUA PELA SUA LÓGICA REAL
-  const EXAMPLE_USER_ID = "609cdd9f9d6a8c001f8e1z99"; // <<< SUBSTITUIR
-  // Agora mongoose.isValidObjectId está disponível
-  if (mongoose.isValidObjectId(EXAMPLE_USER_ID)) {
-    return new Types.ObjectId(EXAMPLE_USER_ID);
+  const session = await getServerSession({ req: request, ...authOptions });
+  const sessionId = session?.user?.id;
+  if (!sessionId) {
+    return null;
   }
-  logger.error("[getUserIdFromRequest] EXAMPLE_USER_ID não é um ObjectId válido.");
+  if (mongoose.isValidObjectId(sessionId)) {
+    return new Types.ObjectId(sessionId);
+  }
+  logger.warn(`[getUserIdFromRequest] ID da sessão inválido: ${sessionId}`);
   return null;
 }
-// --- Fim do Placeholder ---
 
 
 /**


### PR DESCRIPTION
## Summary
- implement `getServerSession` in metrics daily API
- add unit tests for authentication and data retrieval

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685249668e1c832e8f6f3a25240eb526