### PR TITLE
Add consulting knowledge topics

### DIFF
--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -50,6 +50,7 @@ import * as AlgorithmKnowledge from './knowledge/algorithmKnowledge';
 import * as MetricsKnowledge from './knowledge/metricsKnowledge';
 import * as BrandingKnowledge from './knowledge/personalBrandingKnowledge';
 import * as MethodologyKnowledge from './knowledge/methodologyDeepDive';
+import * as ExtraKnowledge from './knowledge/extraKnowledge';
 
 /* ------------------------------------------------------------------ *
  * 1.  JSON-schemas expostos ao LLM                                   *
@@ -773,12 +774,117 @@ const getConsultingKnowledge: ExecutorFn = async (args: z.infer<typeof ZodSchema
     try {
         let knowledge = '';
         switch (topic) {
-             case 'algorithm_overview': knowledge = AlgorithmKnowledge.getAlgorithmOverview(); break;
-             case 'algorithm_feed': knowledge = AlgorithmKnowledge.explainFeedAlgorithm(); break;
-             case 'methodology_cadence_quality': knowledge = MethodologyKnowledge.explainCadenceQuality(); break;
-             case 'metrics_follower_growth': knowledge = MetricsKnowledge.analyzeFollowerGrowth(); break;
-             case 'metrics_propagation_index': knowledge = MetricsKnowledge.explainPropagationIndex(); break;
-            // Adicione mais casos aqui conforme necessário
+            // --- Algorithm knowledge ---
+            case 'algorithm_overview':
+                knowledge = AlgorithmKnowledge.getAlgorithmOverview();
+                break;
+            case 'algorithm_feed':
+                knowledge = AlgorithmKnowledge.explainFeedAlgorithm();
+                break;
+            case 'algorithm_stories':
+                knowledge = AlgorithmKnowledge.explainStoriesAlgorithm();
+                break;
+            case 'algorithm_reels':
+                knowledge = AlgorithmKnowledge.explainReelsAlgorithm();
+                break;
+            case 'algorithm_explore':
+                knowledge = AlgorithmKnowledge.explainExploreAlgorithm();
+                break;
+            case 'engagement_signals':
+                knowledge = AlgorithmKnowledge.listEngagementSignals();
+                break;
+            case 'account_type_differences':
+                knowledge = AlgorithmKnowledge.explainAccountTypeDifferences();
+                break;
+            case 'format_treatment':
+                knowledge = AlgorithmKnowledge.explainFormatTreatment();
+                break;
+            case 'ai_ml_role':
+                knowledge = AlgorithmKnowledge.explainAI_ML_Role();
+                break;
+            case 'recent_updates':
+                knowledge = AlgorithmKnowledge.getRecentAlgorithmUpdates();
+                break;
+            case 'best_practices':
+                knowledge = AlgorithmKnowledge.getBestPractices();
+                break;
+
+            // --- Pricing knowledge ---
+            case 'pricing_overview_instagram':
+                knowledge = PricingKnowledge.getInstagramPricingRanges();
+                break;
+            case 'pricing_overview_tiktok':
+                knowledge = PricingKnowledge.getTikTokPricingRanges();
+                break;
+            case 'pricing_benchmarks_sector':
+                knowledge = PricingKnowledge.getSectorBenchmarks();
+                break;
+            case 'pricing_negotiation_contracts':
+                knowledge = PricingKnowledge.getNegotiationStructureInfo();
+                break;
+            case 'pricing_trends':
+                knowledge = PricingKnowledge.getPricingTrends();
+                break;
+
+            // --- Metrics knowledge ---
+            case 'metrics_analysis':
+                knowledge = MetricsKnowledge.getCoreMetricsAnalysis();
+                break;
+            case 'metrics_retention_rate':
+                knowledge = MetricsKnowledge.explainRetentionRate();
+                break;
+            case 'metrics_avg_watch_time':
+                knowledge = MetricsKnowledge.explainAvgWatchTimeVsDuration();
+                break;
+            case 'metrics_reach_ratio':
+                knowledge = MetricsKnowledge.explainFollowerVsNonFollowerReach();
+                break;
+            case 'metrics_follower_growth':
+                knowledge = MetricsKnowledge.analyzeFollowerGrowth();
+                break;
+            case 'metrics_propagation_index':
+                knowledge = MetricsKnowledge.explainPropagationIndex();
+                break;
+
+            // --- Branding knowledge ---
+            case 'personal_branding_principles':
+                knowledge = BrandingKnowledge.getPersonalBrandingPrinciples();
+                break;
+            case 'branding_aesthetics':
+                knowledge = BrandingKnowledge.explainAestheticsAndVisualStorytelling();
+                break;
+            case 'branding_positioning_by_size':
+                knowledge = BrandingKnowledge.explainPositioningBySize();
+                break;
+            case 'branding_monetization':
+                knowledge = BrandingKnowledge.explainImageAndMonetization();
+                break;
+            case 'branding_case_studies':
+                knowledge = BrandingKnowledge.getBrandingCaseStudies();
+                break;
+            case 'branding_trends':
+                knowledge = BrandingKnowledge.getEmergingBrandingTrends();
+                break;
+
+            // --- Methodology knowledge ---
+            case 'methodology_shares_retention':
+                knowledge = MethodologyKnowledge.explainSharesRetentionImpact();
+                break;
+            case 'methodology_format_proficiency':
+                knowledge = MethodologyKnowledge.explainFormatProficiency();
+                break;
+            case 'methodology_cadence_quality':
+                knowledge = MethodologyKnowledge.explainCadenceQuality();
+                break;
+
+            // --- Misc knowledge ---
+            case 'best_posting_times':
+                knowledge = ExtraKnowledge.getBestPostingTimes();
+                break;
+            case 'community_inspiration_overview':
+                knowledge = ExtraKnowledge.getCommunityInspirationOverview();
+                break;
+
             default:
                 logger.warn(`${fnTag} Tópico não mapeado recebido para User ${loggedUser._id}: ${topic}`);
                 const validTopics = ZodSchemas.GetConsultingKnowledgeArgsSchema.shape.topic._def.values;

--- a/src/app/lib/getConsultingKnowledge.test.ts
+++ b/src/app/lib/getConsultingKnowledge.test.ts
@@ -6,26 +6,15 @@ jest.mock('./logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
 }));
 
-jest.mock('./knowledge/metricsKnowledge', () => ({
-  analyzeFollowerGrowth: jest.fn(() => 'Follower growth analysis'),
-  explainPropagationIndex: jest.fn(() => 'Propagation index explanation'),
-}));
-
 describe('getConsultingKnowledge', () => {
   const user = { _id: new Types.ObjectId() } as any;
+  const topics = (GetConsultingKnowledgeArgsSchema.shape.topic as any)._def.values as string[];
 
-  test('schema accepts new knowledge topics', () => {
-    expect(() => GetConsultingKnowledgeArgsSchema.parse({ topic: 'metrics_follower_growth' })).not.toThrow();
-    expect(() => GetConsultingKnowledgeArgsSchema.parse({ topic: 'metrics_propagation_index' })).not.toThrow();
-  });
-
-  test('dispatches follower growth knowledge', async () => {
-    const result = await functionExecutors.getConsultingKnowledge({ topic: 'metrics_follower_growth' }, user) as any;
-    expect(result.knowledge).toBe('Follower growth analysis');
-  });
-
-  test('dispatches propagation index knowledge', async () => {
-    const result = await functionExecutors.getConsultingKnowledge({ topic: 'metrics_propagation_index' }, user) as any;
-    expect(result.knowledge).toBe('Propagation index explanation');
+  it('returns a non-empty string for every topic', async () => {
+    for (const topic of topics) {
+      const result = await functionExecutors.getConsultingKnowledge({ topic }, user) as any;
+      expect(typeof result.knowledge).toBe('string');
+      expect(result.knowledge.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/app/lib/knowledge/extraKnowledge.ts
+++ b/src/app/lib/knowledge/extraKnowledge.ts
@@ -1,0 +1,23 @@
+// @/app/lib/knowledge/extraKnowledge.ts - v1.0
+// Conhecimento adicional que não se encaixa nas outras categorias.
+
+/**
+ * Dicas gerais sobre melhores horários de postagem.
+ */
+export function getBestPostingTimes(): string {
+    const currentYear = new Date().getFullYear();
+    return `
+**Quando Postar nas Redes (${currentYear})?**
+
+Não existe um horário mágico que funcione para todo mundo. O ideal é observar seus próprios Insights para ver quando seu público está mais ativo. Em geral, manhã cedo, horário de almoço e noite costumam ter picos de uso no Brasil, mas teste diferentes horários e acompanhe as primeiras horas de engajamento para descobrir o que funciona melhor para você.`;
+}
+
+/**
+ * Breve explicação sobre a Comunidade de Inspiração IA Tuca.
+ */
+export function getCommunityInspirationOverview(): string {
+    return `
+**O que é a Comunidade de Inspiração IA Tuca?**
+
+É o nosso acervo de posts da comunidade que tiveram bom desempenho qualitativo. Ele serve para gerar exemplos práticos quando você usa a função de buscar inspirações. Assim você recebe ideias baseadas em conteúdos reais que já engajaram outras pessoas.`;
+}


### PR DESCRIPTION
## Summary
- expand `getConsultingKnowledge` switch with all topics
- add `extraKnowledge` module for posting times and inspiration overview
- cover all consulting topics with a unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c43ef410832eaedd8c5ecd166fef