### PR TITLE
Refactor to single global time period context

### DIFF
--- a/src/app/admin/creator-dashboard/components/GlobalPeriodIndicator.tsx
+++ b/src/app/admin/creator-dashboard/components/GlobalPeriodIndicator.tsx
@@ -1,24 +1,24 @@
 "use client";
-import React from 'react';
-import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
+import React from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 
 interface Props {
   timePeriod?: string;
 }
 
 const LABELS: Record<string, string> = {
-  last_7_days: 'Últimos 7 dias',
-  last_30_days: 'Últimos 30 dias',
-  last_90_days: 'Últimos 90 dias',
-  last_6_months: 'Últimos 6 meses',
-  last_12_months: 'Últimos 12 meses',
-  all_time: 'Todo o período',
+  last_7_days: "Últimos 7 dias",
+  last_30_days: "Últimos 30 dias",
+  last_90_days: "Últimos 90 dias",
+  last_6_months: "Últimos 6 meses",
+  last_12_months: "Últimos 12 meses",
+  all_time: "Todo o período",
 };
 
 const GlobalPeriodIndicator: React.FC<Props> = ({ timePeriod }) => {
   const context = useGlobalTimePeriod();
   const period = timePeriod || context.timePeriod;
-  const label = LABELS[period] || 'Período Personalizado';
+  const label = LABELS[period] || "Período Personalizado";
 
   return (
     <span className="ml-2 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 type GroupingType = "format" | "context" | "proposal";
 
@@ -37,7 +45,6 @@ interface UserAverageEngagementChartProps {
   userId: string | null;
   groupBy: GroupingType;
   chartTitle: string;
-  initialTimePeriod?: string;
   initialEngagementMetric?: string;
 }
 
@@ -45,28 +52,29 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
   userId,
   groupBy,
   chartTitle,
-  initialTimePeriod,
-  initialEngagementMetric = ENGAGEMENT_METRIC_OPTIONS[0]!.value
+  initialEngagementMetric = ENGAGEMENT_METRIC_OPTIONS[0]!.value,
 }) => {
   const [data, setData] = useState<ApiUserAverageEngagementDataPoint[]>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  const [timePeriod, setTimePeriod] = useState<string>(initialTimePeriod || (TIME_PERIOD_OPTIONS[2]?.value || ""));
-  const [engagementMetric, setEngagementMetric] = useState<string>(initialEngagementMetric);
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
+  const [timePeriod, setTimePeriod] = useState<string>(globalTimePeriod);
+  const [engagementMetric, setEngagementMetric] = useState<string>(
+    initialEngagementMetric,
+  );
 
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   useEffect(() => {
     // Se uma métrica inicial diferente for passada como prop e mudar
     setEngagementMetric(initialEngagementMetric);
   }, [initialEngagementMetric]);
-
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -81,13 +89,17 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserAverageEngagementResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
+      setError(
+        err instanceof Error ? err.message : "Ocorreu um erro desconhecido.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -110,24 +122,31 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
     return value.toString();
   };
 
-  const tooltipFormatter = (value: number, name: string, props?: { payload?: ApiUserAverageEngagementDataPoint }) => {
-      const postsCount = props?.payload?.postsCount ?? 0;
-      return [`${value.toLocaleString()} (de ${postsCount} posts)`, name];
+  const tooltipFormatter = (
+    value: number,
+    name: string,
+    props?: { payload?: ApiUserAverageEngagementDataPoint },
+  ) => {
+    const postsCount = props?.payload?.postsCount ?? 0;
+    return [`${value.toLocaleString()} (de ${postsCount} posts)`, name];
   };
-   const xAxisTickFormatter = (value: string) => {
+  const xAxisTickFormatter = (value: string) => {
     if (value && value.length > 12) {
-        return `${value.substring(0, 10)}...`;
+      return `${value.substring(0, 10)}...`;
     }
     return value;
-  }
-
+  };
 
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+          {chartTitle}
+        </h2>
         <div className="flex justify-center items-center h-[350px]">
-          <p className="text-gray-500">Selecione um criador para ver os dados.</p>
+          <p className="text-gray-500">
+            Selecione um criador para ver os dados.
+          </p>
         </div>
       </div>
     );
@@ -135,47 +154,80 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
         <div>
-          <label htmlFor={`timePeriodUserAvgEng-${groupBy}-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <label
+            htmlFor={`timePeriodUserAvgEng-${groupBy}-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Período:
+          </label>
           <select
-            id={`timePeriodUserAvgEng-${groupBy}-${userId || 'default'}`}
+            id={`timePeriodUserAvgEng-${groupBy}-${userId || "default"}`}
             value={timePeriod}
             onChange={(e) => setTimePeriod(e.target.value)}
             disabled={loading}
             className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor={`metricUserAvgEng-${groupBy}-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Métrica:</label>
+          <label
+            htmlFor={`metricUserAvgEng-${groupBy}-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Métrica:
+          </label>
           <select
-            id={`metricUserAvgEng-${groupBy}-${userId || 'default'}`}
+            id={`metricUserAvgEng-${groupBy}-${userId || "default"}`}
             value={engagementMetric}
             onChange={(e) => setEngagementMetric(e.target.value)}
             disabled={loading}
             className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {ENGAGEMENT_METRIC_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {ENGAGEMENT_METRIC_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 350 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 350 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <BarChart data={data} layout="vertical" margin={{ top: 5, right: 30, left: 40, bottom: 5 }}>
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
-              <XAxis type="number" stroke="#666" tick={{ fontSize: 12 }} tickFormatter={yAxisFormatter} />
+              <XAxis
+                type="number"
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={yAxisFormatter}
+              />
               <YAxis
                 type="category"
                 dataKey="name"
@@ -185,22 +237,35 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
                 interval={0}
                 tickFormatter={xAxisTickFormatter}
               />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} wrapperStyle={{ zIndex: 1000 }}/>
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+                wrapperStyle={{ zIndex: 1000 }}
+              />
               <Legend wrapperStyle={{ fontSize: 14 }} />
-              <Bar dataKey="value" name={`Média de ${ENGAGEMENT_METRIC_OPTIONS.find(m=>m.value === engagementMetric)?.label || 'Engajamento'}`} fill="#8884d8" />
+              <Bar
+                dataKey="value"
+                name={`Média de ${ENGAGEMENT_METRIC_OPTIONS.find((m) => m.value === engagementMetric)?.label || "Engajamento"}`}
+                fill="#8884d8"
+              />
             </BarChart>
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para os filtros selecionados.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">
+              Nenhum dado disponível para os filtros selecionados.
+            </p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserAverageEngagementChart);
-

--- a/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import type { TooltipProps } from 'recharts';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import type { TooltipProps } from "recharts";
 
 // Remove custom Payload type, use recharts' Payload type directly in formatter
 
@@ -30,39 +38,52 @@ const ENGAGEMENT_METRIC_OPTIONS = [
   { value: "stats.likes", label: "Curtidas" },
 ];
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#A230ED', '#D930ED', '#ED308C', '#F28E2B', '#E15759', '#76B7B2', '#59A14F', '#EDC948'];
+const COLORS = [
+  "#0088FE",
+  "#00C49F",
+  "#FFBB28",
+  "#FF8042",
+  "#A230ED",
+  "#D930ED",
+  "#ED308C",
+  "#F28E2B",
+  "#E15759",
+  "#76B7B2",
+  "#59A14F",
+  "#EDC948",
+];
 const DEFAULT_MAX_SLICES = 7;
 
 interface UserEngagementDistributionChartProps {
   userId: string | null;
   chartTitle?: string;
-  initialTimePeriod?: string; // Recebido de UserDetailView
 }
 
-const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartProps> = ({
-  userId,
-  chartTitle = "Distribuição de Engajamento por Formato",
-  initialTimePeriod // Usar para o estado inicial do seletor de período
-}) => {
-  const [data, setData] = useState<UserEngagementDistributionResponse['chartData']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+const UserEngagementDistributionChart: React.FC<
+  UserEngagementDistributionChartProps
+> = ({ userId, chartTitle = "Distribuição de Engajamento por Formato" }) => {
+  const [data, setData] = useState<
+    UserEngagementDistributionResponse["chartData"]
+  >([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Estado 'timePeriod' é inicializado com initialTimePeriod ou um default
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
-    initialTimePeriod ?? TIME_PERIOD_OPTIONS[2]?.value ?? ""
+    globalTimePeriod ?? TIME_PERIOD_OPTIONS[2]?.value ?? "",
   );
-  const [engagementMetric, setEngagementMetric] = useState<string>(ENGAGEMENT_METRIC_OPTIONS[0]?.value ?? "");
+  const [engagementMetric, setEngagementMetric] = useState<string>(
+    ENGAGEMENT_METRIC_OPTIONS[0]?.value ?? "",
+  );
   const maxSlices = DEFAULT_MAX_SLICES;
 
-  // Efeito para atualizar timePeriod se initialTimePeriod (prop) mudar
+  // Sincronizar com o período global selecionado
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
-
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -77,13 +98,17 @@ const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartP
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserEngagementDistributionResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
+      setError(
+        err instanceof Error ? err.message : "Ocorreu um erro desconhecido.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -100,13 +125,29 @@ const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartP
     }
   }, [userId, fetchData]);
 
-  const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name }: any) => {
-    if ((percent * 100) < 5) return null;
+  const renderCustomizedLabel = ({
+    cx,
+    cy,
+    midAngle,
+    innerRadius,
+    outerRadius,
+    percent,
+    name,
+  }: any) => {
+    if (percent * 100 < 5) return null;
     const radius = innerRadius + (outerRadius - innerRadius) * 0.6;
-    const x = cx + radius * Math.cos(-midAngle * Math.PI / 180);
-    const y = cy + radius * Math.sin(-midAngle * Math.PI / 180);
+    const x = cx + radius * Math.cos((-midAngle * Math.PI) / 180);
+    const y = cy + radius * Math.sin((-midAngle * Math.PI) / 180);
     return (
-      <text x={x} y={y} fill="white" textAnchor={x > cx ? 'start' : 'end'} dominantBaseline="central" fontSize={10} fontWeight="bold">
+      <text
+        x={x}
+        y={y}
+        fill="white"
+        textAnchor={x > cx ? "start" : "end"}
+        dominantBaseline="central"
+        fontSize={10}
+        fontWeight="bold"
+      >
         {(percent * 100).toFixed(0)}%
       </text>
     );
@@ -116,10 +157,10 @@ const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartP
   const tooltipFormatter = (
     value: number,
     name: string,
-    item?: any
+    item?: any,
   ): [string, string] => {
     const percentage =
-      item && item.payload && typeof item.payload.percentage === 'number'
+      item && item.payload && typeof item.payload.percentage === "number"
         ? item.payload.percentage
         : 0;
     return [`${value.toLocaleString()} (${percentage.toFixed(1)}%)`, name];
@@ -127,42 +168,66 @@ const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartP
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
         <div>
-          <label htmlFor={`timePeriodUserEngDistro-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <label
+            htmlFor={`timePeriodUserEngDistro-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Período:
+          </label>
           <select
-            id={`timePeriodUserEngDistro-${userId || 'default'}`}
+            id={`timePeriodUserEngDistro-${userId || "default"}`}
             value={timePeriod}
             onChange={(e) => setTimePeriod(e.target.value)}
             disabled={loading}
             className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor={`metricUserEngDistro-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Métrica de Engajamento:</label>
+          <label
+            htmlFor={`metricUserEngDistro-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Métrica de Engajamento:
+          </label>
           <select
-            id={`metricUserEngDistro-${userId || 'default'}`}
+            id={`metricUserEngDistro-${userId || "default"}`}
             value={engagementMetric}
             onChange={(e) => setEngagementMetric(e.target.value)}
             disabled={loading}
             className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {ENGAGEMENT_METRIC_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {ENGAGEMENT_METRIC_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 300 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 300 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
             <PieChart>
@@ -178,24 +243,37 @@ const UserEngagementDistributionChart: React.FC<UserEngagementDistributionChartP
                 nameKey="name"
               >
                 {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                  />
                 ))}
               </Pie>
               <Tooltip formatter={tooltipFormatter} />
-              <Legend wrapperStyle={{ fontSize: 12 }} layout="vertical" align="right" verticalAlign="middle" />
+              <Legend
+                wrapperStyle={{ fontSize: 12 }}
+                layout="vertical"
+                align="right"
+                verticalAlign="middle"
+              />
             </PieChart>
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para os filtros selecionados.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">
+              Nenhum dado disponível para os filtros selecionados.
+            </p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserEngagementDistributionChart);
-

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -1,9 +1,18 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import type { TooltipProps } from 'recharts';
-import { formatNullableNumberTooltip } from '@/utils/chartFormatters';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import type { TooltipProps } from "recharts";
+import { formatNullableNumberTooltip } from "@/utils/chartFormatters";
 
 interface ApiChangePoint {
   date: string;
@@ -16,36 +25,37 @@ interface UserFollowerChangeResponse {
 }
 
 const TIME_PERIOD_OPTIONS = [
-  { value: 'last_7_days', label: 'Últimos 7 dias' },
-  { value: 'last_30_days', label: 'Últimos 30 dias' },
-  { value: 'last_90_days', label: 'Últimos 90 dias' },
-  { value: 'last_6_months', label: 'Últimos 6 meses' },
-  { value: 'last_12_months', label: 'Últimos 12 meses' },
-  { value: 'all_time', label: 'Todo o período' },
+  { value: "last_7_days", label: "Últimos 7 dias" },
+  { value: "last_30_days", label: "Últimos 30 dias" },
+  { value: "last_90_days", label: "Últimos 90 dias" },
+  { value: "last_6_months", label: "Últimos 6 meses" },
+  { value: "last_12_months", label: "Últimos 12 meses" },
+  { value: "all_time", label: "Todo o período" },
 ];
 
 interface UserFollowerChangeChartProps {
   userId: string | null;
   chartTitle?: string;
-  initialTimePeriod?: string;
 }
 
 const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
   userId,
-  chartTitle = 'Variação Diária de Seguidores',
-  initialTimePeriod,
+  chartTitle = "Variação Diária de Seguidores",
 }) => {
-  const [data, setData] = useState<UserFollowerChangeResponse['chartData']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [data, setData] = useState<UserFollowerChangeResponse["chartData"]>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
-    initialTimePeriod || TIME_PERIOD_OPTIONS[1]?.value || 'last_30_days'
+    globalTimePeriod || TIME_PERIOD_OPTIONS[1]?.value || "last_30_days",
   );
 
   useEffect(() => {
-    if (initialTimePeriod) setTimePeriod(initialTimePeriod);
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -60,13 +70,19 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserFollowerChangeResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Ocorreu um erro desconhecido ao buscar dados.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -89,15 +105,22 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
 
   const tooltipFormatter: TooltipProps<number, string>["formatter"] = (
     value,
-    name
+    name,
   ) => formatNullableNumberTooltip(value as number | null, name);
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
       {userId && (
         <div className="mb-4">
-          <label htmlFor={`timePeriodUserFollowerChange-${userId}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <label
+            htmlFor={`timePeriodUserFollowerChange-${userId}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Período:
+          </label>
           <select
             id={`timePeriodUserFollowerChange-${userId}`}
             value={timePeriod}
@@ -105,32 +128,53 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {TIME_PERIOD_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            {TIME_PERIOD_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
             ))}
           </select>
         </div>
       )}
-      <div style={{ width: '100%', height: 300 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 300 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <BarChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+            <BarChart
+              data={data}
+              margin={{ top: 5, right: 20, left: -20, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
               <YAxis stroke="#666" tick={{ fontSize: 12 }} />
-              <Tooltip<number, string> formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <Tooltip<number, string>
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+                itemStyle={{ color: "#8884d8" }}
+              />
               <Bar dataKey="change" name="Variação" fill="#8884d8" />
             </BarChart>
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Sem dados no período selecionado.</p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 interface ApiChartDataPoint {
   date: string;
@@ -32,44 +40,40 @@ const GRANULARITY_OPTIONS = [
 interface UserFollowerTrendChartProps {
   userId: string | null;
   chartTitle?: string;
-  initialTimePeriod?: string; // Prop para o período inicial
   initialGranularity?: string;
 }
 
 const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
   userId,
   chartTitle = "Evolução de Seguidores do Criador",
-  initialTimePeriod, // Usar esta prop
-  initialGranularity = GRANULARITY_OPTIONS[0]?.value || "daily"
+  initialGranularity = GRANULARITY_OPTIONS[0]?.value || "daily",
 }) => {
-  const [data, setData] = useState<UserFollowerTrendResponse['chartData']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [data, setData] = useState<UserFollowerTrendResponse["chartData"]>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Estado 'timePeriod' é inicializado com initialTimePeriod ou um default
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
-    initialTimePeriod ||
-    (TIME_PERIOD_OPTIONS[1] && TIME_PERIOD_OPTIONS[1].value) ||
-    (TIME_PERIOD_OPTIONS[0] && TIME_PERIOD_OPTIONS[0].value) ||
-    "last_7_days"
+    globalTimePeriod ||
+      (TIME_PERIOD_OPTIONS[1] && TIME_PERIOD_OPTIONS[1].value) ||
+      (TIME_PERIOD_OPTIONS[0] && TIME_PERIOD_OPTIONS[0].value) ||
+      "last_7_days",
   );
   const [granularity, setGranularity] = useState<string>(initialGranularity);
 
-  // Efeito para atualizar timePeriod se initialTimePeriod (prop) mudar
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   // Efeito para atualizar granularity se initialGranularity (prop) mudar (menos comum, mas para consistência)
-   useEffect(() => {
+  useEffect(() => {
     if (initialGranularity) {
       setGranularity(initialGranularity);
     }
   }, [initialGranularity]);
-
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -85,13 +89,19 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserFollowerTrendResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Ocorreu um erro desconhecido ao buscar dados.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -123,15 +133,19 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
   };
 
   const tooltipFormatter = (value: number, name: string) => {
-      return [value !== null ? value.toLocaleString() : 'N/A', name];
+    return [value !== null ? value.toLocaleString() : "N/A", name];
   };
 
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+          {chartTitle}
+        </h2>
         <div className="flex justify-center items-center h-[300px]">
-          <p className="text-gray-500">Selecione um criador para ver a evolução de seguidores.</p>
+          <p className="text-gray-500">
+            Selecione um criador para ver a evolução de seguidores.
+          </p>
         </div>
       </div>
     );
@@ -139,49 +153,84 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
 
       <div className="flex flex-col sm:flex-row gap-4 mb-6">
         <div>
-          <label htmlFor={`timePeriodUserFollowers-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <label
+            htmlFor={`timePeriodUserFollowers-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Período:
+          </label>
           <select
-            id={`timePeriodUserFollowers-${userId || 'default'}`}
+            id={`timePeriodUserFollowers-${userId || "default"}`}
             value={timePeriod}
             onChange={handleTimePeriodChange}
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor={`granularityUserFollowers-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Granularidade:</label>
+          <label
+            htmlFor={`granularityUserFollowers-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Granularidade:
+          </label>
           <select
-            id={`granularityUserFollowers-${userId || 'default'}`}
+            id={`granularityUserFollowers-${userId || "default"}`}
             value={granularity}
             onChange={handleGranularityChange}
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {GRANULARITY_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {GRANULARITY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 300 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 300 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <LineChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+            <LineChart
+              data={data}
+              margin={{ top: 5, right: 20, left: -20, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
-              <YAxis stroke="#666" tick={{ fontSize: 12 }} tickFormatter={yAxisFormatter} />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#8884d8' }} />
+              <YAxis
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={yAxisFormatter}
+              />
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+                itemStyle={{ color: "#8884d8" }}
+              />
               <Legend wrapperStyle={{ fontSize: 14 }} />
               <Line
                 type="monotone"
@@ -197,15 +246,18 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Sem dados no período selecionado.</p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserFollowerTrendChart);
-

--- a/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 interface MonthlyEngagementDataPoint {
   month: string;
@@ -27,29 +35,30 @@ const TIME_PERIOD_OPTIONS = [
 
 interface UserMonthlyEngagementStackedChartProps {
   userId: string | null;
-  initialTimePeriod?: string;
   chartTitle?: string;
 }
 
-const UserMonthlyEngagementStackedChart: React.FC<UserMonthlyEngagementStackedChartProps> = ({
-  userId,
-  initialTimePeriod,
-  chartTitle = "Engajamento Mensal Detalhado do Criador"
-}) => {
-  const [data, setData] = useState<MonthlyEngagementResponse['chartData']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+const UserMonthlyEngagementStackedChart: React.FC<
+  UserMonthlyEngagementStackedChartProps
+> = ({ userId, chartTitle = "Engajamento Mensal Detalhado do Criador" }) => {
+  const [data, setData] = useState<MonthlyEngagementResponse["chartData"]>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
-    initialTimePeriod ?? (TIME_PERIOD_OPTIONS[1] ? TIME_PERIOD_OPTIONS[1].value : TIME_PERIOD_OPTIONS[0]?.value ?? "last_6_months")
-  ); // Default last_6_months
+    globalTimePeriod ??
+      (TIME_PERIOD_OPTIONS[1]
+        ? TIME_PERIOD_OPTIONS[1].value
+        : (TIME_PERIOD_OPTIONS[0]?.value ?? "last_6_months")),
+  );
 
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -65,13 +74,17 @@ const UserMonthlyEngagementStackedChart: React.FC<UserMonthlyEngagementStackedCh
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: MonthlyEngagementResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
+      setError(
+        err instanceof Error ? err.message : "Ocorreu um erro desconhecido.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -98,15 +111,20 @@ const UserMonthlyEngagementStackedChart: React.FC<UserMonthlyEngagementStackedCh
     return [value.toLocaleString(), name];
   };
 
-  const hasSavedData = data.some(d => d.saved !== undefined && d.saved !== null && d.saved > 0);
-
+  const hasSavedData = data.some(
+    (d) => d.saved !== undefined && d.saved !== null && d.saved > 0,
+  );
 
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-        <h3 className="text-md font-semibold text-gray-700 mb-3">{chartTitle}</h3>
+        <h3 className="text-md font-semibold text-gray-700 mb-3">
+          {chartTitle}
+        </h3>
         <div className="flex justify-center items-center h-[350px]">
-          <p className="text-gray-500">Selecione um criador para ver os dados.</p>
+          <p className="text-gray-500">
+            Selecione um criador para ver os dados.
+          </p>
         </div>
       </div>
     );
@@ -117,49 +135,102 @@ const UserMonthlyEngagementStackedChart: React.FC<UserMonthlyEngagementStackedCh
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-md font-semibold text-gray-700">{chartTitle}</h3>
         <div>
-          <label htmlFor={`timePeriodUserStackedEng-${userId || 'default'}`} className="sr-only">Período</label>
+          <label
+            htmlFor={`timePeriodUserStackedEng-${userId || "default"}`}
+            className="sr-only"
+          >
+            Período
+          </label>
           <select
-            id={`timePeriodUserStackedEng-${userId || 'default'}`}
+            id={`timePeriodUserStackedEng-${userId || "default"}`}
             value={timePeriod}
             onChange={(e) => setTimePeriod(e.target.value)}
             disabled={loading}
             className="p-1.5 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-xs"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 350 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 350 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <BarChart data={data} margin={{ top: 5, right: 5, left: -25, bottom: 5 }}>
+            <BarChart
+              data={data}
+              margin={{ top: 5, right: 5, left: -25, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="month" stroke="#666" tick={{ fontSize: 12 }} />
-              <YAxis stroke="#666" tick={{ fontSize: 12 }} tickFormatter={yAxisFormatter} />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} wrapperStyle={{ zIndex: 1000 }} />
+              <YAxis
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={yAxisFormatter}
+              />
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+                wrapperStyle={{ zIndex: 1000 }}
+              />
               <Legend wrapperStyle={{ fontSize: 14 }} />
-              <Bar dataKey="likes" stackId="engagement" fill="#8884d8" name="Curtidas" />
-              <Bar dataKey="comments" stackId="engagement" fill="#82ca9d" name="Comentários" />
-              <Bar dataKey="shares" stackId="engagement" fill="#ffc658" name="Compart." />
-              {hasSavedData && <Bar dataKey="saved" stackId="engagement" fill="#ff8042" name="Salvos" />}
+              <Bar
+                dataKey="likes"
+                stackId="engagement"
+                fill="#8884d8"
+                name="Curtidas"
+              />
+              <Bar
+                dataKey="comments"
+                stackId="engagement"
+                fill="#82ca9d"
+                name="Comentários"
+              />
+              <Bar
+                dataKey="shares"
+                stackId="engagement"
+                fill="#ffc658"
+                name="Compart."
+              />
+              {hasSavedData && (
+                <Bar
+                  dataKey="saved"
+                  stackId="engagement"
+                  fill="#ff8042"
+                  name="Salvos"
+                />
+              )}
             </BarChart>
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados de engajamento no período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">
+              Sem dados de engajamento no período selecionado.
+            </p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserMonthlyEngagementStackedChart);
-

--- a/src/app/admin/creator-dashboard/components/UserMovingAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMovingAverageEngagementChart.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 interface ApiMovingAverageDataPoint {
   date: string; // YYYY-MM-DD
@@ -17,25 +25,32 @@ interface UserMovingAverageResponse {
 
 // Helper para converter timePeriod string para número de dias
 // Este helper pode ser compartilhado se usado em múltiplos lugares.
-const timePeriodToDataWindowDays = (timePeriod: string | undefined, defaultValue: number = 30): number => {
+const timePeriodToDataWindowDays = (
+  timePeriod: string | undefined,
+  defaultValue: number = 30,
+): number => {
   if (!timePeriod) return defaultValue;
   switch (timePeriod) {
-    case "last_7_days": return 7;
-    case "last_30_days": return 30;
-    case "last_60_days": return 60;
-    case "last_90_days": return 90;
+    case "last_7_days":
+      return 7;
+    case "last_30_days":
+      return 30;
+    case "last_60_days":
+      return 60;
+    case "last_90_days":
+      return 90;
     // Adicionar mais casos se o GlobalTimePeriodFilter tiver outras opções que se aplicam aqui
     default:
       if (timePeriod.startsWith("last_") && timePeriod.endsWith("_days")) {
-        const days = parseInt(timePeriod.split("_")[1] ?? '0');
+        const days = parseInt(timePeriod.split("_")[1] ?? "0");
         return !isNaN(days) && days > 0 ? days : defaultValue;
       }
       return defaultValue;
   }
 };
 
-
-const DATA_WINDOW_OPTIONS = [ // Opções para o seletor interno, se mantido
+const DATA_WINDOW_OPTIONS = [
+  // Opções para o seletor interno, se mantido
   { value: "30", label: "Dados dos Últimos 30 dias" },
   { value: "60", label: "Dados dos Últimos 60 dias" },
   { value: "90", label: "Dados dos Últimos 90 dias" },
@@ -50,33 +65,37 @@ const MOVING_AVERAGE_WINDOW_OPTIONS = [
 interface UserMovingAverageEngagementChartProps {
   userId: string | null;
   chartTitle?: string;
-  initialTimePeriod?: string; // Ex: "last_30_days", vindo da UserDetailView
   initialAvgWindow?: string;
 }
 
-const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChartProps> = ({
+const UserMovingAverageEngagementChart: React.FC<
+  UserMovingAverageEngagementChartProps
+> = ({
   userId,
   chartTitle = "Média Móvel de Engajamento Diário",
-  initialTimePeriod, // Usado para definir o dataWindow inicial
-  initialAvgWindow = MOVING_AVERAGE_WINDOW_OPTIONS[0]?.value ?? "7"
+  initialAvgWindow = MOVING_AVERAGE_WINDOW_OPTIONS[0]?.value ?? "7",
 }) => {
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
 
-  // dataWindow (número de dias) é agora derivado de initialTimePeriod ou default
   const [dataWindow, setDataWindow] = useState<string>(
-    initialTimePeriod ? timePeriodToDataWindowDays(initialTimePeriod).toString() : (DATA_WINDOW_OPTIONS[0]?.value ?? "30")
+    timePeriodToDataWindowDays(globalTimePeriod).toString() ||
+      (DATA_WINDOW_OPTIONS[0]?.value ?? "30"),
   );
   const [avgWindow, setAvgWindow] = useState<string>(initialAvgWindow);
 
-  const [data, setData] = useState<UserMovingAverageResponse['series']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [data, setData] = useState<UserMovingAverageResponse["series"]>([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Atualizar dataWindow se initialTimePeriod mudar (ex: filtro global na UserDetailView)
   useEffect(() => {
-    setDataWindow(initialTimePeriod ? timePeriodToDataWindowDays(initialTimePeriod).toString() : (DATA_WINDOW_OPTIONS[0]?.value ?? "30"));
-  }, [initialTimePeriod]);
-
+    setDataWindow(
+      timePeriodToDataWindowDays(globalTimePeriod).toString() ||
+        (DATA_WINDOW_OPTIONS[0]?.value ?? "30"),
+    );
+  }, [globalTimePeriod]);
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -92,7 +111,9 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
     const currentAvgWindowDays = parseInt(avgWindow, 10);
 
     if (currentAvgWindowDays > currentDataWindowDays) {
-      setError("A janela da média móvel não pode ser maior que a janela de dados.");
+      setError(
+        "A janela da média móvel não pode ser maior que a janela de dados.",
+      );
       setLoading(false);
       setData([]);
       setInsightSummary(undefined);
@@ -104,13 +125,19 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserMovingAverageResponse = await response.json();
       setData(result.series);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Ocorreu um erro desconhecido ao buscar dados.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -134,15 +161,19 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
   };
 
   const tooltipFormatter = (value: number, name: string) => {
-      return [value !== null ? value.toLocaleString() : 'N/A', name];
+    return [value !== null ? value.toLocaleString() : "N/A", name];
   };
 
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+          {chartTitle}
+        </h2>
         <div className="flex justify-center items-center h-[300px]">
-          <p className="text-gray-500">Selecione um criador para ver a média móvel de engajamento.</p>
+          <p className="text-gray-500">
+            Selecione um criador para ver a média móvel de engajamento.
+          </p>
         </div>
       </div>
     );
@@ -150,11 +181,18 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
 
       <div className="flex flex-col sm:flex-row gap-4 mb-6">
         <div>
-          <label htmlFor={`dataWindowUserMovingAvg-${userId}`} className="block text-sm font-medium text-gray-600 mb-1">Janela de Dados:</label>
+          <label
+            htmlFor={`dataWindowUserMovingAvg-${userId}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Janela de Dados:
+          </label>
           <select
             id={`dataWindowUserMovingAvg-${userId}`}
             value={dataWindow} // Controlado pelo estado 'dataWindow'
@@ -162,13 +200,20 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {DATA_WINDOW_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {DATA_WINDOW_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor={`avgWindowUserMovingAvg-${userId}`} className="block text-sm font-medium text-gray-600 mb-1">Janela da Média Móvel:</label>
+          <label
+            htmlFor={`avgWindowUserMovingAvg-${userId}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Janela da Média Móvel:
+          </label>
           <select
             id={`avgWindowUserMovingAvg-${userId}`}
             value={avgWindow}
@@ -176,23 +221,44 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {MOVING_AVERAGE_WINDOW_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {MOVING_AVERAGE_WINDOW_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 300 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 300 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <LineChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+            <LineChart
+              data={data}
+              margin={{ top: 5, right: 20, left: -20, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
               <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
-              <YAxis stroke="#666" tick={{ fontSize: 12 }} tickFormatter={yAxisFormatter} />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} itemStyle={{ color: '#82ca9d' }} />
+              <YAxis
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={yAxisFormatter}
+              />
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+                itemStyle={{ color: "#82ca9d" }}
+              />
               <Legend wrapperStyle={{ fontSize: 14 }} />
               <Line
                 type="monotone"
@@ -208,15 +274,20 @@ const UserMovingAverageEngagementChart: React.FC<UserMovingAverageEngagementChar
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Nenhum dado disponível para os filtros selecionados.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">
+              Nenhum dado disponível para os filtros selecionados.
+            </p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserMovingAverageEngagementChart);
-

--- a/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react';
-import HighlightCard from './HighlightCard';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import { TrendingUp, TrendingDown, Sparkles } from "lucide-react";
+import HighlightCard from "./HighlightCard";
 
 interface PerformanceHighlightItem {
   name: string;
@@ -27,35 +28,49 @@ const TIME_PERIOD_OPTIONS = [
 
 interface UserPerformanceHighlightsProps {
   userId: string | null;
-  initialTimePeriod?: string;
   sectionTitle?: string;
 }
 
 // Ícone de Informação (mantido como estava)
-const InfoIcon: React.FC<{className?: string}> = ({className}) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={className || "h-4 w-4"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
+const InfoIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className || "h-4 w-4"}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
 );
-
 
 const UserPerformanceHighlights: React.FC<UserPerformanceHighlightsProps> = ({
   userId,
-  initialTimePeriod,
-  sectionTitle = "Destaques de Performance do Criador"
+  sectionTitle = "Destaques de Performance do Criador",
 }) => {
-  const [summary, setSummary] = useState<PerformanceSummaryResponse | null>(null);
+  const [summary, setSummary] = useState<PerformanceSummaryResponse | null>(
+    null,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  const defaultTimePeriod = TIME_PERIOD_OPTIONS[1]?.value || TIME_PERIOD_OPTIONS[0]?.value || "last_30_days";
-  const [timePeriod, setTimePeriod] = useState<string>(initialTimePeriod || defaultTimePeriod); // Default last_90_days
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
+  const defaultTimePeriod =
+    TIME_PERIOD_OPTIONS[1]?.value ||
+    TIME_PERIOD_OPTIONS[0]?.value ||
+    "last_30_days";
+  const [timePeriod, setTimePeriod] = useState<string>(
+    globalTimePeriod || defaultTimePeriod,
+  );
 
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   const fetchData = useCallback(async () => {
     if (!userId) {
@@ -70,12 +85,16 @@ const UserPerformanceHighlights: React.FC<UserPerformanceHighlightsProps> = ({
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: PerformanceSummaryResponse = await response.json();
       setSummary(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
+      setError(
+        err instanceof Error ? err.message : "Ocorreu um erro desconhecido.",
+      );
       setSummary(null);
     } finally {
       setLoading(false);
@@ -92,31 +111,48 @@ const UserPerformanceHighlights: React.FC<UserPerformanceHighlightsProps> = ({
   }, [userId, fetchData]);
 
   if (!userId && !loading) {
-      return null;
+    return null;
   }
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
       <div className="flex flex-col sm:flex-row justify-between sm:items-center mb-4">
-        <h3 className="text-md font-semibold text-gray-700 mb-2 sm:mb-0">{sectionTitle}</h3>
+        <h3 className="text-md font-semibold text-gray-700 mb-2 sm:mb-0">
+          {sectionTitle}
+        </h3>
         <div>
-          <label htmlFor={`timePeriodUserHighlights-${userId || 'default'}`} className="sr-only">Período</label>
+          <label
+            htmlFor={`timePeriodUserHighlights-${userId || "default"}`}
+            className="sr-only"
+          >
+            Período
+          </label>
           <select
-            id={`timePeriodUserHighlights-${userId || 'default'}`}
+            id={`timePeriodUserHighlights-${userId || "default"}`}
             value={timePeriod}
             onChange={(e) => setTimePeriod(e.target.value)}
             disabled={loading}
             className="p-1.5 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-xs"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      {loading && <div className="text-center py-5"><p className="text-gray-500">Carregando destaques...</p></div>}
-      {error && <div className="text-center py-5"><p className="text-red-500">Erro: {error}</p></div>}
+      {loading && (
+        <div className="text-center py-5">
+          <p className="text-gray-500">Carregando destaques...</p>
+        </div>
+      )}
+      {error && (
+        <div className="text-center py-5">
+          <p className="text-red-500">Erro: {error}</p>
+        </div>
+      )}
 
       {!loading && !error && summary && (
         <>
@@ -124,36 +160,41 @@ const UserPerformanceHighlights: React.FC<UserPerformanceHighlightsProps> = ({
             <HighlightCard
               title="Melhor Formato"
               highlight={summary.topPerformingFormat}
-              icon={<TrendingUp size={18} className="mr-2 text-green-500"/>}
+              icon={<TrendingUp size={18} className="mr-2 text-green-500" />}
               bgColorClass="bg-green-50"
               textColorClass="text-green-600"
             />
             <HighlightCard
               title="Contexto Principal"
               highlight={summary.topPerformingContext}
-              icon={<Sparkles size={18} className="mr-2 text-blue-500"/>}
+              icon={<Sparkles size={18} className="mr-2 text-blue-500" />}
               bgColorClass="bg-blue-50"
               textColorClass="text-blue-600"
             />
             <HighlightCard
               title="Menor Performance (Formato)"
               highlight={summary.lowPerformingFormat}
-              icon={<TrendingDown size={18} className="mr-2 text-red-500"/>}
+              icon={<TrendingDown size={18} className="mr-2 text-red-500" />}
               bgColorClass="bg-red-50"
               textColorClass="text-red-600"
             />
           </div>
           {summary.insightSummary && (
-            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200">{summary.insightSummary}</p>
+            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200">
+              {summary.insightSummary}
+            </p>
           )}
         </>
       )}
-       {!loading && !error && !summary && (
-         <div className="text-center py-5"><p className="text-gray-500">Nenhum destaque de performance encontrado.</p></div>
+      {!loading && !error && !summary && (
+        <div className="text-center py-5">
+          <p className="text-gray-500">
+            Nenhum destaque de performance encontrado.
+          </p>
+        </div>
       )}
     </div>
   );
 };
 
 export default React.memo(UserPerformanceHighlights);
-

--- a/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 
 interface ApiReachEngagementDataPoint {
   date: string;
@@ -30,38 +38,39 @@ const GRANULARITY_OPTIONS = [
 interface UserReachEngagementTrendChartProps {
   userId: string | null;
   chartTitle?: string;
-  initialTimePeriod?: string;
   initialGranularity?: string;
 }
 
-const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps> = ({
+const UserReachEngagementTrendChart: React.FC<
+  UserReachEngagementTrendChartProps
+> = ({
   userId,
   chartTitle = "Evolução de Alcance e Contas Engajadas do Criador",
-  initialTimePeriod,
-  initialGranularity
+  initialGranularity,
 }) => {
-  const [data, setData] = useState<UserReachEngagementTrendResponse['chartData']>([]);
-  const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
+  const [data, setData] = useState<
+    UserReachEngagementTrendResponse["chartData"]
+  >([]);
+  const [insightSummary, setInsightSummary] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
-    initialTimePeriod ||
-    TIME_PERIOD_OPTIONS[1]?.value ||
-    TIME_PERIOD_OPTIONS[0]?.value ||
-    "last_30_days"
+    globalTimePeriod ||
+      TIME_PERIOD_OPTIONS[1]?.value ||
+      TIME_PERIOD_OPTIONS[0]?.value ||
+      "last_30_days",
   );
   const [granularity, setGranularity] = useState<string>(
-    initialGranularity ||
-    GRANULARITY_OPTIONS[0]?.value ||
-    "daily"
+    initialGranularity || GRANULARITY_OPTIONS[0]?.value || "daily",
   );
 
   useEffect(() => {
-    if (initialTimePeriod) {
-      setTimePeriod(initialTimePeriod);
-    }
-  }, [initialTimePeriod]);
+    setTimePeriod(globalTimePeriod);
+  }, [globalTimePeriod]);
 
   useEffect(() => {
     if (initialGranularity) {
@@ -83,13 +92,19 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        throw new Error(
+          `Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`,
+        );
       }
       const result: UserReachEngagementTrendResponse = await response.json();
       setData(result.chartData);
       setInsightSummary(result.insightSummary);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Ocorreu um erro desconhecido ao buscar dados.",
+      );
       setData([]);
       setInsightSummary(undefined);
     } finally {
@@ -121,12 +136,12 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
   };
 
   const tooltipFormatter = (value: number, name: string) => {
-      return [value !== null ? value.toLocaleString() : 'N/A', name];
+    return [value !== null ? value.toLocaleString() : "N/A", name];
   };
 
   const xAxisTickFormatter = (tick: string) => {
-    if (granularity === 'weekly' && tick.includes('-')) {
-        return `S${tick.split('-')[1]}`;
+    if (granularity === "weekly" && tick.includes("-")) {
+      return `S${tick.split("-")[1]}`;
     }
     // Para diário, poderia formatar YYYY-MM-DD para DD/MM
     // const d = new Date(tick + "T00:00:00Z"); // Assume tick é YYYY-MM-DD
@@ -137,9 +152,13 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+        <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+          {chartTitle}
+        </h2>
         <div className="flex justify-center items-center h-[300px]">
-          <p className="text-gray-500">Selecione um criador para ver os dados de alcance e engajamento.</p>
+          <p className="text-gray-500">
+            Selecione um criador para ver os dados de alcance e engajamento.
+          </p>
         </div>
       </div>
     );
@@ -147,49 +166,89 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
 
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
-      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">{chartTitle}</h2>
+      <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
+        {chartTitle}
+      </h2>
 
       <div className="flex flex-col sm:flex-row gap-4 mb-6">
         <div>
-          <label htmlFor={`timePeriodUserReachEng-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Período:</label>
+          <label
+            htmlFor={`timePeriodUserReachEng-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Período:
+          </label>
           <select
-            id={`timePeriodUserReachEng-${userId || 'default'}`}
+            id={`timePeriodUserReachEng-${userId || "default"}`}
             value={timePeriod}
             onChange={handleTimePeriodChange}
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {TIME_PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor={`granularityUserReachEng-${userId || 'default'}`} className="block text-sm font-medium text-gray-600 mb-1">Granularidade:</label>
+          <label
+            htmlFor={`granularityUserReachEng-${userId || "default"}`}
+            className="block text-sm font-medium text-gray-600 mb-1"
+          >
+            Granularidade:
+          </label>
           <select
-            id={`granularityUserReachEng-${userId || 'default'}`}
+            id={`granularityUserReachEng-${userId || "default"}`}
             value={granularity}
             onChange={handleGranularityChange}
             disabled={loading}
             className="w-full sm:w-auto p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
           >
-            {GRANULARITY_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+            {GRANULARITY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
       </div>
 
-      <div style={{ width: '100%', height: 300 }}>
-        {loading && <div className="flex justify-center items-center h-full"><p className="text-gray-500">Carregando dados...</p></div>}
-        {error && <div className="flex justify-center items-center h-full"><p className="text-red-500">Erro: {error}</p></div>}
+      <div style={{ width: "100%", height: 300 }}>
+        {loading && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Carregando dados...</p>
+          </div>
+        )}
+        {error && (
+          <div className="flex justify-center items-center h-full">
+            <p className="text-red-500">Erro: {error}</p>
+          </div>
+        )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer>
-            <LineChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+            <LineChart
+              data={data}
+              margin={{ top: 5, right: 20, left: -20, bottom: 5 }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
-              <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} tickFormatter={xAxisTickFormatter} />
-              <YAxis stroke="#666" tick={{ fontSize: 12 }} tickFormatter={yAxisFormatter} yAxisId="left" />
-              <Tooltip formatter={tooltipFormatter} labelStyle={{ color: '#333' }} />
+              <XAxis
+                dataKey="date"
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={xAxisTickFormatter}
+              />
+              <YAxis
+                stroke="#666"
+                tick={{ fontSize: 12 }}
+                tickFormatter={yAxisFormatter}
+                yAxisId="left"
+              />
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelStyle={{ color: "#333" }}
+              />
               <Legend wrapperStyle={{ fontSize: 14 }} />
               <Line
                 yAxisId="left"
@@ -217,15 +276,18 @@ const UserReachEngagementTrendChart: React.FC<UserReachEngagementTrendChartProps
           </ResponsiveContainer>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="flex justify-center items-center h-full"><p className="text-gray-500">Sem dados no período selecionado.</p></div>
+          <div className="flex justify-center items-center h-full">
+            <p className="text-gray-500">Sem dados no período selecionado.</p>
+          </div>
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+          {insightSummary}
+        </p>
       )}
     </div>
   );
 };
 
 export default React.memo(UserReachEngagementTrendChart);
-

--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext.tsx
@@ -7,9 +7,13 @@ export interface GlobalTimePeriodContextValue {
   setTimePeriod: (tp: string) => void;
 }
 
-const GlobalTimePeriodContext = createContext<GlobalTimePeriodContextValue | undefined>(undefined);
+const GlobalTimePeriodContext = createContext<
+  GlobalTimePeriodContextValue | undefined
+>(undefined);
 
-export const GlobalTimePeriodProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+export const GlobalTimePeriodProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const [timePeriod, setTimePeriod] = useState<string>("last_90_days");
   return (
     <GlobalTimePeriodContext.Provider value={{ timePeriod, setTimePeriod }}>
@@ -21,7 +25,9 @@ export const GlobalTimePeriodProvider: React.FC<{children: React.ReactNode}> = (
 export const useGlobalTimePeriod = (): GlobalTimePeriodContextValue => {
   const context = useContext(GlobalTimePeriodContext);
   if (!context) {
-    throw new Error("useGlobalTimePeriod must be used within a GlobalTimePeriodProvider");
+    throw new Error(
+      "useGlobalTimePeriod must be used within a GlobalTimePeriodProvider",
+    );
   }
   return context;
 };

--- a/src/app/admin/creator-dashboard/components/views/AdvancedAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/AdvancedAnalysisSection.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import RadarEffectivenessWidget from "../widgets/RadarEffectivenessWidget";
+
+const AdvancedAnalysisSection: React.FC = () => (
+  <section id="advanced-analysis" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Análise Avançada <GlobalPeriodIndicator />
+    </h2>
+    <RadarEffectivenessWidget />
+  </section>
+);
+
+export default AdvancedAnalysisSection;

--- a/src/app/admin/creator-dashboard/components/views/CohortComparisonSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CohortComparisonSection.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import CohortComparisonChart from "../CohortComparisonChart";
+
+interface Props {
+  startDate: string;
+  endDate: string;
+}
+
+const CohortComparisonSection: React.FC<Props> = ({ startDate, endDate }) => (
+  <section id="cohort-comparison" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Comparação de Coortes <GlobalPeriodIndicator />
+    </h2>
+    <CohortComparisonChart
+      metric="engagement_rate_on_reach"
+      startDate={startDate}
+      endDate={endDate}
+      cohorts={[
+        { filterBy: "planStatus", value: "Pro", name: "Plano Pro" },
+        { filterBy: "planStatus", value: "Free", name: "Plano Free" },
+      ]}
+    />
+  </section>
+);
+
+export default CohortComparisonSection;

--- a/src/app/admin/creator-dashboard/components/views/CreatorHighlightsSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorHighlightsSection.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import CreatorsScatterPlot from "../CreatorsScatterPlot";
+
+const CreatorHighlightsSection: React.FC = () => (
+  <section id="creator-highlights-and-scatter-plot" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Destaques e Análise Comparativa de Criadores <GlobalPeriodIndicator />
+    </h2>
+    <p className="text-sm text-gray-500 mb-4 italic">
+      (Em breve: Tabelas de Criadores com melhor performance)
+    </p>
+    <CreatorsScatterPlot />
+  </section>
+);
+
+export default CreatorHighlightsSection;

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import CreatorRankingCard from "../../CreatorRankingCard";
+import TopCreatorsWidget from "../../TopCreatorsWidget";
+
+interface Props {
+  rankingDateRange: { startDate: string; endDate: string };
+  rankingDateLabel: string;
+}
+
+const CreatorRankingSection: React.FC<Props> = ({
+  rankingDateRange,
+  rankingDateLabel,
+}) => (
+  <section id="creator-rankings" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Rankings de Criadores <GlobalPeriodIndicator />
+    </h2>
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+      <CreatorRankingCard
+        title="Maior Engajamento"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        metricLabel="%"
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Mais Interações"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/top-interactions"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Mais Posts"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Mais Compartilhamentos"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <TopCreatorsWidget
+        title="Top Criadores"
+        metric="total_interactions"
+        days={30}
+        limit={5}
+      />
+    </div>
+  </section>
+);
+
+export default CreatorRankingSection;

--- a/src/app/admin/creator-dashboard/components/views/MarketPerformanceSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/MarketPerformanceSection.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import MarketPerformanceChart from "../MarketPerformanceChart";
+
+interface Props {
+  formatOptions: string[];
+  proposalOptions: string[];
+  marketFormat: string;
+  marketProposal: string;
+  setMarketFormat: (v: string) => void;
+  setMarketProposal: (v: string) => void;
+}
+
+const MarketPerformanceSection: React.FC<Props> = ({
+  formatOptions,
+  proposalOptions,
+  marketFormat,
+  marketProposal,
+  setMarketFormat,
+  setMarketProposal,
+}) => (
+  <section id="market-performance" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Desempenho do Mercado <GlobalPeriodIndicator />
+    </h2>
+    <div className="flex flex-col md:flex-row gap-4 mb-4">
+      <div>
+        <label
+          htmlFor="mp-format"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Formato
+        </label>
+        <select
+          id="mp-format"
+          value={marketFormat}
+          onChange={(e) => setMarketFormat(e.target.value)}
+          className="p-2 border border-gray-300 rounded-md text-sm"
+        >
+          {formatOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label
+          htmlFor="mp-proposal"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Proposta
+        </label>
+        <select
+          id="mp-proposal"
+          value={marketProposal}
+          onChange={(e) => setMarketProposal(e.target.value)}
+          className="p-2 border border-gray-300 rounded-md text-sm"
+        >
+          {proposalOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+    <MarketPerformanceChart format={marketFormat} proposal={marketProposal} />
+  </section>
+);
+
+export default MarketPerformanceSection;

--- a/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import PlatformPerformanceHighlights from "../PlatformPerformanceHighlights";
+import PlatformAverageEngagementChart from "../PlatformAverageEngagementChart";
+import PlatformPostDistributionChart from "../PlatformPostDistributionChart";
+import PlatformVideoPerformanceMetrics from "../PlatformVideoPerformanceMetrics";
+import PlatformMonthlyEngagementStackedChart from "../PlatformMonthlyEngagementStackedChart";
+import PlatformEngagementDistributionByFormatChart from "../PlatformEngagementDistributionByFormatChart";
+import ContentPerformanceByTypeChart from "../../ContentPerformanceByTypeChart";
+
+interface Props {
+  startDate: string;
+  endDate: string;
+}
+
+const PlatformContentAnalysisSection: React.FC<Props> = ({
+  startDate,
+  endDate,
+}) => (
+  <section id="platform-content-analysis" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Análise de Conteúdo da Plataforma <GlobalPeriodIndicator />
+    </h2>
+    <div className="mb-6 md:mb-8">
+      <PlatformPerformanceHighlights />
+    </div>
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 md:mb-8">
+      <PlatformAverageEngagementChart
+        initialGroupBy="format"
+        chartTitle="Engajamento Médio por Formato (Plataforma)"
+      />
+      <PlatformAverageEngagementChart
+        initialGroupBy="context"
+        chartTitle="Engajamento Médio por Contexto (Plataforma)"
+      />
+      <PlatformAverageEngagementChart
+        initialGroupBy="proposal"
+        chartTitle="Engajamento Médio por Proposta (Plataforma)"
+      />
+    </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 md:mb-8">
+      <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato (Plataforma)" />
+      <PlatformVideoPerformanceMetrics />
+    </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <PlatformMonthlyEngagementStackedChart />
+      <PlatformEngagementDistributionByFormatChart />
+    </div>
+    <div className="mt-6">
+      <ContentPerformanceByTypeChart dateRangeFilter={{ startDate, endDate }} />
+    </div>
+  </section>
+);
+
+export default PlatformContentAnalysisSection;

--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import PlatformFollowerTrendChart from "../PlatformFollowerTrendChart";
+import PlatformFollowerChangeChart from "../PlatformFollowerChangeChart";
+import PlatformReachEngagementTrendChart from "../PlatformReachEngagementTrendChart";
+import PlatformMovingAverageEngagementChart from "../PlatformMovingAverageEngagementChart";
+import TotalActiveCreatorsKpi from "../kpis/TotalActiveCreatorsKpi";
+import PlatformComparativeKpi from "../kpis/PlatformComparativeKpi";
+
+interface Props {
+  comparisonPeriod: string;
+}
+
+const PlatformOverviewSection: React.FC<Props> = ({ comparisonPeriod }) => (
+  <section id="platform-overview" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Visão Geral da Plataforma <GlobalPeriodIndicator />
+    </h2>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 mb-6 md:mb-8">
+      <TotalActiveCreatorsKpi />
+      <PlatformComparativeKpi
+        kpiName="platformFollowerGrowth"
+        title="Crescimento de Seguidores"
+        comparisonPeriod={comparisonPeriod}
+        tooltip="Crescimento total de seguidores na plataforma comparado ao período anterior selecionado."
+      />
+      <PlatformComparativeKpi
+        kpiName="platformTotalEngagement"
+        title="Engajamento Total"
+        comparisonPeriod={comparisonPeriod}
+        tooltip="Soma total de interações em todos os posts da plataforma comparado ao período anterior selecionado."
+      />
+    </div>
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
+      <PlatformFollowerTrendChart />
+      <PlatformFollowerChangeChart />
+    </div>
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
+      <PlatformReachEngagementTrendChart />
+      <PlatformMovingAverageEngagementChart />
+    </div>
+  </section>
+);
+
+export default PlatformOverviewSection;

--- a/src/app/admin/creator-dashboard/components/views/ProposalRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/ProposalRankingSection.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import ProposalRankingCard from "../../ProposalRankingCard";
+
+interface Props {
+  rankingDateRange: { startDate: string; endDate: string };
+  rankingDateLabel: string;
+}
+
+const ProposalRankingSection: React.FC<Props> = ({
+  rankingDateRange,
+  rankingDateLabel,
+}) => (
+  <section id="proposal-ranking" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Ranking por Proposta <GlobalPeriodIndicator />
+    </h2>
+    <ProposalRankingCard
+      title="Propostas com Mais Interações"
+      apiEndpoint="/api/admin/dashboard/rankings/proposals?metric=total_interactions"
+      dateRangeFilter={rankingDateRange}
+      dateRangeLabel={rankingDateLabel}
+      limit={5}
+    />
+  </section>
+);
+
+export default ProposalRankingSection;

--- a/src/app/admin/creator-dashboard/components/views/TopMoversSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/TopMoversSection.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import TopMoversWidget from "../../TopMoversWidget";
+
+const TopMoversSection: React.FC = () => (
+  <section id="top-movers" className="mb-10">
+    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+      Top Movers <GlobalPeriodIndicator />
+    </h2>
+    <TopMoversWidget />
+  </section>
+);
+
+export default TopMoversSection;

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -1,30 +1,27 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 // User-specific charts & metrics
-import UserFollowerTrendChart from '../UserFollowerTrendChart';
-import UserFollowerChangeChart from '../UserFollowerChangeChart';
-import UserReachEngagementTrendChart from '../UserReachEngagementTrendChart';
-import UserMovingAverageEngagementChart from '../UserMovingAverageEngagementChart';
-import UserAverageEngagementChart from '../UserAverageEngagementChart';
-import UserEngagementDistributionChart from '../UserEngagementDistributionChart';
-import UserVideoPerformanceMetrics from '../UserVideoPerformanceMetrics';
-import UserMonthlyEngagementStackedChart from '../UserMonthlyEngagementStackedChart';
-import UserMonthlyComparisonChart from '../UserMonthlyComparisonChart';
-import UserPerformanceHighlights from '../UserPerformanceHighlights';
+import UserFollowerTrendChart from "../UserFollowerTrendChart";
+import UserFollowerChangeChart from "../UserFollowerChangeChart";
+import UserReachEngagementTrendChart from "../UserReachEngagementTrendChart";
+import UserMovingAverageEngagementChart from "../UserMovingAverageEngagementChart";
+import UserAverageEngagementChart from "../UserAverageEngagementChart";
+import UserEngagementDistributionChart from "../UserEngagementDistributionChart";
+import UserVideoPerformanceMetrics from "../UserVideoPerformanceMetrics";
+import UserMonthlyEngagementStackedChart from "../UserMonthlyEngagementStackedChart";
+import UserMonthlyComparisonChart from "../UserMonthlyComparisonChart";
+import UserPerformanceHighlights from "../UserPerformanceHighlights";
 
 // User-specific components from Módulo 3 (Creator Detail)
-import UserRadarChartComparison from '../UserRadarChartComparison';
-import UserAlertsWidget from '../widgets/UserAlertsWidget';
-import UserComparativeKpi from '../kpis/UserComparativeKpi';
-
+import UserRadarChartComparison from "../UserRadarChartComparison";
+import UserAlertsWidget from "../widgets/UserAlertsWidget";
+import UserComparativeKpi from "../kpis/UserComparativeKpi";
 
 interface UserDetailViewProps {
   userId: string | null;
   userName?: string;
-  // Nova prop para o período inicial dos gráficos/componentes internos
-  initialChartsTimePeriod?: string;
 }
 
 const KPI_COMPARISON_PERIOD_OPTIONS = [
@@ -33,13 +30,13 @@ const KPI_COMPARISON_PERIOD_OPTIONS = [
   { value: "last_30d_vs_previous_30d", label: "30d vs. 30d Anteriores" },
 ];
 
-
 const UserDetailView: React.FC<UserDetailViewProps> = ({
-    userId,
-    userName,
-    initialChartsTimePeriod // Usar este para os componentes filhos
+  userId,
+  userName,
 }) => {
-  const [kpiComparisonPeriod, setKpiComparisonPeriod] = useState<string>(KPI_COMPARISON_PERIOD_OPTIONS[0]!.value);
+  const [kpiComparisonPeriod, setKpiComparisonPeriod] = useState<string>(
+    KPI_COMPARISON_PERIOD_OPTIONS[0]!.value,
+  );
 
   if (!userId) {
     return (
@@ -49,10 +46,10 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
     );
   }
 
-  const displayName = userName || `Criador ID: ${userId.substring(0,8)}...`;
+  const displayName = userName || `Criador ID: ${userId.substring(0, 8)}...`;
 
-  // Se initialChartsTimePeriod não for fornecido, os componentes filhos usarão seus próprios defaults.
-  // Se fornecido, será usado como o valor inicial para os seletores de período dos componentes filhos.
+  // Os gráficos internos leem o período global via contexto,
+  // portanto são atualizados automaticamente quando o filtro principal muda.
 
   return (
     <div className="p-1 md:p-2 mt-8 border-t-2 border-indigo-500 pt-6">
@@ -62,42 +59,68 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
         </h2>
         {/*
           Aqui poderia ir um seletor de período GERAL para TODOS os componentes dentro de UserDetailView,
-          similar ao GlobalTimePeriodFilter da página principal. Se implementado, ele controlaria
-          o `initialChartsTimePeriod` passado para os filhos, ou diretamente uma prop `timePeriod` para eles.
-          Por enquanto, cada componente filho (gráficos de tendência, etc.) tem seu próprio seletor
-          e usará `initialChartsTimePeriod` para seu estado inicial.
+          similar ao GlobalTimePeriodFilter da página principal. Atualmente cada gráfico tem seu próprio seletor,
+          mas eles usam o período global como valor inicial e respondem às mudanças desse filtro.
         */}
       </header>
 
       {/* Seção de KPIs Comparativos do Criador */}
       <section id={`user-kpis-${userId}`} className="mb-10">
         <div className="flex justify-between items-center mb-4">
-            <h3 className="text-xl font-semibold text-gray-700 pb-2">
+          <h3 className="text-xl font-semibold text-gray-700 pb-2">
             Desempenho Comparativo Chave
-            </h3>
-            <div>
-                <label htmlFor={`kpiComparisonPeriod-${userId}`} className="sr-only">Período de Comparação</label>
-                <select
-                    id={`kpiComparisonPeriod-${userId}`}
-                    value={kpiComparisonPeriod}
-                    onChange={(e) => setKpiComparisonPeriod(e.target.value)}
-                    className="p-1.5 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-xs"
-                >
-                    {KPI_COMPARISON_PERIOD_OPTIONS.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                    ))}
-                </select>
-            </div>
+          </h3>
+          <div>
+            <label
+              htmlFor={`kpiComparisonPeriod-${userId}`}
+              className="sr-only"
+            >
+              Período de Comparação
+            </label>
+            <select
+              id={`kpiComparisonPeriod-${userId}`}
+              value={kpiComparisonPeriod}
+              onChange={(e) => setKpiComparisonPeriod(e.target.value)}
+              className="p-1.5 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-xs"
+            >
+              {KPI_COMPARISON_PERIOD_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
-            <UserComparativeKpi userId={userId} kpiName="followerGrowth" title="Crescimento de Seguidores" comparisonPeriod={kpiComparisonPeriod} tooltip="Variação no ganho de seguidores em relação ao período anterior equivalente." />
-            <UserComparativeKpi userId={userId} kpiName="totalEngagement" title="Engajamento Total" comparisonPeriod={kpiComparisonPeriod} tooltip="Variação no total de interações em relação ao período anterior equivalente."/>
-            <UserComparativeKpi userId={userId} kpiName="postingFrequency" title="Frequência de Postagem" comparisonPeriod={kpiComparisonPeriod} tooltip="Variação na frequência semanal de postagens em relação ao período anterior equivalente."/>
+          <UserComparativeKpi
+            userId={userId}
+            kpiName="followerGrowth"
+            title="Crescimento de Seguidores"
+            comparisonPeriod={kpiComparisonPeriod}
+            tooltip="Variação no ganho de seguidores em relação ao período anterior equivalente."
+          />
+          <UserComparativeKpi
+            userId={userId}
+            kpiName="totalEngagement"
+            title="Engajamento Total"
+            comparisonPeriod={kpiComparisonPeriod}
+            tooltip="Variação no total de interações em relação ao período anterior equivalente."
+          />
+          <UserComparativeKpi
+            userId={userId}
+            kpiName="postingFrequency"
+            title="Frequência de Postagem"
+            comparisonPeriod={kpiComparisonPeriod}
+            tooltip="Variação na frequência semanal de postagens em relação ao período anterior equivalente."
+          />
         </div>
       </section>
 
       <section id={`user-performance-highlights-${userId}`} className="mb-10">
-        <UserPerformanceHighlights userId={userId} sectionTitle="Destaques de Performance" initialTimePeriod={initialChartsTimePeriod} />
+        <UserPerformanceHighlights
+          userId={userId}
+          sectionTitle="Destaques de Performance"
+        />
       </section>
 
       <section id={`user-advanced-analysis-${userId}`} className="mb-10">
@@ -105,8 +128,11 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           Análise Avançada e Alertas
         </h3>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <UserRadarChartComparison profile1UserId={userId} chartTitle="Radar Comparativo de Performance"/>
-            <UserAlertsWidget userId={userId} />
+          <UserRadarChartComparison
+            profile1UserId={userId}
+            chartTitle="Radar Comparativo de Performance"
+          />
+          <UserAlertsWidget userId={userId} />
         </div>
       </section>
 
@@ -115,12 +141,24 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           Tendências da Conta
         </h3>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-          <UserFollowerTrendChart userId={userId} chartTitle="Evolução de Seguidores" initialTimePeriod={initialChartsTimePeriod} />
-          <UserFollowerChangeChart userId={userId} chartTitle="Variação Diária de Seguidores" initialTimePeriod={initialChartsTimePeriod} />
+          <UserFollowerTrendChart
+            userId={userId}
+            chartTitle="Evolução de Seguidores"
+          />
+          <UserFollowerChangeChart
+            userId={userId}
+            chartTitle="Variação Diária de Seguidores"
+          />
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-          <UserReachEngagementTrendChart userId={userId} chartTitle="Alcance e Contas Engajadas" initialTimePeriod={initialChartsTimePeriod} />
-          <UserMovingAverageEngagementChart userId={userId} chartTitle="Média Móvel de Engajamento Diário" initialTimePeriod={initialChartsTimePeriod} />
+          <UserReachEngagementTrendChart
+            userId={userId}
+            chartTitle="Alcance e Contas Engajadas"
+          />
+          <UserMovingAverageEngagementChart
+            userId={userId}
+            chartTitle="Média Móvel de Engajamento Diário"
+          />
         </div>
       </section>
 
@@ -133,34 +171,41 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
             userId={userId}
             groupBy="format"
             chartTitle="Engajamento Médio por Formato"
-            initialTimePeriod={initialChartsTimePeriod}
           />
           <UserAverageEngagementChart
             userId={userId}
             groupBy="context"
             chartTitle="Engajamento Médio por Contexto"
-            initialTimePeriod={initialChartsTimePeriod}
           />
           <UserAverageEngagementChart
             userId={userId}
             groupBy="proposal"
             chartTitle="Engajamento Médio por Proposta"
-            initialTimePeriod={initialChartsTimePeriod}
           />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-            <UserEngagementDistributionChart userId={userId} chartTitle="Distribuição de Engajamento por Formato" initialTimePeriod={initialChartsTimePeriod} />
-            <UserVideoPerformanceMetrics userId={userId} chartTitle="Performance de Vídeos" initialTimePeriod={initialChartsTimePeriod} />
+          <UserEngagementDistributionChart
+            userId={userId}
+            chartTitle="Distribuição de Engajamento por Formato"
+          />
+          <UserVideoPerformanceMetrics
+            userId={userId}
+            chartTitle="Performance de Vídeos"
+          />
         </div>
         <div className="grid grid-cols-1 gap-6">
-            <UserMonthlyEngagementStackedChart userId={userId} chartTitle="Engajamento Mensal Detalhado" initialTimePeriod={initialChartsTimePeriod} />
-            <UserMonthlyComparisonChart userId={userId} chartTitle="Comparação Mensal" />
+          <UserMonthlyEngagementStackedChart
+            userId={userId}
+            chartTitle="Engajamento Mensal Detalhado"
+          />
+          <UserMonthlyComparisonChart
+            userId={userId}
+            chartTitle="Comparação Mensal"
+          />
         </div>
       </section>
-
     </div>
   );
 };
 
 export default React.memo(UserDetailView);
-

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -1,89 +1,90 @@
 "use client";
 
-import React, { useState } from 'react';
-import GlobalPeriodIndicator from './components/GlobalPeriodIndicator';
-import CreatorSelector from './components/CreatorSelector';
+import React, { useState } from "react";
+import CreatorSelector from "./components/CreatorSelector";
 
 // Filtro Global
-import GlobalTimePeriodFilter from './components/filters/GlobalTimePeriodFilter';
-import { GlobalTimePeriodProvider, useGlobalTimePeriod } from './components/filters/GlobalTimePeriodContext';
+import GlobalTimePeriodFilter from "./components/filters/GlobalTimePeriodFilter";
+import {
+  GlobalTimePeriodProvider,
+  useGlobalTimePeriod,
+} from "./components/filters/GlobalTimePeriodContext";
 
 // Componentes da Plataforma - Módulo 1 (Visão Geral)
-import PlatformFollowerTrendChart from './components/PlatformFollowerTrendChart';
-import PlatformFollowerChangeChart from './components/PlatformFollowerChangeChart';
-import PlatformReachEngagementTrendChart from './components/PlatformReachEngagementTrendChart';
-import PlatformMovingAverageEngagementChart from './components/PlatformMovingAverageEngagementChart';
-import TotalActiveCreatorsKpi from './components/kpis/TotalActiveCreatorsKpi';
-import PlatformComparativeKpi from './components/kpis/PlatformComparativeKpi';
-import PlatformSummaryKpis from './components/kpis/PlatformSummaryKpis';
+import PlatformSummaryKpis from "./components/kpis/PlatformSummaryKpis";
+import PlatformOverviewSection from "./components/views/PlatformOverviewSection";
+import PlatformContentAnalysisSection from "./components/views/PlatformContentAnalysisSection";
+import ProposalRankingSection from "./components/views/ProposalRankingSection";
+import CreatorRankingSection from "./components/views/CreatorRankingSection";
+import TopMoversSection from "./components/views/TopMoversSection";
+import CohortComparisonSection from "./components/views/CohortComparisonSection";
+import MarketPerformanceSection from "./components/views/MarketPerformanceSection";
+import AdvancedAnalysisSection from "./components/views/AdvancedAnalysisSection";
+import CreatorHighlightsSection from "./components/views/CreatorHighlightsSection";
 
 // Componentes da Plataforma - Módulo 2 (Análise de Conteúdo)
-import PlatformAverageEngagementChart from './components/PlatformAverageEngagementChart';
-import PlatformPostDistributionChart from './components/PlatformPostDistributionChart'; // Contagem de Posts por Formato
-import PlatformEngagementDistributionByFormatChart from './components/PlatformEngagementDistributionByFormatChart'; // Engajamento por Formato
-import PlatformVideoPerformanceMetrics from './components/PlatformVideoPerformanceMetrics';
-import PlatformMonthlyEngagementStackedChart from './components/PlatformMonthlyEngagementStackedChart';
-import PlatformPerformanceHighlights from './components/PlatformPerformanceHighlights';
-import ContentPerformanceByTypeChart from './ContentPerformanceByTypeChart';
-import ProposalRankingCard from './ProposalRankingCard';
-import CreatorRankingCard from './CreatorRankingCard';
-import TopCreatorsWidget from './TopCreatorsWidget';
-import TopMoversWidget from './TopMoversWidget';
-import RadarEffectivenessWidget from './components/widgets/RadarEffectivenessWidget';
-import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
-import CohortComparisonChart from './components/CohortComparisonChart';
-import MarketPerformanceChart from './components/MarketPerformanceChart';
-import CreatorsScatterPlot from './components/CreatorsScatterPlot';
-import ScrollToTopButton from '@/app/components/ScrollToTopButton';
+import { getStartDateFromTimePeriod } from "@/utils/dateHelpers";
+import ScrollToTopButton from "@/app/components/ScrollToTopButton";
 
 // View de Detalhe do Criador (Módulo 3 e partes do Módulo 2 para usuário)
-import UserDetailView from './components/views/UserDetailView';
-
+import UserDetailView from "./components/views/UserDetailView";
 
 const AdminCreatorDashboardContent: React.FC = () => {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
-  const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } = useGlobalTimePeriod();
+  const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } =
+    useGlobalTimePeriod();
 
   const selectedComparisonPeriodForPlatformKPIs = "month_vs_previous";
   const [isSelectorOpen, setIsSelectorOpen] = useState(false);
 
   const formatOptions = ["Reel", "Post Estático", "Carrossel", "Story"];
-  const proposalOptions = ["Educativo", "Humor", "Notícia", "Review", "Tutorial"];
+  const proposalOptions = [
+    "Educativo",
+    "Humor",
+    "Notícia",
+    "Review",
+    "Tutorial",
+  ];
   const [marketFormat, setMarketFormat] = useState<string>(formatOptions[0]!);
-  const [marketProposal, setMarketProposal] = useState<string>(proposalOptions[0]!);
+  const [marketProposal, setMarketProposal] = useState<string>(
+    proposalOptions[0]!,
+  );
 
   const today = new Date();
   const startDateObj = getStartDateFromTimePeriod(today, globalTimePeriod);
   const startDate = startDateObj.toISOString();
   const endDate = today.toISOString();
   const rankingDateRange = { startDate, endDate };
-  const startDateLabel = startDateObj.toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
+  const startDateLabel = startDateObj.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
   });
-  const endDateLabel = today.toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
+  const endDateLabel = today.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
   });
   const rankingDateLabel = `${startDateLabel} - ${endDateLabel}`;
-
 
   const handleUserSelect = (userId: string, userName: string) => {
     setSelectedUserId(userId);
     setSelectedUserName(userName);
-    const userDetailSection = document.getElementById("user-detail-view-container");
+    const userDetailSection = document.getElementById(
+      "user-detail-view-container",
+    );
     if (userDetailSection) {
-        userDetailSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      userDetailSection.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   };
 
   return (
     <div className="p-4 md:p-6 lg:p-8 bg-gray-100 min-h-screen">
       <header className="mb-8 sticky top-0 z-20 bg-gray-100 pb-4 border-b border-gray-200">
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-800">Dashboard Administrativo de Criadores</h1>
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-800">
+          Dashboard Administrativo de Criadores
+        </h1>
 
         <div className="mt-4 p-4 bg-white rounded-md shadow">
           <GlobalTimePeriodFilter
@@ -91,12 +92,12 @@ const AdminCreatorDashboardContent: React.FC = () => {
             onTimePeriodChange={setGlobalTimePeriod}
             // Opções de período para o filtro global podem ser diferentes das opções dos componentes individuais
             options={[
-                { value: "last_7_days", label: "Últimos 7 dias" },
-                { value: "last_30_days", label: "Últimos 30 dias" },
-                { value: "last_90_days", label: "Últimos 90 dias" },
-                { value: "last_6_months", label: "Últimos 6 meses" },
-                { value: "last_12_months", label: "Últimos 12 meses" },
-                { value: "all_time", label: "Todo o período" },
+              { value: "last_7_days", label: "Últimos 7 dias" },
+              { value: "last_30_days", label: "Últimos 30 dias" },
+              { value: "last_90_days", label: "Últimos 90 dias" },
+              { value: "last_6_months", label: "Últimos 6 meses" },
+              { value: "last_12_months", label: "Últimos 12 meses" },
+              { value: "all_time", label: "Todo o período" },
             ]}
           />
         </div>
@@ -106,8 +107,13 @@ const AdminCreatorDashboardContent: React.FC = () => {
         <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
       </section>
 
-      <section id="creator-selection" className="mb-8 p-4 bg-white rounded-lg shadow">
-        <h2 className="text-lg font-semibold text-gray-700 mb-3">Selecionar Criador para Detalhar</h2>
+      <section
+        id="creator-selection"
+        className="mb-8 p-4 bg-white rounded-lg shadow"
+      >
+        <h2 className="text-lg font-semibold text-gray-700 mb-3">
+          Selecionar Criador para Detalhar
+        </h2>
         <div className="flex flex-wrap items-center gap-4">
           <button
             onClick={() => setIsSelectorOpen(true)}
@@ -122,7 +128,10 @@ const AdminCreatorDashboardContent: React.FC = () => {
           )}
           {selectedUserId && (
             <button
-              onClick={() => { setSelectedUserId(null); setSelectedUserName(null); }}
+              onClick={() => {
+                setSelectedUserId(null);
+                setSelectedUserName(null);
+              }}
               className="p-2 rounded-md text-sm bg-gray-200 text-gray-700 hover:bg-gray-300"
             >
               Limpar seleção e voltar à visão geral
@@ -133,198 +142,33 @@ const AdminCreatorDashboardContent: React.FC = () => {
 
       {!selectedUserId && (
         <>
-          <section id="platform-overview" className="mb-10">
-            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Visão Geral da Plataforma <GlobalPeriodIndicator />
-            </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 mb-6 md:mb-8">
-              <TotalActiveCreatorsKpi />
-              <PlatformComparativeKpi
-                kpiName="platformFollowerGrowth"
-                title="Crescimento de Seguidores"
-                comparisonPeriod={selectedComparisonPeriodForPlatformKPIs}
-                tooltip="Crescimento total de seguidores na plataforma comparado ao período anterior selecionado."
-              />
-              <PlatformComparativeKpi
-                kpiName="platformTotalEngagement"
-                title="Engajamento Total"
-                comparisonPeriod={selectedComparisonPeriodForPlatformKPIs}
-                tooltip="Soma total de interações em todos os posts da plataforma comparado ao período anterior selecionado."
-              />
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformFollowerTrendChart />
-              <PlatformFollowerChangeChart />
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformReachEngagementTrendChart />
-              <PlatformMovingAverageEngagementChart />
-            </div>
-          </section>
-
-          <section id="platform-content-analysis" className="mb-10">
-            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Análise de Conteúdo da Plataforma <GlobalPeriodIndicator />
-            </h2>
-            <div className="mb-6 md:mb-8">
-                <PlatformPerformanceHighlights />
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 md:mb-8">
-              <PlatformAverageEngagementChart
-                initialGroupBy="format"
-                chartTitle="Engajamento Médio por Formato (Plataforma)"
-              />
-              <PlatformAverageEngagementChart
-                initialGroupBy="context"
-                chartTitle="Engajamento Médio por Contexto (Plataforma)"
-              />
-              <PlatformAverageEngagementChart
-                initialGroupBy="proposal"
-                chartTitle="Engajamento Médio por Proposta (Plataforma)"
-              />
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 md:mb-8">
-              <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato (Plataforma)" />
-              <PlatformVideoPerformanceMetrics />
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6"> {/* Nova linha ou ajuste no grid */}
-                <PlatformMonthlyEngagementStackedChart />
-                <PlatformEngagementDistributionByFormatChart /> {/* Adicionado aqui */}
-            </div>
-            <div className="mt-6">
-              <ContentPerformanceByTypeChart dateRangeFilter={{ startDate, endDate }} />
-            </div>
-          </section>
-
-          <section id="proposal-ranking" className="mb-10">
-            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Ranking por Proposta <GlobalPeriodIndicator />
-            </h2>
-            <ProposalRankingCard
-              title="Propostas com Mais Interações"
-              apiEndpoint="/api/admin/dashboard/rankings/proposals?metric=total_interactions"
-              dateRangeFilter={rankingDateRange}
-              dateRangeLabel={rankingDateLabel}
-              limit={5}
-            />
-        </section>
-
-        <section id="creator-rankings" className="mb-10">
-          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Rankings de Criadores <GlobalPeriodIndicator />
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            <CreatorRankingCard
-              title="Maior Engajamento"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
-              dateRangeFilter={rankingDateRange}
-              dateRangeLabel={rankingDateLabel}
-              metricLabel="%"
-              limit={5}
-            />
-            <CreatorRankingCard
-              title="Mais Interações"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-interactions"
-              dateRangeFilter={rankingDateRange}
-              dateRangeLabel={rankingDateLabel}
-              limit={5}
-            />
-            <CreatorRankingCard
-              title="Mais Posts"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
-              dateRangeFilter={rankingDateRange}
-              dateRangeLabel={rankingDateLabel}
-              limit={5}
-            />
-              <CreatorRankingCard
-                title="Mais Compartilhamentos"
-                apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
-                dateRangeFilter={rankingDateRange}
-                dateRangeLabel={rankingDateLabel}
-                limit={5}
-              />
-              <TopCreatorsWidget
-                title="Top Criadores"
-                metric="total_interactions"
-                days={30}
-                limit={5}
-              />
-          </div>
-        </section>
-
-        <section id="top-movers" className="mb-10">
-          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Top Movers <GlobalPeriodIndicator />
-          </h2>
-          <TopMoversWidget />
-        </section>
-
-        <section id="cohort-comparison" className="mb-10">
-          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Comparação de Coortes <GlobalPeriodIndicator />
-          </h2>
-          <CohortComparisonChart
-            metric="engagement_rate_on_reach"
+          <PlatformOverviewSection
+            comparisonPeriod={selectedComparisonPeriodForPlatformKPIs}
+          />
+          <PlatformContentAnalysisSection
             startDate={startDate}
             endDate={endDate}
-            cohorts={[
-              { filterBy: 'planStatus', value: 'Pro', name: 'Plano Pro' },
-              { filterBy: 'planStatus', value: 'Free', name: 'Plano Free' }
-            ]}
           />
-        </section>
-
-        <section id="market-performance" className="mb-10">
-          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Desempenho do Mercado <GlobalPeriodIndicator />
-          </h2>
-          <div className="flex flex-col md:flex-row gap-4 mb-4">
-            <div>
-              <label htmlFor="mp-format" className="block text-sm font-medium text-gray-700 mb-1">Formato</label>
-              <select
-                id="mp-format"
-                value={marketFormat}
-                onChange={(e) => setMarketFormat(e.target.value)}
-                className="p-2 border border-gray-300 rounded-md text-sm"
-              >
-                {formatOptions.map((opt) => (
-                  <option key={opt} value={opt}>{opt}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="mp-proposal" className="block text-sm font-medium text-gray-700 mb-1">Proposta</label>
-              <select
-                id="mp-proposal"
-                value={marketProposal}
-                onChange={(e) => setMarketProposal(e.target.value)}
-                className="p-2 border border-gray-300 rounded-md text-sm"
-              >
-                {proposalOptions.map((opt) => (
-                  <option key={opt} value={opt}>{opt}</option>
-                ))}
-              </select>
-            </div>
-          </div>
-          <MarketPerformanceChart format={marketFormat} proposal={marketProposal} />
-        </section>
-
-        <section id="advanced-analysis" className="mb-10">
-          <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-            Análise Avançada <GlobalPeriodIndicator />
-          </h2>
-          <RadarEffectivenessWidget />
-        </section>
-
-        <section id="creator-highlights-and-scatter-plot" className="mb-10">
-            <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-              Destaques e Análise Comparativa de Criadores <GlobalPeriodIndicator />
-            </h2>
-            <p className="text-sm text-gray-500 mb-4 italic">
-              (Em breve: Tabelas de Criadores com melhor performance)
-            </p>
-            <CreatorsScatterPlot />
-          </section>
+          <ProposalRankingSection
+            rankingDateRange={rankingDateRange}
+            rankingDateLabel={rankingDateLabel}
+          />
+          <CreatorRankingSection
+            rankingDateRange={rankingDateRange}
+            rankingDateLabel={rankingDateLabel}
+          />
+          <TopMoversSection />
+          <CohortComparisonSection startDate={startDate} endDate={endDate} />
+          <MarketPerformanceSection
+            formatOptions={formatOptions}
+            proposalOptions={proposalOptions}
+            marketFormat={marketFormat}
+            marketProposal={marketProposal}
+            setMarketFormat={setMarketFormat}
+            setMarketProposal={setMarketProposal}
+          />
+          <AdvancedAnalysisSection />
+          <CreatorHighlightsSection />
         </>
       )}
 
@@ -333,7 +177,6 @@ const AdminCreatorDashboardContent: React.FC = () => {
           <UserDetailView
             userId={selectedUserId}
             userName={selectedUserName ?? undefined}
-            initialChartsTimePeriod={globalTimePeriod} // Passar o período global
           />
         )}
       </div>
@@ -355,4 +198,3 @@ const AdminCreatorDashboardPage: React.FC = () => (
 );
 
 export default AdminCreatorDashboardPage;
-


### PR DESCRIPTION
## Summary
- unify time-period context under `components/filters/GlobalTimePeriodContext`
- show the active period with a `GlobalPeriodIndicator`
- split dashboard page into smaller view components

## Testing
- `npx prettier -w src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx src/app/admin/creator-dashboard/components/views/CreatorHighlightsSection.tsx src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx src/app/admin/creator-dashboard/components/views/TopMoversSection.tsx src/app/admin/creator-dashboard/components/views/ProposalRankingSection.tsx src/app/admin/creator-dashboard/components/views/CohortComparisonSection.tsx src/app/admin/creator-dashboard/components/views/MarketPerformanceSection.tsx src/app/admin/creator-dashboard/components/views/AdvancedAnalysisSection.tsx src/app/admin/creator-dashboard/components/views/UserDetailView.tsx src/app/admin/creator-dashboard/page.tsx src/app/admin/creator-dashboard/components/GlobalPeriodIndicator.tsx src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext.tsx`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfd4d0170832e9dcebb80308ee73a