### PR TITLE
Fix classification labels in dashboard charts

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
-import { getCategoryById } from '../../../lib/classification';
+import { idsStringToLabelsString } from '../../../lib/classification';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -72,7 +72,7 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
       const result: PlatformAverageEngagementResponse = await response.json();
       const mapped = result.chartData.map((d) => ({
         ...d,
-        name: getCategoryById(d.name, groupBy as any)?.label ?? d.name,
+        name: idsStringToLabelsString(d.name, groupBy as any),
       }));
       setData(mapped);
       setInsightSummary(result.insightSummary);

--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { idsStringToLabelsString } from "../../../lib/classification";
 
 interface ApiEngagementDistributionDataPoint {
   name: string;
@@ -67,7 +68,11 @@ const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDi
         throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
       }
       const result: PlatformEngagementDistributionApiResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: idsStringToLabelsString(d.name, 'format'),
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
       setMetricUsed(result.metricUsed);
     } catch (err) {

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { idsStringToLabelsString } from "../../../lib/classification";
 
 interface ApiPostDistributionDataPoint {
   name: string;
@@ -57,7 +58,11 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
         throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
       }
       const result: PlatformPostDistributionResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: idsStringToLabelsString(d.name, 'format'),
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido ao buscar dados.');

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -12,6 +12,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
+import { idsStringToLabelsString } from "../../../lib/classification";
 
 type GroupingType = "format" | "context" | "proposal";
 
@@ -94,7 +95,11 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
         );
       }
       const result: UserAverageEngagementResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: idsStringToLabelsString(d.name, groupBy as any),
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(

--- a/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { TooltipProps } from "recharts";
+import { idsStringToLabelsString } from "../../../lib/classification";
 
 // Remove custom Payload type, use recharts' Payload type directly in formatter
 
@@ -103,7 +104,11 @@ const UserEngagementDistributionChart: React.FC<
         );
       }
       const result: UserEngagementDistributionResponse = await response.json();
-      setData(result.chartData);
+      const mapped = result.chartData.map(d => ({
+        ...d,
+        name: idsStringToLabelsString(d.name, 'format'),
+      }));
+      setData(mapped);
       setInsightSummary(result.insightSummary);
     } catch (err) {
       setError(

--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -192,3 +192,9 @@ export const getCategoryById = (id: string, type: 'format' | 'proposal' | 'conte
 export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string[] {
   return (ids ?? []).map(id => getCategoryById(id, type)?.label ?? id);
 }
+
+export function idsStringToLabelsString(idsString: string, type: 'format'|'proposal'|'context'|'tone'|'reference'): string {
+  if (!idsString) return idsString;
+  const ids = idsString.split(',').map(id => id.trim()).filter(Boolean);
+  return idsToLabels(ids, type).join(', ');
+}


### PR DESCRIPTION
## Summary
- map classification IDs to Portuguese labels in the user and platform charts
- add helper for comma-separated values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661959e700832e8d0b369ceda91841