### PR TITLE
Fix CreatorRankingCard incomplete dateRange test

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorRankingCard.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CreatorRankingCard from './CreatorRankingCard';
 import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
@@ -138,7 +138,11 @@ describe('CreatorRankingCard', () => {
     );
     expect(fetch).not.toHaveBeenCalled();
     // Current behavior is to render "No data" state, as rankingData remains null
-    expect(screen.getByText('Nenhum dado disponível para o período selecionado.')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('Nenhum dado disponível para o período selecionado.')
+    ).toHaveLength(1);
+
+    cleanup();
 
     render(
         <CreatorRankingCard
@@ -148,7 +152,9 @@ describe('CreatorRankingCard', () => {
         />
       );
       expect(fetch).not.toHaveBeenCalled();
-      expect(screen.getByText('Nenhum dado disponível para o período selecionado.')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Nenhum dado disponível para o período selecionado.')
+      ).toHaveLength(1);
   });
 
    it('displays correct metric formatting for very small numbers', async () => {


### PR DESCRIPTION
## Summary
- add `cleanup()` and use `getAllByText` for clarity in CreatorRankingCard incomplete date range test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb749cfc832e9ea80a60152efc75