### PR TITLE
Add post detail view from videos

### DIFF
--- a/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
+++ b/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 import VideosTable, { VideoListItem, metricLabels } from './VideosTable';
+import PostDetailModal from '../PostDetailModal';
 
 interface VideoDrillDownModalProps {
   isOpen: boolean;
@@ -34,6 +35,7 @@ const VideoDrillDownModal: React.FC<VideoDrillDownModalProps> = ({
     sortBy: drillDownMetric || 'postDate',
     sortOrder: 'desc',
   });
+  const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
 
   const fetchVideos = useCallback(async () => {
     if (!isOpen || !userId) return;
@@ -92,6 +94,10 @@ const VideoDrillDownModal: React.FC<VideoDrillDownModalProps> = ({
     setCurrentPage(1);
   };
 
+  const handleRowClick = (postId: string) => {
+    setSelectedPostId(postId);
+  };
+
   const handlePageChange = (newPage: number) => {
     const totalPages = Math.ceil(totalVideos / limit);
     if (newPage >= 1 && newPage <= totalPages && newPage !== currentPage) {
@@ -129,6 +135,7 @@ const VideoDrillDownModal: React.FC<VideoDrillDownModalProps> = ({
               sortConfig={sortConfig}
               onSort={handleSort}
               primaryMetric={sortConfig.sortBy}
+              onRowClick={handleRowClick}
             />
           )}
         </div>
@@ -157,6 +164,11 @@ const VideoDrillDownModal: React.FC<VideoDrillDownModalProps> = ({
           </div>
         )}
       </div>
+      <PostDetailModal
+        isOpen={selectedPostId !== null}
+        onClose={() => setSelectedPostId(null)}
+        postId={selectedPostId}
+      />
     </div>
   );
 };

--- a/src/app/admin/creator-dashboard/components/VideosTable.tsx
+++ b/src/app/admin/creator-dashboard/components/VideosTable.tsx
@@ -31,6 +31,7 @@ interface VideosTableProps {
   sortConfig: SortConfig;
   onSort: (column: string) => void;
   primaryMetric: string;
+  onRowClick?: (postId: string) => void;
 }
 
 export const metricLabels: Record<string, string> = {
@@ -43,7 +44,7 @@ export const metricLabels: Record<string, string> = {
   video_duration_seconds: 'Duração (s)',
 };
 
-const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, primaryMetric }) => {
+const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, primaryMetric, onRowClick }) => {
   const renderSortIcon = (key: string) => {
     if (sortConfig.sortBy !== key) {
       return <ChevronDownIcon className="w-3 h-3 inline text-gray-400 ml-1" />;
@@ -168,7 +169,11 @@ const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, p
         </thead>
         <tbody className="bg-white divide-y divide-gray-200">
           {videos.map((video) => (
-            <tr key={video._id} className="hover:bg-gray-50 transition-colors">
+            <tr
+              key={video._id}
+              className="hover:bg-gray-50 transition-colors cursor-pointer"
+              onClick={() => onRowClick && onRowClick(video._id)}
+            >
               {columns.map((col) => (
                 <td
                   key={col.key}


### PR DESCRIPTION
## Summary
- make VideosTable optionally clickable
- handle row clicks in VideoDrillDownModal to open PostDetailModal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f24f2ee70832eafde6cbef89f6add