### PR TITLE
Add period indicator in admin dashboard

### DIFF
--- a/src/app/admin/creator-dashboard/components/GlobalPeriodIndicator.tsx
+++ b/src/app/admin/creator-dashboard/components/GlobalPeriodIndicator.tsx
@@ -1,0 +1,30 @@
+"use client";
+import React from 'react';
+import { useGlobalTimePeriod } from './GlobalTimePeriodContext';
+
+interface Props {
+  timePeriod?: string;
+}
+
+const LABELS: Record<string, string> = {
+  last_7_days: 'Últimos 7 dias',
+  last_30_days: 'Últimos 30 dias',
+  last_90_days: 'Últimos 90 dias',
+  last_6_months: 'Últimos 6 meses',
+  last_12_months: 'Últimos 12 meses',
+  all_time: 'Todo o período',
+};
+
+const GlobalPeriodIndicator: React.FC<Props> = ({ timePeriod }) => {
+  const context = useGlobalTimePeriod();
+  const period = timePeriod || context.globalTimePeriod;
+  const label = LABELS[period] || 'Período Personalizado';
+
+  return (
+    <span className="ml-2 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+      {label}
+    </span>
+  );
+};
+
+export default GlobalPeriodIndicator;

--- a/src/app/admin/creator-dashboard/components/GlobalTimePeriodContext.tsx
+++ b/src/app/admin/creator-dashboard/components/GlobalTimePeriodContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React, { createContext, useContext } from 'react';
+
+interface GlobalTimePeriodContextValue {
+  globalTimePeriod: string;
+  setGlobalTimePeriod?: (tp: string) => void;
+}
+
+const GlobalTimePeriodContext = createContext<GlobalTimePeriodContextValue | undefined>(undefined);
+
+interface ProviderProps {
+  children: React.ReactNode;
+  value: GlobalTimePeriodContextValue;
+}
+
+export const GlobalTimePeriodProvider: React.FC<ProviderProps> = ({ children, value }) => (
+  <GlobalTimePeriodContext.Provider value={value}>{children}</GlobalTimePeriodContext.Provider>
+);
+
+export const useGlobalTimePeriod = () => {
+  const ctx = useContext(GlobalTimePeriodContext);
+  if (!ctx) {
+    throw new Error('useGlobalTimePeriod must be used within a GlobalTimePeriodProvider');
+  }
+  return ctx;
+};
+
+export default GlobalTimePeriodContext;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useState } from 'react';
+import { GlobalTimePeriodProvider } from './components/GlobalTimePeriodContext';
+import GlobalPeriodIndicator from './components/GlobalPeriodIndicator';
 import CreatorSelector from './components/CreatorSelector';
 
 // Filtro Global
@@ -68,6 +70,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
   };
 
   return (
+    <GlobalTimePeriodProvider value={{ globalTimePeriod, setGlobalTimePeriod }}>
     <div className="p-4 md:p-6 lg:p-8 bg-gray-100 min-h-screen">
       <header className="mb-8 sticky top-0 z-20 bg-gray-100 pb-4 border-b border-gray-200">
         <h1 className="text-2xl md:text-3xl font-bold text-gray-800">Dashboard Administrativo de Criadores</h1>
@@ -122,7 +125,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
         <>
           <section id="platform-overview" className="mb-10">
             <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Visão Geral da Plataforma
+              Visão Geral da Plataforma <GlobalPeriodIndicator />
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 mb-6 md:mb-8">
               <TotalActiveCreatorsKpi />
@@ -151,7 +154,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
           <section id="platform-content-analysis" className="mb-10">
             <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Análise de Conteúdo da Plataforma
+              Análise de Conteúdo da Plataforma <GlobalPeriodIndicator />
             </h2>
             <div className="mb-6 md:mb-8">
                 <PlatformPerformanceHighlights timePeriod={globalTimePeriod}/>
@@ -188,7 +191,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
           <section id="proposal-ranking" className="mb-10">
             <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Ranking por Proposta
+              Ranking por Proposta <GlobalPeriodIndicator />
             </h2>
             <ProposalRankingCard
               title="Propostas com Mais Interações"
@@ -200,7 +203,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
         <section id="creator-rankings" className="mb-10">
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Rankings de Criadores
+            Rankings de Criadores <GlobalPeriodIndicator />
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
             <CreatorRankingCard
@@ -239,14 +242,14 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
         <section id="top-movers" className="mb-10">
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Top Movers
+            Top Movers <GlobalPeriodIndicator />
           </h2>
           <TopMoversWidget />
         </section>
 
         <section id="cohort-comparison" className="mb-10">
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Comparação de Coortes
+            Comparação de Coortes <GlobalPeriodIndicator />
           </h2>
           <CohortComparisonChart
             metric="engagement_rate_on_reach"
@@ -261,7 +264,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
         <section id="market-performance" className="mb-10">
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Desempenho do Mercado
+            Desempenho do Mercado <GlobalPeriodIndicator />
           </h2>
           <div className="flex flex-col md:flex-row gap-4 mb-4">
             <div>
@@ -296,14 +299,14 @@ const AdminCreatorDashboardPage: React.FC = () => {
 
         <section id="advanced-analysis" className="mb-10">
           <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Análise Avançada
+            Análise Avançada <GlobalPeriodIndicator />
           </h2>
           <RadarEffectivenessWidget />
         </section>
 
         <section id="creator-highlights-and-scatter-plot" className="mb-10">
             <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Destaques e Análise Comparativa de Criadores
+              Destaques e Análise Comparativa de Criadores <GlobalPeriodIndicator />
             </h2>
             <p className="text-sm text-gray-500 mb-4 italic">
               (Em breve: Tabelas de Criadores com melhor performance)
@@ -330,6 +333,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
       />
       <ScrollToTopButton />
     </div>
+    </GlobalTimePeriodProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- add global time period context and provider
- create `GlobalPeriodIndicator` to show the current period label
- inject provider into admin dashboard page
- display period indicator beside major section titles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe54e958832e87f22ed125ad5390