### PR TITLE
Restore AlertHistoryEntrySchema fields

### DIFF
--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -257,7 +257,22 @@ const AvailableInstagramAccountSchema = new Schema<IAvailableInstagramAccount>({
 const UserPreferencesSchema = new Schema<IUserPreferences>({/*...*/}, {/*...*/}); // Placeholder for brevity
 const UserLongTermGoalSchema = new Schema<IUserLongTermGoal>({/*...*/}, {/*...*/}); // Placeholder for brevity
 const UserKeyFactSchema = new Schema<IUserKeyFact>({/*...*/}, {/*...*/}); // Placeholder for brevity
-const AlertHistoryEntrySchema = new Schema<IAlertHistoryEntry>({/*...*/}, {/*...*/}); // Placeholder for brevity
+const AlertHistoryEntrySchema = new Schema<IAlertHistoryEntry>({
+  type: { type: String, required: true },
+  date: { type: Date, required: true, default: Date.now },
+  messageForAI: { type: String, default: "" },
+  finalUserMessage: { type: String, default: "" },
+  details: { type: Schema.Types.Mixed, required: true },
+  userInteraction: {
+    type: {
+        type: String,
+        enum: ['explored_further', 'dismissed', 'not_interacted', 'error_sending', 'pending_interaction', 'not_applicable', 'viewed', 'clicked_suggestion', 'provided_feedback'],
+        default: 'pending_interaction'
+    },
+    feedback: { type: String },
+    interactedAt: { type: Date }
+  },
+}, { _id: true });
 
 
 const userSchema = new Schema<IUser>(


### PR DESCRIPTION
## Summary
- restore `AlertHistoryEntrySchema` definition so alert history data is fully persisted

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606e40a718832e8166a1d2692f684f