### PR TITLE
Implement real admin session across dashboard APIs

### DIFF
--- a/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
+++ b/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateAffiliateStatus } from '@/lib/services/adminCreatorService'; // Assumindo que o serviço ainda se chama adminCreatorService
 import { AdminAffiliateStatus, AdminAffiliateUpdateStatusPayload } from '@/types/admin/affiliates';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/affiliates/[affiliateId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/affiliates/route.ts
+++ b/src/app/api/admin/affiliates/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchAffiliates } from '@/lib/services/adminCreatorService'; // Assumindo que o serviço ainda se chama adminCreatorService
 import { AdminAffiliateListParams, AdminAffiliateStatus } from '@/types/admin/affiliates';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor.
@@ -15,12 +16,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/affiliates]';
 
-// Mock Admin Session Validation (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/creators/[creatorId]/status/route.ts
+++ b/src/app/api/admin/creators/[creatorId]/status/route.ts
@@ -4,17 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateCreatorStatus } from '@/lib/services/adminCreatorService'; // Ajuste o caminho
 import { AdminCreatorStatus, AdminCreatorUpdateStatusPayload } from '@/types/admin/creators'; // Ajuste o caminho
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/creators/[creatorId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/creators/route.test.ts
+++ b/src/app/api/admin/creators/route.test.ts
@@ -2,12 +2,22 @@
 import { GET } from './route'; // Ajuste se o nome do arquivo for diferente
 import { fetchCreators } from '@/lib/services/adminCreatorService'; // Ajuste o caminho
 import { NextRequest } from 'next/server';
-// import { mockAdminSession } from '@/utils/tests/mocks/authMocks'; // Supondo um mock de sessão compartilhado
+import { getAdminSession } from '@/lib/getAdminSession';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
+  authOptions: {},
+}));
 
 // Mock o serviço
 jest.mock('@/lib/services/adminCreatorService', () => ({
   fetchCreators: jest.fn(),
 }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 // Mock a sessão de admin (se não estiver usando um helper compartilhado)
 // jest.mock('./route', () => { // Cuidado ao mockar o próprio arquivo
@@ -33,10 +43,7 @@ describe('API Route: GET /api/admin/creators', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock para getAdminSession (se não for mockado globalmente)
-    // (require('./route') as any).getAdminSession.mockResolvedValue(mockAdminSession.authenticatedAdmin);
-    // Como getAdminSession é definido localmente e é um mock simples, não precisamos mocká-lo aqui
-    // a menos que queiramos testar o cenário de não admin, o que exigiria mock do módulo ou da função.
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 and data on successful fetch', async () => {

--- a/src/app/api/admin/creators/route.ts
+++ b/src/app/api/admin/creators/route.ts
@@ -5,8 +5,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchCreators } from '@/lib/services/adminCreatorService'; // Ajuste o caminho se necessário
 import { AdminCreatorStatus, AdminCreatorListParams } from '@/types/admin/creators'; // Ajuste o caminho se necessário
-// import { getServerSession } from "next-auth/next" // Para auth real
-// import { authOptions } from "@/app/api/auth/[...nextauth]/route"; // Para auth real
+import { getAdminSession } from '@/lib/getAdminSession';
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor,
@@ -16,19 +15,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/creators]';
 
-// Mock de validação de sessão de Admin (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  // const session = await getServerSession(authOptions);
-  // if (!session || !(session.user.role === 'admin' || session.user.isAdmin)) {
-  //   logger.warn(`${SERVICE_TAG} Admin session validation failed or user is not admin.`);
-  //   return null;
-  // }
-  // return session;
-  // Mock para desenvolvimento:
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard-summary/route.ts
+++ b/src/app/api/admin/dashboard-summary/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
 import {
   getTotalCreatorsCount,
   getPendingCreatorsCount,
@@ -17,12 +18,6 @@ export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard-summary]';
 
-// Mock Admin Session Validation (substituir pela real com getServerSession)
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } }; // Simula um admin
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/cohorts/compare/route.ts
+++ b/src/app/api/admin/dashboard/cohorts/compare/route.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchCohortComparison } from '@/app/lib/dataService/marketAnalysis/cohortsService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/cohorts/compare]';
 const MAX_COHORTS_TO_COMPARE_API = 5;
@@ -34,15 +35,6 @@ const requestBodySchema = z.object({
 });
 
 // --- Helper Functions ---
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/content-segments/compare/route.test.ts
+++ b/src/app/api/admin/dashboard/content-segments/compare/route.test.ts
@@ -2,10 +2,10 @@ import { POST } from './route'; // Adjust path as necessary
 import { NextRequest } from 'next/server';
 import { fetchSegmentPerformanceData } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -28,7 +28,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   fetchSegmentPerformanceData: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFetchSegmentPerformanceData = fetchSegmentPerformanceData as jest.Mock;
 
@@ -44,7 +44,7 @@ describe('API Route: /api/admin/dashboard/content-segments/compare', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   const validDateRange = {
@@ -169,7 +169,7 @@ describe('API Route: /api/admin/dashboard/content-segments/compare', () => {
 
   // --- Error Handling & Session Tests ---
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const requestBody = { dateRange: validDateRange, segments: [{ criteria: validSegmentCriteria1 }] };
     const req = createMockRequest(requestBody);
     const response = await POST(req);

--- a/src/app/api/admin/dashboard/content-segments/compare/route.ts
+++ b/src/app/api/admin/dashboard/content-segments/compare/route.ts
@@ -5,8 +5,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import {
   fetchSegmentPerformanceData,
   ISegmentPerformanceResult,
@@ -14,6 +12,7 @@ import {
   IFetchSegmentPerformanceArgs,
 } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/content-segments/compare]';
 const MAX_SEGMENTS_TO_COMPARE_API = 5;
@@ -51,14 +50,6 @@ const requestBodySchema = z.object({
 // --- Helper Functions ---
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/content-stats/route.test.ts
+++ b/src/app/api/admin/dashboard/content-stats/route.test.ts
@@ -2,10 +2,10 @@ import { GET } from './route'; // Adjust path as necessary
 import { NextRequest } from 'next/server';
 import { fetchDashboardOverallContentStats } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -27,7 +27,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   fetchDashboardOverallContentStats: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFetchDashboardOverallContentStats = fetchDashboardOverallContentStats as jest.Mock;
 
@@ -42,7 +42,7 @@ describe('API Route: /api/admin/dashboard/content-stats', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 with content stats on a valid request without filters', async () => {
@@ -100,7 +100,7 @@ describe('API Route: /api/admin/dashboard/content-stats', () => {
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const req = createMockRequest();
     const response = await GET(req);
     expect(response.status).toBe(401);

--- a/src/app/api/admin/dashboard/content-stats/route.ts
+++ b/src/app/api/admin/dashboard/content-stats/route.ts
@@ -7,8 +7,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchDashboardOverallContentStats, IFetchDashboardOverallContentStatsFilters } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/content-stats]';
@@ -25,14 +24,6 @@ const querySchema = z.object({
 }, { message: "startDate cannot be after endDate" });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/content/performance-by-type/route.test.ts
+++ b/src/app/api/admin/dashboard/content/performance-by-type/route.test.ts
@@ -1,10 +1,10 @@
 import { GET } from './route';
 import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 import { fetchContentPerformanceByType } from '@/app/lib/dataService/marketAnalysis/segmentService';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -15,7 +15,7 @@ jest.mock('@/app/lib/dataService/marketAnalysis/segmentService', () => ({
   fetchContentPerformanceByType: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 const mockFetchPerf = fetchContentPerformanceByType as jest.Mock;
 
 const makeRequest = (params: Record<string,string> = {}) => {
@@ -27,13 +27,13 @@ beforeEach(() => jest.clearAllMocks());
 
 describe('GET /api/admin/dashboard/content/performance-by-type', () => {
   it('returns 401 when not authenticated', async () => {
-    mockGetServerSession.mockResolvedValue(null);
+    mockGetAdminSession.mockResolvedValue(null);
     const res = await GET(makeRequest({ startDate: '2024-01-01T00:00:00.000Z', endDate: '2024-01-02T00:00:00.000Z' }));
     expect(res.status).toBe(401);
   });
 
   it('returns data when authenticated as admin', async () => {
-    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
     const performance = [{ _id: 'VIDEO', totalPosts: 5 }];
     mockFetchPerf.mockResolvedValue(performance);
 

--- a/src/app/api/admin/dashboard/content/performance-by-type/route.ts
+++ b/src/app/api/admin/dashboard/content/performance-by-type/route.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchContentPerformanceByType } from '@/app/lib/dataService/marketAnalysis/segmentService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const TAG = '/api/admin/dashboard/content/performance-by-type';
 
@@ -21,7 +20,7 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Request received`);
 
   // 1. Admin Session Validation
-  const session = await getServerSession(authOptions);
+  const session = await getAdminSession(req);
   
   // Verificação mais robusta da sessão e do papel do usuário
   if (!session || !session.user || session.user.role !== 'admin') {

--- a/src/app/api/admin/dashboard/contexts/route.ts
+++ b/src/app/api/admin/dashboard/contexts/route.ts
@@ -2,18 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/contexts]';
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.test.ts
+++ b/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.test.ts
@@ -4,10 +4,10 @@ import { Types } from 'mongoose';
 import { fetchCreatorTimeSeriesData } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
 import { DatabaseError } from '@/app/lib/errors'; // Import DatabaseError
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -29,7 +29,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   fetchCreatorTimeSeriesData: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFetchCreatorTimeSeriesData = fetchCreatorTimeSeriesData as jest.Mock;
 const validCreatorId = new Types.ObjectId().toString();
@@ -48,7 +48,7 @@ describe('API Route: /api/admin/dashboard/creators/[creatorId]/time-series', () 
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 with time series data on a valid request', async () => {
@@ -134,7 +134,7 @@ describe('API Route: /api/admin/dashboard/creators/[creatorId]/time-series', () 
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const query = { metric: 'post_count', period: 'monthly', startDate: '2023-01-01T00:00:00Z', endDate: '2023-01-31T00:00:00Z' };
     const req = createMockRequest(validCreatorId, query);
     const response = await GET(req, { params: { creatorId: validCreatorId } });

--- a/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.ts
+++ b/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.ts
@@ -7,9 +7,8 @@ import { z } from 'zod';
 import { Types } from 'mongoose';
 import { logger } from '@/app/lib/logger';
 import { fetchCreatorTimeSeriesData, IFetchCreatorTimeSeriesArgs } from '@/app/lib/dataService/marketAnalysisService';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/creators/[creatorId]/time-series]';
 
@@ -32,14 +31,6 @@ const requestSchema = z.object({
 
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/creators/compare/route.test.ts
+++ b/src/app/api/admin/dashboard/creators/compare/route.test.ts
@@ -4,10 +4,10 @@ import { Types } from 'mongoose';
 import { fetchMultipleCreatorProfiles } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
 import { DatabaseError } from '@/app/lib/errors'; // Import DatabaseError
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -29,7 +29,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   fetchMultipleCreatorProfiles: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFetchMultipleCreatorProfiles = fetchMultipleCreatorProfiles as jest.Mock;
 
@@ -49,7 +49,7 @@ describe('API Route: /api/admin/dashboard/creators/compare', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 with comparison data on a valid request', async () => {
@@ -108,7 +108,7 @@ describe('API Route: /api/admin/dashboard/creators/compare', () => {
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const validBody = { creatorIds: [new Types.ObjectId().toString()] };
     const req = createMockRequest(validBody);
     const response = await POST(req);

--- a/src/app/api/admin/dashboard/creators/compare/route.ts
+++ b/src/app/api/admin/dashboard/creators/compare/route.ts
@@ -6,13 +6,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 // CORREÇÃO: As importações foram atualizadas para usar os caminhos dos serviços modularizados.
 import { getCreatorProfile } from '@/app/lib/dataService/marketAnalysis/profilesService';
 import { ICreatorProfile } from '@/app/lib/dataService/marketAnalysis/types';
 import { DatabaseError } from '@/app/lib/errors';
 import UserModel from '@/app/models/User';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/creators/compare]';
 const MAX_CREATORS_TO_COMPARE_API = 5;
@@ -27,14 +26,6 @@ const requestBodySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Validação da sessão de admin falhou.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/creators/route.test.ts
+++ b/src/app/api/admin/dashboard/creators/route.test.ts
@@ -2,10 +2,10 @@ import { GET } from './route'; // Adjust path as necessary
 import { NextRequest } from 'next/server';
 import { fetchDashboardCreatorsList } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -27,7 +27,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   fetchDashboardCreatorsList: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 // Mock getAdminSession - we'll define its behavior in tests
 // The actual implementation is in the route file, so we mock its behavior via req object or by directly mocking it if it were importable
@@ -48,7 +48,7 @@ describe('API Route: /api/admin/dashboard/creators', () => {
     const req = new NextRequest(url.toString());
     // Simulate admin session by attaching a property that getAdminSession in route might check
     // This is a simplified way to control the session for testing.
-    // In a real scenario with next-auth, you'd mock `getServerSession`.
+    // In a real scenario with next-auth, you'd mock `getAdminSession`.
     (req as any).isAdmin = isAdmin; // This is a conceptual way getAdminSession might be influenced
                                    // The actual getAdminSession in route.ts uses a hardcoded session.
                                    // To test the 401, we'd need to modify getAdminSession or mock it differently.
@@ -67,8 +67,8 @@ describe('API Route: /api/admin/dashboard/creators', () => {
     jest.clearAllMocks();
     mockAdminSession = { user: { name: 'Admin User' } }; // Reset admin session mock
     // Default mock for successful session
-    // (Actual getAdminSession in route is now based on getServerSession)
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    // (Actual getAdminSession in route is now based on getAdminSession)
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 with creators list on valid request', async () => {
@@ -197,7 +197,7 @@ describe('API Route: /api/admin/dashboard/creators', () => {
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const req = createMockRequest();
     const response = await GET(req);
     expect(response.status).toBe(401);

--- a/src/app/api/admin/dashboard/creators/route.ts
+++ b/src/app/api/admin/dashboard/creators/route.ts
@@ -5,11 +5,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { fetchDashboardCreatorsList } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 import { IFetchDashboardCreatorsListParams } from '@/app/lib/dataService/marketAnalysis/types';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor.
@@ -50,14 +49,6 @@ const querySchema = z.object({
 }, { message: "startDate não pode ser posterior a endDate", path: ["endDate"] });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Validação da sessão de admin falhou.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/market-performance/route.ts
+++ b/src/app/api/admin/dashboard/market-performance/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { fetchMarketPerformance } from '@/app/lib/dataService/marketAnalysis/segmentService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/market-performance]';
@@ -16,14 +15,6 @@ const querySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Error ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/platform-summary/route.test.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.test.ts
@@ -1,10 +1,10 @@
 import { GET } from './route';
 import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -15,7 +15,7 @@ jest.mock('@/app/lib/dataService/marketAnalysis/dashboardService', () => ({
   fetchPlatformSummary: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 const mockFetchSummary = fetchPlatformSummary as jest.Mock;
 
 const makeRequest = (params: Record<string, string> = {}) => {
@@ -29,13 +29,13 @@ beforeEach(() => {
 
 describe('GET /api/admin/dashboard/platform-summary', () => {
   it('returns 401 when user is not authenticated', async () => {
-    mockGetServerSession.mockResolvedValue(null);
+    mockGetAdminSession.mockResolvedValue(null);
     const res = await GET(makeRequest());
     expect(res.status).toBe(401);
   });
 
   it('returns summary data when authenticated as admin', async () => {
-    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { id: '1', role: 'admin' } });
     const data = { totalCreators: 10 };
     mockFetchSummary.mockResolvedValue(data);
 

--- a/src/app/api/admin/dashboard/platform-summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 
 const TAG = '/api/admin/dashboard/platform-summary';
@@ -41,7 +40,7 @@ export async function GET(req: NextRequest) {
   logger.info(`${TAG} Request received`);
 
   // 1. Admin Session Validation
-  const session = await getServerSession(authOptions);
+  const session = await getAdminSession(req);
   
   if (!session || !session.user || session.user.role !== 'admin') {
     logger.warn(`${TAG} Unauthorized access attempt.`);

--- a/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
+++ b/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
@@ -4,8 +4,7 @@ import { Types } from 'mongoose';
 import { logger } from '@/app/lib/logger';
 import { fetchPostDetails, IPostDetailsData } from '@/app/lib/dataService/marketAnalysis/postsService'; // Assuming IPostDetailsData is exported
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const TAG = '/api/admin/dashboard/posts/[postId]/details';
 
@@ -23,7 +22,7 @@ export async function GET(
   logger.info(`${TAG} Request received for postId: ${params.postId}`);
 
   // 1. Admin Session Validation
-  const session = await getServerSession(authOptions);
+  const session = await getAdminSession(req);
   
   if (!session || !session.user || session.user.role !== 'admin') {
     logger.warn(`${TAG} Unauthorized access attempt for postId: ${params.postId}`);

--- a/src/app/api/admin/dashboard/posts/route.test.ts
+++ b/src/app/api/admin/dashboard/posts/route.test.ts
@@ -2,10 +2,10 @@ import { GET } from './route'; // Adjust path as necessary
 import { NextRequest } from 'next/server';
 import { findGlobalPostsByCriteria } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -27,7 +27,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   findGlobalPostsByCriteria: jest.fn(),
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFindGlobalPostsByCriteria = findGlobalPostsByCriteria as jest.Mock;
 
@@ -41,7 +41,7 @@ describe('API Route: /api/admin/dashboard/posts', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   it('should return 200 with posts on a valid request with default params', async () => {
@@ -121,7 +121,7 @@ describe('API Route: /api/admin/dashboard/posts', () => {
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const req = createMockRequest();
     const response = await GET(req);
     expect(response.status).toBe(401);

--- a/src/app/api/admin/dashboard/posts/route.ts
+++ b/src/app/api/admin/dashboard/posts/route.ts
@@ -5,10 +5,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { findGlobalPostsByCriteria, FindGlobalPostsArgs } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 // ==================== INÍCIO DA CORREÇÃO ====================
 // Força a rota a ser sempre renderizada dinamicamente no servidor.
@@ -39,14 +38,6 @@ const querySchema = z.object({
 }, { message: "startDate cannot be after endDate" });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/radar/effectiveness/route.ts
+++ b/src/app/api/admin/dashboard/radar/effectiveness/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTucaRadarEffectiveness, IFetchTucaRadarEffectivenessArgs } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/radar/effectiveness]';
@@ -12,15 +13,6 @@ const querySchema = z.object({
   periodDays: z.coerce.number().int().min(1).max(365).optional().default(30)
 });
 
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/creators/most-prolific/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/most-prolific/route.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchMostProlificCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/most-prolific]';
@@ -23,14 +22,6 @@ const querySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/creators/top-engaging/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-engaging/route.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopEngagingCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/top-engaging]';
@@ -23,14 +22,6 @@ const querySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/creators/top-interactions/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-interactions/route.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopInteractionCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/top-interactions]';
@@ -23,14 +22,6 @@ const querySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopSharingCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/top-sharing]';
@@ -23,14 +22,6 @@ const querySchema = z.object({
 });
 
 // Real Admin Session Validation
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/proposals/route.ts
+++ b/src/app/api/admin/dashboard/rankings/proposals/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopProposals, ProposalRankingMetric } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/proposals]';
@@ -20,15 +21,6 @@ const querySchema = z.object({
   path: ['endDate'],
 });
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/rankings/top-creators/route.ts
+++ b/src/app/api/admin/dashboard/rankings/top-creators/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchTopCreators, TopCreatorMetricEnum } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
+import { getAdminSession } from "@/lib/getAdminSession";
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/admin/dashboard/rankings/top-creators]';
@@ -14,15 +15,6 @@ const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
 });
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  const session = { user: { name: 'Admin User' } }; // Mock session
-  const isAdmin = true; // Mock admin check
-  if (!session || !isAdmin) {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/dashboard/top-movers/route.test.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.test.ts
@@ -3,10 +3,10 @@ import { NextRequest } from 'next/server';
 import { fetchTopMoversData } from '@/app/lib/dataService/marketAnalysisService';
 import { logger } from '@/app/lib/logger';
 import { DatabaseError } from '@/app/lib/errors'; // Import DatabaseError
-import { getServerSession } from 'next-auth/next';
+import { getAdminSession } from '@/lib/getAdminSession';
 
-jest.mock('next-auth/next', () => ({
-  getServerSession: jest.fn(),
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
 }));
 
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({
@@ -30,7 +30,7 @@ jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
   // For this test, we'll re-declare minimal versions or trust Zod to handle enum values.
 }));
 
-const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetAdminSession = getAdminSession as jest.Mock;
 
 const mockFetchTopMoversData = fetchTopMoversData as jest.Mock;
 
@@ -46,7 +46,7 @@ describe('API Route: /api/admin/dashboard/top-movers', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
   });
 
   const validPeriods = {
@@ -211,7 +211,7 @@ describe('API Route: /api/admin/dashboard/top-movers', () => {
   });
 
   it('should return 401 if admin session is invalid', async () => {
-    mockGetServerSession.mockResolvedValueOnce({ user: { role: 'user' } });
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user' } });
     const req = createMockRequest(validPayloadBase);
     const response = await POST(req);
     expect(response.status).toBe(401);

--- a/src/app/api/admin/dashboard/top-movers/route.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.ts
@@ -14,8 +14,7 @@ import {
   TopMoverSortBy,     // For Zod enum
 } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/dashboard/top-movers]';
 
@@ -73,14 +72,6 @@ const requestBodySchema = z.object({
 
 // --- Helper Functions ---
 
-async function getAdminSession(_req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'admin') {
-    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
-    return null;
-  }
-  return session;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/intelligence-query/route.ts
+++ b/src/app/api/admin/intelligence-query/route.ts
@@ -18,6 +18,7 @@ import type { ChatCompletionMessageParam } from 'openai/resources/chat/completio
 import { logger } from '@/app/lib/logger';
 import { askAdminLLM } from '@/app/lib/admin-ai/orchestrator';
 import { AdminAIContext } from '@/app/lib/admin-ai/types';
+import { getAdminSession } from "@/lib/getAdminSession";
 
 const SERVICE_TAG = '[api/admin/intelligence-query v5.0.0]';
 
@@ -47,13 +48,6 @@ function apiError(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
 }
 
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string } } | null> {
-  // SIMULAÇÃO: Substitua pela sua lógica real de sessão (ex: next-auth)
-  const session = { user: { name: 'Admin User' } };
-  const isAdmin = true;
-  if (!session || !isAdmin) return null;
-  return session;
-}
 
 // Mapeia as mensagens do cliente para o formato esperado pela OpenAI.
 function mapToOpenAIMessages(messages: ClientMessage[]): ChatCompletionMessageParam[] {

--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
@@ -4,15 +4,10 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { updateRedemptionStatus } from '@/lib/services/adminCreatorService'; // Assumindo nome do serviço
 import { RedemptionStatus, AdminRedemptionUpdateStatusPayload } from '@/types/admin/redemptions';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const SERVICE_TAG = '[api/admin/redemptions/[redemptionId]/status]';
 
-// Mock Admin Session Validation
-async function getAdminSession(req: NextRequest): Promise<{ user: { name: string, role?: string, isAdmin?: boolean } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  if (mockSession.user.role !== 'admin') return null;
-  return mockSession;
-}
 
 function apiError(message: string, status: number): NextResponse {
   logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);

--- a/src/app/api/admin/redemptions/route.ts
+++ b/src/app/api/admin/redemptions/route.ts
@@ -1,12 +1,11 @@
 // src/app/api/admin/redemptions/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import User from "@/app/models/User";
 // <<< ALTERAÇÃO 1: Importamos o modelo E a interface correta que criamos.
 import Redemption, { IRedemption } from "@/app/models/Redemption";
 import { Types } from "mongoose";
+import { getAdminSession } from "@/lib/getAdminSession";
 
 export const runtime = "nodejs";
 export const dynamic = 'force-dynamic';
@@ -57,7 +56,7 @@ export async function GET(request: NextRequest) {
   try {
     await connectToDatabase();
 
-    const session = await getServerSession({ req: request, ...authOptions });
+    const session = await getAdminSession(request);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
     }

--- a/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
@@ -5,13 +5,10 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
 import { checkRateLimit } from '@/utils/rateLimit';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 export const dynamic = 'force-dynamic';
 
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  return mockSession.user.role === 'admin' ? mockSession : null;
-}
 
 function apiError(message: string, status: number) {
   logger.warn(`[generate-media-kit-token] ${message}`);

--- a/src/app/api/admin/users/[userId]/media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/media-kit-token/route.ts
@@ -3,13 +3,10 @@ import { Types } from 'mongoose';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 export const dynamic = 'force-dynamic';
 
-async function getAdminSession(_req: NextRequest): Promise<{ user: { name: string; role?: string } } | null> {
-  const mockSession = { user: { name: 'Admin User', role: 'admin' } };
-  return mockSession.user.role === 'admin' ? mockSession : null;
-}
 
 function apiError(message: string, status: number) {
   logger.warn(`[media-kit-token] ${message}`);

--- a/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
@@ -1,0 +1,58 @@
+import { POST } from '../[userId]/generate-media-kit-token/route';
+import { NextRequest } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { checkRateLimit } from '@/utils/rateLimit';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+jest.mock('@/utils/rateLimit', () => ({
+  checkRateLimit: jest.fn(),
+}));
+jest.mock('@/app/models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockCheckRateLimit = checkRateLimit as jest.Mock;
+const mockFindByIdAndUpdate = UserModel.findByIdAndUpdate as jest.Mock;
+
+function createRequest(userId: string): NextRequest {
+  const req = new NextRequest(`http://localhost/api/admin/users/${userId}/generate-media-kit-token`, { method: 'POST' });
+  (req as any).ip = '127.0.0.1';
+  return req;
+}
+
+describe('POST /api/admin/users/[userId]/generate-media-kit-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 4 });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1', mediaKitToken: 'tok' });
+  });
+
+  it('returns 200 and token on success', async () => {
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.token).toBeDefined();
+  });
+
+  it('returns 401 when session is invalid', async () => {
+    mockGetAdminSession.mockResolvedValueOnce(null);
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 429 when rate limit exceeded', async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, remaining: 0 });
+    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(429);
+  });
+});

--- a/src/app/api/admin/users/__tests__/media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/media-kit-token.test.ts
@@ -1,0 +1,44 @@
+import { DELETE } from '../[userId]/media-kit-token/route';
+import { NextRequest } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+jest.mock('@/app/models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockFindByIdAndUpdate = UserModel.findByIdAndUpdate as jest.Mock;
+
+function createRequest(userId: string): NextRequest {
+  return new NextRequest(`http://localhost/api/admin/users/${userId}/media-kit-token`, { method: 'DELETE' });
+}
+
+describe('DELETE /api/admin/users/[userId]/media-kit-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1' });
+  });
+
+  it('returns 200 on success', async () => {
+    const res = await DELETE(createRequest('1'), { params: { userId: '1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 401 when not authorized', async () => {
+    mockGetAdminSession.mockResolvedValueOnce(null);
+    const res = await DELETE(createRequest('1'), { params: { userId: '1' } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/mediakit/[token]/page.test.ts
+++ b/src/app/mediakit/[token]/page.test.ts
@@ -1,0 +1,31 @@
+import MediaKitPage from './page';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logMediaKitAccess } from '@/lib/logMediaKitAccess';
+import { headers } from 'next/headers';
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findOne: jest.fn() }));
+jest.mock('@/lib/logMediaKitAccess', () => ({ logMediaKitAccess: jest.fn() }));
+jest.mock('next/headers', () => ({ headers: jest.fn() }));
+
+type Params = { params: { token: string } };
+
+const mockFindOne = UserModel.findOne as jest.Mock;
+const mockLogAccess = logMediaKitAccess as jest.Mock;
+const mockHeaders = headers as jest.Mock;
+
+describe('MediaKitPage logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHeaders.mockReturnValue(new Headers({ 'x-real-ip': '1.1.1.1' }));
+    mockFindOne.mockReturnValue({ lean: () => Promise.resolve({ _id: 'u1' }) });
+  });
+
+  it('calls logMediaKitAccess when user exists', async () => {
+    await MediaKitPage({ params: { token: 'tok' } } as Params);
+    expect(mockLogAccess).toHaveBeenCalledWith('u1', '1.1.1.1', undefined);
+  });
+});

--- a/src/lib/getAdminSession.ts
+++ b/src/lib/getAdminSession.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { logger } from '@/app/lib/logger';
+
+export async function getAdminSession(_req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || session.user?.role !== 'admin') {
+      logger.warn('[getAdminSession] session invalid or user not admin');
+      return null;
+    }
+    return session;
+  } catch (err) {
+    logger.error('[getAdminSession] failed to get session', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- remove local admin session mocks and import shared helper
- update dashboard routes to use `getAdminSession`
- adjust related tests for new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616f1641ec832ea23582fcd5190dfb