### PR TITLE
Add follower growth and propagation knowledge topics

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -109,7 +109,7 @@ const validKnowledgeTopics = [
   'pricing_overview_instagram', 'pricing_overview_tiktok',
   'pricing_benchmarks_sector', 'pricing_negotiation_contracts', 'pricing_trends',
   'metrics_analysis', 'metrics_retention_rate',
-  'metrics_avg_watch_time', 'metrics_reach_ratio',
+  'metrics_avg_watch_time', 'metrics_reach_ratio', 'metrics_follower_growth', 'metrics_propagation_index',
   'personal_branding_principles', 'branding_aesthetics',
   'branding_positioning_by_size', 'branding_monetization',
   'branding_case_studies', 'branding_trends',

--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -731,6 +731,8 @@ const getConsultingKnowledge: ExecutorFn = async (args: z.infer<typeof ZodSchema
              case 'algorithm_overview': knowledge = AlgorithmKnowledge.getAlgorithmOverview(); break;
              case 'algorithm_feed': knowledge = AlgorithmKnowledge.explainFeedAlgorithm(); break;
              case 'methodology_cadence_quality': knowledge = MethodologyKnowledge.explainCadenceQuality(); break;
+             case 'metrics_follower_growth': knowledge = MetricsKnowledge.analyzeFollowerGrowth(); break;
+             case 'metrics_propagation_index': knowledge = MetricsKnowledge.explainPropagationIndex(); break;
             // Adicione mais casos aqui conforme necessário
             default:
                 logger.warn(`${fnTag} Tópico não mapeado recebido para User ${loggedUser._id}: ${topic}`);

--- a/src/app/lib/getConsultingKnowledge.test.ts
+++ b/src/app/lib/getConsultingKnowledge.test.ts
@@ -1,0 +1,31 @@
+import { functionExecutors } from './aiFunctions';
+import { GetConsultingKnowledgeArgsSchema } from './aiFunctionSchemas.zod';
+import { Types } from 'mongoose';
+
+jest.mock('./logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}));
+
+jest.mock('./knowledge/metricsKnowledge', () => ({
+  analyzeFollowerGrowth: jest.fn(() => 'Follower growth analysis'),
+  explainPropagationIndex: jest.fn(() => 'Propagation index explanation'),
+}));
+
+describe('getConsultingKnowledge', () => {
+  const user = { _id: new Types.ObjectId() } as any;
+
+  test('schema accepts new knowledge topics', () => {
+    expect(() => GetConsultingKnowledgeArgsSchema.parse({ topic: 'metrics_follower_growth' })).not.toThrow();
+    expect(() => GetConsultingKnowledgeArgsSchema.parse({ topic: 'metrics_propagation_index' })).not.toThrow();
+  });
+
+  test('dispatches follower growth knowledge', async () => {
+    const result = await functionExecutors.getConsultingKnowledge({ topic: 'metrics_follower_growth' }, user) as any;
+    expect(result.knowledge).toBe('Follower growth analysis');
+  });
+
+  test('dispatches propagation index knowledge', async () => {
+    const result = await functionExecutors.getConsultingKnowledge({ topic: 'metrics_propagation_index' }, user) as any;
+    expect(result.knowledge).toBe('Propagation index explanation');
+  });
+});

--- a/src/app/lib/promptSystemFC.ts
+++ b/src/app/lib/promptSystemFC.ts
@@ -22,7 +22,7 @@ export function getSystemPrompt(userName: string = 'usuário'): string { // user
         'pricing_overview_instagram', 'pricing_overview_tiktok',
         'pricing_benchmarks_sector', 'pricing_negotiation_contracts', 'pricing_trends',
         'metrics_analysis', 'metrics_retention_rate',
-        'metrics_avg_watch_time', 'metrics_reach_ratio',
+        'metrics_avg_watch_time', 'metrics_reach_ratio', 'metrics_follower_growth', 'metrics_propagation_index',
         'personal_branding_principles', 'branding_aesthetics',
         'branding_positioning_by_size', 'branding_monetization',
         'branding_case_studies', 'branding_trends',


### PR DESCRIPTION
## Summary
- extend knowledge topic enums to include follower growth and propagation index
- update system prompt list with the new topics
- handle new topics in `getConsultingKnowledge`
- add unit tests for the new topics

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bce81844832e93b5733012f6b6e1