### PR TITLE
Focus search in creator selector

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { SearchBar } from '@/app/components/SearchBar';
 import { UserAvatar } from '@/app/components/UserAvatar';
@@ -17,6 +17,13 @@ export default function CreatorSelector({ isOpen, onClose, onSelect }: CreatorSe
   const [creators, setCreators] = useState<AdminCreatorListItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -64,9 +71,11 @@ export default function CreatorSelector({ isOpen, onClose, onSelect }: CreatorSe
         </div>
         <div className="p-4 space-y-4">
           <SearchBar
+            ref={searchInputRef}
             initialValue={searchTerm}
             onSearchChange={(val) => setSearchTerm(val)}
             placeholder="Buscar por nome ou email..."
+            autoFocus={isOpen}
           />
           <div className="max-h-60 overflow-y-auto divide-y">
             {isLoading && <p className="text-sm text-gray-500 p-2">Carregando...</p>}

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, forwardRef } from 'react';
 import { debounce } from 'lodash';
 import { FaSearch } from 'react-icons/fa'; // Usando react-icons para o ícone
 
@@ -10,6 +10,7 @@ interface SearchBarProps {
   placeholder?: string;
   debounceMs?: number;
   className?: string;
+  autoFocus?: boolean;
 }
 
 /**
@@ -22,13 +23,14 @@ interface SearchBarProps {
  * @param {number} debounceMs - O tempo de espera em milissegundos. Padrão: 500.
  * @param {string} className - Classes CSS adicionais para o container.
  */
-export function SearchBar({
+export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(function SearchBar({
   initialValue = '',
   onSearchChange,
   placeholder = 'Buscar...',
   debounceMs = 500,
   className = '',
-}: SearchBarProps) {
+  autoFocus = false,
+}: SearchBarProps, ref) {
   const [inputValue, setInputValue] = useState(initialValue);
 
   // useMemo garante que a função debounced seja criada apenas uma vez
@@ -59,7 +61,9 @@ export function SearchBar({
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         placeholder={placeholder}
-        className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm 
+        ref={ref}
+        autoFocus={autoFocus}
+        className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm
                    focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm
                    dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
       />


### PR DESCRIPTION
## Summary
- add optional `autoFocus` prop to `SearchBar`
- focus creator selector search bar when opened

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525228b5e8832e9024d90a1beb2191