### PR TITLE
Add Plausible script to MediaKit view

### DIFF
--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
+import Script from 'next/script';
 import { motion } from 'framer-motion';
 import { FaChartLine, FaTrophy, FaEnvelope, FaArrowUp, FaArrowDown, FaEye, FaComments, FaShare, FaBookmark, FaSpinner, FaUsers, FaHeart, FaCalendarAlt } from 'react-icons/fa';
 
@@ -97,6 +98,13 @@ export default function MediaKitView({ user, summary, videos, kpis: initialKpis 
 
   return (
     <div className="bg-slate-50 min-h-screen font-sans">
+      {process.env.NEXT_PUBLIC_ANALYTICS_DOMAIN && (
+        <Script
+          src="https://plausible.io/js/script.js"
+          data-domain={process.env.NEXT_PUBLIC_ANALYTICS_DOMAIN}
+          strategy="lazyOnload"
+        />
+      )}
       <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-10">
           <aside className="lg:col-span-1 space-y-8 lg:sticky lg:top-8 self-start">


### PR DESCRIPTION
## Summary
- load Plausible analytics if `NEXT_PUBLIC_ANALYTICS_DOMAIN` is defined

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861722ea838832e9f6fedb5aceb1e8b