### PR TITLE
Add media kit token tests and logging check

### DIFF
--- a/src/app/api/admin/users/[userId]/revoke-media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/revoke-media-kit-token/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+export const dynamic = 'force-dynamic';
+
+async function getAdminSession(req: NextRequest) {
+  const session = await getServerSession(authOptions, req);
+  if (!session || session.user?.role !== 'admin') return null;
+  return session as any;
+}
+
+function apiError(message: string, status: number) {
+  logger.warn(`[revoke-media-kit-token] ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  const TAG = '[api/admin/users/[userId]/revoke-media-kit-token]';
+  logger.info(`${TAG} Revoking media kit token for user ${userId}`);
+
+  const session = await getAdminSession(req);
+  if (!session) {
+    return apiError('Acesso não autorizado.', 401);
+  }
+
+  if (!Types.ObjectId.isValid(userId)) {
+    return apiError('User ID inválido.', 400);
+  }
+
+  await connectToDatabase();
+
+  const updated = await UserModel.findByIdAndUpdate(
+    userId,
+    { $unset: { mediaKitToken: '' } },
+    { new: true }
+  );
+
+  if (!updated) {
+    return apiError('Usuário não encontrado.', 404);
+  }
+
+  logger.info(`${TAG} Token revoked for user ${userId}`);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from 'next/server';
+import { POST as generatePOST } from '../[userId]/generate-media-kit-token/route';
+import { POST as revokePOST } from '../[userId]/revoke-media-kit-token/route';
+import { getServerSession } from 'next-auth/next';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import crypto from 'crypto';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+
+jest.spyOn(crypto, 'randomBytes').mockReturnValue(Buffer.from('0123456789abcdef'));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindByIdAndUpdate = (UserModel as any).findByIdAndUpdate as jest.Mock;
+
+const makePostRequest = (userId: string) => new NextRequest(`http://localhost/api/admin/users/${userId}/generate-media-kit-token`, { method: 'POST' });
+const makeRevokeRequest = (userId: string) => new NextRequest(`http://localhost/api/admin/users/${userId}/revoke-media-kit-token`, { method: 'POST' });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+  mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+});
+
+describe('generate-media-kit-token POST', () => {
+  const userId = '64f9c0d2f1c2e3a5b6d7e8f9';
+
+  test('successfully generates token', async () => {
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: userId });
+
+    const res = await generatePOST(makePostRequest(userId), { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBeDefined();
+    expect(body.url).toContain(body.token);
+    expect(mockFindByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  test('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const res = await generatePOST(makePostRequest(userId), { params: { userId } });
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 429 when rate limit exceeded', async () => {
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: userId });
+    for (let i = 0; i < 3; i++) {
+      await generatePOST(makePostRequest(userId), { params: { userId } });
+    }
+    const res = await generatePOST(makePostRequest(userId), { params: { userId } });
+    expect(res.status).toBe(429);
+  });
+});
+
+describe('revoke-media-kit-token POST', () => {
+  const userId = '64f9c0d2f1c2e3a5b6d7e8f9';
+
+  test('revokes token when authenticated', async () => {
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: userId });
+    const res = await revokePOST(makeRevokeRequest(userId), { params: { userId } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true });
+    expect(mockFindByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  test('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+    const res = await revokePOST(makeRevokeRequest(userId), { params: { userId } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/lib/logger.ts
+++ b/src/app/lib/logger.ts
@@ -13,3 +13,7 @@ export const logger = winston.createLogger({
     })
   ]
 });
+
+export function logMediaKitAccess(token: string) {
+  logger.info(`[media-kit] token accessed: ${token}`);
+}

--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import MediaKitView from './MediaKitView';
+import { logMediaKitAccess } from '@/app/lib/logger';
 
 // Tipos centralizados para garantir consistência em todo o fluxo de dados.
 import { VideoListItem, PerformanceSummary, KpiComparison } from '@/types/mediakit';
@@ -71,10 +72,12 @@ export default async function MediaKitPage({ params }: { params: { token: string
   
   // Busca o usuário pelo token. `.lean()` é essencial para performance e para passar para o cliente.
   const user = await UserModel.findOne({ mediaKitToken: params.token }).lean();
-  
+
   if (!user) {
     notFound(); // Se o token for inválido, exibe a página 404.
   }
+
+  logMediaKitAccess(params.token);
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
   

--- a/src/app/mediakit/__tests__/mediakit-page.test.tsx
+++ b/src/app/mediakit/__tests__/mediakit-page.test.tsx
@@ -1,0 +1,38 @@
+import MediaKitPage from '../[token]/page';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { logMediaKitAccess } from '@/app/lib/logger';
+import { notFound } from 'next/navigation';
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  findOne: jest.fn(),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  logMediaKitAccess: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(),
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindOne = (UserModel as any).findOne as jest.Mock;
+const mockLogAccess = logMediaKitAccess as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+  mockFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'u1', name: 'User' }) });
+  global.fetch = jest.fn(() => Promise.resolve(new Response('null'))) as any;
+});
+
+test('logs access when page is rendered', async () => {
+  await MediaKitPage({ params: { token: 'tok123' } });
+  expect(mockLogAccess).toHaveBeenCalledWith('tok123');
+});


### PR DESCRIPTION
## Summary
- implement admin media kit token revocation route
- add simple rate limiting to token generation route
- expose `logMediaKitAccess` util and log access from media kit page
- test media kit token generation, revocation and logging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686172324640832e8680b8e9a794c7ed