### PR TITLE
Improve creator search UX

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from "react";
+import { SearchBar } from "@/app/components/SearchBar";
+import { UserAvatar } from "@/app/components/UserAvatar";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import type { AdminCreatorListItem } from "@/types/admin/creators";
+
+interface CreatorQuickSearchProps {
+  onSelect: (creator: { id: string; name: string }) => void;
+  selectedCreatorName?: string | null;
+  onClear?: () => void;
+}
+
+export default function CreatorQuickSearch({
+  onSelect,
+  selectedCreatorName,
+  onClear,
+}: CreatorQuickSearchProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [creators, setCreators] = useState<AdminCreatorListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!searchTerm) {
+      setCreators([]);
+      return;
+    }
+
+    const fetchCreators = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ limit: "5", search: searchTerm });
+        const resp = await fetch(`/api/admin/creators?${params.toString()}`);
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.error || "Erro ao buscar criadores");
+        }
+        const data = await resp.json();
+        setCreators(data.creators || []);
+      } catch (e: any) {
+        setError(e.message);
+        setCreators([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCreators();
+  }, [searchTerm]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, []);
+
+  const handleSelect = (creator: AdminCreatorListItem) => {
+    onSelect({ id: creator._id, name: creator.name });
+    setSearchTerm("");
+    setCreators([]);
+    setShowDropdown(false);
+  };
+
+  return (
+    <div className="relative flex items-center" ref={containerRef}>
+      <SearchBar
+        initialValue=""
+        onSearchChange={(val) => {
+          setSearchTerm(val);
+          setShowDropdown(true);
+        }}
+        placeholder="Buscar criador..."
+        debounceMs={200}
+        className="w-48"
+      />
+      {selectedCreatorName && onClear && (
+        <span className="ml-2 flex items-center text-sm text-indigo-700">
+          <span className="mr-1">{selectedCreatorName}</span>
+          <button
+            onClick={onClear}
+            className="p-1 rounded-full bg-gray-200 hover:bg-gray-300"
+          >
+            <XMarkIcon className="w-4 h-4" />
+          </button>
+        </span>
+      )}
+      {showDropdown && (searchTerm || isLoading) && (
+        <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+          {isLoading && (
+            <p className="p-2 text-sm text-gray-500">Carregando...</p>
+          )}
+          {error && (
+            <p className="p-2 text-sm text-red-600">{error}</p>
+          )}
+          {!isLoading && !error && creators.length === 0 && (
+            <p className="p-2 text-sm text-gray-500">Nenhum criador encontrado.</p>
+          )}
+          {creators.map((creator) => (
+            <button
+              key={creator._id}
+              className="flex items-center w-full text-left px-3 py-2 hover:bg-gray-100"
+              onClick={() => handleSelect(creator)}
+            >
+              <UserAvatar name={creator.name} src={creator.profilePictureUrl} size={24} />
+              <span className="ml-2 text-sm text-gray-800">{creator.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorSelector.tsx
@@ -89,6 +89,7 @@ export default function CreatorSelector({ isOpen, onClose, onSelect }: CreatorSe
             onSearchChange={(val) => setSearchTerm(val)}
             placeholder="Buscar por nome ou email..."
             autoFocus={isOpen}
+            debounceMs={200}
           />
           <div className="max-h-60 overflow-y-auto divide-y">
             {isLoading && <p className="text-sm text-gray-500 p-2">Carregando...</p>}

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -14,7 +14,7 @@ import PlatformContentAnalysisSection from './components/views/PlatformContentAn
 import CreatorRankingSection from './components/views/CreatorRankingSection';
 import TopMoversSection from './components/views/TopMoversSection';
 import UserDetailView from './components/views/UserDetailView';
-import CreatorSelector from './components/CreatorSelector';
+import CreatorQuickSearch from './components/CreatorQuickSearch';
 import ContentTrendChart from './ContentTrendChart';
 import PostDetailModal from './PostDetailModal';
 import ScrollToTopButton from '@/app/components/ScrollToTopButton';
@@ -103,7 +103,6 @@ const AdminCreatorDashboardContent: React.FC = () => {
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
   const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } = useGlobalTimePeriod();
 
-  const [isSelectorOpen, setIsSelectorOpen] = useState(false);
 
   const formatOptions = formatCategories.map(c => c.label);
   const proposalOptions = proposalCategories.map(c => c.label);
@@ -137,10 +136,18 @@ const AdminCreatorDashboardContent: React.FC = () => {
       <div className="min-h-screen bg-brand-light">
         <header className="bg-white shadow-sm sticky top-0 z-40 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center h-16">
+            <div className="flex justify-between items-center h-16 gap-4">
               <Link href="/admin/creator-dashboard" className="flex-shrink-0 flex items-center gap-2 group">
                 <span className="text-brand-pink text-3xl font-bold group-hover:opacity-80 transition-opacity">[2]</span>
               </Link>
+              <CreatorQuickSearch
+                onSelect={(creator) => handleUserSelect(creator.id, creator.name)}
+                selectedCreatorName={selectedUserName}
+                onClear={() => {
+                  setSelectedUserId(null);
+                  setSelectedUserName(null);
+                }}
+              />
               <GlobalTimePeriodFilter
                 selectedTimePeriod={globalTimePeriod}
                 onTimePeriodChange={setGlobalTimePeriod}
@@ -166,38 +173,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
             <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
           </section>
 
-          <section
-            id="creator-selection"
-            className="mb-8 p-4 bg-white rounded-lg shadow"
-          >
-            <h2 className="text-lg font-semibold text-gray-700 mb-3">
-              Selecionar Criador para Detalhar
-            </h2>
-            <div className="flex flex-wrap items-center gap-4">
-              <button
-                onClick={() => setIsSelectorOpen(true)}
-                className="p-2 rounded-md text-sm bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
-              >
-                Buscar Criador
-              </button>
-              {selectedUserName && (
-                <span className="px-2 py-1 text-sm bg-indigo-50 text-indigo-700 rounded">
-                  {selectedUserName}
-                </span>
-              )}
-              {selectedUserId && (
-                <button
-                  onClick={() => {
-                    setSelectedUserId(null);
-                    setSelectedUserName(null);
-                  }}
-                  className="p-2 rounded-md text-sm bg-gray-200 text-gray-700 hover:bg-gray-300"
-                >
-                  Limpar seleção e voltar à visão geral
-                </button>
-              )}
-            </div>
-          </section>
+
           
           {/* --- CORREÇÃO FINAL: Bloco de visão geral reorganizado --- */}
           {!selectedUserId && (
@@ -236,11 +212,6 @@ const AdminCreatorDashboardContent: React.FC = () => {
             )}
           </div>
 
-          <CreatorSelector
-            isOpen={isSelectorOpen}
-            onClose={() => setIsSelectorOpen(false)}
-            onSelect={(creator: {id: string, name: string}) => handleUserSelect(creator.id, creator.name)}
-          />
           <ScrollToTopButton />
         </main>
 


### PR DESCRIPTION
## Summary
- add `CreatorQuickSearch` inline component to select a creator
- move creator search into dashboard header
- speed up search inside `CreatorSelector`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686803e75028832e94246da95e486c73