### PR TITLE
Add authentication tests and metrics helpers coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Install dependencies if you haven't already and then run:
 npm test
 ```
 
+## Banco de Dados
+
+Esta aplicação utiliza MongoDB. Configure as variáveis de ambiente `MONGODB_URI` e `MONGODB_DB_NAME` (ou `DB_NAME`) no arquivo `.env.local` apontando para sua instância. Certifique‑se de que o banco especificado exista antes de iniciar o servidor.
+
 ### Creators Scatter Plot
 
 Na dashboard administrativa, utilize o componente **CreatorsScatterPlot** para comparar métricas de diferentes criadores em um gráfico de dispersão.
@@ -45,9 +49,9 @@ Ele consome o endpoint `/api/v1/users/{userId}/charts/monthly-comparison` e perm
 
 Basta fornecer o `userId` ao componente e ele renderizará um gráfico de colunas com as diferenças mensais.
 
-### Populando o Banco para Testes
+### Populando o Banco para Desenvolvimento
 
-Os gráficos dependem das coleções **AccountInsight** e **Metric**. Caso seu banco esteja vazio, os componentes exibirão a mensagem "Sem dados no período selecionado". Para experimentar localmente, insira alguns registros manualmente no MongoDB:
+Os gráficos dependem das coleções **AccountInsight** e **Metric**. Caso seu banco esteja vazio, os componentes exibirão a mensagem "Sem dados no período selecionado". Para experimentar localmente ou em ambiente de teste, insira alguns registros manualmente no MongoDB:
 
 ```javascript
 use data2content

--- a/src/app/api/admin/dashboard/content/performance-by-type/route.test.ts
+++ b/src/app/api/admin/dashboard/content/performance-by-type/route.test.ts
@@ -1,0 +1,50 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { fetchContentPerformanceByType } from '@/app/lib/dataService/marketAnalysis/segmentService';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/app/lib/dataService/marketAnalysis/segmentService', () => ({
+  fetchContentPerformanceByType: jest.fn(),
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFetchPerf = fetchContentPerformanceByType as jest.Mock;
+
+const makeRequest = (params: Record<string,string> = {}) => {
+  const url = new URL(`http://localhost/api/admin/dashboard/content/performance-by-type?${new URLSearchParams(params)}`);
+  return new NextRequest(url);
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/admin/dashboard/content/performance-by-type', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest({ startDate: '2024-01-01T00:00:00.000Z', endDate: '2024-01-02T00:00:00.000Z' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns data when authenticated as admin', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
+    const performance = [{ _id: 'VIDEO', totalPosts: 5 }];
+    mockFetchPerf.mockResolvedValue(performance);
+
+    const res = await GET(makeRequest({ startDate: '2024-01-01T00:00:00.000Z', endDate: '2024-01-02T00:00:00.000Z' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(performance);
+    expect(fetchContentPerformanceByType).toHaveBeenCalledWith({ dateRange: {
+      startDate: new Date('2024-01-01T00:00:00.000Z'),
+      endDate: new Date('2024-01-02T00:00:00.000Z'),
+    }});
+  });
+});

--- a/src/app/api/admin/dashboard/platform-summary/route.test.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.test.ts
@@ -1,0 +1,52 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/app/lib/dataService/marketAnalysis/dashboardService', () => ({
+  fetchPlatformSummary: jest.fn(),
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFetchSummary = fetchPlatformSummary as jest.Mock;
+
+const makeRequest = (params: Record<string, string> = {}) => {
+  const url = new URL(`http://localhost/api/admin/dashboard/platform-summary?${new URLSearchParams(params)}`);
+  return new NextRequest(url);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/admin/dashboard/platform-summary', () => {
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns summary data when authenticated as admin', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
+    const data = { totalCreators: 10 };
+    mockFetchSummary.mockResolvedValue(data);
+
+    const res = await GET(makeRequest({ startDate: '2024-01-01T00:00:00.000Z', endDate: '2024-01-31T00:00:00.000Z' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(data);
+    expect(fetchPlatformSummary).toHaveBeenCalledWith({ dateRange: {
+      startDate: new Date('2024-01-01T00:00:00.000Z'),
+      endDate: new Date('2024-01-31T00:00:00.000Z'),
+    }});
+  });
+});

--- a/src/utils/platformMetricsHelpers.test.ts
+++ b/src/utils/platformMetricsHelpers.test.ts
@@ -1,0 +1,63 @@
+import { Types } from 'mongoose';
+import { getPlatformMinMaxValues } from './platformMetricsHelpers';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import AccountInsightModel from '@/app/models/AccountInsight';
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  __esModule: true,
+  default: { find: jest.fn() },
+}));
+
+jest.mock('@/app/models/AccountInsight', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockUserFind = UserModel.find as jest.Mock;
+const mockAccountFindOne = AccountInsightModel.findOne as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe('getPlatformMinMaxValues', () => {
+  it('calculates min and max follower counts', async () => {
+    const id1 = new Types.ObjectId();
+    const id2 = new Types.ObjectId();
+
+    mockUserFind.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: id1 }, { _id: id2 }]),
+    });
+
+    const leanFn = jest.fn()
+      .mockResolvedValueOnce({ followersCount: 100 })
+      .mockResolvedValueOnce({ followersCount: 300 });
+    mockAccountFindOne.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      lean: leanFn,
+    });
+
+    const res = await getPlatformMinMaxValues(['totalFollowers']);
+    expect(res.totalFollowers.min).toBe(100);
+    expect(res.totalFollowers.max).toBe(300);
+    expect(connectToDatabase).toHaveBeenCalled();
+    expect(UserModel.find).toHaveBeenCalled();
+    expect(AccountInsightModel.findOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns fallback for unknown metric', async () => {
+    mockUserFind.mockReturnValue({ select: jest.fn().mockReturnThis(), limit: jest.fn().mockReturnThis(), lean: jest.fn().mockResolvedValue([]) });
+    const res = await getPlatformMinMaxValues(['nonexistentMetric']);
+    expect(res.nonexistentMetric).toEqual({ min: 0, max: 100 });
+  });
+});


### PR DESCRIPTION
## Summary
- test authentication in new admin dashboard routes
- cover getPlatformMinMaxValues helper
- document MongoDB requirements and data seeding instructions in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d7166634832ead215a81d611a6e0