### PR TITLE
Add tests for fetchUserAlerts service

### DIFF
--- a/src/lib/services/userAlertsService.test.ts
+++ b/src/lib/services/userAlertsService.test.ts
@@ -1,0 +1,56 @@
+import { Types } from 'mongoose';
+import { fetchUserAlerts } from './userAlertsService';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/dataService/connection';
+
+jest.mock('@/app/models/User', () => ({
+  findById: jest.fn(),
+}));
+
+jest.mock('@/app/lib/dataService/connection');
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindById = UserModel.findById as jest.Mock;
+
+describe('fetchUserAlerts', () => {
+  const validUserId = new Types.ObjectId().toString();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  test('returns alerts sorted by date', async () => {
+    const alerts = [
+      { type: 'B', date: new Date('2024-01-01'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'A', date: new Date('2024-03-01'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'C', date: new Date('2024-02-01'), messageForAI: '', finalUserMessage: '', details: {} },
+    ];
+    mockFindById.mockReturnValue({ lean: () => Promise.resolve({ _id: validUserId, alertHistory: alerts }) });
+
+    const result = await fetchUserAlerts(validUserId);
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(result.map(a => a.type)).toEqual(['A', 'C', 'B']);
+  });
+
+  test('applies limit and types filters', async () => {
+    const alerts = [
+      { type: 'A', date: new Date('2024-03-01'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'B', date: new Date('2024-02-01'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'A', date: new Date('2024-01-01'), messageForAI: '', finalUserMessage: '', details: {} },
+    ];
+    mockFindById.mockReturnValue({ lean: () => Promise.resolve({ _id: validUserId, alertHistory: alerts }) });
+
+    const result = await fetchUserAlerts(validUserId, { limit: 1, types: ['A'] });
+
+    expect(result.length).toBe(1);
+    expect(result[0].type).toBe('A');
+    // Should be the most recent type A
+    expect(result[0].date.toISOString()).toBe(alerts[0].date.toISOString());
+  });
+
+  test('throws on invalid userId', async () => {
+    await expect(fetchUserAlerts('invalid-id')).rejects.toThrow('Invalid userId');
+  });
+});

--- a/src/lib/services/userAlertsService.ts
+++ b/src/lib/services/userAlertsService.ts
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose';
+import { connectToDatabase } from '@/app/lib/dataService/connection';
+import UserModel, { IAlertHistoryEntry } from '@/app/models/User';
+import { logger } from '@/app/lib/logger';
+
+export interface FetchUserAlertsOptions {
+  limit?: number;
+  types?: string[];
+}
+
+export async function fetchUserAlerts(
+  userId: string,
+  options: FetchUserAlertsOptions = {}
+): Promise<IAlertHistoryEntry[]> {
+  const TAG = '[userAlertsService][fetchUserAlerts]';
+
+  if (!mongoose.isValidObjectId(userId)) {
+    logger.error(`${TAG} Invalid userId: ${userId}`);
+    throw new Error('Invalid userId');
+  }
+
+  await connectToDatabase();
+
+  const { limit = 5, types = [] } = options;
+
+  const user = await UserModel.findById(userId, { alertHistory: 1 }).lean();
+  if (!user || !Array.isArray((user as any).alertHistory)) {
+    logger.warn(`${TAG} User ${userId} not found or has no alert history`);
+    return [];
+  }
+
+  let alerts: IAlertHistoryEntry[] = [...(user as any).alertHistory];
+
+  if (types.length > 0) {
+    alerts = alerts.filter(a => types.includes(a.type));
+  }
+
+  alerts.sort((a, b) => {
+    const dateA = a.date instanceof Date ? a.date.getTime() : new Date(a.date).getTime();
+    const dateB = b.date instanceof Date ? b.date.getTime() : new Date(b.date).getTime();
+    return dateB - dateA;
+  });
+
+  return alerts.slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- implement `fetchUserAlerts` service
- add unit tests verifying sorting, filtering and error handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dee67b094832ea6a745370883aa16