### PR TITLE
Add time period helper

### DIFF
--- a/src/app/api/v1/platform/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { camelizeKeys } from '@/utils/camelizeKeys';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 
 // Reutilizar tipos e helpers se possível, ou definir específicos da plataforma
 interface PerformanceHighlight {
@@ -34,19 +35,6 @@ function formatPerformanceValue(value: number, metricFieldId: string): string {
 // CORREÇÃO: Função de verificação de tipo (type guard) para validar o parâmetro
 function isAllowedTimePeriod(period: any): period is TimePeriod {
     return ALLOWED_TIME_PERIODS.includes(period);
-}
-
-// Converte timePeriod em número de dias
-function timePeriodToDays(timePeriod: TimePeriod): number {
-    switch (timePeriod) {
-        case "last_7_days": return 7;
-        case "last_30_days": return 30;
-        case "last_90_days": return 90;
-        case "last_6_months": return 180;
-        case "last_12_months": return 365;
-        case "all_time": return 365 * 5;
-        default: return 90;
-    }
 }
 
 

--- a/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
@@ -5,19 +5,7 @@ import { camelizeKeys } from '@/utils/camelizeKeys';
 
 import aggregatePerformanceHighlights from '@/utils/aggregatePerformanceHighlights';
 import calculatePlatformAverageMetric from '@/utils/calculatePlatformAverageMetric';
-
-// Helper para converter timePeriod string para periodInDays number
-function timePeriodToDays(timePeriod: TimePeriod): number {
-    switch (timePeriod) {
-        case "last_7_days": return 7;
-        case "last_30_days": return 30;
-        case "last_90_days": return 90;
-        case "last_6_months": return 180;
-        case "last_12_months": return 365;
-        case "all_time": return 365 * 5; // Representa "all_time" como um período longo
-        default: return 90; // Default
-    }
-}
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 
 // Helper para formatar valor (simplificado)
 function formatPerformanceValue(value: number, metricField: string): string {

--- a/src/app/api/v1/users/[userId]/performance/conversion-metrics/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/conversion-metrics/route.ts
@@ -3,6 +3,7 @@ import { Types } from 'mongoose';
 import calculateAverageFollowerConversionRatePerPost from '@/utils/calculateAverageFollowerConversionRatePerPost';
 import calculateAccountFollowerConversionRate from '@/utils/calculateAccountFollowerConversionRate';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 
 // Tipos de período
 
@@ -15,18 +16,6 @@ interface UserConversionMetricsResponse {
   insightSummary?: string;
 }
 
-// Converte timePeriod em dias
-function timePeriodToDays(tp: TimePeriod): number {
-  switch (tp) {
-    case 'last_7_days': return 7;
-    case 'last_30_days': return 30;
-    case 'last_90_days': return 90;
-    case 'last_6_months': return 180;
-    case 'last_12_months': return 365;
-    case 'all_time': return 365 * 5;
-    default: return 90;
-  }
-}
 
 export async function GET(
   request: Request,

--- a/src/app/api/v1/users/[userId]/performance/video-metrics/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/video-metrics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
 import calculateAverageVideoMetrics from '@/utils/calculateAverageVideoMetrics';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 
 interface AverageVideoMetricsData {
   averageRetentionRate: number;
@@ -19,17 +20,6 @@ function isAllowedTimePeriod(period: any): period is TimePeriod {
 }
 
 // Helper para converter timePeriod string para periodInDays number
-function timePeriodToDays(timePeriod: TimePeriod): number {
-    switch (timePeriod) {
-        case "last_7_days": return 7;
-        case "last_30_days": return 30;
-        case "last_90_days": return 90;
-        case "last_6_months": return 180;
-        case "last_12_months": return 365;
-        case "all_time": return 365 * 5; // Representa "all_time" como um período longo
-        default: return 90; // Default
-    }
-}
 
 export async function GET(
   request: Request,

--- a/src/utils/timePeriodHelpers.ts
+++ b/src/utils/timePeriodHelpers.ts
@@ -1,0 +1,20 @@
+import { TimePeriod } from '@/app/lib/constants/timePeriods';
+
+export function timePeriodToDays(timePeriod: TimePeriod): number {
+  switch (timePeriod) {
+    case 'last_7_days':
+      return 7;
+    case 'last_30_days':
+      return 30;
+    case 'last_90_days':
+      return 90;
+    case 'last_6_months':
+      return 180;
+    case 'last_12_months':
+      return 365;
+    case 'all_time':
+      return 365 * 5;
+    default:
+      return 90;
+  }
+}


### PR DESCRIPTION
## Summary
- create utility to convert `TimePeriod` strings to days
- reuse helper in performance summary and metrics endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f183bba08832e9b772658ad09e043