### PR TITLE
Remove duplicate React imports in admin tests

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import React from 'react'; // Standard import for React at the top
 import CreatorDashboardPage, { GlobalFiltersState } from './page';
 
 // Mocks for child components - simplified to not return JSX directly from factory

--- a/src/app/admin/creator-dashboard/CreatorDetailModal.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorDetailModal.test.tsx
@@ -6,7 +6,6 @@ import CreatorDetailModal from './CreatorDetailModal';
 // Mock global fetch
 global.fetch = jest.fn();
 
-import React from 'react'; // Standard import for React at the top
 
 // Mock CreatorTimeSeriesChart
 jest.mock('./CreatorTimeSeriesChart', () => jest.fn(({ isLoading, error, data, metricLabel }) => (


### PR DESCRIPTION
## Summary
- clean up duplicate React imports in admin test files

## Testing
- `npm test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb6ce4a4832e8701a0aaa0cd416e