### PR TITLE
Improve TopMovers defaults

### DIFF
--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -79,7 +79,7 @@ export default function TopMoversWidget() {
   const [previousPeriod, setPreviousPeriod] = useState<PeriodState>(initialPeriodState);
   const [currentPeriod, setCurrentPeriod] = useState<PeriodState>(initialPeriodState);
   const [topN, setTopN] = useState<number>(10);
-  const [sortBy, setSortBy] = useState<TopMoverSortBy>('absoluteChange_decrease');
+  const [sortBy, setSortBy] = useState<TopMoverSortBy>('absoluteChange_increase');
 
   const [contentFilters, setContentFilters] = useState<ISegmentDefinition>({});
   const [contextOptions, setContextOptions] = useState<string[]>(DEFAULT_CONTEXTS);
@@ -195,7 +195,7 @@ export default function TopMoversWidget() {
         <div className="flex items-center space-x-2">
           <ChartBarIcon className="h-5 w-5 text-indigo-600" />
           <h3 className="text-lg font-semibold text-gray-800">
-            Top Movers ({ENTITY_TYPE_OPTIONS.find(e=>e.value === entityType)?.label})
+            {`Top Movers – ${ENTITY_TYPE_OPTIONS.find(e => e.value === entityType)?.label} por ${METRIC_OPTIONS.find(m => m.value === metric)?.label} (${SORT_BY_OPTIONS.find(s => s.value === sortBy)?.label})`}
           </h3>
         </div>
         <p className="text-sm text-gray-500 mt-1 ml-7">

--- a/src/app/admin/widgets/TopMoversWidget.tsx
+++ b/src/app/admin/widgets/TopMoversWidget.tsx
@@ -91,7 +91,7 @@ const TopMoversWidget = memo(function TopMoversWidget() {
   const [previousPeriod, setPreviousPeriod] = useState<PeriodState>(initialPeriodState);
   const [currentPeriod, setCurrentPeriod] = useState<PeriodState>(initialPeriodState);
   const [topN, setTopN] = useState<number>(5);
-  const [sortBy, setSortBy] = useState<TopMoverSortBy>('absoluteChange_decrease');
+  const [sortBy, setSortBy] = useState<TopMoverSortBy>('absoluteChange_increase');
   const [contentFilters, setContentFilters] = useState<ISegmentDefinition>({});
   
   const [results, setResults] = useState<ITopMoverResult[] | null>(null);
@@ -200,7 +200,9 @@ const TopMoversWidget = memo(function TopMoversWidget() {
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-800">Top Movers ({ENTITY_TYPE_OPTIONS.find(e=>e.value === entityType)?.label})</h3>
+        <h3 className="text-lg font-semibold text-gray-800">
+          {`Top Movers – ${ENTITY_TYPE_OPTIONS.find(e => e.value === entityType)?.label} por ${METRIC_OPTIONS.find(m => m.value === metric)?.label} (${SORT_BY_OPTIONS.find(s => s.value === sortBy)?.label})`}
+        </h3>
         <p className="text-sm text-gray-500 mt-1">Identifique as maiores variações de performance entre dois períodos.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- show metric and sorting in Top Movers heading
- default to absolute increase sort order for Top Movers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868079174ac832eb43a76f04ec4cb70