### PR TITLE
Add enum for category ranking metrics

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -15,6 +15,7 @@ import {
     ContextType,
     QualitativeObjectiveType
 } from '@/app/lib/constants/communityInspirations.constants';
+import { CategoryRankingMetricEnum } from '@/app/lib/dataService/marketAnalysis/types';
 
 // Schema para getAggregatedReport
 export const GetAggregatedReportArgsSchema = z.object({
@@ -46,9 +47,9 @@ export const GetCategoryRankingArgsSchema = z.object({
     required_error: "A categoria (proposal, format, ou context) é obrigatória.",
     invalid_type_error: "Categoria inválida. Use 'proposal', 'format' ou 'context'."
   }).describe("A dimensão do conteúdo a ser ranqueada."),
-  metric: z.string({
-    invalid_type_error: "A métrica deve ser um texto, como 'shares' ou 'likes'."
-  }).min(1).default('shares').describe("A métrica para o ranking (ex: 'shares', 'likes', 'posts')."),
+  metric: CategoryRankingMetricEnum
+    .default('shares')
+    .describe("A métrica para o ranking (ex: 'shares', 'likes', 'posts')."),
   periodDays: z.number().int().positive().default(90).describe("O período de análise em dias (padrão: 90)."),
   limit: z.number().int().min(1).max(10).default(5).describe("O número de itens no ranking (padrão: 5).")
 }).strict("Apenas os argumentos 'category', 'metric', 'periodDays', e 'limit' são permitidos.");

--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -44,6 +44,7 @@ import {
   getReachEngagementTrend,
   getFpcTrend
 } from './dataService';
+import { CategoryRankingMetricEnum } from './dataService/marketAnalysis/types';
 import { subDays, subYears, startOfDay } from 'date-fns';
 
 import * as PricingKnowledge from './knowledge/pricingKnowledge';
@@ -546,7 +547,7 @@ const getCategoryRanking: ExecutorFn = async (args, loggedUser) => {
   // Validação interna dos argumentos com Zod
   const validationSchema = z.object({
       category: z.enum(['proposal', 'format', 'context']),
-      metric: z.string().default('shares'),
+      metric: CategoryRankingMetricEnum.default('shares'),
       periodDays: z.number().default(90),
       limit: z.number().min(1).max(10).default(5)
   });

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -27,6 +27,17 @@ export const TopCreatorMetricEnum = z.enum([
 ]);
 export type TopCreatorMetric = z.infer<typeof TopCreatorMetricEnum>;
 
+// --- NOVO: Enum para métricas permitidas em rankings de categoria ---
+export const CategoryRankingMetricEnum = z.enum([
+  'shares',
+  'likes',
+  'comments',
+  'reach',
+  'views',
+  'posts',
+]);
+export type CategoryRankingMetric = z.infer<typeof CategoryRankingMetricEnum>;
+
 // --- (REMOVIDO) O Enum e o Tipo abaixo foram substituídos pela nova abordagem genérica ---
 // export const ProposalRankingMetricEnum = z.enum([
 //   'avg_views',


### PR DESCRIPTION
## Summary
- define `CategoryRankingMetricEnum` in marketAnalysis/types
- use the new enum in `GetCategoryRankingArgsSchema`
- validate metric using enum in `getCategoryRanking` executor

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c99ecd3c832e9781207b279ec8e0