### PR TITLE
Implement admin auth helper and media kit tests

### DIFF
--- a/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
+++ b/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateAffiliateStatus } from '@/lib/services/adminCreatorService'; // Assumindo que o serviço ainda se chama adminCreatorService
 import { AdminAffiliateStatus, AdminAffiliateUpdateStatusPayload } from '@/types/admin/affiliates';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/affiliates/[affiliateId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/affiliates/route.ts
+++ b/src/app/api/admin/affiliates/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchAffiliates } from '@/lib/services/adminCreatorService'; // Assumindo que o serviço ainda se chama adminCreatorService
 import { AdminAffiliateListParams, AdminAffiliateStatus } from '@/types/admin/affiliates';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor.
@@ -15,12 +16,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/affiliates]';
 
-// Mock Admin Session Validation (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/creators/[creatorId]/status/route.ts
+++ b/src/app/api/admin/creators/[creatorId]/status/route.ts
@@ -4,17 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateCreatorStatus } from '@/lib/services/adminCreatorService'; // Ajuste o caminho
 import { AdminCreatorStatus, AdminCreatorUpdateStatusPayload } from '@/types/admin/creators'; // Ajuste o caminho
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/creators/[creatorId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/creators/route.test.ts
+++ b/src/app/api/admin/creators/route.test.ts
@@ -2,12 +2,22 @@
 import { GET } from './route'; // Ajuste se o nome do arquivo for diferente
 import { fetchCreators } from '@/lib/services/adminCreatorService'; // Ajuste o caminho
 import { NextRequest } from 'next/server';
-// import { mockAdminSession } from '@/utils/tests/mocks/authMocks'; // Supondo um mock de sessão compartilhado
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
 
 // Mock o serviço
 jest.mock('@/lib/services/adminCreatorService', () => ({
   fetchCreators: jest.fn(),
 }));
+
+const mockGetServerSession = getServerSession as jest.Mock;
 
 // Mock a sessão de admin (se não estiver usando um helper compartilhado)
 // jest.mock('./route', () => { // Cuidado ao mockar o próprio arquivo
@@ -33,10 +43,7 @@ describe('API Route: GET /api/admin/creators', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock para getAdminSession (se não for mockado globalmente)
-    // (require('./route') as any).getAdminSession.mockResolvedValue(mockAdminSession.authenticatedAdmin);
-    // Como getAdminSession é definido localmente e é um mock simples, não precisamos mocká-lo aqui
-    // a menos que queiramos testar o cenário de não admin, o que exigiria mock do módulo ou da função.
+    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 and data on successful fetch', async () => {

--- a/src/app/api/admin/creators/route.ts
+++ b/src/app/api/admin/creators/route.ts
@@ -5,8 +5,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchCreators } from '@/lib/services/adminCreatorService'; // Ajuste o caminho se necessário
 import { AdminCreatorStatus, AdminCreatorListParams } from '@/types/admin/creators'; // Ajuste o caminho se necessário
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getAdminSession } from '@/lib/getAdminSession';
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor,
@@ -16,19 +15,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/creators]';
 
-// Mock de validação de sessão de Admin (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  // const session = await getServerSession(authOptions);
-  // if (!session || !(session.user.role === 'admin' || session.user.isAdmin)) {
-  //   logger.warn(`${SERVICE_TAG} Admin session validation failed or user is not admin.`);
-  //   return null;
-  // }
-  // return session;
-  // Mock para desenvolvimento:
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard-summary/route.ts
+++ b/src/app/api/admin/dashboard-summary/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
 import {
   getTotalCreatorsCount,
   getPendingCreatorsCount,
@@ -17,12 +18,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard-summary]';
 
-// Mock Admin Session Validation (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateRedemptionStatus } from '@/lib/services/adminCreatorService'; // Assumindo nome do serviço
 import { RedemptionStatus, AdminRedemptionUpdateStatusPayload } from '@/types/admin/redemptions';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/redemptions/[redemptionId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
@@ -5,13 +5,10 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
 import { checkRateLimit } from '@/utils/rateLimit';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 export const dynamic = 'force-dynamic';
 
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  return mockSession.user.role === 'admin' ? mockSession : null;
-}
 
 function apiError(message: string, status: number) {
   logger.warn(`[generate-media-kit-token] ${message}`);

--- a/src/app/api/admin/users/[userId]/media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/media-kit-token/route.ts
@@ -3,13 +3,10 @@ import { Types } from 'mongoose';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 export const dynamic = 'force-dynamic';
 
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  return mockSession.user.role === 'admin' ? mockSession : null;
-}
 
 function apiError(message: string, status: number) {
   logger.warn(`[media-kit-token] ${message}`);

--- a/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
@@ -1,0 +1,62 @@
+import { POST } from '../[userId]/generate-media-kit-token/route';
+import { NextRequest } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { checkRateLimit } from '@/utils/rateLimit';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+jest.mock('@/utils/rateLimit', () => ({
+  checkRateLimit: jest.fn(),
+}));
+jest.mock('@/app/models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockCheckRateLimit = checkRateLimit as jest.Mock;
+const mockFindByIdAndUpdate = UserModel.findByIdAndUpdate as jest.Mock;
+
+function createRequest(userId: string): NextRequest {
+  const req = new NextRequest(`http://localhost/api/admin/users/${userId}/generate-media-kit-token`, { method: 'POST' });
+  (req as any).ip = '127.0.0.1';
+  return req;
+}
+
+describe('POST /api/admin/users/[userId]/generate-media-kit-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 4 });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1', mediaKitToken: 'tok' });
+  });
+
+  it('returns 200 and token on success', async () => {
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.token).toBeDefined();
+  });
+
+  it('returns 401 when session is invalid', async () => {
+    mockGetAdminSession.mockResolvedValueOnce(null);
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 429 when rate limit exceeded', async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, remaining: 0 });
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(429);
+  });
+});

--- a/src/app/api/admin/users/__tests__/media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/media-kit-token.test.ts
@@ -1,0 +1,48 @@
+import { DELETE } from '../[userId]/media-kit-token/route';
+import { NextRequest } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+jest.mock('@/app/models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockFindByIdAndUpdate = UserModel.findByIdAndUpdate as jest.Mock;
+
+function createRequest(userId: string): NextRequest {
+  return new NextRequest(`http://localhost/api/admin/users/${userId}/media-kit-token`, { method: 'DELETE' });
+}
+
+describe('DELETE /api/admin/users/[userId]/media-kit-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1' });
+  });
+
+  it('returns 200 on success', async () => {
+    const res = await DELETE(createRequest('1'), { params: { userId: '1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 401 when not authorized', async () => {
+    mockGetAdminSession.mockResolvedValueOnce(null);
+    const res = await DELETE(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/mediakit/[token]/page.test.ts
+++ b/src/app/mediakit/[token]/page.test.ts
@@ -1,0 +1,31 @@
+import MediaKitPage from './page';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logMediaKitAccess } from '@/lib/logMediaKitAccess';
+import { headers } from 'next/headers';
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findOne: jest.fn() }));
+jest.mock('@/lib/logMediaKitAccess', () => ({ logMediaKitAccess: jest.fn() }));
+jest.mock('next/headers', () => ({ headers: jest.fn() }));
+
+type Params = { params: { token: string } };
+
+const mockFindOne = UserModel.findOne as jest.Mock;
+const mockLogAccess = logMediaKitAccess as jest.Mock;
+const mockHeaders = headers as jest.Mock;
+
+describe('MediaKitPage logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHeaders.mockReturnValue(new Headers({ 'x-real-ip': '1.1.1.1' }));
+    mockFindOne.mockReturnValue({ lean: () => Promise.resolve({ _id: 'u1' }) });
+  });
+
+  it('calls logMediaKitAccess when user exists', async () => {
+    await MediaKitPage({ params: { token: 'tok' } } as Params);
+    expect(mockLogAccess).toHaveBeenCalledWith('u1', '1.1.1.1', undefined);
+  });
+});

--- a/src/lib/getAdminSession.ts
+++ b/src/lib/getAdminSession.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { logger } from '@/app/lib/logger';
+
+export async function getAdminSession(_req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || session.user?.role !== 'admin') {
+      logger.warn('[getAdminSession] session invalid or user not admin');
+      return null;
+    }
+    return session;
+  } catch (err) {
+    logger.error('[getAdminSession] failed to get session', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `getAdminSession` helper
- integrate helper in admin API routes
- update admin creators route tests for new session logic
- add tests for media kit token generation, revocation, and page logging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616f1641ec832ea23582fcd5190dfb