### PR TITLE
Handle periodDays=0 in category ranking

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -49,7 +49,7 @@ export const GetCategoryRankingArgsSchema = z.object({
   metric: z.string({
     invalid_type_error: "A métrica deve ser um texto, como 'shares' ou 'likes'."
   }).min(1).default('shares').describe("A métrica para o ranking (ex: 'shares', 'likes', 'posts')."),
-  periodDays: z.number().int().positive().default(90).describe("O período de análise em dias (padrão: 90)."),
+  periodDays: z.number().int().min(0).default(90).describe("O período de análise em dias (0 significa todo o período disponível; padrão: 90)."),
   limit: z.number().int().min(1).max(10).default(5).describe("O número de itens no ranking (padrão: 5).")
 }).strict("Apenas os argumentos 'category', 'metric', 'periodDays', e 'limit' são permitidos.");
 // --- FIM DO NOVO SCHEMA ---

--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -563,7 +563,7 @@ const getCategoryRanking: ExecutorFn = async (args, loggedUser) => {
 
   try {
       const endDate = new Date();
-      const startDate = subDays(endDate, periodDays);
+      const startDate = periodDays === 0 ? new Date(0) : subDays(endDate, periodDays);
 
       const results = await fetchTopCategories({
           userId,
@@ -575,15 +575,18 @@ const getCategoryRanking: ExecutorFn = async (args, loggedUser) => {
 
       if (results.length === 0) {
           logger.info(`${fnTag} Nenhum resultado encontrado para User ${userId}.`);
-          return { message: `Não encontrei dados suficientes sobre seus posts para criar um ranking de '${category}' por '${metric}' nos últimos ${periodDays} dias.` };
+          const periodText = periodDays === 0 ? 'todo o período disponível' : `nos últimos ${periodDays} dias`;
+          return { message: `Não encontrei dados suficientes sobre seus posts para criar um ranking de '${category}' por '${metric}' ${periodText}.` };
       }
 
       logger.info(`${fnTag} Ranking gerado com sucesso para User ${userId}. Itens: ${results.length}`);
       const leader = results[0];
       const rankingList = results.map((item, index) => `${index + 1}. ${item.category}: ${item.value.toLocaleString('pt-BR')}`).join('\n');
 
+      const periodText = periodDays === 0 ? 'todo o período disponível' : `nos últimos ${periodDays} dias`;
       return {
-        summary: `Aqui está o ranking das suas categorias de '${category}' por '${metric}' nos últimos ${periodDays} dias, ${loggedUser.name || 'usuário'}:\n${rankingList}`,          ranking: results
+        summary: `Aqui está o ranking das suas categorias de '${category}' por '${metric}' ${periodText}, ${loggedUser.name || 'usuário'}:\n${rankingList}`,
+        ranking: results
       };
 
   } catch (err: any) {

--- a/src/app/lib/getCategoryRanking.test.ts
+++ b/src/app/lib/getCategoryRanking.test.ts
@@ -1,0 +1,35 @@
+import { functionExecutors } from './aiFunctions';
+import { fetchTopCategories } from './dataService';
+import { Types } from 'mongoose';
+
+jest.mock('./logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}));
+
+jest.mock('./dataService', () => ({
+  ...jest.requireActual('./dataService'),
+  fetchTopCategories: jest.fn()
+}));
+
+describe('getCategoryRanking', () => {
+  const user = { _id: new Types.ObjectId(), name: 'Tester' } as any;
+  const mockedFetch = fetchTopCategories as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetch.mockResolvedValue([
+      { category: 'FORMATO1', value: 10 },
+      { category: 'FORMATO2', value: 5 }
+    ]);
+  });
+
+  it('uses full history when periodDays is 0', async () => {
+    const args = { category: 'format', metric: 'shares', periodDays: 0, limit: 5 };
+    const result = await functionExecutors.getCategoryRanking(args, user) as any;
+
+    const call = mockedFetch.mock.calls[0][0];
+    expect(call.userId).toBe(user._id.toString());
+    expect(call.dateRange.startDate.getTime()).toBe(0);
+    expect(result.summary).toContain('todo o período disponível');
+  });
+});


### PR DESCRIPTION
## Summary
- allow 0 days in the schema by using `.min(0)` and clarify description
- interpret periodDays=0 as 'all available history' in getCategoryRanking
- update summary/messages for this case
- test that periodDays=0 uses the full history

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c9952770832e8f883591f0e5fd24