### PR TITLE
Fix classification labels in dashboard charts

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { getCategoryById } from "../../../lib/classification";
 
 interface ApiEngagementDistributionDataPoint {
   name: string;
@@ -67,7 +68,11 @@ const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDi
         throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
       }
       const result: PlatformEngagementDistributionApiResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: getCategoryById(d.name, 'format')?.label ?? d.name,
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
       setMetricUsed(result.metricUsed);
     } catch (err) {

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { getCategoryById } from "../../../lib/classification";
 
 interface ApiPostDistributionDataPoint {
   name: string;
@@ -57,7 +58,11 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
         throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
       }
       const result: PlatformPostDistributionResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: getCategoryById(d.name, 'format')?.label ?? d.name,
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -12,6 +12,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
+import { getCategoryById } from "../../../lib/classification";
 
 type GroupingType = "format" | "context" | "proposal";
 
@@ -94,7 +95,11 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
         );
       }
       const result: UserAverageEngagementResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: getCategoryById(d.name, groupBy as any)?.label ?? d.name,
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(

--- a/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { TooltipProps } from "recharts";
+import { getCategoryById } from "../../../lib/classification";
 
 // Remove custom Payload type, use recharts' Payload type directly in formatter
 
@@ -103,7 +104,11 @@ const UserEngagementDistributionChart: React.FC<
         );
       }
       const result: UserEngagementDistributionResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: getCategoryById(d.name, 'format')?.label ?? d.name,
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(


### PR DESCRIPTION
## Summary
- map classification IDs to Portuguese labels in the user and platform charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661959e700832e8d0b369ceda91841