### PR TITLE
Fix TopMoversWidget syntax error

### DIFF
--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -268,7 +268,6 @@ export default function TopMoversWidget() {
             </div>
           </>
         )}
-      </div>
       
       <div className="mt-4" />
 


### PR DESCRIPTION
## Summary
- remove stray closing `div` tag in `TopMoversWidget`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865944d7080832ea341ba7bf30f3f3f