### PR TITLE
Add button to open video table from metrics

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -245,6 +245,17 @@ const UserVideoPerformanceMetrics: React.FC<
               />
             </div>
           </div>
+          <div className="mt-4">
+            <button
+              onClick={() => {
+                setDrillDownMetric('views');
+                setIsModalOpen(true);
+              }}
+              className="px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700"
+            >
+              Ver Todos os Vídeos
+            </button>
+          </div>
           {insightSummary && (
             <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100">
               {insightSummary}

--- a/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
@@ -66,4 +66,15 @@ describe('UserVideoPerformanceMetrics', () => {
     );
     expect(screen.getByTestId('drilldown-modal')).toHaveTextContent('views');
   });
+
+  it('opens drill down modal with "views" when "Ver Todos os Vídeos" button is clicked', async () => {
+    render(<UserVideoPerformanceMetrics userId="u1" />);
+    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Ver Todos os Vídeos'));
+    expect(MockVideoDrillDownModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true, drillDownMetric: 'views' }),
+      {}
+    );
+    expect(screen.getByTestId('drilldown-modal')).toHaveTextContent('views');
+  });
 });


### PR DESCRIPTION
## Summary
- enable opening VideoDrillDownModal sorted by views via new button
- test the new "Ver Todos os Vídeos" interaction

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2a005348832eb113b2a79d3fea88