### PR TITLE
Add documentation for new ranking metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Documentação
+
+Consulte o diretório `docs` para informações adicionais, incluindo o [plano de expanção dos rankings](docs/ranking-expansion.md).
+
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/docs/ranking-expansion.md
+++ b/docs/ranking-expansion.md
@@ -1,0 +1,32 @@
+# Plano de Expansão dos Rankings de Criadores no Creator Dashboard
+
+Este documento descreve uma proposta para aumentar o número de rankings exibidos no Creator Dashboard, permitindo análises mais completas de desempenho.
+
+## Rankings Inteligentes Propostos
+
+### Engajamento Médio por Conteúdo Postado
+- **Métrica**: média de interações por conteúdo.
+- **Critérios**: considerar apenas criadores com pelo menos 3 posts no período.
+- **Utilidade**: identifica criadores cujos posts geram alto engajamento individual.
+
+### Alcance Médio por Conteúdo
+- **Métrica**: alcance total dividido pelo número de posts.
+- **Critérios**: incluir criadores com mínimo de 3 posts.
+- **Utilidade**: mede a eficiência de distribuição, mostrando quem alcança mais pessoas em média.
+
+### Variação Percentual de Engajamento
+- **Métrica**: compara o engajamento total do período com o período anterior equivalente.
+- **Critérios**: exigir um volume mínimo de interações em ambos os períodos.
+- **Utilidade**: aponta criadores em crescimento ou queda de desempenho.
+
+### Ranking de Consistência de Performance
+- **Métrica**: avalia o desvio ou variação do engajamento por post, relativo à média.
+- **Critérios**: pelo menos 5 posts e engajamento médio mínimo para confiabilidade.
+- **Utilidade**: revela criadores com desempenho estável entre as publicações.
+
+### Alcance por Seguidor
+- **Métrica**: relação entre o alcance total no período e a contagem de seguidores.
+- **Critérios**: considerar apenas criadores com mais de 1.000 seguidores e ao menos 3 posts.
+- **Utilidade**: identifica quem consegue um alcance desproporcionalmente alto em relação ao tamanho da audiência.
+
+Cada ranking será exibido em um card semelhante aos existentes, respeitando o filtro de período global e ordenado de forma decrescente de acordo com a métrica correspondente.

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -48,6 +48,42 @@ const CreatorRankingSection: React.FC<Props> = ({
         dateRangeLabel={rankingDateLabel}
         limit={5}
       />
+      <CreatorRankingCard
+        title="Engajamento Médio/Post"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/avg-engagement-per-post"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Alcance Médio/Post"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/avg-reach-per-post"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Variação de Engajamento"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/engagement-growth"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        metricLabel="%"
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Consistência de Performance"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/performance-consistency"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Alcance por Seguidor"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/reach-per-follower"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        limit={5}
+      />
       <TopCreatorsWidget
         title="Top Criadores"
         metric="total_interactions"

--- a/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.test.ts
@@ -1,0 +1,56 @@
+import { GET } from './route';
+import { fetchAvgEngagementPerPostCreators } from '@/app/lib/dataService/marketAnalysisService';
+import { NextRequest } from 'next/server';
+import { DatabaseError } from '@/app/lib/errors';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
+  ...jest.requireActual('@/app/lib/dataService/marketAnalysisService'),
+  fetchAvgEngagementPerPostCreators: jest.fn(),
+}));
+
+function mockNextRequest(queryParams: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/creators/avg-engagement-per-post');
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+  return new NextRequest(url.toString());
+}
+
+const sampleRankingData: ICreatorMetricRankItem[] = [
+  { creatorId: 'user1' as any, creatorName: 'Creator One', metricValue: 10, profilePictureUrl: 'url1' },
+];
+
+describe('API Route: /api/admin/dashboard/rankings/creators/avg-engagement-per-post', () => {
+  beforeEach(() => {
+    (fetchAvgEngagementPerPostCreators as jest.Mock).mockClear();
+  });
+
+  it('returns 200 with ranking data', async () => {
+    (fetchAvgEngagementPerPostCreators as jest.Mock).mockResolvedValueOnce(sampleRankingData);
+
+    const request = mockNextRequest({
+      startDate: '2023-01-01T00:00:00.000Z',
+      endDate: '2023-01-31T23:59:59.999Z',
+      limit: '5',
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(sampleRankingData);
+  });
+
+  it('returns 500 on service error', async () => {
+    (fetchAvgEngagementPerPostCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const request = mockNextRequest({
+      startDate: '2023-01-01T00:00:00.000Z',
+      endDate: '2023-01-31T23:59:59.999Z',
+    });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by average engagement per post.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchAvgEngagementPerPostCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/avg-engagement-per-post]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+    };
+
+    const results = await fetchAvgEngagementPerPostCreators(params);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.test.ts
@@ -1,0 +1,46 @@
+import { GET } from './route';
+import { fetchAvgReachPerPostCreators } from '@/app/lib/dataService/marketAnalysisService';
+import { NextRequest } from 'next/server';
+import { DatabaseError } from '@/app/lib/errors';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
+  ...jest.requireActual('@/app/lib/dataService/marketAnalysisService'),
+  fetchAvgReachPerPostCreators: jest.fn(),
+}));
+
+function mockNextRequest(queryParams: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/creators/avg-reach-per-post');
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+  return new NextRequest(url.toString());
+}
+
+const sampleRankingData: ICreatorMetricRankItem[] = [
+  { creatorId: 'u1' as any, creatorName: 'C1', metricValue: 20, profilePictureUrl: 'url' },
+];
+
+describe('API Route: /api/admin/dashboard/rankings/creators/avg-reach-per-post', () => {
+  beforeEach(() => {
+    (fetchAvgReachPerPostCreators as jest.Mock).mockClear();
+  });
+
+  it('returns 200 with ranking data', async () => {
+    (fetchAvgReachPerPostCreators as jest.Mock).mockResolvedValueOnce(sampleRankingData);
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual(sampleRankingData);
+  });
+
+  it('returns 500 on service error', async () => {
+    (fetchAvgReachPerPostCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by average reach per post.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchAvgReachPerPostCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/avg-reach-per-post]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+    };
+
+    const results = await fetchAvgReachPerPostCreators(params);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.test.ts
@@ -1,0 +1,46 @@
+import { GET } from './route';
+import { fetchEngagementVariationCreators } from '@/app/lib/dataService/marketAnalysisService';
+import { NextRequest } from 'next/server';
+import { DatabaseError } from '@/app/lib/errors';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
+  ...jest.requireActual('@/app/lib/dataService/marketAnalysisService'),
+  fetchEngagementVariationCreators: jest.fn(),
+}));
+
+function mockNextRequest(queryParams: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/creators/engagement-growth');
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+  return new NextRequest(url.toString());
+}
+
+const sampleRankingData: ICreatorMetricRankItem[] = [
+  { creatorId: 'u1' as any, creatorName: 'C1', metricValue: 50, profilePictureUrl: 'url' },
+];
+
+describe('API Route: /api/admin/dashboard/rankings/creators/engagement-growth', () => {
+  beforeEach(() => {
+    (fetchEngagementVariationCreators as jest.Mock).mockClear();
+  });
+
+  it('returns 200 with ranking data', async () => {
+    (fetchEngagementVariationCreators as jest.Mock).mockResolvedValueOnce(sampleRankingData);
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual(sampleRankingData);
+  });
+
+  it('returns 500 on service error', async () => {
+    (fetchEngagementVariationCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by engagement growth.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchEngagementVariationCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/engagement-growth]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+    };
+
+    const results = await fetchEngagementVariationCreators(params);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.test.ts
@@ -1,0 +1,46 @@
+import { GET } from './route';
+import { fetchPerformanceConsistencyCreators } from '@/app/lib/dataService/marketAnalysisService';
+import { NextRequest } from 'next/server';
+import { DatabaseError } from '@/app/lib/errors';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
+  ...jest.requireActual('@/app/lib/dataService/marketAnalysisService'),
+  fetchPerformanceConsistencyCreators: jest.fn(),
+}));
+
+function mockNextRequest(queryParams: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/creators/performance-consistency');
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+  return new NextRequest(url.toString());
+}
+
+const sampleRankingData: ICreatorMetricRankItem[] = [
+  { creatorId: 'u1' as any, creatorName: 'C1', metricValue: 0.9, profilePictureUrl: 'url' },
+];
+
+describe('API Route: /api/admin/dashboard/rankings/creators/performance-consistency', () => {
+  beforeEach(() => {
+    (fetchPerformanceConsistencyCreators as jest.Mock).mockClear();
+  });
+
+  it('returns 200 with ranking data', async () => {
+    (fetchPerformanceConsistencyCreators as jest.Mock).mockResolvedValueOnce(sampleRankingData);
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual(sampleRankingData);
+  });
+
+  it('returns 500 on service error', async () => {
+    (fetchPerformanceConsistencyCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by performance consistency.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchPerformanceConsistencyCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/performance-consistency]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+    };
+
+    const results = await fetchPerformanceConsistencyCreators(params);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.test.ts
@@ -1,0 +1,46 @@
+import { GET } from './route';
+import { fetchReachPerFollowerCreators } from '@/app/lib/dataService/marketAnalysisService';
+import { NextRequest } from 'next/server';
+import { DatabaseError } from '@/app/lib/errors';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+jest.mock('@/app/lib/dataService/marketAnalysisService', () => ({
+  ...jest.requireActual('@/app/lib/dataService/marketAnalysisService'),
+  fetchReachPerFollowerCreators: jest.fn(),
+}));
+
+function mockNextRequest(queryParams: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/admin/dashboard/rankings/creators/reach-per-follower');
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+  return new NextRequest(url.toString());
+}
+
+const sampleRankingData: ICreatorMetricRankItem[] = [
+  { creatorId: 'u1' as any, creatorName: 'C1', metricValue: 3.5, profilePictureUrl: 'url' },
+];
+
+describe('API Route: /api/admin/dashboard/rankings/creators/reach-per-follower', () => {
+  beforeEach(() => {
+    (fetchReachPerFollowerCreators as jest.Mock).mockClear();
+  });
+
+  it('returns 200 with ranking data', async () => {
+    (fetchReachPerFollowerCreators as jest.Mock).mockResolvedValueOnce(sampleRankingData);
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual(sampleRankingData);
+  });
+
+  it('returns 500 on service error', async () => {
+    (fetchReachPerFollowerCreators as jest.Mock).mockRejectedValueOnce(new DatabaseError('fail'));
+    const request = mockNextRequest({ startDate: '2023-01-01T00:00:00.000Z', endDate: '2023-01-31T23:59:59.999Z' });
+    const response = await GET(request);
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('fail');
+  });
+});

--- a/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by reach per follower.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchReachPerFollowerCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/rankings/creators/reach-per-follower]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAdminSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+    };
+
+    const results = await fetchReachPerFollowerCreators(params);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- outline plan for expanding creator rankings
- link new doc in README
- implement advanced ranking metrics and new API endpoints
- expose new metrics in creator dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686761550720832e805a4a24f1977023