### PR TITLE
Keep period filter visible in dashboard

### DIFF
--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
@@ -24,12 +24,15 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
   selectedTimePeriod,
   onTimePeriodChange,
   options = DEFAULT_TIME_PERIOD_OPTIONS,
-  label = "Selecionar Período:",
+  label = "Período:",
   disabled = false,
 }) => {
   return (
     <div className="flex items-center">
-      <label htmlFor="globalTimePeriodSelector" className="text-sm font-medium text-gray-700 mr-2 whitespace-nowrap">
+      <label
+        htmlFor="globalTimePeriodSelector"
+        className="hidden sm:block text-sm font-medium text-gray-700 mr-2 whitespace-nowrap"
+      >
         {label}
       </label>
       <select

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -141,17 +141,6 @@ const AdminCreatorDashboardContent: React.FC = () => {
               <Link href="/admin/creator-dashboard" className="flex-shrink-0 flex items-center gap-2 group">
                 <span className="text-brand-pink text-3xl font-bold group-hover:opacity-80 transition-opacity">[2]</span>
               </Link>
-            </div>
-          </div>
-        </header>
-
-        <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-          <h1 className="text-2xl md:text-3xl font-bold text-brand-dark mb-6">
-            Dashboard Administrativo de Criadores
-          </h1>
-
-          <div className="mb-8">
-            <div className="p-4 bg-white rounded-md shadow">
               <GlobalTimePeriodFilter
                 selectedTimePeriod={globalTimePeriod}
                 onTimePeriodChange={setGlobalTimePeriod}
@@ -166,6 +155,12 @@ const AdminCreatorDashboardContent: React.FC = () => {
               />
             </div>
           </div>
+        </header>
+
+        <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-brand-dark mb-6">
+            Dashboard Administrativo de Criadores
+          </h1>
 
           <section id="platform-summary" className="mb-8">
             <PlatformSummaryKpis startDate={startDate} endDate={endDate} />


### PR DESCRIPTION
## Summary
- integrate `GlobalTimePeriodFilter` into the sticky header
- shorten default label to `Período:` and hide it on small screens

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686800dbb9d8832e87d5baf96bdeb274