### PR TITLE
Connect database in performance endpoints

### DIFF
--- a/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
 import {
   ALLOWED_TIME_PERIODS,
   ALLOWED_ENGAGEMENT_METRICS,
@@ -88,6 +89,7 @@ export async function GET(
   }
 
   try {
+    await connectToDatabase();
     const today = new Date();
     const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
     const startDate = getStartDateFromTimePeriod(today, timePeriod);

--- a/src/app/api/v1/platform/performance/post-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/post-distribution-format/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric'; // Descomente para implementação real
+import { connectToDatabase } from '@/app/lib/mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 // Defina FormatType localmente se o módulo não existir
 export enum FormatType {
@@ -68,6 +69,7 @@ export async function GET(
   }
 
   try {
+    await connectToDatabase();
     const today = new Date();
     const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
     const startDate = getStartDateFromTimePeriod(today, timePeriod);

--- a/src/app/api/v1/platform/performance/video-metrics/route.ts
+++ b/src/app/api/v1/platform/performance/video-metrics/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
 import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 
@@ -31,6 +32,7 @@ export async function GET(request: Request) {
   }
 
   try {
+    await connectToDatabase();
     const today = new Date();
     const endDate = new Date(
       today.getFullYear(),


### PR DESCRIPTION
## Summary
- connect to database in video metrics endpoint
- connect to database in post distribution format endpoint
- connect to database in engagement distribution format endpoint

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685e19bfa638832e9bb91755ff354d44