### PR TITLE
Use real sessions in admin routes

### DIFF
--- a/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
+++ b/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateAffiliateStatus } from '@/lib/services/adminCreatorService'; // Assumindo que o serviço ainda se chama adminCreatorService
 import { AdminAffiliateStatus, AdminAffiliateUpdateStatusPayload } from '@/types/admin/affiliates';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 const SERVICE_TAG = '[api/admin/affiliates/[affiliateId]/status]';
-
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -34,9 +29,9 @@ export async function PATCH(
   logger.info(`${TAG} Received request to update status for affiliate (user ID): ${userId}`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/creators/[creatorId]/status/route.ts
+++ b/src/app/api/admin/creators/[creatorId]/status/route.ts
@@ -4,17 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateCreatorStatus } from '@/lib/services/adminCreatorService'; // Ajuste o caminho
 import { AdminCreatorStatus, AdminCreatorUpdateStatusPayload } from '@/types/admin/creators'; // Ajuste o caminho
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 const SERVICE_TAG = '[api/admin/creators/[creatorId]/status]';
-
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -36,9 +29,9 @@ export async function PATCH(
   logger.info(`${TAG} Received request to update status for creatorId: ${creatorId}`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 
@@ -76,9 +69,9 @@ export async function PUT(
   logger.info(`${TAG} Received request to approve creatorId: ${creatorId}`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/creators/route.ts
+++ b/src/app/api/admin/creators/route.ts
@@ -5,8 +5,8 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchCreators } from '@/lib/services/adminCreatorService'; // Ajuste o caminho se necessário
 import { AdminCreatorStatus, AdminCreatorListParams } from '@/types/admin/creators'; // Ajuste o caminho se necessário
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor,
@@ -15,20 +15,6 @@ export const dynamic = 'force-dynamic';
 // ==================== FIM DA CORREÇÃO ======================
 
 const SERVICE_TAG = '[api/admin/creators]';
-
-// Mock de validação de sessão de Admin (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  // const session = await getServerSession(authOptions);
-  // if (!session || !(session.user.role === 'admin' || session.user.isAdmin)) {
-  //   logger.warn(`${SERVICE_TAG} Admin session validation failed or user is not admin.`);
-  //   return null;
-  // }
-  // return session;
-  // Mock para desenvolvimento:
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -50,9 +36,9 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Received request to list creators.`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/dashboard-summary/route.ts
+++ b/src/app/api/admin/dashboard-summary/route.ts
@@ -2,6 +2,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import {
   getTotalCreatorsCount,
   getPendingCreatorsCount,
@@ -17,13 +19,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard-summary]';
 
-// Mock Admin Session Validation (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
-
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
   return NextResponse.json({ error: message }, { status });
@@ -34,9 +29,9 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Received request for dashboard summary KPIs.`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/dashboard/contexts/route.ts
+++ b/src/app/api/admin/dashboard/contexts/route.ts
@@ -2,18 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 const SERVICE_TAG = '[api/admin/dashboard/contexts]';
-
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -25,9 +17,9 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Received request for available contexts.`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado. Sessão de administrador inválida.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
@@ -25,7 +25,7 @@ const querySchema = z.object({
 // Real Admin Session Validation
 async function getAdminSession(_req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
+  if (!session?.user?.isAdmin) {
     logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
     return null;
   }

--- a/src/app/api/admin/dashboard/rankings/top-creators/route.ts
+++ b/src/app/api/admin/dashboard/rankings/top-creators/route.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopCreators, TopCreatorMetricEnum } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/top-creators]';
@@ -14,15 +16,6 @@ const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
 });
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } }; // Mock session
-  const isAdmin = true; // Mock admin check
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -34,8 +27,8 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Received request.`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
       return apiError('Acesso não autorizado.', 401);
     }
 

--- a/src/app/api/admin/intelligence-query/route.ts
+++ b/src/app/api/admin/intelligence-query/route.ts
@@ -13,6 +13,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 // --- Importações da Nova Arquitetura Modular ---
 import { logger } from '@/app/lib/logger';
@@ -47,14 +49,6 @@ function apiError(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
 }
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  // SIMULAÇÃO: Substitua pela sua lógica real de sessão (ex: next-auth)
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) return null;
-  return session;
-}
-
 // Mapeia as mensagens do cliente para o formato esperado pela OpenAI.
 function mapToOpenAIMessages(messages: ClientMessage[]): ChatCompletionMessageParam[] {
     return messages.map((msg): ChatCompletionMessageParam => {
@@ -71,8 +65,8 @@ export async function POST(req: NextRequest) {
   logger.info(`${TAG} Requisição recebida.`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
       return apiError('Acesso não autorizado.', 401);
     }
 

--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateRedemptionStatus } from '@/lib/services/adminCreatorService'; // Assumindo nome do serviço
 import { RedemptionStatus, AdminRedemptionUpdateStatusPayload } from '@/types/admin/redemptions';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 const SERVICE_TAG = '[api/admin/redemptions/[redemptionId]/status]';
-
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
@@ -51,9 +46,9 @@ export async function PATCH(
   logger.info(`${TAG} Received request to update status for redemptionId: ${redemptionId}`);
 
   try {
-    const session = await getAdminSession(req);
-    if (!session) {
-      return apiError('Acesso não autorizado ou privilégios insuficientes.', 401);
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return apiError('Acesso não autorizado.', 401);
     }
     logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
 

--- a/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
@@ -4,13 +4,10 @@ import crypto from 'crypto';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
 export const dynamic = 'force-dynamic';
-
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  return mockSession.user.role === 'admin' ? mockSession : null;
-}
 
 function apiError(message: string, status: number) {
   logger.warn(`[generate-media-kit-token] ${message}`);
@@ -25,8 +22,8 @@ export async function POST(
   const TAG = '[api/admin/users/[userId]/generate-media-kit-token]';
   logger.info(`${TAG} Generating media kit token for user ${userId}`);
 
-  const session = await getAdminSession(req);
-  if (!session) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.isAdmin) {
     return apiError('Acesso não autorizado.', 401);
   }
 
@@ -61,8 +58,8 @@ export async function GET(
   const TAG = '[api/admin/users/[userId]/generate-media-kit-token:GET]';
   logger.info(`${TAG} Fetching media kit token for user ${userId}`);
 
-  const session = await getAdminSession(req);
-  if (!session) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.isAdmin) {
     return apiError('Acesso não autorizado.', 401);
   }
 


### PR DESCRIPTION
## Summary
- replace mock admin session helpers with `getServerSession`
- ensure isAdmin check is enforced for all admin endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617227683c832e95fe96fa5b9a4440