### PR TITLE
Fix CreatorsScatterPlot test mock

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorsScatterPlot.test.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorsScatterPlot.test.tsx
@@ -38,7 +38,11 @@ describe('CreatorsScatterPlot Component', () => {
     (fetch as jest.Mock).mockClear();
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({ plotData: [], xAxisMetricLabel: 'X', yAxisMetricLabel: 'Y' }),
+      json: async () => ({
+        plotData: [{ id: '1', label: 'A', x: 1, y: 1 }],
+        xAxisMetricLabel: 'X',
+        yAxisMetricLabel: 'Y',
+      }),
     });
   });
 


### PR DESCRIPTION
## Summary
- make CreatorsScatterPlot test return a valid data point

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb77caf4832e95de06cf53f275b0