### PR TITLE
Fix heroicons imports in tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -16,6 +16,9 @@ const customJestConfig = {
       '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
       '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
       '^@/app/(.*)$': '<rootDir>/src/app/$1',
+      // Alguns ícones são importados a partir dos módulos ESM individuais,
+      // mapeamos esses caminhos diretamente para os mocks genéricos
+      '^@heroicons/react/24/(solid|outline)/esm/.*$': '<rootDir>/__mocks__/heroicons/24/$1.js',
       '^@heroicons/react/(.*)$': '<rootDir>/__mocks__/heroicons/$1.js',
     },
   };


### PR DESCRIPTION
## Summary
- handle heroicons ESM subpaths in Jest config

## Testing
- `npm install --silent` *(fails: network access blocked)*
- `npm test -- src/app/admin/creator-dashboard` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68530218bf00832eb69c05052ade7ece