### PR TITLE
Add drill-down modal for video metrics

### DIFF
--- a/src/app/admin/creator-dashboard/VideoDrillDownModal.tsx
+++ b/src/app/admin/creator-dashboard/VideoDrillDownModal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+
+interface VideoDrillDownModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userId: string;
+  timePeriod: string;
+  drillDownMetric: string | null;
+}
+
+const VideoDrillDownModal: React.FC<VideoDrillDownModalProps> = ({
+  isOpen,
+  onClose,
+  userId,
+  timePeriod,
+  drillDownMetric,
+}) => {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!isOpen || !drillDownMetric) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const url = `/api/v1/users/${userId}/videos/drilldown?metric=${encodeURIComponent(drillDownMetric)}&timePeriod=${timePeriod}`;
+        const response = await fetch(url);
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
+        }
+        const result = await response.json();
+        setData(result.items || result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Ocorreu um erro desconhecido.");
+        setData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [isOpen, userId, timePeriod, drillDownMetric]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-xl">
+        <div className="flex justify-between items-center p-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-700">
+            Detalhes: {drillDownMetric}
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700" title="Fechar">
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-4 space-y-2 max-h-[70vh] overflow-y-auto">
+          {loading && <p className="text-center text-gray-500">Carregando...</p>}
+          {error && <p className="text-center text-red-500">Erro: {error}</p>}
+          {!loading && !error && data.length === 0 && (
+            <p className="text-center text-gray-500">Sem dados para exibir.</p>
+          )}
+          {!loading && !error && data.length > 0 && (
+            <pre className="text-xs whitespace-pre-wrap">{JSON.stringify(data, null, 2)}</pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VideoDrillDownModal;

--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import VideoDrillDownModal from "../VideoDrillDownModal";
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 
 interface VideoMetricsData {
@@ -80,6 +81,8 @@ const UserVideoPerformanceMetrics: React.FC<
   );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [drillDownMetric, setDrillDownMetric] = useState<string | null>(null);
 
   const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const [timePeriod, setTimePeriod] = useState<string>(
@@ -142,6 +145,11 @@ const UserVideoPerformanceMetrics: React.FC<
     setTimePeriod(e.target.value);
   };
 
+  const handleMetricClick = (metric: string) => {
+    setDrillDownMetric(metric);
+    setIsModalOpen(true);
+  };
+
   if (!userId) {
     return (
       <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
@@ -196,31 +204,46 @@ const UserVideoPerformanceMetrics: React.FC<
       {!loading && !error && metrics && (
         <>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <MetricDisplay
-              label="Retenção Média"
-              value={
-                metrics.averageRetentionRate !== null
-                  ? metrics.averageRetentionRate.toFixed(1)
-                  : null
-              }
-              unit="%"
-              tooltip="Média da porcentagem de vídeo que os espectadores assistem."
-            />
-            <MetricDisplay
-              label="Tempo Médio de Visualização"
-              value={
-                metrics.averageWatchTimeSeconds !== null
-                  ? metrics.averageWatchTimeSeconds.toFixed(0)
-                  : null
-              }
-              unit="s"
-              tooltip="Tempo médio que os espectadores passam assistindo a cada vídeo."
-            />
-            <MetricDisplay
-              label="Total de Vídeos Analisados"
-              value={metrics.numberOfVideoPosts}
-              tooltip="Número de posts de vídeo considerados para estas métricas no período."
-            />
+            <div
+              className="cursor-pointer"
+              onClick={() => handleMetricClick("averageRetentionRate")}
+            >
+              <MetricDisplay
+                label="Retenção Média"
+                value={
+                  metrics.averageRetentionRate !== null
+                    ? metrics.averageRetentionRate.toFixed(1)
+                    : null
+                }
+                unit="%"
+                tooltip="Média da porcentagem de vídeo que os espectadores assistem."
+              />
+            </div>
+            <div
+              className="cursor-pointer"
+              onClick={() => handleMetricClick("averageWatchTimeSeconds")}
+            >
+              <MetricDisplay
+                label="Tempo Médio de Visualização"
+                value={
+                  metrics.averageWatchTimeSeconds !== null
+                    ? metrics.averageWatchTimeSeconds.toFixed(0)
+                    : null
+                }
+                unit="s"
+                tooltip="Tempo médio que os espectadores passam assistindo a cada vídeo."
+              />
+            </div>
+            <div
+              className="cursor-pointer"
+              onClick={() => handleMetricClick("numberOfVideoPosts")}
+            >
+              <MetricDisplay
+                label="Total de Vídeos Analisados"
+                value={metrics.numberOfVideoPosts}
+                tooltip="Número de posts de vídeo considerados para estas métricas no período."
+              />
+            </div>
           </div>
           {insightSummary && (
             <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100">
@@ -234,6 +257,13 @@ const UserVideoPerformanceMetrics: React.FC<
           <p className="text-gray-500">Nenhuma métrica de vídeo encontrada.</p>
         </div>
       )}
+      <VideoDrillDownModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        userId={userId!}
+        timePeriod={timePeriod}
+        drillDownMetric={drillDownMetric}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable modal drilldown in `UserVideoPerformanceMetrics`
- add new `VideoDrillDownModal` component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f183a1ed8832eb4d48541cbbedd6c