### PR TITLE
Add date range labels to ranking cards

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorRankingCard.test.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingCard.test.tsx
@@ -18,6 +18,7 @@ const mockEmptyData: ICreatorMetricRankItem[] = [];
 global.fetch = jest.fn();
 
 const mockDateRange = { startDate: '2023-01-01', endDate: '2023-01-31' };
+const mockDateLabel = '01/01/2023 - 31/01/2023';
 
 describe('CreatorRankingCard', () => {
   beforeEach(() => {
@@ -59,6 +60,7 @@ describe('CreatorRankingCard', () => {
         title="Engaging Users"
         apiEndpoint="/api/engaging"
         dateRangeFilter={mockDateRange}
+        dateRangeLabel={mockDateLabel}
         metricLabel="%"
         limit={3}
       />
@@ -68,6 +70,7 @@ describe('CreatorRankingCard', () => {
     expect(screen.getByText('Engaging Users')).toBeInTheDocument();
     expect(screen.getByText('Bob The Builder')).toBeInTheDocument();
     expect(screen.getByText('Charlie Brown')).toBeInTheDocument();
+    expect(screen.getByText(mockDateLabel)).toBeInTheDocument();
 
     // Check formatted metric values and labels
     expect(screen.getByText('95,50 %')).toBeInTheDocument(); // Alice

--- a/src/app/admin/creator-dashboard/CreatorRankingCard.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingCard.tsx
@@ -12,6 +12,8 @@ interface CreatorRankingCardProps {
     startDate?: string;
     endDate?: string;
   };
+  /** Label describing the formatted date range for display */
+  dateRangeLabel?: string;
   metricLabel?: string;
   limit?: number;
 }
@@ -20,6 +22,7 @@ const CreatorRankingCard: React.FC<CreatorRankingCardProps> = ({
   title,
   apiEndpoint,
   dateRangeFilter,
+  dateRangeLabel,
   metricLabel = '',
   limit = 5,
 }) => {
@@ -102,9 +105,12 @@ const CreatorRankingCard: React.FC<CreatorRankingCardProps> = ({
 
   return (
     <div className="bg-white p-4 rounded-lg shadow border border-gray-200 h-full flex flex-col">
-      <h4 className="text-md font-semibold text-gray-700 mb-3 truncate" title={title}>
+      <h4 className="text-md font-semibold text-gray-700 truncate" title={title}>
         {title}
       </h4>
+      {dateRangeLabel && (
+        <p className="text-xs text-gray-500 mb-3">{dateRangeLabel}</p>
+      )}
       {isLoading && renderSkeleton()}
       {!isLoading && error && (
         <div className="text-center py-4 flex-grow flex flex-col justify-center items-center">

--- a/src/app/admin/creator-dashboard/ProposalRankingCard.tsx
+++ b/src/app/admin/creator-dashboard/ProposalRankingCard.tsx
@@ -11,6 +11,8 @@ interface ProposalRankingCardProps {
     startDate?: string;
     endDate?: string;
   };
+  /** Label describing the formatted date range for display */
+  dateRangeLabel?: string;
   metricLabel?: string;
   limit?: number;
 }
@@ -19,6 +21,7 @@ const ProposalRankingCard: React.FC<ProposalRankingCardProps> = ({
   title,
   apiEndpoint,
   dateRangeFilter,
+  dateRangeLabel,
   metricLabel = '',
   limit = 5,
 }) => {
@@ -87,7 +90,10 @@ const ProposalRankingCard: React.FC<ProposalRankingCardProps> = ({
 
   return (
     <div className="bg-white p-4 rounded-lg shadow border border-gray-200 h-full flex flex-col">
-      <h4 className="text-md font-semibold text-gray-700 mb-3 truncate" title={title}>{title}</h4>
+      <h4 className="text-md font-semibold text-gray-700 truncate" title={title}>{title}</h4>
+      {dateRangeLabel && (
+        <p className="text-xs text-gray-500 mb-3">{dateRangeLabel}</p>
+      )}
       {isLoading && renderSkeleton()}
       {!isLoading && error && (
         <div className="text-center py-4 flex-grow flex flex-col justify-center items-center">

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -56,6 +56,17 @@ const AdminCreatorDashboardPage: React.FC = () => {
   const startDate = startDateObj.toISOString();
   const endDate = today.toISOString();
   const rankingDateRange = { startDate, endDate };
+  const startDateLabel = startDateObj.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  const endDateLabel = today.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  const rankingDateLabel = `${startDateLabel} - ${endDateLabel}`;
 
 
   const handleUserSelect = (userId: string, userName: string) => {
@@ -194,6 +205,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
               title="Propostas com Mais Interações"
               apiEndpoint="/api/admin/dashboard/rankings/proposals?metric=total_interactions"
               dateRangeFilter={rankingDateRange}
+              dateRangeLabel={rankingDateLabel}
               limit={5}
             />
         </section>
@@ -207,6 +219,7 @@ const AdminCreatorDashboardPage: React.FC = () => {
               title="Maior Engajamento"
               apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
               dateRangeFilter={rankingDateRange}
+              dateRangeLabel={rankingDateLabel}
               metricLabel="%"
               limit={5}
             />
@@ -214,18 +227,21 @@ const AdminCreatorDashboardPage: React.FC = () => {
               title="Mais Interações"
               apiEndpoint="/api/admin/dashboard/rankings/creators/top-interactions"
               dateRangeFilter={rankingDateRange}
+              dateRangeLabel={rankingDateLabel}
               limit={5}
             />
             <CreatorRankingCard
               title="Mais Posts"
               apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
               dateRangeFilter={rankingDateRange}
+              dateRangeLabel={rankingDateLabel}
               limit={5}
             />
               <CreatorRankingCard
                 title="Mais Compartilhamentos"
                 apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
                 dateRangeFilter={rankingDateRange}
+                dateRangeLabel={rankingDateLabel}
                 limit={5}
               />
               <TopCreatorsWidget


### PR DESCRIPTION
## Summary
- add optional `dateRangeLabel` prop to `CreatorRankingCard` and `ProposalRankingCard`
- display the label below ranking titles
- compute a formatted date range label in creator dashboard page
- pass the label to ranking components
- test `CreatorRankingCard` shows the supplied label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe5703a0832e8470d6a0306a586d