### PR TITLE
Implement creator highlight tables

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorHighlightsTables.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorHighlightsTables.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from 'react';
+import TopCreatorsWidget from '../TopCreatorsWidget';
+
+const CreatorHighlightsTables: React.FC = () => (
+  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+    <TopCreatorsWidget
+      title="Top Interações"
+      metric="total_interactions"
+      days={30}
+      limit={5}
+    />
+    <TopCreatorsWidget
+      title="Maior Engajamento"
+      metric="engagement_rate_on_reach"
+      metricLabel="%"
+      days={30}
+      limit={5}
+    />
+    <TopCreatorsWidget
+      title="Mais Curtidas"
+      metric="likes"
+      days={30}
+      limit={5}
+    />
+    <TopCreatorsWidget
+      title="Mais Compartilhamentos"
+      metric="shares"
+      days={30}
+      limit={5}
+    />
+  </div>
+);
+
+export default CreatorHighlightsTables;

--- a/src/app/admin/creator-dashboard/components/views/CreatorHighlightsSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorHighlightsSection.tsx
@@ -3,15 +3,14 @@
 import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import CreatorsScatterPlot from "../CreatorsScatterPlot";
+import CreatorHighlightsTables from "../CreatorHighlightsTables";
 
 const CreatorHighlightsSection: React.FC = () => (
   <section id="creator-highlights-and-scatter-plot" className="mb-10">
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
       Destaques e Análise Comparativa de Criadores <GlobalPeriodIndicator />
     </h2>
-    <p className="text-sm text-gray-500 mb-4 italic">
-      (Em breve: Tabelas de Criadores com melhor performance)
-    </p>
+    <CreatorHighlightsTables />
     <CreatorsScatterPlot />
   </section>
 );


### PR DESCRIPTION
## Summary
- show tables of top performing creators in the creator highlights section
- add new `CreatorHighlightsTables` component rendering multiple `TopCreatorsWidget`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f32bf3dc8832e866d91ecaef51be4