### PR TITLE
Fix missing tone and reference columns

### DIFF
--- a/src/app/api/admin/dashboard/posts/route.test.ts
+++ b/src/app/api/admin/dashboard/posts/route.test.ts
@@ -75,6 +75,8 @@ describe('API Route: /api/admin/dashboard/posts', () => {
       context: 'Gaming',
       proposal: 'Livestream',
       format: 'Video',
+      tone: 'Humor',
+      references: 'Cultura Pop',
       minInteractions: '100',
       startDate,
       endDate,
@@ -90,6 +92,8 @@ describe('API Route: /api/admin/dashboard/posts', () => {
       context: 'Gaming',
       proposal: 'Livestream',
       format: 'Video',
+      tone: 'Humor',
+      references: 'Cultura Pop',
       minInteractions: 100,
       dateRange: {
         startDate: new Date(startDate),
@@ -154,6 +158,8 @@ describe('API Route: /api/admin/dashboard/posts', () => {
     expect(calledArgs.context).toBeUndefined();
     expect(calledArgs.proposal).toBeUndefined();
     expect(calledArgs.format).toBeUndefined();
+    expect(calledArgs.tone).toBeUndefined();
+    expect(calledArgs.references).toBeUndefined();
     expect(calledArgs.minInteractions).toBeUndefined();
     expect(calledArgs.dateRange).toBeUndefined();
   });

--- a/src/app/lib/dataService/marketAnalysis/postsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/postsService.ts
@@ -22,7 +22,8 @@ const SERVICE_TAG = '[dataService][postsService]';
 export async function findGlobalPostsByCriteria(args: FindGlobalPostsArgs): Promise<IGlobalPostsPaginatedResult> {
     const TAG = `${SERVICE_TAG}[findGlobalPostsByCriteria]`;
     const {
-        context, proposal, format, minInteractions = 0, page = 1, limit = 10,
+        context, proposal, format, tone, references, minInteractions = 0,
+        page = 1, limit = 10,
         sortBy = 'stats.total_interactions', sortOrder = 'desc', dateRange,
     } = args;
 
@@ -33,6 +34,8 @@ export async function findGlobalPostsByCriteria(args: FindGlobalPostsArgs): Prom
         if (context) matchStage.context = { $regex: context, $options: 'i' };
         if (proposal) matchStage.proposal = { $regex: proposal, $options: 'i' };
         if (format) matchStage.format = { $regex: format, $options: 'i' };
+        if (tone) matchStage.tone = { $regex: tone, $options: 'i' };
+        if (references) matchStage.references = { $regex: references, $options: 'i' };
         if (minInteractions > 0) matchStage['stats.total_interactions'] = { $gte: minInteractions };
         if (dateRange?.startDate) matchStage.postDate = { ...matchStage.postDate, $gte: dateRange.startDate };
         if (dateRange?.endDate) matchStage.postDate = { ...matchStage.postDate, $lte: dateRange.endDate };
@@ -57,7 +60,8 @@ export async function findGlobalPostsByCriteria(args: FindGlobalPostsArgs): Prom
         postsPipeline.push({
             $project: {
                 _id: 1, text_content: 1, description: 1, creatorName: 1, postDate: 1,
-                format: 1, proposal: 1, context: 1, 'stats.total_interactions': '$stats.total_interactions',
+                format: 1, proposal: 1, context: 1, tone: 1, references: 1,
+                'stats.total_interactions': '$stats.total_interactions',
                 'stats.likes': '$stats.likes', 'stats.shares': '$stats.shares',
                 // MODIFICAÇÃO (FASE 1): Adicionados coverUrl e instagramMediaId para a feature de capas.
                 coverUrl: 1,

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -82,6 +82,8 @@ export interface FindGlobalPostsArgs {
     context?: string;
     proposal?: string;
     format?: string;
+    tone?: string;
+    references?: string;
     minInteractions?: number;
     limit?: number;
     page?: number;
@@ -103,6 +105,8 @@ export interface IGlobalPostResult {
   format?: string;
   proposal?: string;
   context?: string;
+  tone?: string;
+  references?: string;
   stats?: {
     total_interactions?: number;
     likes?: number;


### PR DESCRIPTION
## Summary
- expose `tone` and `references` fields in global posts API types
- support tone and reference filters in the posts service
- test passing the new parameters through the API route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675b75d654832e9c2cafef44aa8305