### PR TITLE
Normalize format labels and rely on format field for Reels

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "reclassify": "tsx --env-file=.env.local ./scripts/reclassifyAll.ts",
     "reset-classification": "tsx --env-file=.env.local ./scripts/resetClassificationStatus.ts",
     "ensure-indexes": "tsx --env-file=.env.local ./scripts/ensureIndexes.ts",
-    "force-clean-indexes": "tsx --env-file=.env.local ./scripts/forceCleanIndexes.ts"
+    "force-clean-indexes": "tsx --env-file=.env.local ./scripts/forceCleanIndexes.ts",
+    "fix-formats": "tsx --env-file=.env.local ./scripts/fixFormatLabels.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",

--- a/scripts/fixFormatLabels.ts
+++ b/scripts/fixFormatLabels.ts
@@ -1,0 +1,42 @@
+import mongoose from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import Metric from '@/app/models/Metric';
+import { logger } from '@/app/lib/logger';
+import { formatCategories } from '@/app/lib/classification';
+
+const SCRIPT_TAG = '[SCRIPT_FIX_FORMAT_LABELS]';
+
+const ID_TO_LABEL_MAP = formatCategories.reduce<Record<string, string>>((acc, cat) => {
+  acc[cat.id] = cat.label;
+  return acc;
+}, {});
+
+async function normalizeFormats() {
+  logger.info(`${SCRIPT_TAG} Iniciando normalização do campo 'format'...`);
+  try {
+    await connectToDatabase();
+
+    const lowercaseIds = Object.keys(ID_TO_LABEL_MAP);
+    const query = { format: { $elemMatch: { $in: lowercaseIds } } };
+
+    const docs = await Metric.find(query).select('_id format');
+    if (docs.length === 0) {
+      logger.info(`${SCRIPT_TAG} Nenhum documento com formatos em minúsculo encontrado.`);
+      return;
+    }
+
+    for (const doc of docs) {
+      const currentFormats: string[] = Array.isArray(doc.format) ? doc.format : [];
+      const newFormats = currentFormats.map(f => ID_TO_LABEL_MAP[f] || f);
+      await Metric.updateOne({ _id: doc._id }, { $set: { format: newFormats } });
+    }
+
+    logger.info(`${SCRIPT_TAG} Normalização concluída para ${docs.length} documentos.`);
+  } catch (err) {
+    logger.error(`${SCRIPT_TAG} Erro durante a normalização:`, err);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+normalizeFormats();

--- a/src/app/lib/communityProcessorService.ts
+++ b/src/app/lib/communityProcessorService.ts
@@ -287,9 +287,8 @@ export async function processMetricForCommunity(
         internalSnapshot.shareRate = parseFloat((metric.stats.shares / metric.stats.reach).toFixed(4));
     }
 
-    // CORREÇÃO: Checa se 'Reel' está incluído no array `metric.format`.
-    // E checa metric.type para 'VIDEO' ou 'REEL' (que é um valor do campo IMetric.type)
-    if ((metric.format?.includes('Reel') || metric.type === 'VIDEO' || metric.type === 'REEL') && metric.stats.ig_reels_avg_watch_time) {
+    // CORREÇÃO: Checa apenas o campo `format` padronizado para determinar se é Reel
+    if (metric.format?.some(f => f.toLowerCase() === 'reel') && metric.stats.ig_reels_avg_watch_time) {
         internalSnapshot.reelAvgWatchTimeSec = parseFloat((metric.stats.ig_reels_avg_watch_time / 1000).toFixed(1));
     }
 


### PR DESCRIPTION
## Summary
- add script to fix lowercase format values
- expose npm command `fix-formats`
- check Reels using only the `format` field in community processor

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867063798b8832e9a4af4897bbde3e0