### PR TITLE
fix(recharts): adjust tooltip formatter types

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -51,7 +51,9 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
     fetchData();
   }, [fetchData]);
 
-  const tooltipFormatter = (value: number | null) => (value !== null ? value.toLocaleString() : 'N/A');
+  const tooltipFormatter = (value: number | null, name: string) => {
+    return [value !== null ? value.toLocaleString() : 'N/A', name];
+  };
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -85,7 +85,9 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
     setTimePeriod(e.target.value);
   };
 
-  const tooltipFormatter = (value: number | null) => (value !== null ? value.toLocaleString() : 'N/A');
+  const tooltipFormatter = (value: number | null, name: string) => {
+    return [value !== null ? value.toLocaleString() : 'N/A', name];
+  };
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">


### PR DESCRIPTION
## Summary
- fix type signature for tooltip formatter to match Recharts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6852dc89d03c832e9a065cea0041f175