### PR TITLE
Improve creator detail usability

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformKpiCard.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformKpiCard.tsx
@@ -64,8 +64,14 @@ const PlatformKpiCard: React.FC<PlatformKpiCardProps> = ({
   };
 
   const changeDisplay = () => {
-    if (isLoading || error || !change ) return <div className="h-4"></div>; // Placeholder para manter altura
-    return <p className={`text-xs mt-1 ${getChangeColor()}`}>{change}</p>;
+    if (isLoading || error || !change) return <div className="h-4"></div>; // Placeholder para manter altura
+    const arrow = changeType === 'positive' ? '▲' : changeType === 'negative' ? '▼' : '';
+    return (
+      <p className={`text-xs mt-1 flex items-center ${getChangeColor()}`}>
+        {arrow && <span className="mr-1">{arrow}</span>}
+        {change}
+      </p>
+    );
   };
 
 

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -52,6 +52,7 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
   const [timePeriod, setTimePeriod] = useState<string>(
     globalTimePeriod || TIME_PERIOD_OPTIONS[1]?.value || "last_30_days",
   );
+  const timePeriodLabel = TIME_PERIOD_OPTIONS.find((o) => o.value === timePeriod)?.label;
 
   useEffect(() => {
     setTimePeriod(globalTimePeriod);
@@ -112,6 +113,9 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
       <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
         {chartTitle}
+        {timePeriodLabel && (
+          <span className="ml-2 text-xs font-normal text-gray-500">({timePeriodLabel})</span>
+        )}
       </h2>
       {userId && (
         <div className="mb-4">

--- a/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
@@ -63,6 +63,7 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
       "last_7_days",
   );
   const [granularity, setGranularity] = useState<string>(initialGranularity);
+  const timePeriodLabel = TIME_PERIOD_OPTIONS.find((o) => o.value === timePeriod)?.label;
 
   useEffect(() => {
     setTimePeriod(globalTimePeriod);
@@ -155,6 +156,9 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
       <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-700">
         {chartTitle}
+        {timePeriodLabel && (
+          <span className="ml-2 text-xs font-normal text-gray-500">({timePeriodLabel})</span>
+        )}
       </h2>
 
       <div className="flex flex-col sm:flex-row gap-4 mb-6">

--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -27,6 +27,12 @@ interface UserVideoPerformanceMetricsProps {
   chartTitle?: string;
 }
 
+const formatWatchTime = (seconds: number): string => {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return `${m}m ${s}s`;
+};
+
 // Sub-componente MetricDisplay e InfoIcon (assumindo que estão definidos em outro lugar ou copiados aqui se necessário)
 // Para este exemplo, vou copiá-los para manter o componente autocontido, mas em um projeto real seriam importados.
 const InfoIcon: React.FC<{ className?: string }> = ({ className }) => (
@@ -66,7 +72,7 @@ const MetricDisplay: React.FC<{
     </div>
     <div className="text-xl font-bold text-indigo-600">
       {value !== null && value !== undefined
-        ? `${value.toLocaleString()}${unit || ""}`
+        ? `${typeof value === 'number' ? value.toLocaleString() : value}${unit || ""}`
         : "-"}
     </div>
   </div>
@@ -167,10 +173,10 @@ const UserVideoPerformanceMetrics: React.FC<
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-md font-semibold text-gray-700">{chartTitle}</h3>
-        <div>
+        <div className="flex items-center gap-2">
           <label
             htmlFor={`timePeriodUserVideo-${userId || "default"}`}
-            className="sr-only"
+            className="text-xs font-medium text-gray-600"
           >
             Período
           </label>
@@ -227,10 +233,9 @@ const UserVideoPerformanceMetrics: React.FC<
                 label="Tempo Médio de Visualização"
                 value={
                   metrics.averageWatchTimeSeconds !== null
-                    ? metrics.averageWatchTimeSeconds.toFixed(0)
+                    ? formatWatchTime(metrics.averageWatchTimeSeconds)
                     : null
                 }
-                unit="s"
                 tooltip="Tempo médio que os espectadores passam assistindo a cada vídeo."
               />
             </div>

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -57,6 +57,35 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
         <h2 className="text-2xl md:text-3xl font-bold text-indigo-700">
           Análise Detalhada: {displayName}
         </h2>
+        <nav className="mt-4">
+          <ul className="flex flex-wrap gap-4 text-sm font-medium text-indigo-600">
+            <li>
+              <a href={`#user-kpis-${userId}`} className="hover:underline">
+                Geral
+              </a>
+            </li>
+            <li>
+              <a href={`#user-performance-highlights-${userId}`} className="hover:underline">
+                Destaques
+              </a>
+            </li>
+            <li>
+              <a href={`#user-advanced-analysis-${userId}`} className="hover:underline">
+                Análise & Alertas
+              </a>
+            </li>
+            <li>
+              <a href={`#user-trends-${userId}`} className="hover:underline">
+                Tendências
+              </a>
+            </li>
+            <li>
+              <a href={`#user-content-performance-${userId}`} className="hover:underline">
+                Conteúdo
+              </a>
+            </li>
+          </ul>
+        </nav>
         {/*
           Aqui poderia ir um seletor de período GERAL para TODOS os componentes dentro de UserDetailView,
           similar ao GlobalTimePeriodFilter da página principal. Atualmente cada gráfico tem seu próprio seletor,
@@ -70,12 +99,12 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           <h3 className="text-xl font-semibold text-gray-700 pb-2">
             Desempenho Comparativo Chave
           </h3>
-          <div>
+          <div className="flex items-center gap-2">
             <label
               htmlFor={`kpiComparisonPeriod-${userId}`}
-              className="sr-only"
+              className="text-xs font-medium text-gray-600"
             >
-              Período de Comparação
+              Comparar:
             </label>
             <select
               id={`kpiComparisonPeriod-${userId}`}

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -146,6 +146,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
                 onClear={() => {
                   setSelectedUserId(null);
                   setSelectedUserName(null);
+                  window.scrollTo({ top: 0, behavior: 'smooth' });
                 }}
               />
               <GlobalTimePeriodFilter


### PR DESCRIPTION
## Summary
- add navigation index in creator detail view and highlight KPI comparison period
- show trend period in follower charts
- convert watch time to minutes/seconds and display label for video period
- add up/down arrow to KPI change values
- scroll to top when clearing creator selection

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680fbec48c832e9fa9075f30b00e7a