### PR TITLE
Add benchmarking and trend metrics

### DIFF
--- a/src/app/admin/creator-dashboard/components/HighlightCard.tsx
+++ b/src/app/admin/creator-dashboard/components/HighlightCard.tsx
@@ -9,6 +9,9 @@ export interface PerformanceHighlightItem {
   value: number;
   valueFormatted: string;
   postsCount?: number;
+  platformAverage?: number;
+  platformAverageFormatted?: string;
+  changePercentage?: number;
 }
 
 export interface HighlightCardProps {
@@ -51,7 +54,15 @@ const HighlightCard: React.FC<HighlightCardProps> = ({
         {highlight.postsCount && (
           <span className="ml-1">({highlight.postsCount} posts)</span>
         )}
+        {highlight.platformAverageFormatted && (
+          <span className="ml-1 text-[10px] text-gray-400">(Média plataforma: {highlight.platformAverageFormatted})</span>
+        )}
       </p>
+      {typeof highlight.changePercentage === 'number' && (
+        <p className={`text-xs mt-1 ${highlight.changePercentage >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+          {highlight.changePercentage >= 0 ? '▲' : '▼'} {Math.abs(highlight.changePercentage).toFixed(1)}% vs. período anterior
+        </p>
+      )}
     </div>
   );
 };

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -12,6 +12,9 @@ interface PerformanceHighlightItem {
   value: number;
   valueFormatted: string;
   postsCount?: number;
+  platformAverage?: number;
+  platformAverageFormatted?: string;
+  changePercentage?: number;
 }
 
 interface PerformanceSummaryResponse {

--- a/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
@@ -11,6 +11,9 @@ interface PerformanceHighlightItem {
   value: number;
   valueFormatted: string;
   postsCount?: number;
+  platformAverage?: number;
+  platformAverageFormatted?: string;
+  changePercentage?: number;
 }
 
 interface PerformanceSummaryResponse {

--- a/src/utils/aggregatePerformanceHighlights.ts
+++ b/src/utils/aggregatePerformanceHighlights.ts
@@ -19,11 +19,12 @@ export interface PerformanceHighlightsAggregation {
 async function aggregatePerformanceHighlights(
   userId: string | Types.ObjectId,
   periodInDays: number,
-  metricField: string
+  metricField: string,
+  referenceDate: Date = new Date()
 ): Promise<PerformanceHighlightsAggregation> {
   const resolvedUserId =
     typeof userId === "string" ? new Types.ObjectId(userId) : userId;
-  const today = new Date();
+  const today = new Date(referenceDate);
   const endDate = new Date(
     today.getFullYear(),
     today.getMonth(),

--- a/src/utils/aggregatePlatformPerformanceHighlights.ts
+++ b/src/utils/aggregatePlatformPerformanceHighlights.ts
@@ -18,9 +18,10 @@ export interface PlatformPerformanceHighlightsAggregation {
 
 async function aggregatePlatformPerformanceHighlights(
   periodInDays: number,
-  metricField: string
+  metricField: string,
+  referenceDate: Date = new Date()
 ): Promise<PlatformPerformanceHighlightsAggregation> {
-  const today = new Date();
+  const today = new Date(referenceDate);
   const endDate = new Date(
     today.getFullYear(),
     today.getMonth(),

--- a/src/utils/calculatePlatformAverageMetric.ts
+++ b/src/utils/calculatePlatformAverageMetric.ts
@@ -1,0 +1,50 @@
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { getStartDateFromTimePeriod } from './dateHelpers';
+import { getFromCache, setInCache } from '@/app/lib/stateService';
+import { CACHE_TTL_SECONDS } from '@/app/lib/constants';
+import { PipelineStage } from 'mongoose';
+
+async function calculatePlatformAverageMetric(
+  periodInDays: number,
+  metricField: string,
+  referenceDate: Date = new Date()
+): Promise<number> {
+  const ref = new Date(referenceDate);
+  const endDate = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate(), 23, 59, 59, 999);
+  const startDate = getStartDateFromTimePeriod(ref, `last_${periodInDays}_days`);
+
+  const cacheKey = `platform_avg:${metricField}:${periodInDays}:${ref.toISOString().slice(0, 10)}`;
+
+  const cached = await getFromCache(cacheKey);
+  if (cached !== null) {
+    const parsed = Number(cached);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  try {
+    await connectToDatabase();
+
+    const pipeline: PipelineStage[] = [
+      { $match: { postDate: { $gte: startDate, $lte: endDate } } },
+      { $project: { metricValue: `$${metricField}` } },
+      { $match: { metricValue: { $ne: null } } },
+      { $group: { _id: null, avg: { $avg: '$metricValue' } } }
+    ];
+
+    const [result] = await MetricModel.aggregate(pipeline);
+    const avg = result?.avg ?? 0;
+    try {
+      await setInCache(cacheKey, String(avg), CACHE_TTL_SECONDS);
+    } catch (cacheError) {
+      logger.warn('Error caching platform average metric:', cacheError);
+    }
+    return avg;
+  } catch (error) {
+    logger.error('Error calculating platform average metric:', error);
+    return 0;
+  }
+}
+
+export default calculatePlatformAverageMetric;


### PR DESCRIPTION
## Summary
- extend highlight utilities to accept a reference date
- add API util to compute platform-wide averages
- include benchmark and change percent in user highlight API
- show new data in HighlightCard component
- update related dashboard components
- cache platform average metric

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f13eed8f4832e800f8d1b070e9533