### PR TITLE
Add idsToLabels helper and apply across components

### DIFF
--- a/src/app/admin/creator-dashboard/ContentTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/ContentTrendChart.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   Legend,
 } from 'recharts';
+import { idsToLabels } from '../../lib/classification';
 
 // --- Tipos e Interfaces ---
 
@@ -108,9 +109,12 @@ const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
   const filteredData = data.slice(0, dayLimit);
 
   // Função auxiliar para renderizar os arrays de metadados
-  const renderMetaList = (items?: string[]) => {
-    if (!items || items.length === 0) return 'N/A';
-    return items.join(', ');
+  const renderMetaList = (
+    items: string[] | undefined,
+    type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+  ) => {
+    const labels = idsToLabels(items, type);
+    return labels.length > 0 ? labels.join(', ') : 'N/A';
   };
 
   return (
@@ -180,11 +184,11 @@ const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
         {/* ATUALIZADO: Aside para exibir as 5 dimensões */}
         <aside className="w-full md:w-48 mt-4 md:mt-0 text-sm space-y-1">
           <h4 className="text-md font-semibold text-gray-700 mb-1">Classificação</h4>
-          <p><strong>Formato:</strong> {renderMetaList(meta.format)}</p>
-          <p><strong>Proposta:</strong> {renderMetaList(meta.proposal)}</p>
-          <p><strong>Contexto:</strong> {renderMetaList(meta.context)}</p>
-          <p><strong>Tom:</strong> {renderMetaList(meta.tone)}</p>
-          <p><strong>Referências:</strong> {renderMetaList(meta.references)}</p>
+          <p><strong>Formato:</strong> {renderMetaList(meta.format, 'format')}</p>
+          <p><strong>Proposta:</strong> {renderMetaList(meta.proposal, 'proposal')}</p>
+          <p><strong>Contexto:</strong> {renderMetaList(meta.context, 'context')}</p>
+          <p><strong>Tom:</strong> {renderMetaList(meta.tone, 'tone')}</p>
+          <p><strong>Referências:</strong> {renderMetaList(meta.references, 'reference')}</p>
         </aside>
       </div>
     </div>

--- a/src/app/admin/creator-dashboard/PostDetailModal.tsx
+++ b/src/app/admin/creator-dashboard/PostDetailModal.tsx
@@ -28,6 +28,7 @@ import {
   Tooltip, 
   Legend,
 } from 'recharts';
+import { idsToLabels } from '../../lib/classification';
 
 // --- Helper Component for Loading State ---
 const SkeletonBlock = ({ width = 'w-full', height = 'h-4' }: { width?: string; height?: string }) => (
@@ -153,9 +154,12 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, post
   }
 
   // ATUALIZADO: Função para renderizar os arrays de classificação
-  const renderMetaList = (items?: string[]) => {
-    if (!items || items.length === 0) return 'N/A';
-    return items.join(', ');
+  const renderMetaList = (
+    items: string[] | undefined,
+    type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+  ) => {
+    const labels = idsToLabels(items, type);
+    return labels.length > 0 ? labels.join(', ') : 'N/A';
   };
 
   const renderGeneralInfo = () => (
@@ -174,11 +178,11 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, post
           <p><strong className="font-medium text-gray-700">Data:</strong> {postData.postDate ? new Date(postData.postDate).toLocaleDateString('pt-BR', { year: 'numeric', month: 'long', day: 'numeric' }) : 'N/A'}</p>
           <p><strong className="font-medium text-gray-700">Tipo:</strong> {postData.type || 'N/A'}</p>
           {/* ATUALIZADO: Renderização para as 5 dimensões */}
-          <p><strong className="font-medium text-gray-700">Formato:</strong> {renderMetaList(postData.format)}</p>
-          <p><strong className="font-medium text-gray-700">Proposta:</strong> {renderMetaList(postData.proposal)}</p>
-          <p><strong className="font-medium text-gray-700">Contexto:</strong> {renderMetaList(postData.context)}</p>
-          <p><strong className="font-medium text-gray-700">Tom:</strong> {renderMetaList(postData.tone)}</p>
-          <p><strong className="font-medium text-gray-700">Referências:</strong> {renderMetaList(postData.references)}</p>
+          <p><strong className="font-medium text-gray-700">Formato:</strong> {renderMetaList(postData.format, 'format')}</p>
+          <p><strong className="font-medium text-gray-700">Proposta:</strong> {renderMetaList(postData.proposal, 'proposal')}</p>
+          <p><strong className="font-medium text-gray-700">Contexto:</strong> {renderMetaList(postData.context, 'context')}</p>
+          <p><strong className="font-medium text-gray-700">Tom:</strong> {renderMetaList(postData.tone, 'tone')}</p>
+          <p><strong className="font-medium text-gray-700">Referências:</strong> {renderMetaList(postData.references, 'reference')}</p>
           {postData.theme && <p><strong className="font-medium text-gray-700">Tema:</strong> {postData.theme}</p>}
           {postData.coverUrl && <p><strong className="font-medium text-gray-700">Capa:</strong> <a href={postData.coverUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:underline break-all">{postData.coverUrl}</a></p>}
           <p className="mt-2 pt-2 border-t border-gray-200"><strong className="font-medium text-gray-700">Descrição:</strong> {postData.description || 'N/A'}</p>

--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -188,3 +188,7 @@ export const getCategoryById = (id: string, type: 'format' | 'proposal' | 'conte
   }
   return list.find(cat => cat.id === id);
 };
+
+export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string[] {
+  return (ids ?? []).map(id => getCategoryById(id, type)?.label ?? id);
+}


### PR DESCRIPTION
## Summary
- map IDs to labels with `idsToLabels`
- display labels in PostDetailModal, ContentTrendChart and GlobalPostsExplorer
- deduplicate category definitions in GlobalPostsExplorer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660c0bd41c832e828b937d58ad8fc5