### PR TITLE
Add user videos list API

### DIFF
--- a/src/app/api/v1/users/[userId]/videos/list/route.test.ts
+++ b/src/app/api/v1/users/[userId]/videos/list/route.test.ts
@@ -1,0 +1,57 @@
+import { GET } from './route';
+import MetricModel from '@/app/models/Metric';
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+const mockAggregate = MetricModel.aggregate as jest.Mock;
+
+const createRequest = (userId: string, search: string = ''): NextRequest => {
+  const url = `http://localhost/api/v1/users/${userId}/videos/list${search}`;
+  return new NextRequest(url);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/v1/users/[userId]/videos/list', () => {
+  const userId = new Types.ObjectId().toString();
+
+  it('returns videos with pagination using defaults', async () => {
+    const aggResult = [{ videos: [{ id: 1 }], totalCount: [{ count: 3 }] }];
+    mockAggregate.mockResolvedValueOnce(aggResult);
+
+    const req = createRequest(userId);
+    const res = await GET(req, { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.videos).toEqual([{ id: 1 }]);
+    expect(body.pagination.totalVideos).toBe(3);
+    expect(mockAggregate).toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid timePeriod', async () => {
+    const req = createRequest(userId, '?timePeriod=bad');
+    const res = await GET(req, { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('timePeriod inválido');
+    expect(mockAggregate).not.toHaveBeenCalled();
+  });
+
+  it('handles db errors', async () => {
+    mockAggregate.mockRejectedValueOnce(new Error('db error'));
+    const req = createRequest(userId);
+    const res = await GET(req, { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Erro ao buscar vídeos.');
+  });
+});

--- a/src/app/api/v1/users/[userId]/videos/list/route.ts
+++ b/src/app/api/v1/users/[userId]/videos/list/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+
+const DEFAULT_VIDEO_TYPES = ['REEL', 'VIDEO'];
+
+export async function GET(
+  request: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json({ error: 'User ID inválido ou ausente.' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod') as TimePeriod | null;
+  const sortBy = searchParams.get('sortBy') || 'postDate';
+  const sortOrder = searchParams.get('sortOrder') === 'asc' ? 'asc' : 'desc';
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const limit = parseInt(searchParams.get('limit') || '10', 10);
+
+  const timePeriod: TimePeriod = timePeriodParam && ALLOWED_TIME_PERIODS.includes(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !ALLOWED_TIME_PERIODS.includes(timePeriodParam)) {
+    return NextResponse.json(
+      { error: `timePeriod inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await connectToDatabase();
+    const userObjectId = new Types.ObjectId(userId);
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+    const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+    const matchStage: any = { user: userObjectId, type: { $in: DEFAULT_VIDEO_TYPES } };
+    if (timePeriod !== 'all_time') {
+      matchStage.postDate = { $gte: startDate, $lte: endDate };
+    }
+
+    const skip = (page - 1) * limit;
+    const sortDirection = sortOrder === 'asc' ? 1 : -1;
+
+    const pipeline = [
+      { $match: matchStage },
+      {
+        $addFields: {
+          average_video_watch_time_seconds: {
+            $cond: {
+              if: { $gt: [{ $ifNull: ['$stats.ig_reels_avg_watch_time', 0] }, 0] },
+              then: { $divide: ['$stats.ig_reels_avg_watch_time', 1000] },
+              else: null
+            }
+          },
+          retention_rate: {
+            $cond: {
+              if: {
+                $and: [
+                  { $gt: [{ $ifNull: ['$stats.ig_reels_avg_watch_time', 0] }, 0] },
+                  { $gt: [{ $ifNull: ['$stats.video_duration_seconds', 0] }, 0] }
+                ]
+              },
+              then: {
+                $divide: [
+                  { $divide: ['$stats.ig_reels_avg_watch_time', 1000] },
+                  '$stats.video_duration_seconds'
+                ]
+              },
+              else: null
+            }
+          }
+        }
+      },
+      { $sort: { [sortBy]: sortDirection } },
+      {
+        $facet: {
+          videos: [ { $skip: skip }, { $limit: limit } ],
+          totalCount: [ { $count: 'count' } ]
+        }
+      }
+    ];
+
+    const [agg] = await MetricModel.aggregate(pipeline);
+    const videos = agg?.videos || [];
+    const totalVideos = agg?.totalCount?.[0]?.count || 0;
+    const totalPages = Math.ceil(totalVideos / limit) || 1;
+
+    return NextResponse.json({
+      videos,
+      pagination: {
+        currentPage: page,
+        totalPages,
+        totalVideos
+      }
+    });
+  } catch (error) {
+    console.error('[API USER/VIDEOS/LIST] Error:', error);
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao buscar vídeos.', details: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- implement API route to list user videos with aggregation and pagination
- compute watch time and retention in MongoDB pipeline
- provide test coverage for the new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f18378fd4832e8172ff58ab462cee