### PR TITLE
Document camelCase API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ db.metrics.insertOne({
 
 Crie alguns documentos com datas diferentes para que os gráficos possam calcular tendências e médias.
 
+## API Response Conventions
+
+All endpoints under `src/app/api` return JSON using **camelCase** keys. For example,
+the metric history routes (`/api/metricsHistory` and `/api/metrics/[metricId]/daily`)
+expose fields like `engagementRate`, `likes` and `comments`. Highlight endpoints
+such as `/api/v1/users/{userId}/highlights/performance-summary` also follow this
+convention with keys like `topPerformingFormat` and `valueFormatted`.
+
+Front‑end components should rely on camelCase when accessing response data. The
+API serialization layer automatically converts snake\_case keys to camelCase via
+the `camelizeKeys` utility.
+
 
 ## Learn More
 

--- a/src/app/api/metricsHistory/route.ts
+++ b/src/app/api/metricsHistory/route.ts
@@ -8,6 +8,7 @@ import { connectToDatabase } from "@/app/lib/mongoose"; // Ajuste o caminho
 import Metric from "@/app/models/Metric"; // <<< USA MetricModel >>>
 import type { Session } from "next-auth";
 import { logger } from '@/app/lib/logger'; // Ajuste o caminho
+import { camelizeKeys } from '@/utils/camelizeKeys';
 
 // <<< ADICIONADO: Força a rota a ser dinâmica >>>
 export const dynamic = 'force-dynamic';
@@ -200,7 +201,8 @@ export async function GET(request: NextRequest) { // Usa NextRequest
     // Ex: borderColor: "rgba(75,192,192,1)", backgroundColor: "rgba(75,192,192,0.2)"
 
     logger.info(`${TAG} Histórico de métricas preparado para User ${userId}.`);
-    return NextResponse.json({ history }, { status: 200 });
+    const camelHistory = camelizeKeys(history);
+    return NextResponse.json({ history: camelHistory }, { status: 200 });
 
   } catch (error: unknown) {
     logger.error(`${TAG} Erro:`, error);

--- a/src/app/api/v1/platform/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
 import { ALLOWED_TIME_PERIODS } from '@/app/lib/constants/timePeriods';
 // Para implementação real, seriam necessárias funções de agregação da plataforma
 // que determinariam o top/low formato/contexto em nível de plataforma.
@@ -121,7 +122,7 @@ export async function GET(
     }
 
 
-  return NextResponse.json(response, { status: 200 });
+  return NextResponse.json(camelizeKeys(response), { status: 200 });
 
   // Exemplo de tratamento de erro (se fosse uma busca real)
   // catch (error) {

--- a/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS } from '@/app/lib/constants/timePeriods';
+import { camelizeKeys } from '@/utils/camelizeKeys';
 
 import aggregatePerformanceHighlights from '@/utils/aggregatePerformanceHighlights';
 
@@ -124,7 +125,7 @@ export async function GET(
     }
 
 
-    return NextResponse.json(response, { status: 200 });
+    return NextResponse.json(camelizeKeys(response), { status: 200 });
 
   } catch (error) {
     console.error(`[API USER/HIGHLIGHTS/PERFORMANCE-SUMMARY] Error for userId ${userId}:`, error);

--- a/src/utils/camelizeKeys.ts
+++ b/src/utils/camelizeKeys.ts
@@ -1,0 +1,15 @@
+export function camelize(str: string): string {
+  return str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+export function camelizeKeys(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(camelizeKeys);
+  }
+  if (obj !== null && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [camelize(k), camelizeKeys(v)])
+    );
+  }
+  return obj;
+}


### PR DESCRIPTION
## Summary
- add new `camelizeKeys` helper
- enforce camelCase responses in metrics history and highlight endpoints
- document camelCase convention in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d0edd880832eb7457c97252805d6