### PR TITLE
Add sortBy metric mapping for user videos API

### DIFF
--- a/src/app/api/v1/users/[userId]/videos/list/route.test.ts
+++ b/src/app/api/v1/users/[userId]/videos/list/route.test.ts
@@ -46,6 +46,27 @@ describe('GET /api/v1/users/[userId]/videos/list', () => {
     });
   });
 
+  it('maps sortBy params using helper', async () => {
+    mockFindUserVideoPosts.mockResolvedValueOnce({
+      videos: [],
+      totalVideos: 0,
+      page: 1,
+      limit: 10,
+    });
+
+    const req = createRequest(userId, '?sortBy=views');
+    await GET(req, { params: { userId } });
+
+    expect(mockFindUserVideoPosts).toHaveBeenCalledWith({
+      userId,
+      timePeriod: 'last_90_days',
+      sortBy: 'stats.views',
+      sortOrder: 'desc',
+      page: 1,
+      limit: 10,
+    });
+  });
+
   it('returns 400 for invalid timePeriod', async () => {
     const req = createRequest(userId, '?timePeriod=bad');
     const res = await GET(req, { params: { userId } });

--- a/src/app/api/v1/users/[userId]/videos/list/route.ts
+++ b/src/app/api/v1/users/[userId]/videos/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
 import { findUserVideoPosts } from '@/app/lib/dataService/marketAnalysis/postsService';
+import { mapMetricToDbField } from '@/app/lib/dataService/marketAnalysis/helpers';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 
 // Default sorting when none is provided via query params
@@ -18,7 +19,8 @@ export async function GET(
 
   const { searchParams } = new URL(request.url);
   const timePeriodParam = searchParams.get('timePeriod') as TimePeriod | null;
-  const sortBy = searchParams.get('sortBy') || DEFAULT_SORT_BY;
+  const sortByParam = searchParams.get('sortBy') || DEFAULT_SORT_BY;
+  const sortBy = mapMetricToDbField(sortByParam);
   const sortOrder = searchParams.get('sortOrder') === 'asc' ? 'asc' : 'desc';
   const page = parseInt(searchParams.get('page') || '1', 10);
   const limit = parseInt(searchParams.get('limit') || '10', 10);

--- a/src/app/lib/dataService/marketAnalysis/helpers.ts
+++ b/src/app/lib/dataService/marketAnalysis/helpers.ts
@@ -34,6 +34,13 @@ export const createBasePipeline = (): PipelineStage[] => [
  * @returns {string} O nome do campo no banco de dados.
  */
 export function mapMetricToDbField(metric: string): string {
-    // Atualmente, assume uma correspondência direta. Expanda se os nomes divergirem.
-    return metric;
+    const metricMap: Record<string, string> = {
+        views: 'stats.views',
+        likes: 'stats.likes',
+        comments: 'stats.comments',
+        shares: 'stats.shares',
+        total_interactions: 'stats.total_interactions',
+    };
+
+    return metricMap[metric] || metric;
 }


### PR DESCRIPTION
## Summary
- extend `mapMetricToDbField` to translate metrics like `views` → `stats.views`
- map the `sortBy` query parameter in the user videos list endpoint using the helper
- test new mapping logic in the route tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2a036c80832eaa08b362af5d4274