### PR TITLE
Improve Global Posts Explorer

### DIFF
--- a/src/app/api/admin/dashboard/posts/route.test.ts
+++ b/src/app/api/admin/dashboard/posts/route.test.ts
@@ -77,6 +77,7 @@ describe('API Route: /api/admin/dashboard/posts', () => {
       format: 'Video',
       tone: 'Humor',
       references: 'Cultura Pop',
+      searchText: 'foo',
       minInteractions: '100',
       startDate,
       endDate,
@@ -94,6 +95,7 @@ describe('API Route: /api/admin/dashboard/posts', () => {
       format: 'Video',
       tone: 'Humor',
       references: 'Cultura Pop',
+      searchText: 'foo',
       minInteractions: 100,
       dateRange: {
         startDate: new Date(startDate),

--- a/src/app/api/admin/dashboard/posts/route.ts
+++ b/src/app/api/admin/dashboard/posts/route.ts
@@ -25,6 +25,7 @@ const querySchema = z.object({
   format: z.string().optional(),
   tone: z.string().optional(), // NOVO: Filtro por tom
   references: z.string().optional(), // NOVO: Filtro por referências
+  searchText: z.string().optional(),
   minInteractions: z.coerce.number().int().min(0).optional(),
   startDate: z.string().datetime({ offset: true }).optional().transform(val => val ? new Date(val) : undefined),
   endDate: z.string().datetime({ offset: true }).optional().transform(val => val ? new Date(val) : undefined),

--- a/src/app/lib/dataService/marketAnalysis/postsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/postsService.ts
@@ -22,7 +22,7 @@ const SERVICE_TAG = '[dataService][postsService]';
 export async function findGlobalPostsByCriteria(args: FindGlobalPostsArgs): Promise<IGlobalPostsPaginatedResult> {
     const TAG = `${SERVICE_TAG}[findGlobalPostsByCriteria]`;
     const {
-        context, proposal, format, tone, references, minInteractions = 0,
+        context, proposal, format, tone, references, searchText, minInteractions = 0,
         page = 1, limit = 10,
         sortBy = 'stats.total_interactions', sortOrder = 'desc', dateRange,
     } = args;
@@ -36,6 +36,13 @@ export async function findGlobalPostsByCriteria(args: FindGlobalPostsArgs): Prom
         if (format) matchStage.format = { $regex: format, $options: 'i' };
         if (tone) matchStage.tone = { $regex: tone, $options: 'i' };
         if (references) matchStage.references = { $regex: references, $options: 'i' };
+        if (searchText) {
+            matchStage.$or = [
+                { text_content: { $regex: searchText, $options: 'i' } },
+                { description: { $regex: searchText, $options: 'i' } },
+                { creatorName: { $regex: searchText, $options: 'i' } },
+            ];
+        }
         if (minInteractions > 0) matchStage['stats.total_interactions'] = { $gte: minInteractions };
         if (dateRange?.startDate) matchStage.postDate = { ...matchStage.postDate, $gte: dateRange.startDate };
         if (dateRange?.endDate) matchStage.postDate = { ...matchStage.postDate, $lte: dateRange.endDate };

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -84,6 +84,8 @@ export interface FindGlobalPostsArgs {
     format?: string;
     tone?: string;
     references?: string;
+    /** Texto de busca para título, descrição ou nome do criador */
+    searchText?: string;
     minInteractions?: number;
     limit?: number;
     page?: number;


### PR DESCRIPTION
## Summary
- add text search support to post filtering
- make filters collapsible and add mobile toggle
- show details modal with post info and trend chart
- wire new search parameter in API and service
- update route tests for search parameter

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'next')*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680d46fa70832ea7957ef4381ab961