### PR TITLE
Add total followers info to Media Kit

### DIFF
--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -170,6 +170,9 @@ export default function MediaKitView({ user, summary, videos, kpis: initialKpis 
                         <TrendIndicator value={kpiData.followerGrowth?.percentageChange ?? null} />
                       </p>
                       <p className="text-xs text-gray-500 mt-1">Novos seguidores no período selecionado.</p>
+                      {user.followers_count !== undefined && (
+                        <p className="text-xl font-bold text-gray-900">Total de seguidores: {user.followers_count.toLocaleString('pt-BR')}</p>
+                      )}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- show user's total followers under follower growth section with bigger text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6867561add0c832e941d04b2191ae5fa