### PR TITLE
Fix metric click mapping and tests

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -206,7 +206,7 @@ const UserVideoPerformanceMetrics: React.FC<
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div
               className="cursor-pointer"
-              onClick={() => handleMetricClick("averageRetentionRate")}
+              onClick={() => handleMetricClick("retention_rate")}
             >
               <MetricDisplay
                 label="Retenção Média"
@@ -221,7 +221,7 @@ const UserVideoPerformanceMetrics: React.FC<
             </div>
             <div
               className="cursor-pointer"
-              onClick={() => handleMetricClick("averageWatchTimeSeconds")}
+              onClick={() => handleMetricClick("average_video_watch_time_seconds")}
             >
               <MetricDisplay
                 label="Tempo Médio de Visualização"
@@ -236,7 +236,7 @@ const UserVideoPerformanceMetrics: React.FC<
             </div>
             <div
               className="cursor-pointer"
-              onClick={() => handleMetricClick("numberOfVideoPosts")}
+              onClick={() => handleMetricClick("views")}
             >
               <MetricDisplay
                 label="Total de Vídeos Analisados"

--- a/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserVideoPerformanceMetrics from '../UserVideoPerformanceMetrics';
+import { useGlobalTimePeriod } from '../filters/GlobalTimePeriodContext';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(),
+}));
+
+jest.mock('../VideoDrillDownModal', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(({ isOpen, drillDownMetric }) =>
+      isOpen ? <div data-testid="drilldown-modal">{drillDownMetric}</div> : null,
+    ),
+  };
+});
+
+const mockUseGlobalTimePeriod = useGlobalTimePeriod as jest.Mock;
+const MockVideoDrillDownModal = require('../VideoDrillDownModal').default as jest.Mock;
+
+describe('UserVideoPerformanceMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGlobalTimePeriod.mockReturnValue({ timePeriod: 'last_30_days' });
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        averageRetentionRate: 50,
+        averageWatchTimeSeconds: 120,
+        numberOfVideoPosts: 10,
+      }),
+    });
+  });
+
+  it('opens drill down modal with "retention_rate" when Retenção Média is clicked', async () => {
+    render(<UserVideoPerformanceMetrics userId="u1" />);
+    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Retenção Média'));
+    expect(MockVideoDrillDownModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true, drillDownMetric: 'retention_rate' }),
+      {}
+    );
+    expect(screen.getByTestId('drilldown-modal')).toHaveTextContent('retention_rate');
+  });
+
+  it('opens drill down modal with "average_video_watch_time_seconds" when Tempo Médio de Visualização is clicked', async () => {
+    render(<UserVideoPerformanceMetrics userId="u1" />);
+    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Tempo Médio de Visualização'));
+    expect(MockVideoDrillDownModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true, drillDownMetric: 'average_video_watch_time_seconds' }),
+      {}
+    );
+    expect(screen.getByTestId('drilldown-modal')).toHaveTextContent('average_video_watch_time_seconds');
+  });
+
+  it('opens drill down modal with "views" when Total de Vídeos Analisados is clicked', async () => {
+    render(<UserVideoPerformanceMetrics userId="u1" />);
+    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Total de Vídeos Analisados'));
+    expect(MockVideoDrillDownModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true, drillDownMetric: 'views' }),
+      {}
+    );
+    expect(screen.getByTestId('drilldown-modal')).toHaveTextContent('views');
+  });
+});


### PR DESCRIPTION
## Summary
- map metric clicks in UserVideoPerformanceMetrics to API metric names
- test modal open metric when each card is clicked

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f24eeb0f8832e867d823a3fd3493d