### PR TITLE
Implement FPC trend history feature

### DIFF
--- a/src/app/api/v1/users/[userId]/trends/fpc-history/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/fpc-history/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import getFpcTrendChartData from '@/charts/getFpcTrendChartData';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+
+const ALLOWED_GRANULARITIES = ['weekly','monthly'];
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: Request, { params }: { params: { userId: string } }) {
+  const { userId } = params;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json({ error: 'User ID inválido ou ausente.' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const format = searchParams.get('format');
+  const proposal = searchParams.get('proposal');
+  const context = searchParams.get('context');
+  const timePeriodParam = searchParams.get('timePeriod');
+  const granularityParam = searchParams.get('granularity');
+
+  if (!format || !proposal || !context) {
+    return NextResponse.json({ error: 'Parâmetros format, proposal e context são obrigatórios.' }, { status: 400 });
+  }
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam : 'last_90_days';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  const granularity = ALLOWED_GRANULARITIES.includes(granularityParam || '') ? granularityParam as 'weekly'|'monthly' : 'weekly';
+  if (granularityParam && !ALLOWED_GRANULARITIES.includes(granularityParam)) {
+    return NextResponse.json({ error: `Granularity inválida. Permitidas: ${ALLOWED_GRANULARITIES.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    const data = await getFpcTrendChartData(userId, format, proposal, context, timePeriod, granularity);
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error(`[API TRENDS/FPC-HISTORY] Error for userId ${userId}:`, error);
+    const msg = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: msg }, { status: 500 });
+  }
+}

--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -108,6 +108,14 @@ export const GetUserTrendArgsSchema = z.object({
   granularity: z.enum(['daily', 'weekly', 'monthly']).default('daily')
 }).strict();
 
+export const GetFpcTrendHistoryArgsSchema = z.object({
+  format: z.enum(VALID_FORMATS),
+  proposal: z.enum(VALID_PROPOSALS),
+  context: z.enum(VALID_CONTEXTS),
+  timePeriod: z.enum(ALLOWED_TIME_PERIODS).default('last_90_days'),
+  granularity: z.enum(['weekly','monthly']).default('weekly')
+}).strict();
+
 // Schema para getConsultingKnowledge
 const validKnowledgeTopics = [
   'algorithm_overview', 'algorithm_feed', 'algorithm_stories', 'algorithm_reels',
@@ -178,6 +186,7 @@ export const functionValidators: ValidatorMap = {
   getDailyMetricHistory: GetDailyMetricHistoryArgsSchema,
   getMetricsHistory: GetMetricsHistoryArgsSchema,
   getUserTrend: GetUserTrendArgsSchema,
+  getFpcTrendHistory: GetFpcTrendHistoryArgsSchema,
   getConsultingKnowledge: GetConsultingKnowledgeArgsSchema,
   getLatestAccountInsights: GetLatestAccountInsightsArgsSchema,
   fetchCommunityInspirations: FetchCommunityInspirationsArgsSchema,

--- a/src/app/lib/dataService/index.ts
+++ b/src/app/lib/dataService/index.ts
@@ -54,8 +54,9 @@ export {
 // Funções de tendências (followers, alcance e engajamento)
 export {
     getFollowerTrend,
-    getReachEngagementTrend
+    getReachEngagementTrend,
+    getFpcTrend
 } from './trendService';
 // -------------------------------------------------------------
 
-logger.info('[dataService][index] Módulos do dataService carregados e prontos para uso.');
+logger.info('[dataService][index] Módulos do dataService carregados e prontos para uso.')

--- a/src/app/lib/dataService/trendService.ts
+++ b/src/app/lib/dataService/trendService.ts
@@ -44,3 +44,26 @@ export async function getReachEngagementTrend(
     throw new Error('Falha ao buscar tendência de alcance/engajamento');
   }
 }
+
+export async function getFpcTrend(
+  userId: string,
+  format: string,
+  proposal: string,
+  context: string,
+  timePeriod: TimePeriod = 'last_90_days',
+  granularity: 'weekly' | 'monthly' = 'weekly'
+) {
+  const TAG = `${SERVICE_TAG}[getFpcTrend]`;
+  const url = `${BASE_URL}/api/v1/users/${userId}/trends/fpc-history?format=${encodeURIComponent(format)}&proposal=${encodeURIComponent(proposal)}&context=${encodeURIComponent(context)}&timePeriod=${timePeriod}&granularity=${granularity}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      logger.error(`${TAG} HTTP ${res.status} ao buscar FPC trend.`);
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    return await res.json();
+  } catch (err) {
+    logger.error(`${TAG} Erro ao chamar API`, err);
+    throw new Error('Falha ao buscar tendência FPC');
+  }
+}

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -238,3 +238,13 @@ export interface ReachEngagementTrendData {
     chartData: ReachEngagementTrendPoint[];
     insightSummary?: string;
 }
+
+export interface FpcTrendPoint {
+    date: string;
+    avgInteractions: number | null;
+}
+
+export interface FpcTrendData {
+    chartData: FpcTrendPoint[];
+    insightSummary?: string;
+}

--- a/src/app/lib/promptSystemFC.ts
+++ b/src/app/lib/promptSystemFC.ts
@@ -10,6 +10,7 @@ export function getSystemPrompt(userName: string = 'usuário'): string { // user
     const GET_TOP_POSTS_FUNC_NAME = 'getTopPosts';
     const GET_CATEGORY_RANKING_FUNC_NAME = 'getCategoryRanking'; // (NOVO)
     const GET_USER_TREND_FUNC_NAME = 'getUserTrend';
+    const GET_FPC_TREND_HISTORY_FUNC_NAME = 'getFpcTrendHistory';
     const GET_DAY_PCO_STATS_FUNC_NAME = 'getDayPCOStats';
     const GET_METRIC_DETAILS_BY_ID_FUNC_NAME = 'getMetricDetailsById';
     const FIND_POSTS_BY_CRITERIA_FUNC_NAME = 'findPostsByCriteria';
@@ -71,6 +72,7 @@ Regras Gerais de Operação
 
     * **(NOVO) RANKING DE CATEGORIAS (\`${GET_CATEGORY_RANKING_FUNC_NAME}\`):** Use esta ferramenta para fornecer ao usuário uma visão clara de quais dos *seus* próprios formatos, propostas ou contextos de conteúdo estão performando melhor com base em uma métrica (curtidas, compartilhamentos, etc.) ou quais são os mais publicados. É uma excelente ferramenta para identificar padrões de sucesso e pontos de melhoria no conteúdo do usuário e para ser usada de forma proativa.
     * **(NOVO) TENDÊNCIAS DO USUÁRIO (\`${GET_USER_TREND_FUNC_NAME}\`):** Use para gerar gráficos de evolução de seguidores ou de alcance/engajamento ao longo do tempo.
+    * **(NOVO) HISTÓRICO F/P/C (\`${GET_FPC_TREND_HISTORY_FUNC_NAME}\`):** Analise a média de interações por semana ou mês para uma combinação específica de formato, proposta e contexto.
 
     * **REGRA DE OURO: IDENTIFICAÇÃO CORRETA DE IDs DE POSTS (ATUALIZADO - v2.33.4)**
         * ... (seção existente) ...

--- a/src/charts/getFpcTrendChartData.ts
+++ b/src/charts/getFpcTrendChartData.ts
@@ -1,0 +1,98 @@
+import { Types } from 'mongoose';
+import MetricModel, { IMetric } from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import {
+  getStartDateFromTimePeriod,
+  addDays,
+  addMonths,
+  getYearWeek,
+  formatDateYYYYMM
+} from '@/utils/dateHelpers';
+import { TimePeriod } from '@/app/lib/constants/timePeriods';
+
+interface FpcTrendPoint {
+  date: string;
+  avgInteractions: number | null;
+}
+
+export interface FpcTrendChartResponse {
+  chartData: FpcTrendPoint[];
+  insightSummary?: string;
+}
+
+export default async function getFpcTrendChartData(
+  userId: string | Types.ObjectId,
+  format: string,
+  proposal: string,
+  context: string,
+  timePeriod: TimePeriod = 'last_90_days',
+  granularity: 'weekly' | 'monthly' = 'weekly'
+): Promise<FpcTrendChartResponse> {
+  const resolvedUserId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
+  const TAG = '[charts][getFpcTrendChartData]';
+
+  const today = new Date();
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+  const response: FpcTrendChartResponse = { chartData: [], insightSummary: 'Sem dados para o período.' };
+
+  try {
+    await connectToDatabase();
+
+    const query: any = { user: resolvedUserId, postDate: { $gte: startDate, $lte: endDate } };
+    if (format) query.format = format;
+    if (proposal) query.proposal = proposal;
+    if (context) query.context = context;
+
+    const posts: Pick<IMetric,'postDate'|'stats'>[] = await MetricModel.find(query)
+      .select('postDate stats.total_interactions')
+      .sort({ postDate: 1 })
+      .lean();
+
+    const map = new Map<string, { sum: number; count: number }>();
+    for (const post of posts) {
+      const value = post.stats?.total_interactions;
+      if (typeof value !== 'number') continue;
+      const key = granularity === 'monthly'
+        ? formatDateYYYYMM(post.postDate)
+        : getYearWeek(post.postDate);
+      const agg = map.get(key) || { sum: 0, count: 0 };
+      agg.sum += value;
+      agg.count += 1;
+      map.set(key, agg);
+    }
+
+    let cursor = new Date(startDate);
+    while (cursor <= endDate) {
+      const key = granularity === 'monthly'
+        ? formatDateYYYYMM(cursor)
+        : getYearWeek(cursor);
+      const entry = map.get(key);
+      const avg = entry ? entry.sum / entry.count : null;
+      response.chartData.push({ date: key, avgInteractions: entry ? Math.round(avg) : null });
+      if (granularity === 'monthly') {
+        cursor = addMonths(cursor, 1);
+      } else {
+        cursor = addDays(cursor, 7);
+      }
+    }
+
+    const valid = response.chartData.filter(p => p.avgInteractions !== null);
+    if (valid.length) {
+      const overall = valid.reduce((s, p) => s + (p.avgInteractions || 0), 0) / valid.length;
+      const periodText = timePeriod === 'all_time'
+        ? 'todo o período'
+        : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months',' meses');
+      response.insightSummary =
+        `Média de ${overall.toFixed(0)} interações por ${granularity === 'monthly' ? 'mês' : 'semana'} para ${format}/${proposal}/${context} nos ${periodText}.`;
+    }
+
+    return response;
+  } catch (err) {
+    logger.error(`${TAG} Erro ao buscar dados`, err);
+    response.insightSummary = 'Erro ao buscar dados.';
+    return response;
+  }
+}


### PR DESCRIPTION
## Summary
- add chart util to compute FPC trend history
- expose new API route for FPC trends
- add dataService wrapper `getFpcTrend`
- define FpcTrend types
- update AI schemas and executors
- document new function in system prompt

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c471b38c832eb9b3c825814f3719