### PR TITLE
Implement global time period context

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -35,24 +36,23 @@ const GROUP_BY_OPTIONS = [ // Usado apenas se o seletor de groupBy fosse habilit
 ];
 
 interface PlatformAverageEngagementChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   initialGroupBy: GroupingType;
   chartTitle: string;
   initialEngagementMetric?: string;
 }
 
 const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartProps> = ({
-  timePeriod,
   initialGroupBy,
   chartTitle,
   initialEngagementMetric = ENGAGEMENT_METRIC_OPTIONS[0]!.value
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<ApiAverageEngagementDataPoint[]>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // timePeriod é agora uma prop
+  // timePeriod vem do contexto global
   const [engagementMetric, setEngagementMetric] = useState<string>(initialEngagementMetric);
   // groupBy é controlado por initialGroupBy, não muda internamente por seletor neste componente
   const groupBy = initialGroupBy;
@@ -61,7 +61,7 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
     setLoading(true);
     setError(null);
     try {
-      // Usa timePeriod da prop
+      // Usa timePeriod do contexto
       const apiUrl = `/api/v1/platform/performance/average-engagement?timePeriod=${timePeriod}&engagementMetricField=${engagementMetric}&groupBy=${groupBy}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
 interface ApiEngagementDistributionDataPoint {
@@ -33,16 +34,15 @@ const COLORS = [
 const DEFAULT_MAX_SLICES = 7;
 
 interface PlatformEngagementDistributionByFormatChartProps {
-  timePeriod: string;
   chartTitle?: string;
   initialEngagementMetric?: EngagementMetricValue;
 }
 
 const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDistributionByFormatChartProps> = ({
-  timePeriod,
   chartTitle = 'Distribuição de Engajamento por Formato (Plataforma)',
   initialEngagementMetric,
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   // Garantir valor padrão não indefinido
   const defaultMetric = ENGAGEMENT_METRIC_OPTIONS[0].value;
   const initMetric = initialEngagementMetric ?? defaultMetric;

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import type { TooltipProps } from 'recharts';
 import { formatNullableNumberTooltip } from '@/utils/chartFormatters';
@@ -15,13 +16,10 @@ interface PlatformFollowerChangeResponse {
   insightSummary?: string;
 }
 
-interface PlatformFollowerChangeChartProps {
-  timePeriod: string;
-}
+interface PlatformFollowerChangeChartProps {}
 
-const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = ({
-  timePeriod
-}) => {
+const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = () => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformFollowerChangeResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -24,26 +25,25 @@ const GRANULARITY_OPTIONS = [
 ];
 
 interface PlatformFollowerTrendChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   initialGranularity?: string;
 }
 
 const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
-  timePeriod, // Prop vinda da página principal
   initialGranularity = GRANULARITY_OPTIONS[0]?.value || "daily"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformFollowerTrendResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  // timePeriod não é mais um estado local
+  // timePeriod vem do contexto global
   const [granularity, setGranularity] = useState<string>(initialGranularity);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      // Usa timePeriod da prop e granularity do estado local
+      // Usa timePeriod do contexto e granularity do estado local
       const apiUrl = `/api/v1/platform/trends/followers?timePeriod=${timePeriod}&granularity=${granularity}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -23,25 +24,24 @@ interface MonthlyEngagementResponse {
 // const TIME_PERIOD_OPTIONS = [ ... ];
 
 interface PlatformMonthlyEngagementStackedChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   chartTitle?: string;
 }
 
 const PlatformMonthlyEngagementStackedChart: React.FC<PlatformMonthlyEngagementStackedChartProps> = ({
-  timePeriod, // Prop vinda da página principal
   chartTitle = "Engajamento Mensal Detalhado da Plataforma"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<MonthlyEngagementResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  // timePeriod não é mais um estado local
+  // timePeriod vem do contexto global
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      // Usa timePeriod da prop na URL da API
+      // Usa timePeriod do contexto na URL da API
       const apiUrl = `/api/v1/platform/charts/monthly-engagement-stacked?timePeriod=${timePeriod}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -39,20 +40,19 @@ const timePeriodToDataWindowDays = (timePeriod: string): number => {
 };
 
 interface PlatformMovingAverageEngagementChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx), ex: "last_30_days"
   initialAvgWindow?: string;
 }
 
 const PlatformMovingAverageEngagementChart: React.FC<PlatformMovingAverageEngagementChartProps> = ({
-  timePeriod,
   initialAvgWindow = MOVING_AVERAGE_WINDOW_OPTIONS[0]?.value ?? "7"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformMovingAverageResponse['series']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // dataWindow (número de dias) é agora derivado da prop timePeriod
+  // dataWindow (número de dias) é derivado do timePeriod do contexto
   const dataWindowInDays = timePeriodToDataWindowDays(timePeriod);
   const [avgWindow, setAvgWindow] = useState<string>(initialAvgWindow);
 

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react'; // Ícones
 import HighlightCard from './HighlightCard';
 
@@ -32,24 +33,23 @@ const InfoIcon: React.FC<{className?: string}> = ({className}) => (
 );
 
 interface PlatformPerformanceHighlightsProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   sectionTitle?: string;
 }
 
 const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps> = ({
-  timePeriod, // Prop vinda da página principal
   sectionTitle = "Destaques de Performance da Plataforma"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [summary, setSummary] = useState<PerformanceSummaryResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  // timePeriod não é mais um estado local
+  // timePeriod vem do contexto global
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      // Usa timePeriod da prop na URL da API
+      // Usa timePeriod do contexto na URL da API
       const apiUrl = `/api/v1/platform/highlights/performance-summary?timePeriod=${timePeriod}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
 interface ApiPostDistributionDataPoint {
@@ -27,21 +28,20 @@ const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#A230ED', '#D930ED'
 const DEFAULT_MAX_SLICES = 7;
 
 interface PlatformPostDistributionChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   chartTitle?: string;
   // initialEngagementMetric foi removido, pois este gráfico agora é fixo para contagem de posts
 }
 
 const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps> = ({
-  timePeriod, // Prop vinda da página principal
   chartTitle = "Distribuição de Posts por Formato (Plataforma)"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformPostDistributionResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // timePeriod é prop, não mais um estado local.
+  // timePeriod vem do contexto global.
   // engagementMetric não é mais necessário.
   const maxSlices = DEFAULT_MAX_SLICES; // Pode ser uma prop se necessário
 
@@ -70,9 +70,9 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
 
   useEffect(() => {
     fetchData();
-  }, [fetchData]); // fetchData agora depende de timePeriod (prop) e maxSlices (constante)
+  }, [fetchData]); // fetchData agora depende de timePeriod (contexto) e maxSlices (constante)
 
-  // handleTimePeriodChange não é mais necessário aqui, pois é controlado pelo pai
+  // handleTimePeriodChange não é mais necessário aqui, pois o período vem do contexto
   // handleEngagementMetricChange não é mais necessário
 
   const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name }: any) => {
@@ -98,7 +98,7 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6 md:mt-0">
       <div className="flex flex-col sm:flex-row justify-between sm:items-center mb-4">
         <h2 className="text-lg md:text-xl font-semibold text-gray-700 mb-2 sm:mb-0">{chartTitle}</h2>
-        {/* Seletores de timePeriod e engagementMetric removidos. TimePeriod é controlado pelo pai. */}
+        {/* Seletores de timePeriod e engagementMetric removidos. TimePeriod é fornecido pelo contexto. */}
         {/* Seletor de maxSlices poderia ser adicionado aqui se desejado */}
       </div>
 

--- a/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -25,19 +26,18 @@ const GRANULARITY_OPTIONS = [
 ];
 
 interface PlatformReachEngagementTrendChartProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   initialGranularity?: string;
 }
 
 const PlatformReachEngagementTrendChart: React.FC<PlatformReachEngagementTrendChartProps> = ({
-  timePeriod,
   initialGranularity = GRANULARITY_OPTIONS[0]!.value
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformReachEngagementTrendResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  // timePeriod não é mais um estado local
+  // timePeriod vem do contexto global
   const [granularity, setGranularity] = useState<string>(initialGranularity);
 
   const fetchData = useCallback(async () => {

--- a/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 
 // Reutilizar as interfaces e componentes auxiliares
 interface VideoMetricsData {
@@ -44,14 +45,13 @@ const InfoIcon: React.FC<{className?: string}> = ({className}) => (
 );
 
 interface PlatformVideoPerformanceMetricsProps {
-  timePeriod: string; // Recebido do pai (page.tsx)
   chartTitle?: string;
 }
 
 const PlatformVideoPerformanceMetrics: React.FC<PlatformVideoPerformanceMetricsProps> = ({
-  timePeriod, // Prop vinda da página principal
   chartTitle = "Performance de Vídeos da Plataforma"
 }) => {
+  const { timePeriod } = useGlobalTimePeriod();
   const [metrics, setMetrics] = useState<VideoMetricsData | null>(null);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
@@ -62,7 +62,7 @@ const PlatformVideoPerformanceMetrics: React.FC<PlatformVideoPerformanceMetricsP
     setLoading(true);
     setError(null);
     try {
-      // Usa timePeriod da prop na URL da API
+      // Usa timePeriod do contexto na URL da API
       const apiUrl = `/api/v1/platform/performance/video-metrics?timePeriod=${timePeriod}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+
+export interface GlobalTimePeriodContextValue {
+  timePeriod: string;
+  setTimePeriod: (tp: string) => void;
+}
+
+const GlobalTimePeriodContext = createContext<GlobalTimePeriodContextValue | undefined>(undefined);
+
+export const GlobalTimePeriodProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  const [timePeriod, setTimePeriod] = useState<string>("last_90_days");
+  return (
+    <GlobalTimePeriodContext.Provider value={{ timePeriod, setTimePeriod }}>
+      {children}
+    </GlobalTimePeriodContext.Provider>
+  );
+};
+
+export const useGlobalTimePeriod = (): GlobalTimePeriodContextValue => {
+  const context = useContext(GlobalTimePeriodContext);
+  if (!context) {
+    throw new Error("useGlobalTimePeriod must be used within a GlobalTimePeriodProvider");
+  }
+  return context;
+};
+
+export default GlobalTimePeriodContext;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -5,6 +5,7 @@ import CreatorSelector from './components/CreatorSelector';
 
 // Filtro Global
 import GlobalTimePeriodFilter from './components/filters/GlobalTimePeriodFilter';
+import { GlobalTimePeriodProvider, useGlobalTimePeriod } from './components/filters/GlobalTimePeriodContext';
 
 // Componentes da Plataforma - Módulo 1 (Visão Geral)
 import PlatformFollowerTrendChart from './components/PlatformFollowerTrendChart';
@@ -38,10 +39,10 @@ import ScrollToTopButton from '@/app/components/ScrollToTopButton';
 import UserDetailView from './components/views/UserDetailView';
 
 
-const AdminCreatorDashboardPage: React.FC = () => {
+const AdminCreatorDashboardContent: React.FC = () => {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
-  const [globalTimePeriod, setGlobalTimePeriod] = useState<string>("last_90_days"); // Default para 90 dias
+  const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } = useGlobalTimePeriod();
 
   const selectedComparisonPeriodForPlatformKPIs = "month_vs_previous";
   const [isSelectorOpen, setIsSelectorOpen] = useState(false);
@@ -140,12 +141,12 @@ const AdminCreatorDashboardPage: React.FC = () => {
               />
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformFollowerTrendChart timePeriod={globalTimePeriod} />
-              <PlatformFollowerChangeChart timePeriod={globalTimePeriod} />
+              <PlatformFollowerTrendChart />
+              <PlatformFollowerChangeChart />
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformReachEngagementTrendChart timePeriod={globalTimePeriod} />
-              <PlatformMovingAverageEngagementChart timePeriod={globalTimePeriod} />
+              <PlatformReachEngagementTrendChart />
+              <PlatformMovingAverageEngagementChart />
             </div>
           </section>
 
@@ -154,32 +155,29 @@ const AdminCreatorDashboardPage: React.FC = () => {
               Análise de Conteúdo da Plataforma
             </h2>
             <div className="mb-6 md:mb-8">
-                <PlatformPerformanceHighlights timePeriod={globalTimePeriod}/>
+                <PlatformPerformanceHighlights />
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 md:mb-8">
               <PlatformAverageEngagementChart
                 initialGroupBy="format"
                 chartTitle="Engajamento Médio por Formato (Plataforma)"
-                timePeriod={globalTimePeriod}
               />
               <PlatformAverageEngagementChart
                 initialGroupBy="context"
                 chartTitle="Engajamento Médio por Contexto (Plataforma)"
-                timePeriod={globalTimePeriod}
               />
               <PlatformAverageEngagementChart
                 initialGroupBy="proposal"
                 chartTitle="Engajamento Médio por Proposta (Plataforma)"
-                timePeriod={globalTimePeriod}
               />
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformPostDistributionChart timePeriod={globalTimePeriod} chartTitle="Distribuição de Posts por Formato (Plataforma)" />
-              <PlatformVideoPerformanceMetrics timePeriod={globalTimePeriod} />
+              <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato (Plataforma)" />
+              <PlatformVideoPerformanceMetrics />
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6"> {/* Nova linha ou ajuste no grid */}
-                <PlatformMonthlyEngagementStackedChart timePeriod={globalTimePeriod} />
-                <PlatformEngagementDistributionByFormatChart timePeriod={globalTimePeriod} /> {/* Adicionado aqui */}
+                <PlatformMonthlyEngagementStackedChart />
+                <PlatformEngagementDistributionByFormatChart /> {/* Adicionado aqui */}
             </div>
             <div className="mt-6">
               <ContentPerformanceByTypeChart dateRangeFilter={{ startDate, endDate }} />
@@ -332,6 +330,12 @@ const AdminCreatorDashboardPage: React.FC = () => {
     </div>
   );
 };
+
+const AdminCreatorDashboardPage: React.FC = () => (
+  <GlobalTimePeriodProvider>
+    <AdminCreatorDashboardContent />
+  </GlobalTimePeriodProvider>
+);
 
 export default AdminCreatorDashboardPage;
 


### PR DESCRIPTION
## Summary
- add `GlobalTimePeriodContext` to provide dashboard-wide period
- wrap creator dashboard page with context provider
- refactor platform components to read timePeriod from context

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe563724832eaa5ad6974ce715ca