### PR TITLE
Improve media kit table usability

### DIFF
--- a/src/app/admin/creator-dashboard/components/VideosTable.tsx
+++ b/src/app/admin/creator-dashboard/components/VideosTable.tsx
@@ -36,6 +36,10 @@ interface VideosTableProps {
   onSort: (column: string) => void;
   primaryMetric: string;
   onRowClick?: (postId: string) => void;
+  /**
+   * When true the table becomes read only: sorting and row clicks are disabled.
+   */
+  readOnly?: boolean;
 }
 
 export const metricLabels: Record<string, string> = {
@@ -52,7 +56,7 @@ export const metricLabels: Record<string, string> = {
   retention_rate: 'Retenção',
 };
 
-const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, onRowClick }) => {
+const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, onRowClick, readOnly = false }) => {
   const renderSortIcon = (key: string) => {
     if (sortConfig.sortBy !== key) {
       return <ChevronDownIcon className="w-3 h-3 inline text-gray-400 opacity-50 ml-1" />;
@@ -100,13 +104,13 @@ const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, o
                 key={col.key}
                 scope="col"
                 className={`px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider text-${col.align} ${
-                  col.sortable ? 'cursor-pointer hover:bg-gray-200 transition-colors' : ''
+                  col.sortable && !readOnly ? 'cursor-pointer hover:bg-gray-200 transition-colors' : ''
                 }`}
-                onClick={() => col.sortable && onSort(col.key)}
+                onClick={() => !readOnly && col.sortable && onSort(col.key)}
               >
                 <div className={`flex items-center ${col.align === 'center' ? 'justify-center' : ''}`}>
                   {col.label}
-                  {col.sortable && renderSortIcon(col.key)}
+                  {col.sortable && !readOnly && renderSortIcon(col.key)}
                 </div>
               </th>
             ))}
@@ -117,9 +121,9 @@ const VideosTable: React.FC<VideosTableProps> = ({ videos, sortConfig, onSort, o
             <tr
               key={video._id}
               className="hover:bg-indigo-50 transition-colors"
-              onClick={() => onRowClick && onRowClick(video._id)}
-              tabIndex={0}
-              role="button"
+              {...(!readOnly && onRowClick
+                ? { onClick: () => onRowClick(video._id), tabIndex: 0, role: 'button' }
+                : {})}
             >
               {/* MUDANÇA: Adicionada célula para renderizar a thumbnail */}
               <td className="px-4 py-2">

--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -149,13 +149,19 @@ export default async function MediaKitPage({ params }: { params: { token: string
           sortConfig={{ sortBy: 'stats.views', sortOrder: 'desc' }}
           onSort={() => {}}
           primaryMetric="stats.views"
+          readOnly
         />
       </div>
 
       <div className="bg-indigo-600 text-white text-center p-6 rounded-xl">
         <h3 className="text-2xl font-semibold mb-2">Vamos trabalhar juntos?</h3>
         <p className="mb-4">Entre em contato para parcerias e oportunidades.</p>
-        <a href="mailto:arthur@data2content.ai" className="bg-white text-indigo-700 px-6 py-3 rounded-lg font-semibold">Fale Conosco</a>
+        <a
+          href={`mailto:${user.email}`}
+          className="bg-white text-indigo-700 px-6 py-3 rounded-lg font-semibold"
+        >
+          Fale Conosco
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make `VideosTable` support read-only mode
- disable sorting and row click for media kit table
- use creator email in media kit CTA

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608b4f4aa8832e8e34a15ea0b283bf