### PR TITLE
Use finalUserMessage in alerts widget

### DIFF
--- a/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
+++ b/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
@@ -15,7 +15,7 @@ interface AlertResponseItem {
   type: AlertTypeEnum | string; // string para flexibilidade se novos tipos surgirem
   date: string; // YYYY-MM-DD
   title: string;
-  summary: string;
+  finalUserMessage: string;
   details: any;
 }
 
@@ -139,12 +139,12 @@ const UserAlertsWidget: React.FC<UserAlertsWidgetProps> = ({
                     {expandedAlerts.has(alert.alertId) ? <ChevronUp size={18} className="text-gray-500"/> : <ChevronDown size={18} className="text-gray-500"/>}
                 </div>
                 {!expandedAlerts.has(alert.alertId) && (
-                     <p className="text-xs text-gray-600 mt-1 ml-8 truncate">{alert.summary}</p>
+                     <p className="text-xs text-gray-600 mt-1 ml-8 truncate">{alert.finalUserMessage}</p>
                 )}
               </button>
               {expandedAlerts.has(alert.alertId) && (
                 <div className="p-3 border-t border-gray-200 bg-gray-50">
-                  <p className="text-sm text-gray-700 mb-2">{alert.summary}</p>
+                  <p className="text-sm text-gray-700 mb-2">{alert.finalUserMessage}</p>
                   <div className="text-xs text-gray-600 bg-white p-2 rounded border border-gray-300">
                     <pre className="whitespace-pre-wrap break-all">{JSON.stringify(alert.details, null, 2)}</pre>
                   </div>

--- a/src/app/api/v1/users/[userId]/alerts/active/route.ts
+++ b/src/app/api/v1/users/[userId]/alerts/active/route.ts
@@ -13,7 +13,7 @@ interface AlertResponseItem {
   type: string;
   date: string;
   title: string;
-  summary: string;
+  finalUserMessage: string;
   details: any;
 }
 
@@ -59,7 +59,7 @@ export async function GET(
       type: a.type,
       date: (a.date instanceof Date ? a.date : new Date(a.date)).toISOString().split('T')[0]!,
       title: a.type,
-      summary: a.finalUserMessage,
+      finalUserMessage: a.finalUserMessage,
       details: a.details,
     }));
 


### PR DESCRIPTION
## Summary
- rename `summary` field to `finalUserMessage` in `UserAlertsWidget` alert type
- render `finalUserMessage` instead of summary
- adjust alerts API to return `finalUserMessage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df8e1e90c832ebb44cb5e76348187