### PR TITLE
Implement platform performance aggregation

### DIFF
--- a/src/utils/aggregatePlatformPerformanceHighlights.ts
+++ b/src/utils/aggregatePlatformPerformanceHighlights.ts
@@ -1,0 +1,128 @@
+import MetricModel from "@/app/models/Metric";
+import { PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface AggregatedHighlight {
+  name: string | null;
+  average: number;
+  count: number;
+}
+
+export interface PlatformPerformanceHighlightsAggregation {
+  topFormat: AggregatedHighlight | null;
+  lowFormat: AggregatedHighlight | null;
+  topContext: AggregatedHighlight | null;
+}
+
+async function aggregatePlatformPerformanceHighlights(
+  periodInDays: number,
+  metricField: string
+): Promise<PlatformPerformanceHighlightsAggregation> {
+  const today = new Date();
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const initial: PlatformPerformanceHighlightsAggregation = {
+    topFormat: null,
+    lowFormat: null,
+    topContext: null,
+  };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    const projectStage: PipelineStage.Project = {
+      $project: {
+        format: { $ifNull: ["$format", null] },
+        context: { $ifNull: ["$context", null] },
+        metricValue: `$${metricField}`,
+      },
+    };
+
+    const metricFilterStage: PipelineStage.Match = {
+      $match: { metricValue: { $ne: null } },
+    };
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      projectStage,
+      metricFilterStage,
+      {
+        $facet: {
+          byFormat: [
+            {
+              $group: {
+                _id: "$format",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byContext: [
+            {
+              $group: {
+                _id: "$context",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+        },
+      },
+    ];
+
+    const [agg] = await MetricModel.aggregate(pipeline);
+
+    if (agg?.byFormat?.length) {
+      const topF = agg.byFormat[0];
+      const lowF = agg.byFormat[agg.byFormat.length - 1];
+      initial.topFormat = {
+        name: topF._id ?? null,
+        average: topF.avg ?? 0,
+        count: topF.count ?? 0,
+      };
+      initial.lowFormat = {
+        name: lowF._id ?? null,
+        average: lowF.avg ?? 0,
+        count: lowF.count ?? 0,
+      };
+    }
+
+    if (agg?.byContext?.length) {
+      const topC = agg.byContext[0];
+      initial.topContext = {
+        name: topC._id ?? null,
+        average: topC.avg ?? 0,
+        count: topC.count ?? 0,
+      };
+    }
+
+    return initial;
+  } catch (error) {
+    logger.error("Error in aggregatePlatformPerformanceHighlights:", error);
+    return initial;
+  }
+}
+
+export default aggregatePlatformPerformanceHighlights;


### PR DESCRIPTION
## Summary
- aggregate platform performance by format and context
- use the aggregation in the platform performance summary API

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685e19ca2d94832ebc977b1cef238e84