### PR TITLE
Fix Jest config for TSX tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 export default {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    moduleNameMapper: {
-      '^@/app/(.*)$': '<rootDir>/src/app/$1',
-    },
-  };
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@/app/(.*)$': '<rootDir>/src/app/$1',
+  },
+  transform: {},
+};


### PR DESCRIPTION
## Summary
- adjust Jest config to work with TypeScript React files using `ts-jest`
- switch to jsdom test environment

## Testing
- `npm test -- src/app/admin/creator-dashboard` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed98eaec832e879ec47299a52685