### PR TITLE
Fix time period filter in platform overview

### DIFF
--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
+import { useGlobalTimePeriod } from "../filters/GlobalTimePeriodContext";
 import PlatformFollowerTrendChart from "../PlatformFollowerTrendChart";
 import PlatformFollowerChangeChart from "../PlatformFollowerChangeChart";
 import PlatformReachEngagementTrendChart from "../PlatformReachEngagementTrendChart";
@@ -9,11 +10,20 @@ import PlatformMovingAverageEngagementChart from "../PlatformMovingAverageEngage
 import TotalActiveCreatorsKpi from "../kpis/TotalActiveCreatorsKpi";
 import PlatformComparativeKpi from "../kpis/PlatformComparativeKpi";
 
-interface Props {
-  comparisonPeriod: string;
-}
+const TIME_PERIOD_TO_COMPARISON: Record<string, string> = {
+  last_7_days: "last_7d_vs_previous_7d",
+  last_30_days: "last_30d_vs_previous_30d",
+  last_90_days: "last_30d_vs_previous_30d",
+  last_6_months: "month_vs_previous",
+  last_12_months: "month_vs_previous",
+  all_time: "month_vs_previous",
+};
 
-const PlatformOverviewSection: React.FC<Props> = ({ comparisonPeriod }) => (
+const PlatformOverviewSection: React.FC = () => {
+  const { timePeriod } = useGlobalTimePeriod();
+  const comparisonPeriod = TIME_PERIOD_TO_COMPARISON[timePeriod] || "month_vs_previous";
+
+  return (
   <section id="platform-overview" className="mb-10">
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
       Visão Geral da Plataforma <GlobalPeriodIndicator />
@@ -41,7 +51,9 @@ const PlatformOverviewSection: React.FC<Props> = ({ comparisonPeriod }) => (
       <PlatformReachEngagementTrendChart />
       <PlatformMovingAverageEngagementChart />
     </div>
+
   </section>
-);
+  );
+};
 
 export default PlatformOverviewSection;

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -445,9 +445,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
 
       {!selectedUserId && (
         <>
-          <PlatformOverviewSection
-            comparisonPeriod={"month_vs_previous"}
-          />
+          <PlatformOverviewSection />
           <PlatformContentAnalysisSection
             startDate={startDate}
             endDate={endDate}


### PR DESCRIPTION
## Summary
- link global period filter to PlatformOverviewSection
- stop passing fixed comparison period from page

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658cc911ac832eb727d67512fa792c