### PR TITLE
Remove unused import from creator dashboard test

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorDashboardPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import CreatorDashboardPage, { GlobalFiltersState } from './page';
+import CreatorDashboardPage from './page';
 
 // Mocks for child components - simplified to not return JSX directly from factory
 jest.mock('./CreatorTable', () => jest.fn(() => <div data-testid="creator-table-mock">CreatorTable</div>));


### PR DESCRIPTION
## Summary
- clean up `CreatorDashboardPage.test.tsx` by removing an unused `GlobalFiltersState` import

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe52c3f4832e8a4e9fdbf756c877