### PR TITLE
Implement platform conversion metrics

### DIFF
--- a/src/app/api/v1/platform/performance/conversion-metrics/route.ts
+++ b/src/app/api/v1/platform/performance/conversion-metrics/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
 import { ALLOWED_TIME_PERIODS } from '@/app/lib/constants/timePeriods';
-// Para implementação real, seriam necessárias funções de agregação da plataforma
-// import { calculatePlatformAverageFollowerConversionRatePerPost } from '@/utils/platformMetrics';
-// import { calculatePlatformAccountFollowerConversionRate } from '@/utils/platformMetrics';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import { fetchPlatformConversionMetrics } from '@/app/lib/dataService/marketAnalysisService';
 
 
 interface PlatformConversionMetricsResponse {
-  averageFollowerConversionRatePerPost: number | null;
-  accountFollowerConversionRate: number | null;
-  numberOfPostsConsideredForRate: number | null;    // Total de posts da plataforma considerados
-  accountsEngagedInPeriod: number | null;           // Total de contas engajadas na plataforma
-  followersGainedInPeriod: number | null;           // Total de seguidores ganhos na plataforma
-  insightSummary?: string;
+  averageFollowerConversionRatePerPost: number;
+  accountFollowerConversionRate: number;
+  numberOfPostsConsideredForRate: number;
+  accountsEngagedInPeriod: number;
+  followersGainedInPeriod: number;
 }
 
 // Helper para converter timePeriod string para periodInDays number (pode ser compartilhado)
@@ -38,58 +36,17 @@ export async function GET(
     return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
   }
 
-  // const periodInDaysValue = timePeriodToDays(timePeriod);
+  const today = new Date();
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const startDate = getStartDateFromTimePeriod(today, timePeriod);
 
-  // --- Simulação de Lógica de Backend para Dados Agregados da Plataforma ---
-  // Em uma implementação real, esta API chamaria funções que agregam
-  // `calculateAverageFollowerConversionRatePerPost` e `calculateAccountFollowerConversionRate`
-  // para todos os usuários ou um segmento relevante.
-
-  // Por agora, dados hardcoded para demonstração:
-  let responsePayload: PlatformConversionMetricsResponse;
-
-  // Simular dados diferentes baseados no período
-  if (timePeriod === "last_7_days") {
-    responsePayload = {
-      averageFollowerConversionRatePerPost: 1.8, // 1.8%
-      accountFollowerConversionRate: 1.0,        // 1.0%
-      numberOfPostsConsideredForRate: 15000,
-      accountsEngagedInPeriod: 800000,
-      followersGainedInPeriod: 8000,
-      insightSummary: `Na última semana, a conversão média por post na plataforma foi de 1.8%, e a da conta foi de 1.0%.`
-    };
-  } else if (timePeriod === "last_30_days") {
-    responsePayload = {
-      averageFollowerConversionRatePerPost: 2.0, // 2.0%
-      accountFollowerConversionRate: 1.2,        // 1.2%
-      numberOfPostsConsideredForRate: 60000,     // 15000 * 4
-      accountsEngagedInPeriod: 3000000,    // ~800k * 4
-      followersGainedInPeriod: 36000,      // 8000 * 4.5
-      insightSummary: `Nos últimos 30 dias, a conversão média por post na plataforma foi de 2.0%, e a da conta foi de 1.2%.`
-    };
-  } else { // Default (last_90_days ou outros)
-     responsePayload = {
-      averageFollowerConversionRatePerPost: 2.2, // 2.2%
-      accountFollowerConversionRate: 1.3,        // 1.3%
-      numberOfPostsConsideredForRate: 180000,    // 60000 * 3
-      accountsEngagedInPeriod: 8500000,     // ~3M * 3
-      followersGainedInPeriod: 110500,     // ~36k * 3
-      insightSummary: `Nos últimos 90 dias, a conversão média por post na plataforma foi de 2.2%, e a da conta foi de 1.3%.`
-    };
+  try {
+    const metrics = await fetchPlatformConversionMetrics({ dateRange: { startDate, endDate } });
+    return NextResponse.json(metrics, { status: 200 });
+  } catch (error: any) {
+    console.error('[API PLATFORM/PERFORMANCE/CONVERSION-METRICS] Error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação de métricas de conversão da plataforma.', details: errorMessage }, { status: 500 });
   }
-
-  // TODO: Implementar lógica de agregação real da plataforma.
-  // Os valores acima para numberOfPosts, accountsEngaged, followersGained são totais da plataforma.
-  // As taxas (averageFollowerConversionRatePerPost, accountFollowerConversionRate) seriam médias ponderadas
-  // ou calculadas sobre os totais agregados (ex: total_followers_gained_platform / total_accounts_engaged_platform).
-
-  return NextResponse.json(responsePayload, { status: 200 });
-
-  // Exemplo de tratamento de erro (se fosse uma busca real)
-  // catch (error) {
-  //   console.error("[API PLATFORM/PERFORMANCE/CONVERSION-METRICS] Error:", error);
-  //   const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
-  //   return NextResponse.json({ error: "Erro ao processar sua solicitação de métricas de conversão da plataforma.", details: errorMessage }, { status: 500 });
-  // }
 }
 

--- a/src/app/lib/dataService/marketAnalysis/conversionMetricsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/conversionMetricsService.ts
@@ -1,0 +1,89 @@
+import { PipelineStage } from 'mongoose';
+import { logger } from '@/app/lib/logger';
+import MetricModel from '@/app/models/Metric';
+import AccountInsightModel from '@/app/models/AccountInsight';
+import { connectToDatabase } from '../connection';
+import { DatabaseError } from '@/app/lib/errors';
+import { IFetchPlatformConversionMetricsArgs, IPlatformConversionMetrics } from './types';
+
+const SERVICE_TAG = '[dataService][conversionMetricsService]';
+
+export async function fetchPlatformConversionMetrics(
+  args: IFetchPlatformConversionMetricsArgs
+): Promise<IPlatformConversionMetrics> {
+  const TAG = `${SERVICE_TAG}[fetchPlatformConversionMetrics]`;
+  logger.info(`${TAG} Aggregating metrics for date range: ${args.dateRange.startDate.toISOString()} - ${args.dateRange.endDate.toISOString()}`);
+
+  try {
+    await connectToDatabase();
+
+    const { startDate, endDate } = args.dateRange;
+
+    const postMatch: PipelineStage.Match['$match'] = {
+      postDate: { $gte: startDate, $lte: endDate },
+      'stats.follower_conversion_rate': { $exists: true, $ne: null, $type: 'number' },
+    };
+
+    const postPipeline: PipelineStage[] = [
+      { $match: postMatch },
+      {
+        $group: {
+          _id: null,
+          count: { $sum: 1 },
+          avgRate: { $avg: '$stats.follower_conversion_rate' },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          count: { $ifNull: ['$count', 0] },
+          avgRate: { $ifNull: ['$avgRate', 0] },
+        },
+      },
+    ];
+
+    const postResults = await MetricModel.aggregate(postPipeline);
+    const numberOfPosts = postResults[0]?.count || 0;
+    const avgConversionPerPost = postResults[0]?.avgRate || 0;
+
+    const insightMatch: PipelineStage.Match['$match'] = {
+      recordedAt: { $gte: startDate, $lte: endDate },
+    };
+
+    const insightPipeline: PipelineStage[] = [
+      { $match: insightMatch },
+      {
+        $group: {
+          _id: null,
+          accountsEngaged: { $sum: '$accountInsightsPeriod.accounts_engaged' },
+          followerGains: { $sum: '$accountInsightsPeriod.follows_and_unfollows.follower_gains' },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          accountsEngaged: { $ifNull: ['$accountsEngaged', 0] },
+          followerGains: { $ifNull: ['$followerGains', 0] },
+        },
+      },
+    ];
+
+    const insightResults = await AccountInsightModel.aggregate(insightPipeline);
+    const accountsEngaged = insightResults[0]?.accountsEngaged || 0;
+    const followersGained = insightResults[0]?.followerGains || 0;
+
+    const accountConversionRate = accountsEngaged > 0 ? (followersGained / accountsEngaged) * 100 : 0;
+    const averageFollowerConversionRatePerPost = avgConversionPerPost * 100;
+
+    return {
+      averageFollowerConversionRatePerPost: parseFloat(averageFollowerConversionRatePerPost.toFixed(2)),
+      accountFollowerConversionRate: parseFloat(accountConversionRate.toFixed(2)),
+      numberOfPostsConsideredForRate: numberOfPosts,
+      accountsEngagedInPeriod: accountsEngaged,
+      followersGainedInPeriod: followersGained,
+    };
+  } catch (error: any) {
+    logger.error(`${TAG} Error aggregating platform conversion metrics:`, error);
+    throw new DatabaseError(`Failed to aggregate platform conversion metrics: ${error.message}`);
+  }
+}

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -270,3 +270,18 @@ export interface ITopMoverResult {
   absoluteChange: number;
   percentageChange: number | null;
 }
+
+export interface IFetchPlatformConversionMetricsArgs {
+  dateRange: {
+    startDate: Date;
+    endDate: Date;
+  };
+}
+
+export interface IPlatformConversionMetrics {
+  averageFollowerConversionRatePerPost: number;
+  accountFollowerConversionRate: number;
+  numberOfPostsConsideredForRate: number;
+  accountsEngagedInPeriod: number;
+  followersGainedInPeriod: number;
+}

--- a/src/app/lib/dataService/marketAnalysisService.ts
+++ b/src/app/lib/dataService/marketAnalysisService.ts
@@ -35,3 +35,6 @@ export * from './marketAnalysis/radarService';
 
 // Exporta as funções de comparação de coortes
 export * from './marketAnalysis/cohortsService';
+
+// Exporta métricas de conversão agregadas da plataforma
+export * from './marketAnalysis/conversionMetricsService';


### PR DESCRIPTION
## Summary
- remove mocked backend logic from platform conversion metrics route
- implement data service to aggregate platform conversion metrics
- expose new service in marketAnalysisService
- define platform conversion metrics types

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d7007e88832e92c1a3146592e4b2