### PR TITLE
Add Redis-backed rate limit for media kit token

### DIFF
--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,0 +1,49 @@
+import { createClient, RedisClientType } from 'redis';
+import { logger } from '@/app/lib/logger';
+
+let client: RedisClientType | null = null;
+
+function getClient(): RedisClientType | null {
+  if (client) return client;
+
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    logger.warn('[rateLimit] REDIS_URL not configured. Rate limiting disabled.');
+    return null;
+  }
+
+  client = createClient({ url });
+  client.on('error', (err) => logger.error('[rateLimit] Redis error', err));
+  client.connect().catch((err) => {
+    logger.error('[rateLimit] Failed to connect to Redis', err);
+  });
+
+  return client;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+}
+
+export async function checkRateLimit(
+  key: string,
+  limit: number,
+  windowSeconds: number
+): Promise<RateLimitResult> {
+  const redis = getClient();
+  if (!redis) {
+    return { allowed: true, remaining: limit };
+  }
+
+  try {
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, windowSeconds);
+    }
+    return { allowed: count <= limit, remaining: Math.max(0, limit - count) };
+  } catch (err) {
+    logger.error('[rateLimit] Error during rate limit check', err);
+    return { allowed: true, remaining: limit };
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple Redis-based rate limiter
- check the limiter when creating media kit tokens
- return HTTP 429 if the limit is exceeded

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861722d15f0832eb74fa930948c6c8d