### PR TITLE
Add media kit metrics filter and averages

### DIFF
--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -35,10 +35,18 @@ export interface VideoListItem {
     followerGrowth: KPIComparisonData;
     engagementRate: KPIComparisonData; // <- A definição correta
     postingFrequency: KPIComparisonData;
+    avgViewsPerPost: KPIComparisonData;
+    avgCommentsPerPost: KPIComparisonData;
+    avgSharesPerPost: KPIComparisonData;
+    avgSavesPerPost: KPIComparisonData;
     insightSummary?: {
       followerGrowth?: string;
       engagementRate?: string;
       postingFrequency?: string;
+      avgViewsPerPost?: string;
+      avgCommentsPerPost?: string;
+      avgSharesPerPost?: string;
+      avgSavesPerPost?: string;
     };
   }
   


### PR DESCRIPTION
## Summary
- extend `KpiComparison` types with average metrics
- compute averages for views, comments, shares and saves in KPI API
- add period filter and display new metrics in media kit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b2271f7c832e8b9a7d89a6ebe3f2