### PR TITLE
Implement creator approval API and connect admin UI

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorTable.tsx
+++ b/src/app/admin/creator-dashboard/CreatorTable.tsx
@@ -229,9 +229,17 @@ const CreatorTable = memo(function CreatorTable({ planStatusFilter, expertiseLev
   const handleUpdateCreatorStatus = async (creatorId: string, newStatus: 'approved') => {
       setUpdateStatus(prev => ({ ...prev, [creatorId]: 'approving' }));
       try {
-          // A API para esta ação precisaria ser criada. Ex: /api/admin/creators/[id]/status
-          // await fetch(`/api/admin/creators/${creatorId}/status`, { ... });
-          await new Promise(resolve => setTimeout(resolve, 1000)); // Simula delay da API
+          const response = await fetch(`/api/admin/creators/${creatorId}/status`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ status: newStatus }),
+          });
+
+          if (!response.ok) {
+              const data = await response.json().catch(() => ({}));
+              throw new Error(data.error || 'Erro ao atualizar status do criador.');
+          }
+
           toast.success('Criador aprovado com sucesso!');
           fetchData();
       } catch (error: any) {

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -93,8 +93,8 @@ const AdminCreatorDashboardPage: React.FC = () => {
         <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
       </section>
 
-      <section id="creator-selection-simulation" className="mb-8 p-4 bg-white rounded-lg shadow">
-        <h2 className="text-lg font-semibold text-gray-700 mb-3">Simular Seleção de Criador Detalhado:</h2>
+      <section id="creator-selection" className="mb-8 p-4 bg-white rounded-lg shadow">
+        <h2 className="text-lg font-semibold text-gray-700 mb-3">Selecionar Criador para Detalhar</h2>
         <div className="flex flex-wrap items-center gap-4">
           <button
             onClick={() => setIsSelectorOpen(true)}
@@ -112,7 +112,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
               onClick={() => { setSelectedUserId(null); setSelectedUserName(null); }}
               className="p-2 rounded-md text-sm bg-gray-200 text-gray-700 hover:bg-gray-300"
             >
-              Limpar Seleção (Ver Visão Geral da Plataforma)
+              Limpar seleção e voltar à visão geral
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add real approval call in `CreatorTable`
- rename creator selection section and text in admin dashboard
- implement PUT endpoint for approving creators
- test new PUT route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d71272b4832eb570e91696af0761