### PR TITLE
Add heroicons mocks for Jest tests

### DIFF
--- a/__mocks__/heroicons/24/outline.js
+++ b/__mocks__/heroicons/24/outline.js
@@ -1,0 +1,9 @@
+const React = require('react');
+
+module.exports = new Proxy({}, {
+  get: (target, prop) => {
+    return function Icon(props) {
+      return React.createElement('svg', { ...props, 'data-icon': prop });
+    };
+  }
+});

--- a/__mocks__/heroicons/24/solid.js
+++ b/__mocks__/heroicons/24/solid.js
@@ -1,0 +1,9 @@
+const React = require('react');
+
+module.exports = new Proxy({}, {
+  get: (target, prop) => {
+    return function Icon(props) {
+      return React.createElement('svg', { ...props, 'data-icon': prop });
+    };
+  }
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -11,13 +11,14 @@ const customJestConfig = {
   testEnvironment: 'jsdom',
   // Se você estiver usando @testing-library/jest-dom, descomente a linha abaixo
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  moduleNameMapper: {
-    // Mapeamentos para mocks e alias (mantemos o que já tínhamos)
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
-    '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
-    '^@/app/(.*)$': '<rootDir>/src/app/$1',
-  },
-};
+    moduleNameMapper: {
+      // Mapeamentos para mocks e alias (mantemos o que já tínhamos)
+      '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+      '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
+      '^@/app/(.*)$': '<rootDir>/src/app/$1',
+      '^@heroicons/react/(.*)$': '<rootDir>/__mocks__/heroicons/$1.js',
+    },
+  };
 
 // createJestConfig é exportado desta forma para garantir que o next/jest possa carregar a configuração do Next.js, que é assíncrona
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- map heroicons imports to custom mocks in `jest.config.cjs`
- add stub components for heroicons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ffa599b4832e99ce9437a4f524ce