### PR TITLE
Implement active creator comparison KPI

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/PlatformComparativeKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformComparativeKpi.tsx
@@ -20,14 +20,20 @@ interface PlatformPeriodicComparisonResponse {
   platformFollowerGrowth: KPIComparisonData;
   platformTotalEngagement: KPIComparisonData;
   platformPostingFrequency?: KPIComparisonData;
+  platformActiveCreators?: KPIComparisonData;
   insightSummary?: {
     platformFollowerGrowth?: string;
     platformTotalEngagement?: string;
     platformPostingFrequency?: string;
+    platformActiveCreators?: string;
   };
 }
 
-type KpiName = "platformFollowerGrowth" | "platformTotalEngagement" | "platformPostingFrequency";
+type KpiName =
+  | "platformFollowerGrowth"
+  | "platformTotalEngagement"
+  | "platformPostingFrequency"
+  | "platformActiveCreators";
 
 interface PlatformComparativeKpiProps {
   kpiName: KpiName;

--- a/src/app/admin/creator-dashboard/components/kpis/TotalActiveCreatorsKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/TotalActiveCreatorsKpi.tsx
@@ -1,56 +1,28 @@
 "use client";
 
-import React, { useState, useEffect, memo } from 'react';
-import PlatformKpiCard from '../PlatformKpiCard'; // Ajuste o caminho se o KpiCard estiver em outro local
+import React, { memo } from "react";
+import PlatformComparativeKpi from "./PlatformComparativeKpi";
+import { useGlobalTimePeriod } from "../filters/GlobalTimePeriodContext";
 
-interface PlatformKpisSummaryResponse {
-  totalActiveCreators: number;
-  insightSummary?: string; // Embora o KpiCard não use diretamente o insightSummary do endpoint de summary
-}
+const TIME_PERIOD_TO_COMPARISON: Record<string, string> = {
+  last_7_days: "last_7d_vs_previous_7d",
+  last_30_days: "last_30d_vs_previous_30d",
+  last_90_days: "last_30d_vs_previous_30d",
+  last_6_months: "month_vs_previous",
+  last_12_months: "month_vs_previous",
+  all_time: "month_vs_previous",
+};
 
 const TotalActiveCreatorsKpi: React.FC = () => {
-  const [totalCreators, setTotalCreators] = useState<number | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  // Opcional: Se quisermos exibir o insightSummary específico deste KPI, podemos armazená-lo.
-  // const [kpiInsight, setKpiInsight] = useState<string | undefined>(undefined);
-
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const apiUrl = `/api/v1/platform/kpis/summary`; // Endpoint para buscar o total de criadores
-        const response = await fetch(apiUrl);
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          throw new Error(`Erro HTTP: ${response.status} - ${errorData.error || response.statusText}`);
-        }
-        const result: PlatformKpisSummaryResponse = await response.json();
-        setTotalCreators(result.totalActiveCreators);
-        // if (result.insightSummary) setKpiInsight(result.insightSummary);
-        // O insightSummary do summary pode ser mais geral. Para o card, o título já diz o que é.
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Ocorreu um erro desconhecido.');
-        setTotalCreators(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []); // Executa apenas uma vez ao montar o componente
+  const { timePeriod } = useGlobalTimePeriod();
+  const comparisonPeriod = TIME_PERIOD_TO_COMPARISON[timePeriod] || "month_vs_previous";
 
   return (
-    <PlatformKpiCard
+    <PlatformComparativeKpi
+      kpiName="platformActiveCreators"
       title="Total de Criadores Ativos"
-      value={totalCreators}
-      isLoading={loading}
-      error={error}
-      tooltip="Número total de criadores considerados ativos na plataforma."
-      // change e changeType não são aplicáveis para este KPI simples de "total"
-      // a menos que se queira comparar com um período anterior, o que exigiria mais lógica.
+      comparisonPeriod={comparisonPeriod}
+      tooltip="Número total de criadores considerados ativos na plataforma comparado ao período anterior."
     />
   );
 };


### PR DESCRIPTION
## Summary
- compute active creators on periodic-comparison API
- expose `platformActiveCreators` in `PlatformComparativeKpi`
- show active creators KPI using comparative card

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68680b92970c832e85a4aa6b0fa5b044