### PR TITLE
Handle ESC in CreatorSelector

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
@@ -20,6 +20,19 @@ export default function CreatorSelector({ isOpen, onClose, onSelect }: CreatorSe
 
   useEffect(() => {
     if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
 
     const fetchCreators = async () => {
       setIsLoading(true);


### PR DESCRIPTION
## Summary
- close CreatorSelector modal on Escape key press

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685252318bc8832e91940b3859ed3569