### PR TITLE
Display final user message in alerts widget

### DIFF
--- a/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
+++ b/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
@@ -15,7 +15,7 @@ interface AlertResponseItem {
   type: AlertTypeEnum | string; // string para flexibilidade se novos tipos surgirem
   date: string; // YYYY-MM-DD
   title: string;
-  summary: string;
+  finalUserMessage: string;
   details: any;
 }
 
@@ -139,12 +139,12 @@ const UserAlertsWidget: React.FC<UserAlertsWidgetProps> = ({
                     {expandedAlerts.has(alert.alertId) ? <ChevronUp size={18} className="text-gray-500"/> : <ChevronDown size={18} className="text-gray-500"/>}
                 </div>
                 {!expandedAlerts.has(alert.alertId) && (
-                     <p className="text-xs text-gray-600 mt-1 ml-8 truncate">{alert.summary}</p>
+                     <p className="text-xs text-gray-600 mt-1 ml-8 truncate">{alert.finalUserMessage}</p>
                 )}
               </button>
               {expandedAlerts.has(alert.alertId) && (
                 <div className="p-3 border-t border-gray-200 bg-gray-50">
-                  <p className="text-sm text-gray-700 mb-2">{alert.summary}</p>
+                  <p className="text-sm text-gray-700 mb-2">{alert.finalUserMessage}</p>
                   <div className="text-xs text-gray-600 bg-white p-2 rounded border border-gray-300">
                     <pre className="whitespace-pre-wrap break-all">{JSON.stringify(alert.details, null, 2)}</pre>
                   </div>

--- a/src/app/api/v1/users/[userId]/alerts/active/route.ts
+++ b/src/app/api/v1/users/[userId]/alerts/active/route.ts
@@ -13,7 +13,7 @@ interface AlertResponseItem {
   type: string;
   date: string;
   title: string;
-  summary: string;
+  finalUserMessage: string;
   details: any;
 }
 
@@ -63,7 +63,7 @@ export async function GET(
       type: AlertTypeEnum.FOLLOWER_STAGNATION,
       date: todayFormatted,
       title: "Estagnação de Seguidores",
-      summary: "Seu crescimento de seguidores desacelerou significativamente nos últimos 14 dias.",
+      finalUserMessage: "Seu crescimento de seguidores desacelerou significativamente nos últimos 14 dias.",
       details: { currentGrowthRate: 0.005, previousGrowthRate: 0.02, periodDays: 14 }
     },
     {
@@ -71,7 +71,7 @@ export async function GET(
       type: AlertTypeEnum.FORGOTTEN_FORMAT,
       date: yesterdayFormatted,
       title: "Formato Esquecido: Reels",
-      summary: "Você não posta Reels há 25 dias. Este formato costumava ter bom engajamento.",
+      finalUserMessage: "Você não posta Reels há 25 dias. Este formato costumava ter bom engajamento.",
       details: { format: "REEL", daysSinceLastUsed: 25, avgMetricValue: 1500, metricName: "total_interactions" }
     },
     {
@@ -79,7 +79,7 @@ export async function GET(
       type: AlertTypeEnum.CONTENT_PERFORMANCE_DROP,
       date: fiveDaysAgoFormatted,
       title: "Queda de Performance em Conteúdo",
-      summary: "O engajamento médio dos seus últimos 5 posts de Imagem caiu 30% comparado à média anterior.",
+      finalUserMessage: "O engajamento médio dos seus últimos 5 posts de Imagem caiu 30% comparado à média anterior.",
       details: { contentType: "IMAGE", dropPercentage: -30, lastPostsCount: 5, currentAvg: 500, previousAvg: 714 }
     },
     {
@@ -87,7 +87,7 @@ export async function GET(
       type: AlertTypeEnum.FOLLOWER_STAGNATION,
       date: addDays(new Date(), -10).toISOString().split('T')[0]!,
       title: "Estagnação de Seguidores (Antigo)",
-      summary: "Seu crescimento de seguidores desacelerou (alerta mais antigo).",
+      finalUserMessage: "Seu crescimento de seguidores desacelerou (alerta mais antigo).",
       details: { currentGrowthRate: 0.008, previousGrowthRate: 0.03, periodDays: 14 }
     }
   ];


### PR DESCRIPTION
## Summary
- replace `summary` with `finalUserMessage` for user alerts
- show truncated `finalUserMessage` when collapsed
- keep alert details in expanded view
- update mock API route with new field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dee656268832eb6424c525890dc41