### PR TITLE
Implement media kit management

### DIFF
--- a/src/app/admin/creators-management/page.tsx
+++ b/src/app/admin/creators-management/page.tsx
@@ -155,11 +155,30 @@ export default function CreatorsManagementPage() {
     }
   };
 
+  const handleGenerateMediaKit = async (creatorId: string) => {
+    const loadingId = toast.loading('Gerando link...');
+    try {
+      const res = await fetch(`/api/admin/users/${creatorId}/generate-media-kit-token`, { method: 'POST' });
+      toast.dismiss(loadingId);
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Falha ao gerar link');
+      }
+      const data = await res.json();
+      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitToken: data.token } : c));
+      toast.success('Link gerado!');
+    } catch (e: any) {
+      toast.dismiss(loadingId);
+      toast.error(e.message);
+    }
+  };
+
   const columns: ColumnConfig<AdminCreatorListItem>[] = useMemo(() => [
     { key: 'name', label: 'Nome', sortable: true },
     { key: 'email', label: 'Email', sortable: true },
     { key: 'registrationDate', label: 'Data Registro', sortable: true },
     { key: 'planStatus', label: 'Plano', sortable: true },
+    { key: 'mediaKit', label: 'Mídia Kit', sortable: false },
     { key: 'adminStatus', label: 'Status Admin', sortable: true },
     { key: 'actions', label: 'Ações', sortable: false, headerClassName: 'text-right', className: 'text-right' },
   ], []);
@@ -278,6 +297,25 @@ export default function CreatorsManagementPage() {
                     {creator.registrationDate ? new Date(creator.registrationDate).toLocaleDateString('pt-BR') : 'N/A'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{creator.planStatus || 'N/A'}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    {creator.mediaKitToken ? (
+                      <a
+                        href={`/mediakit/${creator.mediaKitToken}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-indigo-600 hover:underline"
+                      >
+                        Abrir
+                      </a>
+                    ) : (
+                      <button
+                        onClick={() => handleGenerateMediaKit(creator._id)}
+                        className="text-indigo-600 hover:underline"
+                      >
+                        Gerar
+                      </button>
+                    )}
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <StatusBadge status={creator.adminStatus} size="sm" />
                   </td>

--- a/src/lib/services/adminCreatorService.test.ts
+++ b/src/lib/services/adminCreatorService.test.ts
@@ -122,7 +122,8 @@ describe('AdminCreatorService', () => {
           email: 'one@example.com',
           planStatus: 'Pro',
           adminStatus: 'approved',
-          profile_picture_url: 'url1'
+          profile_picture_url: 'url1',
+          mediaKitToken: 'token1',
           // registrationDate é omitido para testar fallback para _id.getTimestamp()
         },
         {
@@ -131,7 +132,8 @@ describe('AdminCreatorService', () => {
           email: 'two@example.com',
           adminStatus: 'pending',
           registrationDate: date2,
-          profile_picture_url: 'url2'
+          profile_picture_url: 'url2',
+          mediaKitToken: undefined,
         },
       ];
       (UserModel.exec as jest.Mock).mockResolvedValueOnce(mockUserData.map(u => ({...u, _id: u._id.toString() }))); // lean() returns plain objects
@@ -147,6 +149,7 @@ describe('AdminCreatorService', () => {
         planStatus: 'Pro',
         adminStatus: 'approved',
         profilePictureUrl: 'url1',
+        mediaKitToken: 'token1',
         registrationDate: date1, // from _id.getTimestamp()
       }));
        expect(creators[1]).toEqual(expect.objectContaining({
@@ -155,6 +158,7 @@ describe('AdminCreatorService', () => {
         email: 'two@example.com',
         adminStatus: 'pending',
         profilePictureUrl: 'url2',
+        mediaKitToken: undefined,
         registrationDate: date2,
       }));
     });

--- a/src/lib/services/adminCreatorService.ts
+++ b/src/lib/services/adminCreatorService.ts
@@ -120,7 +120,17 @@ export async function fetchCreators(
     // Assumindo que IUser tem campos como adminStatus e registrationDate (ou _id para inferir registrationDate)
     // e que profile_picture_url é o nome do campo no UserModel
     const creators: AdminCreatorListItem[] = creatorsData.map((userDoc) => {
-      const user = userDoc as IUser & { _id: Types.ObjectId; registrationDate?: Date; adminStatus?: AdminCreatorStatus; profile_picture_url?: string; planStatus?: string; inferredExpertiseLevel?: string; name?: string; email?: string };
+      const user = userDoc as IUser & {
+        _id: Types.ObjectId;
+        registrationDate?: Date;
+        adminStatus?: AdminCreatorStatus;
+        profile_picture_url?: string;
+        planStatus?: string;
+        inferredExpertiseLevel?: string;
+        mediaKitToken?: string;
+        name?: string;
+        email?: string;
+      };
       return {
         _id: user._id.toString(),
         name: user.name || 'N/A',
@@ -128,6 +138,7 @@ export async function fetchCreators(
         planStatus: user.planStatus,
         inferredExpertiseLevel: user.inferredExpertiseLevel,
         profilePictureUrl: user.profile_picture_url,
+        mediaKitToken: user.mediaKitToken,
         adminStatus: user.adminStatus || 'pending', // Default se não existir
         registrationDate: user.registrationDate || user._id.getTimestamp(), // Usa _id se registrationDate não existir
         // totalPostsInPeriod e lastActivityDate seriam calculados separadamente se necessário via $lookup ou outra query

--- a/src/types/admin/creators.ts
+++ b/src/types/admin/creators.ts
@@ -11,6 +11,7 @@ export interface AdminCreatorListItem {
   planStatus?: string; // Status do plano (ex: 'Free', 'Pro', 'Trial') - vindo do UserModel
   inferredExpertiseLevel?: string; // Nível de expertise inferido - vindo do UserModel
   profilePictureUrl?: string; // URL da foto de perfil
+  mediaKitToken?: string; // Token do mídia kit, se já gerado
 
   totalPostsInPeriod?: number; // Número de posts no período filtrado (se aplicável ao contexto da lista)
   lastActivityDate?: Date | string; // Data da última atividade (post)


### PR DESCRIPTION
## Summary
- expose `mediaKitToken` on admin creator listing types and service
- add GET method to retrieve media kit link
- show media kit column in admin creators table with a generate button
- allow generating media kit links via admin UI
- update tests for new field

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686084a15d98832eac9ab4852f18bf7c