### PR TITLE
Fix tooltip formatter type constraints

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -53,10 +53,10 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
     fetchData();
   }, [fetchData]);
 
-  const tooltipFormatter: TooltipProps<number | null, string>["formatter"] = (
+  const tooltipFormatter: TooltipProps<number, string>["formatter"] = (
     value,
     name
-  ) => formatNullableNumberTooltip(value, name);
+  ) => formatNullableNumberTooltip(value as number | null, name);
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -87,10 +87,10 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
     setTimePeriod(e.target.value);
   };
 
-  const tooltipFormatter: TooltipProps<number | null, string>["formatter"] = (
+  const tooltipFormatter: TooltipProps<number, string>["formatter"] = (
     value,
     name
-  ) => formatNullableNumberTooltip(value, name);
+  ) => formatNullableNumberTooltip(value as number | null, name);
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">


### PR DESCRIPTION
## Summary
- fix type mismatch on tooltip formatters by using `TooltipProps<number, string>` and casting the value back to `number | null`
- apply same fix in both follower change charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e1496d6c832eb69bb5401e327ce4