### PR TITLE
Improve global period filter label

### DIFF
--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
@@ -24,7 +24,7 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
   selectedTimePeriod,
   onTimePeriodChange,
   options = DEFAULT_TIME_PERIOD_OPTIONS,
-  label = "Período:",
+  label = "Selecionar Período",
   disabled = false,
 }) => {
   return (
@@ -37,6 +37,8 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
       </label>
       <select
         id="globalTimePeriodSelector"
+        aria-label={label}
+        title={label}
         value={selectedTimePeriod}
         onChange={(e) => onTimePeriodChange(e.target.value)}
         disabled={disabled}


### PR DESCRIPTION
## Summary
- tweak GlobalTimePeriodFilter default label
- add accessible title for the select

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686812bcefc4832ea7f292095a0bb91d