### PR TITLE
Implementação de fetchUserAlerts e integração no endpoint

### DIFF
--- a/src/app/api/v1/users/[userId]/alerts/active/route.ts
+++ b/src/app/api/v1/users/[userId]/alerts/active/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
-import { addDays } from '@/utils/dateHelpers';
+import { fetchUserAlerts } from '@/app/lib/dataService/userService';
 
 enum AlertTypeEnum {
   FOLLOWER_STAGNATION = "FollowerStagnation",
@@ -51,65 +51,34 @@ export async function GET(
 
   const filterTypes = typesParam.filter(t => ALLOWED_ALERT_TYPES.includes(t as AlertTypeEnum));
 
-  const todayFormatted = new Date().toISOString().split('T')[0]!;
-  const yesterday = addDays(new Date(), -1);
-  const yesterdayFormatted = yesterday.toISOString().split('T')[0]!;
-  const fiveDaysAgo = addDays(new Date(), -5);
-  const fiveDaysAgoFormatted = fiveDaysAgo.toISOString().split('T')[0]!;
+  try {
+    const { alerts, totalAlerts } = await fetchUserAlerts(userId, { limit, types: filterTypes });
 
-  const allMockAlerts: AlertResponseItem[] = [
-    {
-      alertId: new Types.ObjectId().toString(),
-      type: AlertTypeEnum.FOLLOWER_STAGNATION,
-      date: todayFormatted,
-      title: "Estagnação de Seguidores",
-      summary: "Seu crescimento de seguidores desacelerou significativamente nos últimos 14 dias.",
-      details: { currentGrowthRate: 0.005, previousGrowthRate: 0.02, periodDays: 14 }
-    },
-    {
-      alertId: new Types.ObjectId().toString(),
-      type: AlertTypeEnum.FORGOTTEN_FORMAT,
-      date: yesterdayFormatted,
-      title: "Formato Esquecido: Reels",
-      summary: "Você não posta Reels há 25 dias. Este formato costumava ter bom engajamento.",
-      details: { format: "REEL", daysSinceLastUsed: 25, avgMetricValue: 1500, metricName: "total_interactions" }
-    },
-    {
-      alertId: new Types.ObjectId().toString(),
-      type: AlertTypeEnum.CONTENT_PERFORMANCE_DROP,
-      date: fiveDaysAgoFormatted,
-      title: "Queda de Performance em Conteúdo",
-      summary: "O engajamento médio dos seus últimos 5 posts de Imagem caiu 30% comparado à média anterior.",
-      details: { contentType: "IMAGE", dropPercentage: -30, lastPostsCount: 5, currentAvg: 500, previousAvg: 714 }
-    },
-    {
-      alertId: new Types.ObjectId().toString(),
-      type: AlertTypeEnum.FOLLOWER_STAGNATION,
-      date: addDays(new Date(), -10).toISOString().split('T')[0]!,
-      title: "Estagnação de Seguidores (Antigo)",
-      summary: "Seu crescimento de seguidores desacelerou (alerta mais antigo).",
-      details: { currentGrowthRate: 0.008, previousGrowthRate: 0.03, periodDays: 14 }
+    const mappedAlerts: AlertResponseItem[] = alerts.map((a) => ({
+      alertId: (a._id ?? new Types.ObjectId()).toString(),
+      type: a.type,
+      date: (a.date instanceof Date ? a.date : new Date(a.date)).toISOString().split('T')[0]!,
+      title: a.type,
+      summary: a.finalUserMessage,
+      details: a.details,
+    }));
+
+    const response: UserAlertsResponse = {
+      alerts: mappedAlerts,
+      totalAlerts,
+      insightSummary: mappedAlerts.length > 0
+        ? `Você tem ${totalAlerts > limit ? 'pelo menos ' : ''}${mappedAlerts.length} alerta(s) relevante(s).`
+        : 'Nenhum alerta novo.',
+    };
+
+    if (mappedAlerts.length > 0 && mappedAlerts.length < totalAlerts) {
+      response.insightSummary += ` Mostrando os ${mappedAlerts.length} mais recentes de ${totalAlerts} alertas correspondentes.`;
     }
-  ];
 
-  const filtered = filterTypes.length > 0
-    ? allMockAlerts.filter(alert => filterTypes.includes(alert.type))
-    : allMockAlerts;
-
-  const paginated = filtered
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, limit);
-
-  const response: UserAlertsResponse = {
-    alerts: paginated,
-    totalAlerts: filtered.length,
-    insightSummary: paginated.length > 0
-      ? `Você tem ${filtered.length > limit ? 'pelo menos ' : ''}${paginated.length} alerta(s) relevante(s).`
-      : "Nenhum alerta novo."
-  };
-  if (paginated.length > 0 && paginated.length < filtered.length) {
-    response.insightSummary += ` Mostrando os ${paginated.length} mais recentes de ${filtered.length} alertas correspondentes.`;
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    console.error(`[API USER/ALERTS/ACTIVE] Error for userId ${userId}:`, error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao buscar alertas do usuário.', details: errorMessage }, { status: 500 });
   }
-
-  return NextResponse.json(response, { status: 200 });
 }

--- a/src/app/lib/dataService/userService.ts
+++ b/src/app/lib/dataService/userService.ts
@@ -333,6 +333,66 @@ export async function addAlertToHistory(
   }
 }
 
+export interface FetchUserAlertsOptions {
+  limit?: number;
+  types?: string[];
+}
+
+export interface FetchUserAlertsResult {
+  alerts: IAlertHistoryEntry[];
+  totalAlerts: number;
+}
+
+export async function fetchUserAlerts(
+  userId: string,
+  { limit = 5, types = [] }: FetchUserAlertsOptions = {}
+): Promise<FetchUserAlertsResult> {
+  const TAG = '[dataService][userService][fetchUserAlerts]';
+
+  if (!mongoose.isValidObjectId(userId)) {
+    logger.error(`${TAG} ID de utilizador inválido: ${userId}`);
+    throw new DatabaseError(`ID de utilizador inválido: ${userId}`);
+  }
+
+  try {
+    await connectToDatabase();
+    const userObjectId = new Types.ObjectId(userId);
+
+    const pipeline: any[] = [
+      { $match: { _id: userObjectId } },
+      { $unwind: '$alertHistory' },
+    ];
+
+    if (types.length > 0) {
+      pipeline.push({ $match: { 'alertHistory.type': { $in: types } } });
+    }
+
+    pipeline.push({
+      $facet: {
+        alerts: [
+          { $sort: { 'alertHistory.date': -1 } },
+          { $limit: limit },
+          { $replaceRoot: { newRoot: '$alertHistory' } },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    });
+
+    const results = await User.aggregate(pipeline);
+    const first = results[0] || { alerts: [], totalCount: [] };
+
+    const alerts = (first.alerts || []) as IAlertHistoryEntry[];
+    const totalAlerts = first.totalCount[0]?.count || 0;
+
+    return { alerts, totalAlerts };
+  } catch (error: any) {
+    logger.error(`${TAG} Erro ao buscar alertas para o utilizador ${userId}:`, error);
+    throw new DatabaseError(`Erro ao buscar alertas: ${error.message}`);
+  }
+}
+
 /**
  * Exclui a conta de um utilizador e todos os dados associados de forma transacional.
  * @param userId - O ID do utilizador a ser excluído.


### PR DESCRIPTION
## Summary
- cria função `fetchUserAlerts` no `userService`
- substitui mocks no endpoint `/alerts/active` para usar dados reais

## Testing
- `npm test` *(falhou: `jest` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685dee63b8ec832e824117937baa6504