### PR TITLE
Add time period support to TopCreatorsWidget

### DIFF
--- a/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
@@ -3,12 +3,15 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import SkeletonBlock from './SkeletonBlock';
 import { TopCreatorMetric } from '@/app/lib/dataService/marketAnalysisService';
+import { useGlobalTimePeriod } from './components/filters/GlobalTimePeriodContext';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { TimePeriod } from '@/app/lib/constants/timePeriods';
 
 interface TopCreatorsWidgetProps {
   title: string;
   context?: string;
   metric?: TopCreatorMetric;
-  days?: number;
+  timePeriod?: TimePeriod;
   limit?: number;
   metricLabel?: string;
 }
@@ -17,10 +20,14 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
   title,
   context,
   metric = 'total_interactions',
-  days = 30,
+  timePeriod,
   limit = 5,
   metricLabel = '',
 }) => {
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
+  const effectiveTimePeriod: TimePeriod = timePeriod || (globalTimePeriod as TimePeriod);
+  const days = timePeriodToDays(effectiveTimePeriod);
+
   const [rankingData, setRankingData] = useState<any[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/admin/creator-dashboard/components/CreatorHighlightsTables.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorHighlightsTables.tsx
@@ -2,35 +2,39 @@
 
 import React from 'react';
 import TopCreatorsWidget from '../TopCreatorsWidget';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 
-const CreatorHighlightsTables: React.FC = () => (
-  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-    <TopCreatorsWidget
-      title="Top Interações"
-      metric="total_interactions"
-      days={30}
-      limit={5}
-    />
-    <TopCreatorsWidget
-      title="Maior Engajamento"
-      metric="engagement_rate_on_reach"
-      metricLabel="%"
-      days={30}
-      limit={5}
-    />
-    <TopCreatorsWidget
-      title="Mais Curtidas"
-      metric="likes"
-      days={30}
-      limit={5}
-    />
-    <TopCreatorsWidget
-      title="Mais Compartilhamentos"
-      metric="shares"
-      days={30}
-      limit={5}
-    />
-  </div>
-);
+const CreatorHighlightsTables: React.FC = () => {
+  const { timePeriod } = useGlobalTimePeriod();
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <TopCreatorsWidget
+        title="Top Interações"
+        metric="total_interactions"
+        timePeriod={timePeriod}
+        limit={5}
+      />
+      <TopCreatorsWidget
+        title="Maior Engajamento"
+        metric="engagement_rate_on_reach"
+        metricLabel="%"
+        timePeriod={timePeriod}
+        limit={5}
+      />
+      <TopCreatorsWidget
+        title="Mais Curtidas"
+        metric="likes"
+        timePeriod={timePeriod}
+        limit={5}
+      />
+      <TopCreatorsWidget
+        title="Mais Compartilhamentos"
+        metric="shares"
+        timePeriod={timePeriod}
+        limit={5}
+      />
+    </div>
+  );
+};
 
 export default CreatorHighlightsTables;

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import CreatorRankingCard from "../../CreatorRankingCard";
 import TopCreatorsWidget from "../../TopCreatorsWidget";
+import { useGlobalTimePeriod } from "../filters/GlobalTimePeriodContext";
 
 interface Props {
   rankingDateRange: { startDate: string; endDate: string };
@@ -13,12 +14,14 @@ interface Props {
 const CreatorRankingSection: React.FC<Props> = ({
   rankingDateRange,
   rankingDateLabel,
-}) => (
-  <section id="creator-rankings" className="mb-10">
-    <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-      Rankings de Criadores <GlobalPeriodIndicator />
-    </h2>
-    <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+}) => {
+  const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
+  return (
+    <section id="creator-rankings" className="mb-10">
+      <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+        Rankings de Criadores <GlobalPeriodIndicator />
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
       <CreatorRankingCard
         title="Maior Engajamento"
         apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
@@ -94,13 +97,14 @@ const CreatorRankingSection: React.FC<Props> = ({
         limit={5}
       />
       <TopCreatorsWidget
-        title="Top Criadores (30 dias)"
+        title="Top Criadores"
         metric="total_interactions"
-        days={30}
+        timePeriod={globalTimePeriod}
         limit={5}
       />
     </div>
   </section>
-);
+  );
+};
 
 export default CreatorRankingSection;


### PR DESCRIPTION
## Summary
- update `TopCreatorsWidget` to accept a `timePeriod` prop
- use global time period when none is provided
- adjust `CreatorRankingSection` and `CreatorHighlightsTables` to pass the period

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868168161e8832e92df91d316f78a8f