### PR TITLE
Add media kit token revoke endpoint

### DIFF
--- a/src/app/admin/creators-management/page.tsx
+++ b/src/app/admin/creators-management/page.tsx
@@ -173,6 +173,23 @@ export default function CreatorsManagementPage() {
     }
   };
 
+  const handleRevokeMediaKit = async (creatorId: string) => {
+    const loadingId = toast.loading('Revogando link...');
+    try {
+      const res = await fetch(`/api/admin/users/${creatorId}/media-kit-token`, { method: 'DELETE' });
+      toast.dismiss(loadingId);
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Falha ao revogar link');
+      }
+      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitToken: undefined } : c));
+      toast.success('Link revogado!');
+    } catch (e: any) {
+      toast.dismiss(loadingId);
+      toast.error(e.message);
+    }
+  };
+
   const columns: ColumnConfig<AdminCreatorListItem>[] = useMemo(() => [
     { key: 'name', label: 'Nome', sortable: true },
     { key: 'email', label: 'Email', sortable: true },
@@ -299,14 +316,22 @@ export default function CreatorsManagementPage() {
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{creator.planStatus || 'N/A'}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
                     {creator.mediaKitToken ? (
-                      <a
-                        href={`/mediakit/${creator.mediaKitToken}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-indigo-600 hover:underline"
-                      >
-                        Abrir
-                      </a>
+                      <div className="space-x-2">
+                        <a
+                          href={`/mediakit/${creator.mediaKitToken}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-indigo-600 hover:underline"
+                        >
+                          Abrir
+                        </a>
+                        <button
+                          onClick={() => handleRevokeMediaKit(creator._id)}
+                          className="text-red-600 hover:underline"
+                        >
+                          Revogar
+                        </button>
+                      </div>
                     ) : (
                       <button
                         onClick={() => handleGenerateMediaKit(creator._id)}

--- a/src/app/api/admin/users/[userId]/media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/media-kit-token/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { logger } from '@/app/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
+  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
+  return mockSession.user.role === 'admin' ? mockSession : null;
+}
+
+function apiError(message: string, status: number) {
+  logger.warn(`[media-kit-token] ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  const TAG = '[api/admin/users/[userId]/media-kit-token:DELETE]';
+  logger.info(`${TAG} Revoking media kit token for user ${userId}`);
+
+  const session = await getAdminSession(req);
+  if (!session) {
+    return apiError('Acesso não autorizado.', 401);
+  }
+
+  if (!Types.ObjectId.isValid(userId)) {
+    return apiError('User ID inválido.', 400);
+  }
+
+  await connectToDatabase();
+
+  const updated = await UserModel.findByIdAndUpdate(
+    userId,
+    { $unset: { mediaKitToken: '' } },
+    { new: true }
+  );
+
+  if (!updated) {
+    return apiError('Usuário não encontrado.', 404);
+  }
+
+  logger.info(`${TAG} Token revoked for user ${userId}`);
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add DELETE handler to revoke user's media kit token
- show revoke option in creators management page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617228978c832eb5162b336195fd47