### PR TITLE
Improve creator ranking UX

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorRankingCard.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingCard.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
 import SkeletonBlock from './SkeletonBlock';
+import CreatorRankingModal from './CreatorRankingModal';
 
 interface CreatorRankingCardProps {
   title: string;
@@ -48,6 +49,7 @@ const CreatorRankingCard: React.FC<CreatorRankingCardProps> = ({
   const [rankingData, setRankingData] = useState<ICreatorMetricRankItem[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!dateRangeFilter?.startDate || !dateRangeFilter?.endDate) {
@@ -191,6 +193,21 @@ const CreatorRankingCard: React.FC<CreatorRankingCardProps> = ({
             Nenhum dado disponível para o período selecionado.
         </div>
       )}
+      <div className="mt-3 text-right">
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="text-xs font-semibold text-indigo-600 hover:text-indigo-800"
+        >
+          Ver mais &rarr;
+        </button>
+      </div>
+      <CreatorRankingModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        apiEndpoint={apiEndpoint}
+        dateRangeFilter={dateRangeFilter}
+        metricLabel={metricLabel}
+      />
     </div>
   );
 };

--- a/src/app/admin/creator-dashboard/CreatorRankingModal.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingModal.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { XMarkIcon } from '@heroicons/react/24/solid';
+import { ICreatorMetricRankItem } from '@/app/lib/dataService/marketAnalysisService';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  apiEndpoint: string;
+  dateRangeFilter?: { startDate?: string; endDate?: string };
+  metricLabel?: string;
+}
+
+const CreatorRankingModal: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  apiEndpoint,
+  dateRangeFilter,
+  metricLabel = '',
+}) => {
+  const [data, setData] = useState<ICreatorMetricRankItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams({ limit: '50' });
+      if (dateRangeFilter?.startDate) {
+        const d = new Date(dateRangeFilter.startDate);
+        const utc = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0));
+        params.append('startDate', utc.toISOString());
+      }
+      if (dateRangeFilter?.endDate) {
+        const d = new Date(dateRangeFilter.endDate);
+        const utc = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999));
+        params.append('endDate', utc.toISOString());
+      }
+
+      try {
+        const res = await fetch(`${apiEndpoint}?${params.toString()}`);
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || 'Erro ao buscar ranking');
+        }
+        const result: ICreatorMetricRankItem[] = await res.json();
+        setData(result);
+      } catch (e: any) {
+        setError(e.message);
+        setData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [isOpen, apiEndpoint, dateRangeFilter]);
+
+  const formatMetricValue = (value: number) => {
+    if (Number.isInteger(value)) return value.toLocaleString('pt-BR');
+    return parseFloat(value.toFixed(2)).toLocaleString('pt-BR', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex justify-center items-center p-4" role="dialog" aria-modal="true">
+      <div className="bg-white w-full max-w-lg rounded-xl shadow-2xl flex flex-col max-h-[90vh]">
+        <header className="flex items-center justify-between p-4 border-b sticky top-0 bg-white z-10">
+          <h3 className="text-lg font-semibold text-gray-800">Ranking Completo</h3>
+          <button onClick={onClose} className="p-1.5 rounded-full text-gray-500 hover:bg-gray-100 transition-colors">
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </header>
+        <div className="p-4 overflow-y-auto">
+          {loading ? (
+            <p className="text-center py-10 text-gray-500">Carregando dados...</p>
+          ) : error ? (
+            <p className="text-center py-10 text-red-500">Erro ao carregar os dados. Tente novamente.</p>
+          ) : data.length > 0 ? (
+            <ol className="space-y-3">
+              {data.map((item, index) => (
+                <li key={item.creatorId.toString()} className="flex items-center space-x-3">
+                  <span className="text-sm font-medium text-gray-500 w-6 text-right">{index + 1}.</span>
+                  {item.profilePictureUrl ? (
+                    <Image src={item.profilePictureUrl} alt={item.creatorName || 'Creator'} width={32} height={32} className="w-8 h-8 rounded-full object-cover" />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-xs font-semibold text-gray-500">
+                      {item.creatorName?.substring(0, 1).toUpperCase() || '?'}
+                    </div>
+                  )}
+                  <p className="flex-1 truncate text-gray-800">{item.creatorName || 'Desconhecido'}</p>
+                  <span className="text-sm text-indigo-600 font-semibold whitespace-nowrap">
+                    {formatMetricValue(item.metricValue)}
+                    {metricLabel && ` ${metricLabel}`}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="text-center py-10 text-gray-500">Nenhum dado disponível.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreatorRankingModal;

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -18,7 +18,8 @@ const CreatorRankingSection: React.FC<Props> = ({
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
       Rankings de Criadores <GlobalPeriodIndicator />
     </h2>
-    <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+    <h3 className="text-lg font-semibold text-gray-600 mt-4 mb-2">Engajamento</h3>
+    <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
       <CreatorRankingCard
         title="Maior Engajamento"
         apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
@@ -34,14 +35,6 @@ const CreatorRankingSection: React.FC<Props> = ({
         dateRangeFilter={rankingDateRange}
         dateRangeLabel={rankingDateLabel}
         tooltip="Soma de todas as interações (curtidas, comentários, etc.) no período."
-        limit={5}
-      />
-      <CreatorRankingCard
-        title="Mais Posts"
-        apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
-        dateRangeFilter={rankingDateRange}
-        dateRangeLabel={rankingDateLabel}
-        tooltip="Quantidade total de conteúdos publicados no período selecionado."
         limit={5}
       />
       <CreatorRankingCard
@@ -61,14 +54,6 @@ const CreatorRankingSection: React.FC<Props> = ({
         limit={5}
       />
       <CreatorRankingCard
-        title="Alcance Médio/Post"
-        apiEndpoint="/api/admin/dashboard/rankings/creators/avg-reach-per-post"
-        dateRangeFilter={rankingDateRange}
-        dateRangeLabel={rankingDateLabel}
-        tooltip="Média de alcance por post; inclui criadores com pelo menos 3 posts."
-        limit={5}
-      />
-      <CreatorRankingCard
         title="Variação de Engajamento"
         apiEndpoint="/api/admin/dashboard/rankings/creators/engagement-growth"
         dateRangeFilter={rankingDateRange}
@@ -83,6 +68,25 @@ const CreatorRankingSection: React.FC<Props> = ({
         dateRangeFilter={rankingDateRange}
         dateRangeLabel={rankingDateLabel}
         tooltip="Avalia a regularidade do engajamento por post; exige ao menos 5 posts relevantes."
+        limit={5}
+      />
+    </div>
+    <h3 className="text-lg font-semibold text-gray-600 mt-4 mb-2">Alcance</h3>
+    <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+      <CreatorRankingCard
+        title="Mais Posts"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        tooltip="Quantidade total de conteúdos publicados no período selecionado."
+        limit={5}
+      />
+      <CreatorRankingCard
+        title="Alcance Médio/Post"
+        apiEndpoint="/api/admin/dashboard/rankings/creators/avg-reach-per-post"
+        dateRangeFilter={rankingDateRange}
+        dateRangeLabel={rankingDateLabel}
+        tooltip="Média de alcance por post; inclui criadores com pelo menos 3 posts."
         limit={5}
       />
       <CreatorRankingCard


### PR DESCRIPTION
## Summary
- separate creator ranking metrics into Engajamento vs Alcance groups
- add a CreatorRankingModal component to show the full list of creators
- make CreatorRankingCard link to the modal via "Ver mais"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686816af08b8832e8d2c543f374fde20