### PR TITLE
Enable public post detail view

### DIFF
--- a/src/app/admin/creator-dashboard/PostDetailModal.tsx
+++ b/src/app/admin/creator-dashboard/PostDetailModal.tsx
@@ -88,9 +88,10 @@ interface PostDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   postId: string | null;
+  publicMode?: boolean;
 }
 
-const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, postId }) => {
+const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, postId, publicMode = false }) => {
   const [postData, setPostData] = useState<IPostDetailsData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -103,7 +104,9 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, post
       setError(null);
       setPostData(null);
 
-      const apiUrl = `/api/admin/dashboard/posts/${postId}/details`;
+      const apiUrl = publicMode
+        ? `/api/v1/posts/${postId}/details`
+        : `/api/admin/dashboard/posts/${postId}/details`;
 
       try {
         const response = await fetch(apiUrl);

--- a/src/app/api/v1/posts/[postId]/details/route.ts
+++ b/src/app/api/v1/posts/[postId]/details/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import { logger } from '@/app/lib/logger';
+import { fetchPostDetails } from '@/app/lib/dataService/marketAnalysis/postsService';
+import { DatabaseError } from '@/app/lib/errors';
+
+const TAG = '/api/v1/posts/[postId]/details';
+
+const pathParamsSchema = z.object({
+  postId: z.string().refine((val) => Types.ObjectId.isValid(val), {
+    message: 'Invalid MongoDB ObjectId format for postId.',
+  }),
+});
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { postId: string } }
+) {
+  logger.info(`${TAG} Request received for postId: ${params.postId}`);
+
+  const validationResult = pathParamsSchema.safeParse(params);
+  if (!validationResult.success) {
+    logger.warn(`${TAG} Invalid postId: ${params.postId}`, validationResult.error.flatten());
+    return NextResponse.json(
+      { error: 'Invalid postId format', details: validationResult.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { postId } = validationResult.data;
+  logger.info(`${TAG} Path parameter validated: ${postId}`);
+
+  try {
+    logger.info(`${TAG} Calling fetchPostDetails service for postId: ${postId}`);
+    const postDetails = await fetchPostDetails({ postId });
+
+    if (!postDetails) {
+      logger.warn(`${TAG} Post details not found for postId: ${postId}`);
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    }
+
+    const { user, rawData, source, classificationStatus, classificationError, createdAt, updatedAt, __v, collabCreator, ...publicData } = postDetails as any;
+
+    logger.info(`${TAG} Successfully fetched post details for postId: ${postId}`);
+    return NextResponse.json(publicData, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Error in request handler for postId ${postId}:`, {
+      message: error.message,
+      stack: error.stack,
+    });
+
+    if (error instanceof DatabaseError) {
+      return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -213,6 +213,7 @@ export default function MediaKitView({ user, summary, videos, kpis: initialKpis 
         isOpen={selectedPostId !== null}
         onClose={handleCloseModal}
         postId={selectedPostId}
+        publicMode
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow PostDetailModal to fetch from a public API route when needed
- expose a new route `/api/v1/posts/[postId]/details`
- use the public fetch mode inside the MediaKit view

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e918cacc832e8a4c013bd4364e1c