### PR TITLE
Update TopMovers metrics

### DIFF
--- a/src/app/admin/creator-dashboard/TopMoversWidget.test.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.test.tsx
@@ -18,8 +18,8 @@ jest.mock('@heroicons/react/24/outline', () => ({
 }));
 
 const mockTopMoversData: ITopMoverResult[] = [
-  { entityId: 'post1', entityName: 'Amazing Post Alpha', metricName: 'cumulative_likes', previousValue: 100, currentValue: 150, absoluteChange: 50, percentageChange: 0.5 },
-  { entityId: 'post2', entityName: 'Brilliant Post Beta', metricName: 'cumulative_likes', previousValue: 200, currentValue: 50, absoluteChange: -150, percentageChange: -0.75 },
+  { entityId: 'post1', entityName: 'Amazing Post Alpha', metricName: 'cumulativeLikes', previousValue: 100, currentValue: 150, absoluteChange: 50, percentageChange: 0.5 },
+  { entityId: 'post2', entityName: 'Brilliant Post Beta', metricName: 'cumulativeLikes', previousValue: 200, currentValue: 50, absoluteChange: -150, percentageChange: -0.75 },
 ];
 
 describe('TopMoversWidget Component', () => {
@@ -37,7 +37,7 @@ describe('TopMoversWidget Component', () => {
 
     // Check default values of some select elements
     expect(screen.getByLabelText('Entidade')).toHaveValue('content');
-    expect(screen.getByLabelText('Métrica')).toHaveValue('cumulative_views');
+    expect(screen.getByLabelText('Métrica')).toHaveValue('cumulativeViews');
     expect(screen.getByLabelText('Ordenar Por')).toHaveValue('absoluteChange_decrease');
     expect(screen.getByLabelText('Top N')).toHaveValue(10);
 
@@ -47,8 +47,8 @@ describe('TopMoversWidget Component', () => {
   test('updates internal state on parameter change', () => {
     render(<TopMoversWidget />);
     const metricSelect = screen.getByLabelText('Métrica') as HTMLSelectElement;
-    fireEvent.change(metricSelect, { target: { value: 'cumulative_shares' } });
-    expect(metricSelect.value).toBe('cumulative_shares');
+    fireEvent.change(metricSelect, { target: { value: 'cumulativeShares' } });
+    expect(metricSelect.value).toBe('cumulativeShares');
 
     const topNInput = screen.getByLabelText('Top N') as HTMLInputElement;
     fireEvent.change(topNInput, { target: { value: '5' } });
@@ -128,7 +128,7 @@ describe('TopMoversWidget Component', () => {
     fireEvent.change(screen.getByLabelText('Fim', { selector: '#tm-currEnd' }), { target: { value: '2023-01-31' } });
 
     // Select metric and other params
-    fireEvent.change(screen.getByLabelText('Métrica'), { target: { value: 'cumulative_shares' } });
+    fireEvent.change(screen.getByLabelText('Métrica'), { target: { value: 'cumulativeShares' } });
     fireEvent.change(screen.getByLabelText('Formato (Conteúdo)'), { target: { value: 'Reel' } });
 
     fireEvent.click(screen.getByText('Analisar Top Movers'));
@@ -140,7 +140,7 @@ describe('TopMoversWidget Component', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         entityType: 'content',
-        metric: 'cumulative_shares',
+        metric: 'cumulativeShares',
         previousPeriod: { startDate: new Date('2023-01-01T00:00:00.000Z'), endDate: new Date('2023-01-15T00:00:00.000Z') },
         currentPeriod: { startDate: new Date('2023-01-16T00:00:00.000Z'), endDate: new Date('2023-01-31T00:00:00.000Z') },
         topN: 10,
@@ -238,8 +238,8 @@ describe('TopMoversWidget Component', () => {
 
     test('renders creator results with profile picture placeholder', async () => {
         const creatorMockData: ITopMoverResult[] = [
-            { entityId: 'creator1', entityName: 'Creator Gamma', metricName: 'cumulative_views', previousValue: 1000, currentValue: 2000, absoluteChange: 1000, percentageChange: 1, profilePictureUrl: undefined },
-            { entityId: 'creator2', entityName: 'Creator Delta', metricName: 'cumulative_views', previousValue: 500, currentValue: 1500, absoluteChange: 1000, percentageChange: 2, profilePictureUrl: 'delta.jpg' },
+            { entityId: 'creator1', entityName: 'Creator Gamma', metricName: 'cumulativeViews', previousValue: 1000, currentValue: 2000, absoluteChange: 1000, percentageChange: 1, profilePictureUrl: undefined },
+            { entityId: 'creator2', entityName: 'Creator Delta', metricName: 'cumulativeViews', previousValue: 500, currentValue: 1500, absoluteChange: 1000, percentageChange: 2, profilePictureUrl: 'delta.jpg' },
         ];
         (fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: async () => creatorMockData });
 

--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -56,14 +56,14 @@ const ENTITY_TYPE_OPTIONS: { value: TopMoverEntityType; label: string; disabled?
 ];
 
 const METRIC_OPTIONS: { value: TopMoverMetric; label: string }[] = [
-    { value: 'cumulative_views', label: 'Visualizações Acumuladas' },
-    { value: 'cumulative_likes', label: 'Likes Acumulados' },
-    { value: 'cumulative_shares', label: 'Compartilhamentos Acumulados' },
-    { value: 'cumulative_comments', label: 'Comentários Acumulados' },
-    { value: 'cumulative_saves', label: 'Salvamentos Acumulados' },
-    { value: 'cumulative_reach', label: 'Alcance Acumulado' },
-    { value: 'cumulative_impressions', label: 'Impressões Acumuladas' },
-    { value: 'cumulative_total_interactions', label: 'Interações Totais Acumuladas' },
+    { value: 'cumulativeViews', label: 'Visualizações Acumuladas' },
+    { value: 'cumulativeLikes', label: 'Likes Acumulados' },
+    { value: 'cumulativeShares', label: 'Compartilhamentos Acumulados' },
+    { value: 'cumulativeComments', label: 'Comentários Acumulados' },
+    { value: 'cumulativeSaved', label: 'Salvamentos Acumulados' },
+    { value: 'cumulativeReach', label: 'Alcance Acumulado' },
+    { value: 'cumulativeImpressions', label: 'Impressões Acumuladas' },
+    { value: 'cumulativeTotalInteractions', label: 'Interações Totais Acumuladas' },
 ];
 
 const SORT_BY_OPTIONS: { value: TopMoverSortBy; label: string }[] = [
@@ -93,7 +93,7 @@ const formatDisplayPercentageTM = (num?: number | null): string => {
 
 export default function TopMoversWidget() {
   const [entityType, setEntityType] = useState<TopMoverEntityType>('content');
-  const [metric, setMetric] = useState<TopMoverMetric>('cumulative_views');
+  const [metric, setMetric] = useState<TopMoverMetric>('cumulativeViews');
   const [previousPeriod, setPreviousPeriod] = useState<PeriodState>(initialPeriodState);
   const [currentPeriod, setCurrentPeriod] = useState<PeriodState>(initialPeriodState);
   const [topN, setTopN] = useState<number>(10);

--- a/src/app/admin/widgets/TopMoversWidget.tsx
+++ b/src/app/admin/widgets/TopMoversWidget.tsx
@@ -65,10 +65,10 @@ const ENTITY_TYPE_OPTIONS: { value: TopMoverEntityType; label: string; }[] = [
 ];
 
 const METRIC_OPTIONS: { value: TopMoverMetric; label: string }[] = [
-    { value: 'cumulative_views', label: 'Visualizações' },
-    { value: 'cumulative_likes', label: 'Likes' },
-    { value: 'cumulative_shares', label: 'Partilhas' },
-    { value: 'cumulative_total_interactions', label: 'Interações' },
+    { value: 'cumulativeViews', label: 'Visualizações' },
+    { value: 'cumulativeLikes', label: 'Likes' },
+    { value: 'cumulativeShares', label: 'Partilhas' },
+    { value: 'cumulativeTotalInteractions', label: 'Interações' },
 ];
 
 const SORT_BY_OPTIONS: { value: TopMoverSortBy; label: string }[] = [
@@ -87,7 +87,7 @@ const formatDisplayPercentageTM = (num?: number | null) => num ? `${(num * 100).
 
 const TopMoversWidget = memo(function TopMoversWidget() {
   const [entityType, setEntityType] = useState<TopMoverEntityType>('content');
-  const [metric, setMetric] = useState<TopMoverMetric>('cumulative_views');
+  const [metric, setMetric] = useState<TopMoverMetric>('cumulativeViews');
   const [previousPeriod, setPreviousPeriod] = useState<PeriodState>(initialPeriodState);
   const [currentPeriod, setCurrentPeriod] = useState<PeriodState>(initialPeriodState);
   const [topN, setTopN] = useState<number>(5);

--- a/src/app/api/admin/dashboard/top-movers/route.test.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.test.ts
@@ -50,7 +50,7 @@ describe('API Route: /api/admin/dashboard/top-movers', () => {
 
   const validPayloadBase = {
     entityType: 'content',
-    metric: 'cumulative_likes',
+    metric: 'cumulativeLikes',
     ...validPeriods,
   };
 
@@ -66,7 +66,7 @@ describe('API Route: /api/admin/dashboard/top-movers', () => {
     expect(body).toEqual(mockResults);
     expect(fetchTopMoversData).toHaveBeenCalledWith(expect.objectContaining({
       entityType: 'content',
-      metric: 'cumulative_likes',
+      metric: 'cumulativeLikes',
       previousPeriod: {
         startDate: new Date(validPeriods.previousPeriod.startDate),
         endDate: new Date(validPeriods.previousPeriod.endDate),

--- a/src/app/api/admin/dashboard/top-movers/route.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.ts
@@ -44,8 +44,8 @@ const creatorFiltersSchema = z.object({
 
 // Manually list out string literals for Zod enums from types
 const topMoverMetricLiterals: [TopMoverMetric, ...TopMoverMetric[]] = [
-  'cumulative_views', 'cumulative_likes', 'cumulative_shares', 'cumulative_comments',
-  'cumulative_saves', 'cumulative_reach', 'cumulative_impressions', 'cumulative_total_interactions'
+  'cumulativeViews', 'cumulativeLikes', 'cumulativeShares', 'cumulativeComments',
+  'cumulativeSaved', 'cumulativeReach', 'cumulativeImpressions', 'cumulativeTotalInteractions'
 ];
 const topMoverMetricEnum = z.enum(topMoverMetricLiterals);
 

--- a/src/app/api/metrics/[metricId]/daily/route.ts
+++ b/src/app/api/metrics/[metricId]/daily/route.ts
@@ -96,7 +96,7 @@ export async function GET(
       .select( // Seleciona os campos desejados para a resposta
         'date ' +
         'dailyViews dailyLikes dailyComments dailyShares dailySaved dailyReach dailyFollows dailyProfileVisits ' +
-        'cumulativeViews cumulativeLikes cumulativeComments cumulativeShares cumulativeSaved cumulativeReach cumulativeFollows cumulativeProfileVisits cumulativeTotalInteractions ' +
+        'cumulativeViews cumulativeLikes cumulativeComments cumulativeShares cumulativeSaved cumulativeReach cumulativeImpressions cumulativeFollows cumulativeProfileVisits cumulativeTotalInteractions ' +
         '-_id' // Exclui o _id de cada snapshot
       )
       .lean(); // Retorna objetos JS puros

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -229,14 +229,14 @@ export interface IPeriod {
 export type TopMoverEntityType = 'content' | 'creator';
 
 export type TopMoverMetric =
-  | 'cumulative_views'
-  | 'cumulative_likes'
-  | 'cumulative_shares'
-  | 'cumulative_comments'
-  | 'cumulative_saves'
-  | 'cumulative_reach'
-  | 'cumulative_impressions'
-  | 'cumulative_total_interactions';
+  | 'cumulativeViews'
+  | 'cumulativeLikes'
+  | 'cumulativeShares'
+  | 'cumulativeComments'
+  | 'cumulativeSaved'
+  | 'cumulativeReach'
+  | 'cumulativeImpressions'
+  | 'cumulativeTotalInteractions';
 
 export type TopMoverSortBy =
   | 'absoluteChange_increase'

--- a/src/app/lib/dataService/marketAnalysisService.test.ts
+++ b/src/app/lib/dataService/marketAnalysisService.test.ts
@@ -288,7 +288,7 @@ describe('MarketAnalysisService', () => {
     const previousPeriod = { startDate: new Date('2023-01-01Z'), endDate: new Date('2023-01-31Z') };
     const currentPeriod = { startDate: new Date('2023-02-01Z'), endDate: new Date('2023-02-28Z') };
     const baseArgs: IFetchTopMoversArgs = {
-      entityType: 'content', metric: 'cumulative_likes', previousPeriod, currentPeriod, topN: 5,
+      entityType: 'content', metric: 'cumulativeLikes', previousPeriod, currentPeriod, topN: 5,
     };
     const mockMetricDetails = [{ _id: metricId1, description: 'Post about Cats' }];
 
@@ -320,7 +320,7 @@ describe('MarketAnalysisService', () => {
 
     const baseCreatorArgs: IFetchTopMoversArgs = {
       entityType: 'creator',
-      metric: 'cumulative_total_interactions',
+      metric: 'cumulativeTotalInteractions',
       previousPeriod,
       currentPeriod,
       topN: 3,

--- a/src/app/lib/instagram/db/metricActions.ts
+++ b/src/app/lib/instagram/db/metricActions.ts
@@ -190,7 +190,8 @@ async function createOrUpdateDailySnapshot(metric: IMetric): Promise<void> {
     }).sort({ date: -1 }).lean<IDailyMetricSnapshot>();
 
     const previousCumulativeStats: Partial<Record<keyof IMetricStats | 'reelsVideoViewTotalTime', number>> = {
-      views: 0, likes: 0, comments: 0, shares: 0, saved: 0, reach: 0, follows: 0, profile_visits: 0, total_interactions: 0,
+      views: 0, likes: 0, comments: 0, shares: 0, saved: 0, reach: 0, impressions: 0, follows: 0,
+      profile_visits: 0, total_interactions: 0,
       reelsVideoViewTotalTime: 0,
     };
 
@@ -202,6 +203,7 @@ async function createOrUpdateDailySnapshot(metric: IMetric): Promise<void> {
         shares: lastSnapshot.cumulativeShares ?? 0,
         saved: lastSnapshot.cumulativeSaved ?? 0,
         reach: lastSnapshot.cumulativeReach ?? 0,
+        impressions: lastSnapshot.cumulativeImpressions ?? 0,
         follows: lastSnapshot.cumulativeFollows ?? 0,
         profile_visits: lastSnapshot.cumulativeProfileVisits ?? 0,
         total_interactions: lastSnapshot.cumulativeTotalInteractions ?? 0,
@@ -217,7 +219,7 @@ async function createOrUpdateDailySnapshot(metric: IMetric): Promise<void> {
 
     const dailyStats: Partial<Record<keyof IDailyMetricSnapshot, number>> = {};
     const metricsToCalculateDelta: (keyof IMetricStats)[] = [
-      'views', 'likes', 'comments', 'shares', 'saved', 'reach', 'follows', 'profile_visits'
+      'views', 'likes', 'comments', 'shares', 'saved', 'reach', 'impressions', 'follows', 'profile_visits'
     ];
 
     for (const metricName of metricsToCalculateDelta) {
@@ -260,6 +262,7 @@ async function createOrUpdateDailySnapshot(metric: IMetric): Promise<void> {
       dailyFollows: dailyStats.dailyFollows,
       dailyProfileVisits: dailyStats.dailyProfileVisits,
       dailyReelsVideoViewTotalTime: dailyStats.dailyReelsVideoViewTotalTime,
+      dailyImpressions: dailyStats.dailyImpressions,
       
       cumulativeViews: Number(currentMetricStats.views ?? 0),
       cumulativeLikes: Number(currentMetricStats.likes ?? 0),
@@ -267,6 +270,7 @@ async function createOrUpdateDailySnapshot(metric: IMetric): Promise<void> {
       cumulativeShares: Number(currentMetricStats.shares ?? 0),
       cumulativeSaved: Number(currentMetricStats.saved ?? 0),
       cumulativeReach: Number(currentMetricStats.reach ?? 0),
+      cumulativeImpressions: Number(currentMetricStats.impressions ?? 0),
       cumulativeFollows: Number(currentMetricStats.follows ?? 0),
       cumulativeProfileVisits: Number(currentMetricStats.profile_visits ?? 0),
       cumulativeTotalInteractions: Number(currentMetricStats.total_interactions ?? 0),

--- a/src/app/models/DailyMetricSnapshot.ts
+++ b/src/app/models/DailyMetricSnapshot.ts
@@ -20,12 +20,14 @@ export interface IDailyMetricSnapshot extends Document {
   dailyFollows?: number;
   dailyProfileVisits?: number;
   dailyReelsVideoViewTotalTime?: number;
+  dailyImpressions?: number;
   cumulativeViews?: number;
   cumulativeLikes?: number;
   cumulativeComments?: number;
   cumulativeShares?: number;
   cumulativeSaved?: number;
   cumulativeReach?: number;
+  cumulativeImpressions?: number;
   cumulativeFollows?: number;
   cumulativeProfileVisits?: number;
   cumulativeTotalInteractions?: number;
@@ -55,12 +57,14 @@ const dailyMetricSnapshotSchema = new Schema<IDailyMetricSnapshot>(
     dailyFollows: { type: Number, default: 0 },
     dailyProfileVisits: { type: Number, default: 0 },
     dailyReelsVideoViewTotalTime: { type: Number, default: 0 },
+    dailyImpressions: { type: Number, default: 0 },
     cumulativeViews: { type: Number, default: 0 },
     cumulativeLikes: { type: Number, default: 0 },
     cumulativeComments: { type: Number, default: 0 },
     cumulativeShares: { type: Number, default: 0 },
     cumulativeSaved: { type: Number, default: 0 },
     cumulativeReach: { type: Number, default: 0 },
+    cumulativeImpressions: { type: Number, default: 0 },
     cumulativeFollows: { type: Number, default: 0 },
     cumulativeProfileVisits: { type: Number, default: 0 },
     cumulativeTotalInteractions: { type: Number, default: 0 },


### PR DESCRIPTION
## Summary
- use camelCase metric names in TopMovers widgets
- reflect new metric names in API route and type definitions
- track cumulativeImpressions in DailyMetricSnapshot
- adjust Instagram snapshot actions to handle impressions
- update tests to match new fields

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d0de26b8832ead4505d78ec7236d