### PR TITLE
Add metrics filter for media kit

### DIFF
--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -1,7 +1,7 @@
 // src/app/mediakit/[token]/MediaKitView.tsx (CORRIGIDO)
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { FaChartLine, FaTrophy, FaStar, FaChartBar, FaEnvelope, FaArrowUp, FaArrowDown } from 'react-icons/fa';
 
@@ -34,6 +34,47 @@ export default function MediaKitView({ user, summary, videos, kpis }: MediaKitVi
     })
   };
 
+  const PERIOD_OPTIONS = [
+    { value: 'month_vs_previous', label: 'Mês vs. Anterior' },
+    { value: 'last_7d_vs_previous_7d', label: '7d vs. 7d Anteriores' },
+    { value: 'last_30d_vs_previous_30d', label: '30d vs. 30d Anteriores' }
+  ];
+  const [comparisonPeriod, setComparisonPeriod] = useState<string>(PERIOD_OPTIONS[2].value);
+  const [kpiData, setKpiData] = useState<typeof kpis>(kpis);
+
+  const METRIC_OPTIONS = [
+    { key: 'followerGrowth', label: 'Pulso do Crescimento' },
+    { key: 'engagementRate', label: 'Conexão com a Audiência' },
+    { key: 'postingFrequency', label: 'Consistência e Alcance' },
+    { key: 'avgViewsPerPost', label: 'Média de Visualizações' },
+    { key: 'avgCommentsPerPost', label: 'Média de Comentários' },
+    { key: 'avgSharesPerPost', label: 'Média de Compartilhamentos' },
+    { key: 'avgSavesPerPost', label: 'Média de Salvamentos' },
+  ] as const;
+  const [visibleMetrics, setVisibleMetrics] = useState<Record<string, boolean>>(
+    METRIC_OPTIONS.reduce((acc, opt) => ({ ...acc, [opt.key]: true }), {} as Record<string, boolean>)
+  );
+
+  function toggleMetric(key: string) {
+    setVisibleMetrics((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  useEffect(() => {
+    async function fetchData() {
+      if (!user?._id) return;
+      try {
+        const res = await fetch(`/api/v1/users/${user._id}/kpis/periodic-comparison?comparisonPeriod=${comparisonPeriod}`);
+        if (res.ok) {
+          const data = await res.json();
+          setKpiData(data);
+        }
+      } catch (err) {
+        console.error('Erro ao buscar KPIs', err);
+      }
+    }
+    fetchData();
+  }, [comparisonPeriod, user?._id]);
+
   return (
     <div className="bg-slate-50 min-h-screen font-sans">
       <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
@@ -51,33 +92,102 @@ export default function MediaKitView({ user, summary, videos, kpis }: MediaKitVi
                 {user.biography && <p className="text-gray-600 mt-5 text-center whitespace-pre-line font-light">{user.biography}</p>}
               </div>
             </motion.div>
-            {(summary || kpis) && (
+            {(summary || kpiData) && (
               <motion.div variants={cardVariants} initial="hidden" animate="visible" custom={1}>
                 <div className="bg-white p-6 sm:p-8 rounded-xl shadow-lg border-t-4 border-pink-500 space-y-6">
                   <div className="flex items-center gap-3">
                     <FaChartLine className="w-6 h-6 text-pink-500" />
-                    <h2 className="text-xl font-bold text-gray-800">Performance e Destaques</h2>
+                    <h2 className="text-xl font-bold text-gray-800 flex-grow">Performance e Destaques</h2>
+                    <select
+                      className="text-sm border-gray-300 rounded-md"
+                      value={comparisonPeriod}
+                      onChange={(e) => setComparisonPeriod(e.target.value)}
+                    >
+                      {PERIOD_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <details className="ml-2 text-sm">
+                      <summary className="cursor-pointer select-none">Métricas</summary>
+                      <div className="mt-2 bg-white p-2 border rounded shadow-md absolute z-10">
+                        {METRIC_OPTIONS.map((opt) => (
+                          <label key={opt.key} className="block whitespace-nowrap">
+                            <input
+                              type="checkbox"
+                              className="mr-1"
+                              checked={visibleMetrics[opt.key]}
+                              onChange={() => toggleMetric(opt.key)}
+                            />
+                            {opt.label}
+                          </label>
+                        ))}
+                      </div>
+                    </details>
                   </div>
-                  {kpis && (
+                  {kpiData && (
                     <div className="space-y-4">
-                       <div className="p-4 rounded-lg bg-gray-50 border border-gray-200">
-                           <h3 className="text-sm font-semibold text-gray-700 flex items-center">
-                               Pulso do Crescimento
-                               <TrendIndicator value={kpis.followerGrowth?.percentageChange} />
-                           </h3>
-                           <p className="text-3xl font-bold text-gray-900 mt-1">+{kpis.followerGrowth?.currentValue?.toLocaleString() ?? 'N/A'}</p>
-                           <p className="text-xs text-gray-500 mt-1">{kpis.insightSummary?.followerGrowth}</p>
-                       </div>
-                       <div className="p-4 rounded-lg bg-gray-50 border border-gray-200">
-                           <h3 className="text-sm font-semibold text-gray-700 flex items-center">
-                               Conexão com a Audiência
-                               {/* CORREÇÃO: Adicionado '?' para evitar o erro caso engagementRate não exista */}
-                               <TrendIndicator value={kpis.engagementRate?.percentageChange} />
-                           </h3>
-                           <p className="text-3xl font-bold text-gray-900 mt-1">{kpis.engagementRate?.currentValue?.toFixed(2) ?? 'N/A'}%</p>
-                           <p className="text-xs text-gray-500 mt-1">{kpis.insightSummary?.engagementRate}</p>
-                       </div>
-                      <MetricCardWithTrend label="Consistência e Alcance" value={kpis.postingFrequency?.currentValue?.toFixed(1)} trendData={kpis.postingFrequency?.chartData?.map(c => c.value)} recommendation={kpis.insightSummary?.postingFrequency || ''}/>
+                      {visibleMetrics.followerGrowth && (
+                        <div className="p-4 rounded-lg bg-gray-50 border border-gray-200">
+                          <h3 className="text-sm font-semibold text-gray-700 flex items-center">
+                            Pulso do Crescimento
+                            <TrendIndicator value={kpiData.followerGrowth?.percentageChange} />
+                          </h3>
+                          <p className="text-3xl font-bold text-gray-900 mt-1">{kpiData.followerGrowth?.currentValue?.toLocaleString() ?? 'N/A'}</p>
+                          <p className="text-xs text-gray-500 mt-1">{kpiData.insightSummary?.followerGrowth}</p>
+                        </div>
+                      )}
+                      {visibleMetrics.engagementRate && (
+                        <div className="p-4 rounded-lg bg-gray-50 border border-gray-200">
+                          <h3 className="text-sm font-semibold text-gray-700 flex items-center">
+                            Conexão com a Audiência
+                            <TrendIndicator value={kpiData.engagementRate?.percentageChange} />
+                          </h3>
+                          <p className="text-3xl font-bold text-gray-900 mt-1">{kpiData.engagementRate?.currentValue?.toFixed(2) ?? 'N/A'}%</p>
+                          <p className="text-xs text-gray-500 mt-1">{kpiData.insightSummary?.engagementRate}</p>
+                        </div>
+                      )}
+                      {visibleMetrics.postingFrequency && (
+                        <MetricCardWithTrend
+                          label="Consistência e Alcance"
+                          value={kpiData.postingFrequency?.currentValue?.toFixed(1)}
+                          trendData={kpiData.postingFrequency?.chartData?.map((c) => c.value)}
+                          recommendation={kpiData.insightSummary?.postingFrequency || ''}
+                        />
+                      )}
+                      {visibleMetrics.avgViewsPerPost && (
+                        <MetricCardWithTrend
+                          label="Média de Visualizações"
+                          value={kpiData.avgViewsPerPost?.currentValue?.toFixed(0)}
+                          trendData={kpiData.avgViewsPerPost?.chartData?.map((c) => c.value)}
+                          recommendation=""
+                        />
+                      )}
+                      {visibleMetrics.avgCommentsPerPost && (
+                        <MetricCardWithTrend
+                          label="Média de Comentários"
+                          value={kpiData.avgCommentsPerPost?.currentValue?.toFixed(0)}
+                          trendData={kpiData.avgCommentsPerPost?.chartData?.map((c) => c.value)}
+                          recommendation=""
+                        />
+                      )}
+                      {visibleMetrics.avgSharesPerPost && (
+                        <MetricCardWithTrend
+                          label="Média de Compartilhamentos"
+                          value={kpiData.avgSharesPerPost?.currentValue?.toFixed(0)}
+                          trendData={kpiData.avgSharesPerPost?.chartData?.map((c) => c.value)}
+                          recommendation=""
+                        />
+                      )}
+                      {visibleMetrics.avgSavesPerPost && (
+                        <MetricCardWithTrend
+                          label="Média de Salvamentos"
+                          value={kpiData.avgSavesPerPost?.currentValue?.toFixed(0)}
+                          trendData={kpiData.avgSavesPerPost?.chartData?.map((c) => c.value)}
+                          recommendation=""
+                        />
+                      )}
                     </div>
                   )}
                   {summary && (

--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -35,10 +35,18 @@ export interface VideoListItem {
     followerGrowth: KPIComparisonData;
     engagementRate: KPIComparisonData; // <- A definição correta
     postingFrequency: KPIComparisonData;
+    avgViewsPerPost: KPIComparisonData;
+    avgCommentsPerPost: KPIComparisonData;
+    avgSharesPerPost: KPIComparisonData;
+    avgSavesPerPost: KPIComparisonData;
     insightSummary?: {
       followerGrowth?: string;
       engagementRate?: string;
       postingFrequency?: string;
+      avgViewsPerPost?: string;
+      avgCommentsPerPost?: string;
+      avgSharesPerPost?: string;
+      avgSavesPerPost?: string;
     };
   }
   


### PR DESCRIPTION
## Summary
- add checkbox filter to choose which metrics are displayed in MediaKitView
- allow toggling of follower growth, engagement rate, posting frequency, and new average metrics

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b2271f7c832e8b9a7d89a6ebe3f2