### PR TITLE
Implement metrics history function

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -96,6 +96,11 @@ export const GetDailyMetricHistoryArgsSchema = z.object({
   metricId: z.string().min(1, { message: "O ID da métrica não pode ser vazio." }),
 }).strict();
 
+export const GetMetricsHistoryArgsSchema = z.object({
+  days: z.number().int().positive().default(360)
+    .describe('Quantidade de dias a considerar no histórico (padrão: 360).')
+}).strict();
+
 // Schema para getConsultingKnowledge
 const validKnowledgeTopics = [
   'algorithm_overview', 'algorithm_feed', 'algorithm_stories', 'algorithm_reels',
@@ -164,6 +169,7 @@ export const functionValidators: ValidatorMap = {
   getMetricDetailsById: GetMetricDetailsByIdArgsSchema,
   findPostsByCriteria: FindPostsByCriteriaArgsSchema,
   getDailyMetricHistory: GetDailyMetricHistoryArgsSchema,
+  getMetricsHistory: GetMetricsHistoryArgsSchema,
   getConsultingKnowledge: GetConsultingKnowledgeArgsSchema,
   getLatestAccountInsights: GetLatestAccountInsightsArgsSchema,
   fetchCommunityInspirations: FetchCommunityInspirationsArgsSchema,

--- a/src/app/lib/dataService/index.ts
+++ b/src/app/lib/dataService/index.ts
@@ -31,7 +31,8 @@ export {
     getRecentPostObjectsWithAggregatedMetrics,
     getTopPostsByMetric,
     getMetricDetails,
-    findMetricsByCriteria
+    findMetricsByCriteria,
+    getMetricsHistory
 } from './reportService';
 
 // Funções relacionadas com a Comunidade de Inspiração

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -194,3 +194,26 @@ export interface FindMetricsCriteriaArgs {
     sortBy?: 'postDate' | 'stats.shares' | 'stats.saved' | 'stats.likes' | 'stats.reach';
     sortOrder?: 'asc' | 'desc';
 }
+
+export interface MetricsHistoryDataset {
+    label: string;
+    data: number[];
+}
+
+export interface MetricsHistoryEntry {
+    labels: string[];
+    datasets: MetricsHistoryDataset[];
+}
+
+export interface MetricsHistory {
+    engagementRate: MetricsHistoryEntry;
+    propagationIndex: MetricsHistoryEntry;
+    likeCommentRatio: MetricsHistoryEntry;
+    saveRateOnReach: MetricsHistoryEntry;
+    followerConversionRate: MetricsHistoryEntry;
+    retentionRate: MetricsHistoryEntry;
+    engagementDeepVsReach: MetricsHistoryEntry;
+    engagementFastVsReach: MetricsHistoryEntry;
+    likes: MetricsHistoryEntry;
+    comments: MetricsHistoryEntry;
+}


### PR DESCRIPTION
## Summary
- add schemas for metrics history
- implement getMetricsHistory executor and data service
- expose new function and types through dataService index
- allow LLM to call getMetricsHistory

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6864b5a44900832e8ee318b8dd42b714