### PR TITLE
Include zero-engagement formats in distribution charts

### DIFF
--- a/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
@@ -114,17 +114,7 @@ export async function GET(
 
     const grandTotalEngagement = aggregationResult.reduce((sum, item) => sum + item.totalEngagementValue, 0);
 
-    if (grandTotalEngagement === 0) {
-      // Isso pode acontecer se todos os posts tiverem 0 para a métrica de engajamento selecionada.
-      return NextResponse.json({
-            chartData: [],
-            metricUsed: engagementMetricField,
-            insightSummary: `Nenhum ${engagementMetricField.replace("stats.","")} encontrado para os formatos no período.`
-        }, { status: 200 });
-    }
-
     let tempChartData: EngagementDistributionDataPoint[] = aggregationResult
-      .filter(item => item.totalEngagementValue > 0) // Apenas considerar se o valor for positivo
       .map(item => {
         const formatKey = item._id as string; // _id do $group é o format
         const formatName = DEFAULT_FORMAT_MAPPING[formatKey] || formatKey.toString().replace(/_/g, ' ').toLocaleLowerCase().replace(/\b\w/g, l => l.toUpperCase());
@@ -155,7 +145,7 @@ export async function GET(
       metricUsed: engagementMetricField,
       insightSummary: `Distribuição de ${engagementMetricField.replace("stats.","")} da plataforma por formato (${timePeriod.replace("_", " ").replace("_days"," dias").replace("_months"," meses")}).`
     };
-    if (finalChartData.length > 0) {
+    if (grandTotalEngagement > 0 && finalChartData.length > 0) {
         const firstData = finalChartData[0];
         if (firstData && firstData.name !== "Outros") {
             response.insightSummary += ` O formato com maior contribuição é ${firstData.name} (${firstData.percentage.toFixed(1)}%).`;

--- a/src/charts/getEngagementDistributionByFormatChartData.test.ts
+++ b/src/charts/getEngagementDistributionByFormatChartData.test.ts
@@ -112,14 +112,20 @@ describe('getEngagementDistributionByFormatChartData', () => {
     expect(result.insightSummary).toBe('Nenhum dado de engajamento encontrado para o período.');
   });
 
-  test('Posts sem engajamento relevante retornam array vazio', async () => {
+  test('Posts sem engajamento relevante retornam valores zero', async () => {
     const agg = [
       { _id: FormatType.REEL, totalEngagement: 0 },
       { _id: FormatType.IMAGE, totalEngagement: 0 },
     ];
     (MetricModel.aggregate as jest.Mock).mockResolvedValue(agg);
     const result = await getEngagementDistributionByFormatChartData(userId, 'last_30_days', engagementMetricField);
-    expect(result.chartData).toEqual([]);
+    expect(result.chartData.length).toBe(2);
+    expect(result.chartData).toEqual(
+      expect.arrayContaining([
+        { name: 'Reel', value: 0, percentage: 0 },
+        { name: 'Image', value: 0, percentage: 0 },
+      ])
+    );
     expect(result.insightSummary).toBe('Nenhum dado de engajamento encontrado para o período.');
   });
 

--- a/src/charts/getEngagementDistributionByFormatChartData.ts
+++ b/src/charts/getEngagementDistributionByFormatChartData.ts
@@ -72,12 +72,7 @@ async function getEngagementDistributionByFormatChartData(
 
     const grandTotalEngagement = aggregationResult.reduce((sum, item) => sum + item.totalEngagement, 0);
 
-    if (grandTotalEngagement === 0) {
-      return initialResponse;
-    }
-
     let tempChartData: EngagementDistributionDataPoint[] = aggregationResult
-      .filter(item => item.totalEngagement > 0)
       .map(item => {
         const formatKey = item._id as string;
         const formatName = (formatMapping && formatMapping[formatKey])
@@ -87,7 +82,7 @@ async function getEngagementDistributionByFormatChartData(
         return {
           name: formatName,
           value: item.totalEngagement,
-          percentage: (item.totalEngagement / grandTotalEngagement) * 100,
+          percentage: grandTotalEngagement > 0 ? (item.totalEngagement / grandTotalEngagement) * 100 : 0,
         } as EngagementDistributionDataPoint;
       });
 
@@ -101,14 +96,14 @@ async function getEngagementDistributionByFormatChartData(
         {
           name: "Outros",
           value: sumValueOthers,
-          percentage: (sumValueOthers / grandTotalEngagement) * 100,
+          percentage: grandTotalEngagement > 0 ? (sumValueOthers / grandTotalEngagement) * 100 : 0,
         },
       ];
     } else {
       initialResponse.chartData = tempChartData;
     }
 
-    if (initialResponse.chartData.length > 0) {
+    if (grandTotalEngagement > 0 && initialResponse.chartData.length > 0) {
         const topSlice = initialResponse.chartData[0]!;
         if (topSlice.name !== "Outros" && initialResponse.chartData.length > 1) {
             initialResponse.insightSummary = `${topSlice.name} é o formato com maior engajamento, representando ${topSlice.percentage.toFixed(1)}% do total.`;


### PR DESCRIPTION
## Summary
- keep formats with zero engagement in format distribution charts
- include them in the platform engagement distribution API
- update test to assert zero-value entries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524ed79cd4832e80bbccb7f714181e