### PR TITLE
chore: use logger for platform routes

### DIFF
--- a/src/app/api/v1/platform/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/platform/kpis/periodic-comparison/route.ts
@@ -3,6 +3,7 @@ import UserModel from '@/app/models/User';
 import AccountInsightModel from '@/app/models/AccountInsight';
 import MetricModel from '@/app/models/Metric'; // Importar MetricModel
 import calculateAverageEngagementPerPost from '@/utils/calculateAverageEngagementPerPost'; // Usado para engajamento
+import { logger } from '@/app/lib/logger';
 import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneric } from '@/utils/dateHelpers';
 import { Types } from 'mongoose';
 
@@ -143,7 +144,7 @@ export async function GET(
     const engagementResultsCurrent = await Promise.allSettled(engagementPromisesCurrent);
     engagementResultsCurrent.forEach(result => {
         if (result.status === 'fulfilled') currentPlatformTotalEngagement += result.value.totalEngagement;
-        else console.error("Error fetching current engagement for a user:", result.reason);
+        else logger.error("Error fetching current engagement for a user:", result.reason);
     });
 
     const engagementPromisesPrevious = userIds.map(uid =>
@@ -152,7 +153,7 @@ export async function GET(
     const engagementResultsPrevious = await Promise.allSettled(engagementPromisesPrevious);
     engagementResultsPrevious.forEach(result => {
         if (result.status === 'fulfilled') previousPlatformTotalEngagement += result.value.totalEngagement;
-        else console.error("Error fetching previous engagement for a user:", result.reason);
+        else logger.error("Error fetching previous engagement for a user:", result.reason);
     });
 
     const totalEngagementData: KPIComparisonData = {
@@ -200,7 +201,7 @@ export async function GET(
     return NextResponse.json(response, { status: 200 });
 
   } catch (error) {
-    console.error("[API PLATFORM/KPIS/PERIODIC] Error fetching platform periodic comparison KPIs:", error);
+    logger.error("[API PLATFORM/KPIS/PERIODIC] Error fetching platform periodic comparison KPIs:", error);
     const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
     const errorKpi: KPIComparisonData = { currentValue: null, previousValue: null, percentageChange: null, chartData: [{name: periodNamePrevious, value:0}, {name: periodNameCurrent, value:0}]};
     return NextResponse.json({

--- a/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric';
+import { logger } from '@/app/lib/logger';
 // Define FormatType enum locally if the import is not available
 enum FormatType {
   IMAGE = "IMAGE",
@@ -164,7 +165,7 @@ export async function GET(
     return NextResponse.json(response, { status: 200 });
 
   } catch (error) {
-    console.error(`[API PLATFORM/PERFORMANCE/ENGAGEMENT-DISTRIBUTION-FORMAT] Error:`, error);
+    logger.error(`[API PLATFORM/PERFORMANCE/ENGAGEMENT-DISTRIBUTION-FORMAT] Error:`, error);
     const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
     return NextResponse.json({
         error: "Erro ao processar sua solicitação.",

--- a/src/app/api/v1/platform/performance/post-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/post-distribution-format/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric'; // Descomente para implementação real
+import { logger } from '@/app/lib/logger';
 // Defina FormatType localmente se o módulo não existir
 export enum FormatType {
   IMAGE = "IMAGE",
@@ -130,7 +131,7 @@ export async function GET(
     return NextResponse.json(response, { status: 200 });
 
   } catch (error) {
-    console.error("[API PLATFORM/PERFORMANCE/POST-DISTRO-FORMAT] Error:", error);
+    logger.error("[API PLATFORM/PERFORMANCE/POST-DISTRO-FORMAT] Error:", error);
     const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
     return NextResponse.json({ error: "Erro ao processar sua solicitação.", details: errorMessage }, { status: 500 });
   }

--- a/src/app/api/v1/platform/performance/video-metrics/route.ts
+++ b/src/app/api/v1/platform/performance/video-metrics/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric';
 import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import { logger } from '@/app/lib/logger';
 
 // Periodos permitidos para o filtro de tempo
 const ALLOWED_TIME_PERIODS = [
@@ -128,7 +129,7 @@ export async function GET(request: Request) {
       insightSummary: summary,
     });
   } catch (error) {
-    console.error('[API PLATFORM/VIDEO-METRICS]', error);
+    logger.error('[API PLATFORM/VIDEO-METRICS]', error);
     return NextResponse.json(
       {
         error: 'Erro ao processar métricas de vídeo.',

--- a/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
@@ -5,6 +5,7 @@ import {
     formatDateYYYYMMDD,
     // getStartDateFromTimePeriod // Não diretamente usado, pois as janelas são calculadas de forma diferente
 } from '@/utils/dateHelpers';
+import { logger } from '@/app/lib/logger';
 
 // Tipos de dados para a resposta
 interface MovingAverageDataPoint {
@@ -218,7 +219,7 @@ export async function GET(
     return NextResponse.json(initialResponse, { status: 200 });
 
   } catch (error) {
-    console.error("[API PLATFORM/TRENDS/MOVING-AVERAGE-ENGAGEMENT] Error:", error);
+    logger.error("[API PLATFORM/TRENDS/MOVING-AVERAGE-ENGAGEMENT] Error:", error);
     const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
     // Preenche a série com nulls para todos os dias da janela de dados em caso de erro
     let iterDate = new Date(dataStartDateForDisplay); // Use dataStartDateForDisplay

--- a/src/app/api/v1/platform/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/reach-engagement/route.ts
@@ -3,6 +3,7 @@ import UserModel from '@/app/models/User'; // Importar UserModel
 import getReachEngagementTrendChartData from '@/charts/getReachEngagementTrendChartData';
 import getReachInteractionTrendChartData from '@/charts/getReachInteractionTrendChartData';
 import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
 
 interface ReachEngagementChartResponse {
   chartData: ApiReachEngagementDataPoint[];
@@ -84,7 +85,7 @@ export async function GET(
           }
         });
       } else if (result.status === 'rejected') {
-        console.error(`Erro ao buscar dados de alcance/engajamento para um usuário durante agregação:`, result.reason);
+        logger.error(`Erro ao buscar dados de alcance/engajamento para um usuário durante agregação:`, result.reason);
       }
     });
 
@@ -135,7 +136,7 @@ export async function GET(
     return NextResponse.json(response, { status: 200 });
 
   } catch (error) {
-    console.error(`[API PLATFORM/TRENDS/REACH-ENGAGEMENT] Error aggregating platform data:`, error);
+    logger.error(`[API PLATFORM/TRENDS/REACH-ENGAGEMENT] Error aggregating platform data:`, error);
     const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
     return NextResponse.json({ error: "Erro ao processar sua solicitação.", details: errorMessage }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- replace console.error with logger.error in platform API routes
- import logger where needed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852514f18e8832eadda499791510829