### PR TITLE
Improve platform content analysis UI

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -57,7 +57,7 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
   const [error, setError] = useState<string | null>(null);
   const [engagementMetric, setEngagementMetric] = useState<string>(initialEngagementMetric);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const groupBy = initialGroupBy;
+  const [groupBy, setGroupBy] = useState<GroupingType>(initialGroupBy);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -112,7 +112,17 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
           </div>
           <div>
             <label htmlFor={`groupByAvgEngPlatform-${groupBy}`} className="block text-sm font-medium text-gray-600 mb-1">Agrupar por:</label>
-            <input type="text" id={`groupByAvgEngPlatform-${groupBy}`} value={GROUP_BY_OPTIONS.find(opt => opt.value === groupBy)?.label || groupBy} disabled className="w-full p-2 border border-gray-300 rounded-md shadow-sm bg-gray-100 text-sm" />
+            <select
+              id={`groupByAvgEngPlatform-${groupBy}`}
+              value={groupBy}
+              onChange={(e) => setGroupBy(e.target.value as GroupingType)}
+              disabled={loading}
+              className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+            >
+              {GROUP_BY_OPTIONS.map(option => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
           </div>
         </div>
 

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -89,14 +89,14 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
               textColorClass="text-green-600"
             />
             <HighlightCard
-              title="Contexto Principal (Plataforma)"
+              title="Contexto de Melhor Desempenho (Plataforma)"
               highlight={summary.topPerformingContext}
               icon={<Sparkles size={18} className="mr-2 text-blue-500"/>}
               bgColorClass="bg-blue-50"
               textColorClass="text-blue-600"
             />
             <HighlightCard
-              title="Menor Performance (Formato, Plataforma)"
+              title="Formato de Pior Desempenho"
               highlight={summary.lowPerformingFormat}
               icon={<TrendingDown size={18} className="mr-2 text-red-500"/>}
               bgColorClass="bg-red-50"

--- a/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
@@ -27,25 +27,16 @@ const PlatformContentAnalysisSection: React.FC<Props> = ({
       <PlatformPerformanceHighlights />
     </div>
 
-    {/* ✅ LAYOUT ATUALIZADO PARA 2 COLUNAS LADO A LADO */}
+    <div className="mb-6 md:mb-8">
+      <PlatformVideoPerformanceMetrics />
+    </div>
+
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
       <PlatformAverageEngagementChart
         initialGroupBy="context"
-        chartTitle="Engajamento Médio por Contexto (Plataforma)"
+        chartTitle="Engajamento Médio da Plataforma"
       />
-      <PlatformAverageEngagementChart
-        initialGroupBy="proposal"
-        chartTitle="Engajamento Médio por Proposta (Plataforma)"
-      />
-    </div>
-
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 md:mb-8">
-      {/* O gráfico de Formato pode viver aqui, ao lado de outras métricas */}
-      <PlatformAverageEngagementChart
-        initialGroupBy="format"
-        chartTitle="Engajamento Médio por Formato (Plataforma)"
-      />
-      <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato (Plataforma)" />
+      <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato" />
     </div>
     
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- allow changing grouping on PlatformAverageEngagementChart
- rename performance highlight cards for clarity
- simplify PlatformContentAnalysisSection layout and include video metrics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686808d144d8832e8252327916ff738e