### PR TITLE
Implement platform dashboard optimizations

### DIFF
--- a/src/app/admin/creator-dashboard/components/__tests__/PlatformVideoPerformanceMetrics.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/PlatformVideoPerformanceMetrics.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlatformVideoPerformanceMetrics from '../PlatformVideoPerformanceMetrics';
+import { useGlobalTimePeriod } from '../filters/GlobalTimePeriodContext';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(),
+}));
+
+const mockUseGlobalTimePeriod = useGlobalTimePeriod as jest.Mock;
+
+beforeEach(() => {
+  (global.fetch as any) = jest.fn();
+  mockUseGlobalTimePeriod.mockReturnValue({ timePeriod: 'last_30_days' });
+});
+
+describe('PlatformVideoPerformanceMetrics', () => {
+  it('renders metrics on success', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        averageRetentionRate: 50,
+        averageWatchTimeSeconds: 120,
+        numberOfVideoPosts: 10,
+        insightSummary: 'Resumo',
+      }),
+    });
+
+    render(<PlatformVideoPerformanceMetrics />);
+
+    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    expect(screen.getByText('120s')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('Resumo')).toBeInTheDocument();
+  });
+
+  it('shows no data message', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        averageRetentionRate: null,
+        averageWatchTimeSeconds: null,
+        numberOfVideoPosts: null,
+      }),
+    });
+
+    render(<PlatformVideoPerformanceMetrics />);
+    await waitFor(() =>
+      expect(screen.getByText('Nenhuma métrica de vídeo encontrada para a plataforma.')).toBeInTheDocument()
+    );
+  });
+
+  it('renders error state', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Bad' }),
+    });
+    render(<PlatformVideoPerformanceMetrics />);
+
+    await waitFor(() => expect(screen.getByText(/Erro:/)).toBeInTheDocument());
+  });
+});

--- a/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
@@ -1,0 +1,40 @@
+import { GET } from './route';
+import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/utils/aggregatePlatformPerformanceHighlights');
+
+const mockAgg = aggregatePlatformPerformanceHighlights as jest.Mock;
+
+const makeRequest = (search = '') => new NextRequest(`http://localhost/api/v1/platform/highlights/performance-summary${search}`);
+
+describe('GET /api/v1/platform/highlights/performance-summary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns formatted highlights', async () => {
+    mockAgg.mockResolvedValueOnce({
+      topFormat: { name: 'VIDEO', average: 10, count: 2 },
+      lowFormat: { name: 'IMAGE', average: 2, count: 1 },
+      topContext: { name: 'FEED', average: 5, count: 3 },
+    });
+
+    const res = await GET(makeRequest('?timePeriod=last_30_days'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalled();
+    expect(body.topPerformingFormat.name).toBe('VIDEO');
+    expect(body.lowPerformingFormat.name).toBe('IMAGE');
+    expect(body.topPerformingContext.name).toBe('FEED');
+  });
+
+  it('returns 400 for invalid timePeriod', async () => {
+    const res = await GET(makeRequest('?timePeriod=bad'));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Time period inválido');
+    expect(mockAgg).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import DailyMetricSnapshotModel from '@/app/models/DailyMetricSnapshot'; // Para implementação real
+import { connectToDatabase } from '@/app/lib/mongoose';
 import {
     addDays,
     formatDateYYYYMMDD,
@@ -30,6 +31,8 @@ export async function GET(
   request: Request
 ) {
   const { searchParams } = new URL(request.url);
+
+  await connectToDatabase();
 
   let dataWindowInDays = DEFAULT_DATA_WINDOW_DAYS;
   const dataWindowParam = searchParams.get('dataWindowInDays');

--- a/src/utils/__tests__/aggregatePlatformPerformanceHighlights.test.ts
+++ b/src/utils/__tests__/aggregatePlatformPerformanceHighlights.test.ts
@@ -1,0 +1,48 @@
+import aggregatePlatformPerformanceHighlights from '../aggregatePlatformPerformanceHighlights';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = MetricModel.aggregate as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+describe('aggregatePlatformPerformanceHighlights', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('aggregates and formats highlights', async () => {
+    mockAgg.mockResolvedValueOnce([
+      {
+        byFormat: [
+          { _id: 'VIDEO', avg: 10, count: 2 },
+          { _id: 'IMAGE', avg: 2, count: 1 },
+        ],
+        byContext: [
+          { _id: 'FEED', avg: 5, count: 3 },
+        ],
+      },
+    ]);
+
+    const res = await aggregatePlatformPerformanceHighlights(30, 'stats.total_interactions');
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockAgg).toHaveBeenCalled();
+    expect(res.topFormat).toEqual({ name: 'VIDEO', average: 10, count: 2 });
+    expect(res.lowFormat).toEqual({ name: 'IMAGE', average: 2, count: 1 });
+    expect(res.topContext).toEqual({ name: 'FEED', average: 5, count: 3 });
+  });
+
+  it('handles empty aggregation', async () => {
+    mockAgg.mockResolvedValueOnce([{}]);
+    const res = await aggregatePlatformPerformanceHighlights(30, 'stats.total_interactions');
+    expect(res).toEqual({ topFormat: null, lowFormat: null, topContext: null });
+  });
+});

--- a/src/utils/platformMetricsHelpers.test.ts
+++ b/src/utils/platformMetricsHelpers.test.ts
@@ -3,6 +3,10 @@ import { getPlatformMinMaxValues } from './platformMetricsHelpers';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import AccountInsightModel from '@/app/models/AccountInsight';
+import calculateAverageEngagementPerPost from './calculateAverageEngagementPerPost';
+import calculateFollowerGrowthRate from './calculateFollowerGrowthRate';
+import calculateWeeklyPostingFrequency from './calculateWeeklyPostingFrequency';
+import calculateAverageVideoMetrics from './calculateAverageVideoMetrics';
 
 jest.mock('@/app/lib/mongoose', () => ({
   connectToDatabase: jest.fn(),
@@ -18,9 +22,18 @@ jest.mock('@/app/models/AccountInsight', () => ({
   default: { findOne: jest.fn() },
 }));
 
+jest.mock('./calculateAverageEngagementPerPost');
+jest.mock('./calculateFollowerGrowthRate');
+jest.mock('./calculateWeeklyPostingFrequency');
+jest.mock('./calculateAverageVideoMetrics');
+
 const mockConnect = connectToDatabase as jest.Mock;
 const mockUserFind = UserModel.find as jest.Mock;
 const mockAccountFindOne = AccountInsightModel.findOne as jest.Mock;
+const mockAvgEng = calculateAverageEngagementPerPost as jest.Mock;
+const mockGrowth = calculateFollowerGrowthRate as jest.Mock;
+const mockWeekly = calculateWeeklyPostingFrequency as jest.Mock;
+const mockVideo = calculateAverageVideoMetrics as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -59,5 +72,44 @@ describe('getPlatformMinMaxValues', () => {
     mockUserFind.mockReturnValue({ select: jest.fn().mockReturnThis(), limit: jest.fn().mockReturnThis(), lean: jest.fn().mockResolvedValue([]) });
     const res = await getPlatformMinMaxValues(['nonexistentMetric']);
     expect(res.nonexistentMetric).toEqual({ min: 0, max: 100 });
+  });
+
+  it('uses calculation helpers for complex metrics', async () => {
+    const id1 = new Types.ObjectId();
+    const id2 = new Types.ObjectId();
+
+    mockUserFind.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: id1 }, { _id: id2 }]),
+    });
+
+    mockAvgEng.mockResolvedValueOnce({ averageEngagementPerPost: 10 })
+      .mockResolvedValueOnce({ averageEngagementPerPost: 20 });
+    mockGrowth.mockResolvedValueOnce({ percentageGrowth: -0.1 })
+      .mockResolvedValueOnce({ percentageGrowth: 0.5 });
+    mockWeekly.mockResolvedValueOnce({ currentWeeklyFrequency: 2 })
+      .mockResolvedValueOnce({ currentWeeklyFrequency: 5 });
+    mockVideo.mockResolvedValueOnce({ averageRetentionRate: 30 })
+      .mockResolvedValueOnce({ averageRetentionRate: 60 });
+
+    const res = await getPlatformMinMaxValues([
+      'avgEngagementPerPost30d',
+      'followerGrowthRatePercent30d',
+      'avgWeeklyPostingFrequency30d',
+      'avgVideoRetentionRate90d',
+    ]);
+
+    expect(mockAvgEng).toHaveBeenCalledTimes(2);
+    expect(res.avgEngagementPerPost30d).toEqual({ min: 10, max: 20 });
+
+    expect(mockGrowth).toHaveBeenCalledTimes(2);
+    expect(res.followerGrowthRatePercent30d).toEqual({ min: -0.1, max: 0.5 });
+
+    expect(mockWeekly).toHaveBeenCalledTimes(2);
+    expect(res.avgWeeklyPostingFrequency30d).toEqual({ min: 2, max: 5 });
+
+    expect(mockVideo).toHaveBeenCalledTimes(2);
+    expect(res.avgVideoRetentionRate90d).toEqual({ min: 30, max: 60 });
   });
 });


### PR DESCRIPTION
## Summary
- connect to DB in moving-average engagement trend route
- compute real min/max platform metrics via per-user calculations
- test platform performance highlight aggregation
- test highlights API route
- test PlatformVideoPerformanceMetrics component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e17e8d2ac832e91d210cd409508c8