### PR TITLE
Fix classification labels for charts

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import { getCategoryById } from "../../../lib/classification";
+import { getCategoryById, commaSeparatedIdsToLabels } from "../../../lib/classification";
 
 interface ApiEngagementDistributionDataPoint {
   name: string;
@@ -70,7 +70,7 @@ const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDi
       const result: PlatformEngagementDistributionApiResponse = await response.json();
       const mapped = result.chartData.map(d => ({
         ...d,
-        name: getCategoryById(d.name, 'format')?.label ?? d.name,
+        name: commaSeparatedIdsToLabels(d.name, 'format') || d.name,
       }));
       setData(mapped);
       setInsightSummary(result.insightSummary);

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -12,7 +12,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
-import { getCategoryById } from "../../../lib/classification";
+import { getCategoryById, commaSeparatedIdsToLabels } from "../../../lib/classification";
 
 type GroupingType = "format" | "context" | "proposal";
 
@@ -97,7 +97,7 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
       const result: UserAverageEngagementResponse = await response.json();
       const mapped = result.chartData.map(d => ({
         ...d,
-        name: getCategoryById(d.name, groupBy as any)?.label ?? d.name,
+        name: commaSeparatedIdsToLabels(d.name, groupBy as any) || d.name,
       }));
       setData(mapped);
       setInsightSummary(result.insightSummary);

--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -192,3 +192,14 @@ export const getCategoryById = (id: string, type: 'format' | 'proposal' | 'conte
 export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string[] {
   return (ids ?? []).map(id => getCategoryById(id, type)?.label ?? id);
 }
+
+// Novo helper para traduzir strings com IDs separados por vírgula
+export function commaSeparatedIdsToLabels(ids: string | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string {
+  if (!ids) return '';
+  return ids
+    .split(',')
+    .map(id => id.trim())
+    .filter(id => id.length > 0)
+    .map(id => getCategoryById(id, type)?.label ?? id)
+    .join(', ');
+}


### PR DESCRIPTION
## Summary
- add `commaSeparatedIdsToLabels` helper for strings like `"reel,photo"`
- use new helper in platform engagement distribution chart
- translate multiple ids in user average engagement chart

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden when trying to fetch jest)*

------
https://chatgpt.com/codex/tasks/task_e_6866218b904c832ea82cfe4fd0fdd87a