### PR TITLE
Fix tooltip formatter types

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import type { TooltipProps } from 'recharts';
+import { formatNullableNumberTooltip } from '@/utils/chartFormatters';
 
 interface ApiChangePoint {
   date: string;
@@ -51,9 +53,10 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
     fetchData();
   }, [fetchData]);
 
-  const tooltipFormatter = (value: number | null, name: string) => {
-    return [value !== null ? value.toLocaleString() : 'N/A', name];
-  };
+  const tooltipFormatter: TooltipProps<number | null, string>["formatter"] = (
+    value,
+    name
+  ) => formatNullableNumberTooltip(value, name);
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
@@ -71,7 +74,7 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
               <YAxis stroke="#666" tick={{ fontSize: 12 }} />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <Tooltip<number | null, string> formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
               <Bar dataKey="change" name="Variação" fill="#8884d8" />
             </BarChart>
           </ResponsiveContainer>

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import type { TooltipProps } from 'recharts';
+import { formatNullableNumberTooltip } from '@/utils/chartFormatters';
 
 interface ApiChangePoint {
   date: string;
@@ -85,9 +87,10 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
     setTimePeriod(e.target.value);
   };
 
-  const tooltipFormatter = (value: number | null, name: string) => {
-    return [value !== null ? value.toLocaleString() : 'N/A', name];
-  };
+  const tooltipFormatter: TooltipProps<number | null, string>["formatter"] = (
+    value,
+    name
+  ) => formatNullableNumberTooltip(value, name);
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
@@ -117,7 +120,7 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
               <YAxis stroke="#666" tick={{ fontSize: 12 }} />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <Tooltip<number | null, string> formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
               <Bar dataKey="change" name="Variação" fill="#8884d8" />
             </BarChart>
           </ResponsiveContainer>

--- a/src/utils/chartFormatters.ts
+++ b/src/utils/chartFormatters.ts
@@ -1,0 +1,3 @@
+export function formatNullableNumberTooltip(value: number | null, name: string): [string, string] {
+  return [value !== null ? value.toLocaleString() : 'N/A', name];
+}


### PR DESCRIPTION
## Summary
- add shared formatter for recharts tooltips
- type Tooltip components that receive nullable numbers
- use utility in follower change charts

## Testing
- `tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dfd0ffc0832e9b885663c1116c86