### PR TITLE
Improve admin dashboard UX

### DIFF
--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -32,6 +32,7 @@ import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
 import CohortComparisonChart from './components/CohortComparisonChart';
 import MarketPerformanceChart from './components/MarketPerformanceChart';
 import CreatorsScatterPlot from './components/CreatorsScatterPlot';
+import ScrollToTopButton from '@/app/components/ScrollToTopButton';
 
 // View de Detalhe do Criador (Módulo 3 e partes do Módulo 2 para usuário)
 import UserDetailView from './components/views/UserDetailView';
@@ -68,7 +69,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
   return (
     <div className="p-4 md:p-6 lg:p-8 bg-gray-100 min-h-screen">
-      <header className="mb-8">
+      <header className="mb-8 sticky top-0 z-20 bg-gray-100 pb-4 border-b border-gray-200">
         <h1 className="text-2xl md:text-3xl font-bold text-gray-800">Dashboard Administrativo de Criadores</h1>
 
         <div className="mt-4 p-4 bg-white rounded-md shadow">
@@ -327,6 +328,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
         onClose={() => setIsSelectorOpen(false)}
         onSelect={(creator) => handleUserSelect(creator.id, creator.name)}
       />
+      <ScrollToTopButton />
     </div>
   );
 };

--- a/src/app/components/ScrollToTopButton.tsx
+++ b/src/app/components/ScrollToTopButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { ChevronUpIcon } from "@heroicons/react/24/outline";
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      if (window.scrollY > 200) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+    window.addEventListener("scroll", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      aria-label="Voltar ao topo"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className="fixed bottom-6 right-6 p-2 rounded-full bg-indigo-600 text-white shadow-md hover:bg-indigo-700"
+    >
+      <ChevronUpIcon className="w-5 h-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- make the creator dashboard header sticky so the filter stays visible
- add ScrollToTopButton component
- show scroll-to-top on the creator dashboard page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685253dc6840832e9fcf2b3b87e4b51e