### PR TITLE
Add MediaKit access logging

### DIFF
--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
+import { headers } from 'next/headers';
+import { logMediaKitAccess } from '@/lib/logMediaKitAccess';
 import MediaKitView from './MediaKitView';
 
 // Tipos centralizados para garantir consistência em todo o fluxo de dados.
@@ -75,6 +77,12 @@ export default async function MediaKitPage({ params }: { params: { token: string
   if (!user) {
     notFound(); // Se o token for inválido, exibe a página 404.
   }
+
+  // Registra o acesso ao Mídia Kit para fins de auditoria
+  const reqHeaders = headers();
+  const ip = reqHeaders.get('x-real-ip') || reqHeaders.get('x-forwarded-for') || '';
+  const referer = reqHeaders.get('referer') || undefined;
+  await logMediaKitAccess(user._id.toString(), ip, referer);
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
   

--- a/src/app/models/MediaKitAccessLog.ts
+++ b/src/app/models/MediaKitAccessLog.ts
@@ -1,0 +1,26 @@
+import { Schema, model, models, Document, Types, Model } from "mongoose";
+
+export interface IMediaKitAccessLog extends Document {
+  user: Types.ObjectId;
+  ip: string;
+  referer?: string;
+  timestamp: Date;
+}
+
+const mediaKitAccessLogSchema = new Schema<IMediaKitAccessLog>({
+  user: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  ip: { type: String, required: true },
+  referer: { type: String },
+  timestamp: { type: Date, required: true, default: Date.now },
+});
+
+// Índices para consultas por usuário e ordenação por data
+mediaKitAccessLogSchema.index({ user: 1 });
+mediaKitAccessLogSchema.index({ timestamp: -1 });
+
+const MediaKitAccessLogModel: Model<IMediaKitAccessLog> =
+  models.MediaKitAccessLog ||
+  model<IMediaKitAccessLog>("MediaKitAccessLog", mediaKitAccessLogSchema);
+
+export default MediaKitAccessLogModel;
+

--- a/src/lib/logMediaKitAccess.ts
+++ b/src/lib/logMediaKitAccess.ts
@@ -1,0 +1,17 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import MediaKitAccessLogModel from '@/app/models/MediaKitAccessLog';
+import { logger } from '@/app/lib/logger';
+
+/**
+ * Registra um acesso ao Media Kit.
+ */
+export async function logMediaKitAccess(userId: string, ip: string, referer?: string): Promise<void> {
+  const TAG = '[logMediaKitAccess]';
+  try {
+    await connectToDatabase();
+    await MediaKitAccessLogModel.create({ user: userId, ip, referer, timestamp: new Date() });
+  } catch (err) {
+    logger.error(`${TAG} Failed to log access for user ${userId}:`, err);
+  }
+}
+


### PR DESCRIPTION
## Summary
- create model `MediaKitAccessLog`
- add `logMediaKitAccess` utility
- log each visit in the media kit page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686172276dc4832ea00ee1f43bb28205