### PR TITLE
Implement aggregatePerformanceHighlights util and refactor API

### DIFF
--- a/src/app/api/v1/platform/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.ts
@@ -53,13 +53,10 @@ export async function GET(
   const performanceMetricLabel = DEFAULT_PERFORMANCE_METRIC_LABEL;
 
 
-  // --- Simulação de Lógica de Backend para Dados Agregados da Plataforma ---
-  // TODO: Implementar lógica de agregação real da plataforma.
-  // Isso envolveria:
-  // 1. Chamar funções como `getAverageEngagementByGrouping` para toda a plataforma.
-  // 2. A partir desses resultados (médias por formato/contexto), identificar o top/low.
-  //    - Top: Simplesmente o maior valor médio.
-  //    - Low: O menor valor médio, talvez com um threshold mínimo de posts na plataforma para esse grupo.
+// --- Simulação de Lógica de Backend para Dados Agregados da Plataforma ---
+// TODO: Quando houver dados reais da plataforma, reutilizar
+// `aggregatePerformanceHighlights` para calcular top/low formatos e contextos
+// em nível global. Abaixo permanecem valores mockados para demonstração.
 
   // Por agora, dados hardcoded para demonstração:
   let topFormatName = "Reel";

--- a/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
@@ -1,12 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
 
-import getTopPerformingFormat from '@/utils/getTopPerformingFormat';
-import getLowPerformingFormat from '@/utils/getLowPerformingFormat';
-import getTopPerformingContext from '@/utils/getTopPerformingContext';
-// Supondo que FormatPerformanceData e ContextPerformanceData são exportados ou podemos redefinir aqui
-// import { FormatPerformanceData } from '@/utils/getTopPerformingFormat'; (se exportado)
-// import { ContextPerformanceData } from '@/utils/getTopPerformingContext'; (se exportado)
+import aggregatePerformanceHighlights from '@/utils/aggregatePerformanceHighlights';
 
 // Helper para converter timePeriod string para periodInDays number
 function timePeriodToDays(timePeriod: string): number {
@@ -79,37 +74,33 @@ export async function GET(
 
 
   try {
-    const [
-      topFormatResult,
-      lowFormatResult,
-      topContextResult
-    ] = await Promise.all([
-      getTopPerformingFormat(userId, periodInDaysValue, performanceMetricField),
-      getLowPerformingFormat(userId, periodInDaysValue, performanceMetricField), // minPosts default é 3
-      getTopPerformingContext(userId, periodInDaysValue, performanceMetricField)
-    ]);
+    const aggResult = await aggregatePerformanceHighlights(
+      userId,
+      periodInDaysValue,
+      performanceMetricField
+    );
 
     const response: PerformanceSummaryResponse = {
-      topPerformingFormat: topFormatResult ? {
-        name: topFormatResult.format as string, // Assumindo que format é string ou FormatType
+      topPerformingFormat: aggResult.topFormat ? {
+        name: aggResult.topFormat.name as string,
         metricName: performanceMetricLabel,
-        value: topFormatResult.averagePerformance,
-        valueFormatted: formatPerformanceValue(topFormatResult.averagePerformance, performanceMetricField),
-        postsCount: topFormatResult.postsCount
+        value: aggResult.topFormat.average,
+        valueFormatted: formatPerformanceValue(aggResult.topFormat.average, performanceMetricField),
+        postsCount: aggResult.topFormat.count
       } : null,
-      lowPerformingFormat: lowFormatResult ? {
-        name: lowFormatResult.format as string,
+      lowPerformingFormat: aggResult.lowFormat ? {
+        name: aggResult.lowFormat.name as string,
         metricName: performanceMetricLabel,
-        value: lowFormatResult.averagePerformance,
-        valueFormatted: formatPerformanceValue(lowFormatResult.averagePerformance, performanceMetricField),
-        postsCount: lowFormatResult.postsCount
+        value: aggResult.lowFormat.average,
+        valueFormatted: formatPerformanceValue(aggResult.lowFormat.average, performanceMetricField),
+        postsCount: aggResult.lowFormat.count
       } : null,
-      topPerformingContext: topContextResult ? {
-        name: topContextResult.context as string,
+      topPerformingContext: aggResult.topContext ? {
+        name: aggResult.topContext.name as string,
         metricName: performanceMetricLabel,
-        value: topContextResult.averagePerformance,
-        valueFormatted: formatPerformanceValue(topContextResult.averagePerformance, performanceMetricField),
-        postsCount: topContextResult.postsCount
+        value: aggResult.topContext.average,
+        valueFormatted: formatPerformanceValue(aggResult.topContext.average, performanceMetricField),
+        postsCount: aggResult.topContext.count
       } : null,
       insightSummary: "" // Será construído abaixo
     };

--- a/src/utils/aggregatePerformanceHighlights.ts
+++ b/src/utils/aggregatePerformanceHighlights.ts
@@ -1,0 +1,135 @@
+import MetricModel from "@/app/models/Metric";
+import { Types, PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface AggregatedHighlight {
+  name: string | null;
+  average: number;
+  count: number;
+}
+
+export interface PerformanceHighlightsAggregation {
+  topFormat: AggregatedHighlight | null;
+  lowFormat: AggregatedHighlight | null;
+  topContext: AggregatedHighlight | null;
+}
+
+async function aggregatePerformanceHighlights(
+  userId: string | Types.ObjectId,
+  periodInDays: number,
+  metricField: string
+): Promise<PerformanceHighlightsAggregation> {
+  const resolvedUserId =
+    typeof userId === "string" ? new Types.ObjectId(userId) : userId;
+  const today = new Date();
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const initial: PerformanceHighlightsAggregation = {
+    topFormat: null,
+    lowFormat: null,
+    topContext: null,
+  };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        user: resolvedUserId,
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    const projectStage: PipelineStage.Project = {
+      $project: {
+        format: { $ifNull: ["$format", null] },
+        context: { $ifNull: ["$context", null] },
+        metricValue: `$${metricField}`,
+      },
+    };
+
+    const metricFilterStage: PipelineStage.Match = {
+      $match: { metricValue: { $ne: null } },
+    };
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      projectStage,
+      metricFilterStage,
+      {
+        $facet: {
+          byFormat: [
+            {
+              $group: {
+                _id: "$format",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byContext: [
+            {
+              $group: {
+                _id: "$context",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+        },
+      },
+    ];
+
+    const [agg] = await MetricModel.aggregate(pipeline);
+
+    if (agg?.byFormat?.length) {
+      const topF = agg.byFormat[0];
+      const lowF = agg.byFormat[agg.byFormat.length - 1];
+      initial.topFormat = {
+        name: topF._id ?? null,
+        average: topF.avg ?? 0,
+        count: topF.count ?? 0,
+      };
+      initial.lowFormat = {
+        name: lowF._id ?? null,
+        average: lowF.avg ?? 0,
+        count: lowF.count ?? 0,
+      };
+    }
+
+    if (agg?.byContext?.length) {
+      const topC = agg.byContext[0];
+      initial.topContext = {
+        name: topC._id ?? null,
+        average: topC.avg ?? 0,
+        count: topC.count ?? 0,
+      };
+    }
+
+    return initial;
+  } catch (error) {
+    logger.error(
+      `Error in aggregatePerformanceHighlights for user ${resolvedUserId}:`,
+      error
+    );
+    return initial;
+  }
+}
+
+export default aggregatePerformanceHighlights;


### PR DESCRIPTION
## Summary
- add `aggregatePerformanceHighlights` aggregator utility to fetch top/low formats and best context in one query
- refactor user performance-summary API route to use new aggregation
- document future use in platform performance-summary endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525164ea7c832eae0701b6c31badfb