### PR TITLE
Add metric enum validation for category ranking

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { Types } from 'mongoose';
+import { CategoryRankingMetricEnum } from '@/app/lib/dataService/marketAnalysis/types';
 import {
     VALID_FORMATS,
     VALID_PROPOSALS,
@@ -46,9 +47,7 @@ export const GetCategoryRankingArgsSchema = z.object({
     required_error: "A categoria (proposal, format, ou context) é obrigatória.",
     invalid_type_error: "Categoria inválida. Use 'proposal', 'format' ou 'context'."
   }).describe("A dimensão do conteúdo a ser ranqueada."),
-  metric: z.string({
-    invalid_type_error: "A métrica deve ser um texto, como 'shares' ou 'likes'."
-  }).min(1).default('shares').describe("A métrica para o ranking (ex: 'shares', 'likes', 'posts')."),
+  metric: CategoryRankingMetricEnum.default('shares').describe("A métrica para o ranking."),
   periodDays: z.number().int().min(0).default(90).describe("O período de análise em dias (0 significa todo o período disponível; padrão: 90)."),
   limit: z.number().int().min(1).max(10).default(5).describe("O número de itens no ranking (padrão: 5).")
 }).strict("Apenas os argumentos 'category', 'metric', 'periodDays', e 'limit' são permitidos.");

--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -44,6 +44,7 @@ import {
   getReachEngagementTrend,
   getFpcTrend
 } from './dataService';
+import { CategoryRankingMetricEnum } from './dataService/marketAnalysis/types';
 import { subDays, subYears, startOfDay } from 'date-fns';
 
 import * as PricingKnowledge from './knowledge/pricingKnowledge';
@@ -546,8 +547,8 @@ const getCategoryRanking: ExecutorFn = async (args, loggedUser) => {
   // Validação interna dos argumentos com Zod
   const validationSchema = z.object({
       category: z.enum(['proposal', 'format', 'context']),
-      metric: z.string().default('shares'),
-      periodDays: z.number().default(90),
+      metric: CategoryRankingMetricEnum.default('shares'),
+      periodDays: z.number().min(0).default(90),
       limit: z.number().min(1).max(10).default(5)
   });
 

--- a/src/app/lib/dataService/marketAnalysis/rankingsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/rankingsService.ts
@@ -9,11 +9,12 @@ import { logger } from '@/app/lib/logger';
 import MetricModel from '@/app/models/Metric';
 import { connectToDatabase } from '../connection';
 import { DatabaseError } from '@/app/lib/errors';
-import { 
-  IFetchCreatorRankingParams, 
-  ICreatorMetricRankItem, 
+import {
+  IFetchCreatorRankingParams,
+  ICreatorMetricRankItem,
   ICategoryMetricRankItem,
-  RankableCategory
+  RankableCategory,
+  CategoryRankingMetric
 } from './types';
 
 const SERVICE_TAG = '[dataService][rankingsService]';
@@ -257,7 +258,7 @@ export async function fetchTopCategories(params: {
   userId?: string; // (ALTERADO) userId agora é opcional
   dateRange: { startDate: Date; endDate: Date };
   category: RankableCategory;
-  metric: string; 
+  metric: CategoryRankingMetric;
   limit?: number;
 }): Promise<ICategoryMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchTopCategories]`;

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -27,6 +27,17 @@ export const TopCreatorMetricEnum = z.enum([
 ]);
 export type TopCreatorMetric = z.infer<typeof TopCreatorMetricEnum>;
 
+// --- Allowed metrics for category ranking ---
+export const CategoryRankingMetricEnum = z.enum([
+  'shares',
+  'likes',
+  'comments',
+  'reach',
+  'views',
+  'posts'
+]);
+export type CategoryRankingMetric = z.infer<typeof CategoryRankingMetricEnum>;
+
 // --- (REMOVIDO) O Enum e o Tipo abaixo foram substituídos pela nova abordagem genérica ---
 // export const ProposalRankingMetricEnum = z.enum([
 //   'avg_views',

--- a/src/app/lib/getCategoryRanking.test.ts
+++ b/src/app/lib/getCategoryRanking.test.ts
@@ -32,4 +32,11 @@ describe('getCategoryRanking', () => {
     expect(call.dateRange.startDate.getTime()).toBe(0);
     expect(result.summary).toContain('todo o período disponível');
   });
+
+  it('rejects invalid metrics early', async () => {
+    const args = { category: 'format', metric: 'invalid', periodDays: 30, limit: 5 };
+    const result = await functionExecutors.getCategoryRanking(args, user) as any;
+    expect(result.error).toBeDefined();
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- define `CategoryRankingMetricEnum` for allowable ranking metrics
- enforce metric enum in `getCategoryRanking` schema and executor
- update `fetchTopCategories` to accept the typed metric
- test invalid metric handling in `getCategoryRanking`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b2466118832ebbfeb03c44df8e07