### PR TITLE
Add comments, shares and saved to user video posts

### DIFF
--- a/src/app/lib/dataService/marketAnalysis/postsService.test.ts
+++ b/src/app/lib/dataService/marketAnalysis/postsService.test.ts
@@ -140,6 +140,14 @@ describe('postsService', () => {
       expect(addFields).toBeDefined();
       const sortStage = videosPipeline.find((s: any) => s.$sort);
       expect(sortStage).toEqual({ $sort: { 'stats.total_interactions': -1 } });
+      const projectStage = videosPipeline.find((s: any) => s.$project).$project;
+      expect(projectStage).toEqual(
+        expect.objectContaining({
+          'stats.comments': '$stats.comments',
+          'stats.shares': '$stats.shares',
+          'stats.saved': '$stats.saved',
+        })
+      );
       expect(videosPipeline).toContainEqual({ $limit: 10 });
 
       expect(result.totalVideos).toBe(mockVideos.length);

--- a/src/app/lib/dataService/marketAnalysis/postsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/postsService.ts
@@ -224,6 +224,9 @@ export async function findUserVideoPosts({
           'stats.views': '$stats.views',
           'stats.likes': '$stats.likes',
           'stats.total_interactions': '$stats.total_interactions',
+          'stats.comments': '$stats.comments',
+          'stats.shares': '$stats.shares',
+          'stats.saved': '$stats.saved',
         },
       },
     ];


### PR DESCRIPTION
## Summary
- include comments, shares and saved counts in the projection for `findUserVideoPosts`
- verify the new fields are included in the aggregation pipeline in unit tests

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc33e724832e9e4f4f067fd41faa