### PR TITLE
Add keyboard accessibility for VideosTable rows

### DIFF
--- a/src/app/admin/creator-dashboard/components/VideosTable.tsx
+++ b/src/app/admin/creator-dashboard/components/VideosTable.tsx
@@ -173,6 +173,14 @@ const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, p
               key={video._id}
               className="hover:bg-gray-50 transition-colors cursor-pointer"
               onClick={() => onRowClick && onRowClick(video._id)}
+              tabIndex={0}
+              role="button"
+              onKeyDown={(e) => {
+                if ((e.key === 'Enter' || e.key === ' ') && onRowClick) {
+                  e.preventDefault();
+                  onRowClick(video._id);
+                }
+              }}
             >
               {columns.map((col) => (
                 <td


### PR DESCRIPTION
## Summary
- make video table rows focusable and operable with keyboard

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2a097b28832e8b3c2bc1ce152bff