### PR TITLE
Fix ContentStatsWidgets tests

### DIFF
--- a/src/app/admin/creator-dashboard/ContentStatsWidgets.test.tsx
+++ b/src/app/admin/creator-dashboard/ContentStatsWidgets.test.tsx
@@ -36,7 +36,7 @@ const mockStats: IDashboardOverallStats = {
 
 describe('ContentStatsWidgets Component', () => {
   beforeEach(() => {
-    (fetch as jest.Mock).mockClear();
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => mockStats,
@@ -67,12 +67,14 @@ describe('ContentStatsWidgets Component', () => {
   });
 
   test('displays loading state initially', () => {
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockImplementationOnce(() => new Promise(() => {})); // Keep it loading
     render(<ContentStatsWidgets />);
     expect(screen.getByText('Carregando estatísticas...')).toBeInTheDocument();
   });
 
   test('displays error state and retry button if fetch fails', async () => {
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockRejectedValueOnce(new Error('API Error Stats'));
     render(<ContentStatsWidgets />);
     expect(await screen.findByText(/Erro ao carregar dados: API Error Stats/)).toBeInTheDocument();
@@ -80,6 +82,7 @@ describe('ContentStatsWidgets Component', () => {
   });
 
   test('retry button calls fetchData again', async () => {
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockRejectedValueOnce(new Error('Initial API Error'));
     render(<ContentStatsWidgets />);
 
@@ -98,6 +101,7 @@ describe('ContentStatsWidgets Component', () => {
   });
 
   test('displays "no stats available" message when data is null or empty', async () => {
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => null, // Simulate API returning null
@@ -111,6 +115,7 @@ describe('ContentStatsWidgets Component', () => {
         ...mockStats,
         breakdownByFormat: [], // Empty data for this chart
     };
+    (fetch as jest.Mock).mockReset();
     (fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: async () => partialMockStats,
@@ -138,9 +143,8 @@ describe('ContentStatsWidgets Component', () => {
     render(<ContentStatsWidgets dateRangeFilter={dateRange} />);
 
     await waitFor(() => {
-        expect(fetch).toHaveBeenCalledWith(
-            `/api/admin/dashboard/content-stats?startDate=${new Date(dateRange.startDate).toISOString()}&endDate=${new Date(dateRange.endDate).toISOString()}`
-        );
+        const expectedUrl = `/api/admin/dashboard/content-stats?startDate=${encodeURIComponent(new Date(dateRange.startDate).toISOString())}&endDate=${encodeURIComponent(new Date(dateRange.endDate).toISOString())}`;
+        expect(fetch).toHaveBeenCalledWith(expectedUrl);
     });
   });
 
@@ -159,9 +163,8 @@ describe('ContentStatsWidgets Component', () => {
 
     await waitFor(() => {
         expect(fetch).toHaveBeenCalledTimes(2); // Should fetch again
-        expect(fetch).toHaveBeenLastCalledWith(
-             `/api/admin/dashboard/content-stats?startDate=${new Date(newDateRange.startDate).toISOString()}&endDate=${new Date(newDateRange.endDate).toISOString()}`
-        );
+        const expectedUrl = `/api/admin/dashboard/content-stats?startDate=${encodeURIComponent(new Date(newDateRange.startDate).toISOString())}&endDate=${encodeURIComponent(new Date(newDateRange.endDate).toISOString())}`;
+        expect(fetch).toHaveBeenLastCalledWith(expectedUrl);
     });
     expect(await screen.findByText('500')).toBeInTheDocument(); // Check if new data is rendered
   });

--- a/src/app/admin/creator-dashboard/ContentStatsWidgets.tsx
+++ b/src/app/admin/creator-dashboard/ContentStatsWidgets.tsx
@@ -25,9 +25,12 @@ const formatKpiValue = (value?: number | string): string => {
 };
 
 const formatPercentage = (value?: number): string => {
-    if (value === null || typeof value === 'undefined') return 'N/A';
-    return `${(value * 100).toFixed(1)}%`;
-}
+  if (value === null || typeof value === 'undefined') return 'N/A';
+  return `${(value * 100).toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })}%`;
+};
 
 interface ContentStatsWidgetsProps {
   dateRangeFilter?: {
@@ -102,6 +105,7 @@ const ContentStatsWidgets = memo(function ContentStatsWidgets({ dateRangeFilter 
   if (isLoading) {
     return (
       <div className="space-y-6">
+        <p className="sr-only">Carregando estatísticas...</p>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {Array.from({ length: 3 }).map((_, index) => (
             <div key={`kpi-skel-${index}`} className="bg-white p-5 rounded-lg shadow border border-gray-200">
@@ -129,7 +133,7 @@ const ContentStatsWidgets = memo(function ContentStatsWidgets({ dateRangeFilter 
   if (error) {
     return (
       <div className="p-6 bg-white rounded-xl shadow-sm border border-gray-200 min-h-[400px] flex flex-col justify-center items-center">
-        <p className="text-red-500 text-center mb-4">Erro ao carregar dados: {error}</p>
+        <p className="text-red-500 text-center mb-4">{`Erro ao carregar dados: ${error}`}</p>
         <button
             onClick={fetchData}
             className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"


### PR DESCRIPTION
## Summary
- fix percent format using pt-BR locale
- show loading message for accessibility
- fix error message interpolation
- improve test setup and expectations for dateRange

## Testing
- `npm test -- -t ContentStatsWidgets` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f93af684832ea0db478e8962ac06