### PR TITLE
Switch media kit tokens to slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Example:
 |---------------------|------:|------:|---------:|
 | ![thumb](public/images/default-profile.png) [Primeiro Reels](https://instagram.com/p/abc123) | 10k | 520 | 30 |
 
+### Media Kit Slugs
+
+Media kit links are now created using a slug based on the creator's name.
+Admin users can generate or revoke this slug from the creators management page, and
+the public URL becomes `/mediakit/<slug>`.
+
 
 
 ## Learn More

--- a/src/app/admin/creators-management/page.tsx
+++ b/src/app/admin/creators-management/page.tsx
@@ -165,7 +165,7 @@ export default function CreatorsManagementPage() {
         throw new Error(data.error || 'Falha ao gerar link');
       }
       const data = await res.json();
-      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitToken: data.token } : c));
+      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitSlug: data.slug } : c));
       toast.success('Link gerado!');
     } catch (e: any) {
       toast.dismiss(loadingId);
@@ -182,7 +182,7 @@ export default function CreatorsManagementPage() {
         const data = await res.json();
         throw new Error(data.error || 'Falha ao revogar link');
       }
-      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitToken: undefined } : c));
+      setCreators(prev => prev.map(c => c._id === creatorId ? { ...c, mediaKitSlug: undefined } : c));
       toast.success('Link revogado!');
     } catch (e: any) {
       toast.dismiss(loadingId);
@@ -315,10 +315,10 @@ export default function CreatorsManagementPage() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{creator.planStatus || 'N/A'}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
-                    {creator.mediaKitToken ? (
+                    {creator.mediaKitSlug ? (
                       <div className="space-x-2">
                         <a
-                          href={`/mediakit/${creator.mediaKitToken}`}
+                          href={`/mediakit/${creator.mediaKitSlug}`}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-indigo-600 hover:underline"

--- a/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/generate-media-kit-token/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Types } from 'mongoose';
 import crypto from 'crypto';
+import slugify from '@/utils/slugify';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
 import { checkRateLimit } from '@/utils/rateLimit';
 import { getAdminSession } from '@/lib/getAdminSession';
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 
@@ -41,10 +43,22 @@ export async function POST(
 
   await connectToDatabase();
 
-  const token = crypto.randomBytes(16).toString('hex');
+  const user = await UserModel.findById(userId).select('name').lean();
+  if (!user) {
+    return apiError('Usuário não encontrado.', 404);
+  }
+
+  const baseSlug = slugify(user.name || 'usuario');
+  let slug = baseSlug;
+  while (
+    await UserModel.exists({ mediaKitSlug: slug, _id: { $ne: userId } })
+  ) {
+    slug = `${baseSlug}-${crypto.randomBytes(2).toString('hex')}`;
+  }
+
   const updated = await UserModel.findByIdAndUpdate(
     userId,
-    { mediaKitToken: token },
+    { mediaKitSlug: slug },
     { new: true }
   );
 
@@ -52,10 +66,10 @@ export async function POST(
     return apiError('Usuário não encontrado.', 404);
   }
 
-  const url = `${req.nextUrl.origin}/mediakit/${token}`;
-  logger.info(`${TAG} Token generated for user ${userId}`);
+  const url = `${req.nextUrl.origin}/mediakit/${slug}`;
+  logger.info(`${TAG} Slug generated for user ${userId}`);
 
-  return NextResponse.json({ token, url });
+  return NextResponse.json({ slug, url });
 }
 
 export async function GET(
@@ -77,13 +91,13 @@ export async function GET(
 
   await connectToDatabase();
 
-  const user = await UserModel.findById(userId).select('mediaKitToken').lean();
+  const user = await UserModel.findById(userId).select('mediaKitSlug').lean();
   if (!user) {
     return apiError('Usuário não encontrado.', 404);
   }
 
-  const token = user.mediaKitToken;
-  const url = token ? `${req.nextUrl.origin}/mediakit/${token}` : null;
-  logger.info(`${TAG} Returning token for user ${userId}`);
-  return NextResponse.json({ token, url });
+  const slug = user.mediaKitSlug;
+  const url = slug ? `${req.nextUrl.origin}/mediakit/${slug}` : null;
+  logger.info(`${TAG} Returning slug for user ${userId}`);
+  return NextResponse.json({ slug, url });
 }

--- a/src/app/api/admin/users/[userId]/media-kit-token/route.ts
+++ b/src/app/api/admin/users/[userId]/media-kit-token/route.ts
@@ -5,6 +5,7 @@ import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
 import { getAdminSession } from '@/lib/getAdminSession';
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 
@@ -34,7 +35,7 @@ export async function DELETE(
 
   const updated = await UserModel.findByIdAndUpdate(
     userId,
-    { $unset: { mediaKitToken: '' } },
+    { $unset: { mediaKitSlug: '' } },
     { new: true }
   );
 

--- a/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
@@ -38,14 +38,14 @@ describe('POST /api/admin/users/[userId]/generate-media-kit-token', () => {
     jest.clearAllMocks();
     mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
     mockCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 4 });
-    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1', mediaKitToken: 'tok' });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1', mediaKitSlug: 'slug' });
   });
 
-  it('returns 200 and token on success', async () => {
+  it('returns 200 and slug on success', async () => {
     const res = await POST(createRequest('1'), { params: { userId: '1' } });
     const body = await res.json();
     expect(res.status).toBe(200);
-    expect(body.token).toBeDefined();
+    expect(body.slug).toBeDefined();
   });
 
   it('returns 401 when session is invalid', async () => {

--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -71,8 +71,8 @@ async function fetchKpis(baseUrl: string, userId: string): Promise<KpiComparison
 export default async function MediaKitPage({ params }: { params: { token: string } }) {
   await connectToDatabase();
   
-  // Busca o usuário pelo token. `.lean()` é essencial para performance e para passar para o cliente.
-  const user = await UserModel.findOne({ mediaKitToken: params.token }).lean();
+  // Busca o usuário pelo slug. `.lean()` é essencial para performance e para passar para o cliente.
+  const user = await UserModel.findOne({ mediaKitSlug: params.token }).lean();
   
   if (!user) {
     notFound(); // Se o token for inválido, exibe a página 404.

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -197,6 +197,7 @@ export interface IUser extends Document {
   linkToken?: string;
   linkTokenExpiresAt?: Date;
   mediaKitToken?: string;
+  mediaKitSlug?: string;
   role: string;
   planStatus?: string;
   planExpiresAt?: Date | null;
@@ -317,6 +318,7 @@ const userSchema = new Schema<IUser>(
     linkToken: { type: String, index: true, sparse: true },
     linkTokenExpiresAt: { type: Date },
     mediaKitToken: { type: String, unique: true, sparse: true },
+    mediaKitSlug: { type: String, unique: true, sparse: true },
     role: { type: String, default: "user" },
     planExpiresAt: { type: Date, default: null },
     whatsappVerificationCode: { type: String, default: null, index: true },

--- a/src/lib/services/adminCreatorService.test.ts
+++ b/src/lib/services/adminCreatorService.test.ts
@@ -123,7 +123,7 @@ describe('AdminCreatorService', () => {
           planStatus: 'Pro',
           adminStatus: 'approved',
           profile_picture_url: 'url1',
-          mediaKitToken: 'token1',
+          mediaKitSlug: 'token1',
           // registrationDate é omitido para testar fallback para _id.getTimestamp()
         },
         {
@@ -133,7 +133,7 @@ describe('AdminCreatorService', () => {
           adminStatus: 'pending',
           registrationDate: date2,
           profile_picture_url: 'url2',
-          mediaKitToken: undefined,
+          mediaKitSlug: undefined,
         },
       ];
       (UserModel.exec as jest.Mock).mockResolvedValueOnce(mockUserData.map(u => ({...u, _id: u._id.toString() }))); // lean() returns plain objects
@@ -149,7 +149,7 @@ describe('AdminCreatorService', () => {
         planStatus: 'Pro',
         adminStatus: 'approved',
         profilePictureUrl: 'url1',
-        mediaKitToken: 'token1',
+        mediaKitSlug: 'token1',
         registrationDate: date1, // from _id.getTimestamp()
       }));
        expect(creators[1]).toEqual(expect.objectContaining({
@@ -158,7 +158,7 @@ describe('AdminCreatorService', () => {
         email: 'two@example.com',
         adminStatus: 'pending',
         profilePictureUrl: 'url2',
-        mediaKitToken: undefined,
+        mediaKitSlug: undefined,
         registrationDate: date2,
       }));
     });

--- a/src/lib/services/adminCreatorService.ts
+++ b/src/lib/services/adminCreatorService.ts
@@ -98,7 +98,7 @@ export async function fetchCreators(
         profile_picture_url?: string;
         planStatus?: string;
         inferredExpertiseLevel?: string;
-        mediaKitToken?: string;
+        mediaKitSlug?: string;
         name?: string;
         email?: string;
       };
@@ -109,7 +109,7 @@ export async function fetchCreators(
         planStatus: user.planStatus,
         inferredExpertiseLevel: user.inferredExpertiseLevel,
         profilePictureUrl: user.profile_picture_url,
-        mediaKitToken: user.mediaKitToken,
+        mediaKitSlug: user.mediaKitSlug,
         adminStatus: user.adminStatus || 'pending',
         registrationDate: user.registrationDate || user._id.getTimestamp(),
       };

--- a/src/types/admin/creators.ts
+++ b/src/types/admin/creators.ts
@@ -11,7 +11,7 @@ export interface AdminCreatorListItem {
   planStatus?: string; // Status do plano (ex: 'Free', 'Pro', 'Trial') - vindo do UserModel
   inferredExpertiseLevel?: string; // Nível de expertise inferido - vindo do UserModel
   profilePictureUrl?: string; // URL da foto de perfil
-  mediaKitToken?: string; // Token do mídia kit, se já gerado
+  mediaKitSlug?: string; // Slug do mídia kit, se já gerado
 
   totalPostsInPeriod?: number; // Número de posts no período filtrado (se aplicável ao contexto da lista)
   lastActivityDate?: Date | string; // Data da última atividade (post)

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,12 @@
+export default function slugify(input: string): string {
+  return input
+    .normalize('NFD')
+    // Remove accents and diacritics
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Summary
- add `mediaKitSlug` to `User` model and schema
- create `slugify` helper
- generate media kit slugs instead of tokens
- revoke `mediaKitSlug` in admin endpoints
- lookup mediakit page by slug
- update admin creator list logic and types
- adjust tests and docs
- fix slugify diacritic removal
- ensure slug generation uses Node runtime and avoids collisions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition file for 'next')*


------
https://chatgpt.com/codex/tasks/task_e_6861ab06f13c832ebd34d3a159113c76