### PR TITLE
Fix media kit tags labels

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { getCategoryById } from '../../../lib/classification';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -69,7 +70,11 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
         throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
       }
       const result: PlatformAverageEngagementResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map((d) => ({
+        ...d,
+        name: getCategoryById(d.name, groupBy as any)?.label ?? d.name,
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');

--- a/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
+++ b/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { idsToLabels } from '../../../lib/classification';
 import { 
     XMarkIcon, 
     FireIcon,
@@ -35,13 +36,19 @@ const InstagramIcon = (props: React.SVGProps<SVGSVGElement>) => (
     </svg>
 );
 
-const ClassificationTags: React.FC<{ title: string; tags?: string[]; colorClasses: string }> = ({ title, tags, colorClasses }) => {
-  if (!tags || tags.length === 0) return null;
+const ClassificationTags: React.FC<{
+  title: string;
+  tags?: string[];
+  colorClasses: string;
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference';
+}> = ({ title, tags, colorClasses, type }) => {
+  const labels = idsToLabels(tags, type);
+  if (labels.length === 0) return null;
   return (
     <div>
       <h5 className="text-xs font-semibold text-gray-500 mb-1">{title}</h5>
       <div className="flex flex-wrap gap-1">
-        {tags.map(tag => (
+        {labels.map(tag => (
           <span key={tag} className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${colorClasses}`}>
             {tag}
           </span>
@@ -128,11 +135,11 @@ const VideoCard: React.FC<{ video: VideoListItem; index: number; readOnly?: bool
         </div>
 
         <div className="col-span-12 md:col-span-3 space-y-2">
-          <ClassificationTags title="Formato" tags={video.format} colorClasses="bg-gray-100 text-gray-800" />
-          <ClassificationTags title="Proposta" tags={video.proposal} colorClasses="bg-blue-100 text-blue-800" />
-          <ClassificationTags title="Contexto" tags={video.context} colorClasses="bg-purple-100 text-purple-800" />
-          <ClassificationTags title="Tom" tags={video.tone} colorClasses="bg-yellow-100 text-yellow-800" />
-          <ClassificationTags title="Referências" tags={video.references} colorClasses="bg-green-100 text-green-800" />
+          <ClassificationTags title="Formato" tags={video.format} type="format" colorClasses="bg-gray-100 text-gray-800" />
+          <ClassificationTags title="Proposta" tags={video.proposal} type="proposal" colorClasses="bg-blue-100 text-blue-800" />
+          <ClassificationTags title="Contexto" tags={video.context} type="context" colorClasses="bg-purple-100 text-purple-800" />
+          <ClassificationTags title="Tom" tags={video.tone} type="tone" colorClasses="bg-yellow-100 text-yellow-800" />
+          <ClassificationTags title="Referências" tags={video.references} type="reference" colorClasses="bg-green-100 text-green-800" />
         </div>
 
         <div className="col-span-6 md:col-span-1 text-left md:text-center">

--- a/src/app/admin/creator-dashboard/components/VideosTable.tsx
+++ b/src/app/admin/creator-dashboard/components/VideosTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { idsToLabels } from '../../../lib/classification';
 import { 
     FireIcon, 
     EyeIcon, 
@@ -64,9 +65,15 @@ const VideoCard: React.FC<{ video: VideoListItem; index: number; readOnly?: bool
 
         {/* ✅ 'Reel' movido de volta para cá para agrupar todas as tags */}
         <div className="col-span-12 md:col-span-2 flex flex-wrap gap-1.5 content-start">
-          {video.format?.map(tag => <span key={tag} className={`${tagBaseClasses} bg-gray-100 text-gray-700`}>{tag}</span>)}
-          {video.proposal?.map(tag => <span key={tag} className={`${tagBaseClasses} bg-blue-100 text-blue-800`}>{tag}</span>)}
-          {video.context?.map(tag => <span key={tag} className={`${tagBaseClasses} bg-purple-100 text-purple-800`}>{tag}</span>)}
+          {idsToLabels(video.format, 'format').map(tag => (
+            <span key={tag} className={`${tagBaseClasses} bg-gray-100 text-gray-700`}>{tag}</span>
+          ))}
+          {idsToLabels(video.proposal, 'proposal').map(tag => (
+            <span key={tag} className={`${tagBaseClasses} bg-blue-100 text-blue-800`}>{tag}</span>
+          ))}
+          {idsToLabels(video.context, 'context').map(tag => (
+            <span key={tag} className={`${tagBaseClasses} bg-purple-100 text-purple-800`}>{tag}</span>
+          ))}
         </div>
 
         <div className="col-span-12 md:col-span-1 text-left md:text-center">


### PR DESCRIPTION
## Summary
- localize tag labels in Media Kit tables
- convert drilldown modal classification tags to Portuguese labels
- translate category names in platform average engagement charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660a5bebb8832eac2a5ad4ea9007c0