### PR TITLE
Add insight icons to chart summaries

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorsScatterPlot.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorsScatterPlot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useCallback } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import CreatorSelector from './CreatorSelector';
 import {
   ScatterChart,
@@ -279,7 +280,8 @@ export default function CreatorsScatterPlot() {
       </div>
 
       {data?.insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {data.insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -158,7 +159,10 @@ const PlatformAverageEngagementChart: React.FC<PlatformAverageEngagementChartPro
         </div>
 
         {insightSummary && !loading && !error && (
-          <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+          <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+            <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+            {insightSummary}
+          </p>
         )}
       </div>
 

--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { getCategoryById, commaSeparatedIdsToLabels } from "../../../lib/classification";
@@ -180,7 +181,10 @@ const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDi
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import type { TooltipProps } from 'recharts';
@@ -82,7 +83,10 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -137,7 +138,10 @@ const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMonthlyEngagementStackedChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -106,7 +107,10 @@ const PlatformMonthlyEngagementStackedChart: React.FC<PlatformMonthlyEngagementS
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -154,7 +155,10 @@ const PlatformMovingAverageEngagementChart: React.FC<PlatformMovingAverageEngage
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react';
 import HighlightCard from './HighlightCard';
@@ -104,7 +105,10 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
             />
           </div>
           {summary.insightSummary && (
-            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200">{summary.insightSummary}</p>
+            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200 flex items-start">
+              <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+              {summary.insightSummary}
+            </p>
           )}
         </>
       )}

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { getCategoryById } from "../../../lib/classification";
@@ -144,7 +145,10 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
@@ -160,7 +161,10 @@ const PlatformReachEngagementTrendChart: React.FC<PlatformReachEngagementTrendCh
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 
 // Reutilizar as interfaces e componentes auxiliares
@@ -121,7 +122,10 @@ const PlatformVideoPerformanceMetrics: React.FC<PlatformVideoPerformanceMetricsP
             />
           </div>
           {insightSummary && (
-            <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100">{insightSummary}</p>
+            <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100 flex items-start">
+              <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+              {insightSummary}
+            </p>
           )}
         </>
       )}

--- a/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   BarChart,
@@ -297,7 +298,8 @@ const UserAverageEngagementChart: React.FC<UserAverageEngagementChartProps> = ({
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserEngagementDistributionChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   PieChart,
@@ -273,7 +274,8 @@ const UserEngagementDistributionChart: React.FC<
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerChangeChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   BarChart,
@@ -176,7 +177,8 @@ const UserFollowerChangeChart: React.FC<UserFollowerChangeChartProps> = ({
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFollowerTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   LineChart,
@@ -256,7 +257,8 @@ const UserFollowerTrendChart: React.FC<UserFollowerTrendChartProps> = ({
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserMonthlyComparisonChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMonthlyComparisonChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
@@ -174,7 +175,10 @@ const UserMonthlyComparisonChart: React.FC<UserMonthlyComparisonChartProps> = ({
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100">{insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMonthlyEngagementStackedChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   BarChart,
@@ -225,7 +226,8 @@ const UserMonthlyEngagementStackedChart: React.FC<
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100">
+        <p className="text-xs md:text-sm text-gray-600 mt-3 pt-2 border-t border-gray-100 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserMovingAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserMovingAverageEngagementChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   LineChart,
@@ -282,7 +283,8 @@ const UserMovingAverageEngagementChart: React.FC<
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/UserPerformanceHighlights.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import { TrendingUp, TrendingDown, Sparkles } from "lucide-react";
 import HighlightCard from "./HighlightCard";
@@ -183,7 +184,8 @@ const UserPerformanceHighlights: React.FC<UserPerformanceHighlightsProps> = ({
             />
           </div>
           {summary.insightSummary && (
-            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200">
+            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200 flex items-start">
+              <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
               {summary.insightSummary}
             </p>
           )}

--- a/src/app/admin/creator-dashboard/components/UserRadarChartComparison.tsx
+++ b/src/app/admin/creator-dashboard/components/UserRadarChartComparison.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import ComparisonTargetSearch, { ComparisonTarget } from './ComparisonTargetSearch';
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Legend, Tooltip, ResponsiveContainer } from 'recharts';
 
@@ -197,7 +198,10 @@ const UserRadarChartComparison: React.FC<UserRadarChartComparisonProps> = ({
         )}
       </div>
       {chartData?.insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">{chartData.insightSummary}</p>
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {chartData.insightSummary}
+        </p>
       )}
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 import {
   LineChart,
@@ -282,7 +283,8 @@ const UserReachEngagementTrendChart: React.FC<
         )}
       </div>
       {insightSummary && !loading && !error && (
-        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200">
+        <p className="text-xs md:text-sm text-gray-600 mt-4 pt-2 border-t border-gray-200 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
           {insightSummary}
         </p>
       )}

--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import VideoDrillDownModal from "./VideoDrillDownModal";
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
 
@@ -262,7 +263,8 @@ const UserVideoPerformanceMetrics: React.FC<
             </button>
           </div>
           {insightSummary && (
-            <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100">
+            <p className="text-xs text-gray-600 mt-3 pt-2 border-t border-gray-100 flex items-start">
+              <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
               {insightSummary}
             </p>
           )}

--- a/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
+++ b/src/app/admin/creator-dashboard/components/widgets/UserAlertsWidget.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { AlertTriangle, Info, Zap, ChevronDown, ChevronUp } from 'lucide-react'; // Usando lucide-react para ícones
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 
 // Tipos espelhando a resposta da API
 enum AlertTypeEnum {
@@ -114,7 +115,10 @@ const UserAlertsWidget: React.FC<UserAlertsWidgetProps> = ({
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md mt-6">
       <h2 className="text-lg md:text-xl font-semibold mb-1 text-gray-700">Alertas Recentes do Criador</h2>
       {alertsResponse?.insightSummary && (
-        <p className="text-xs text-gray-500 mb-4">{alertsResponse.insightSummary}</p>
+        <p className="text-xs text-gray-500 mb-4 flex items-start">
+          <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+          {alertsResponse.insightSummary}
+        </p>
       )}
 
       {loading && <div className="flex justify-center items-center py-4"><p className="text-gray-500">Carregando alertas...</p></div>}


### PR DESCRIPTION
## Summary
- import LightBulbIcon from heroicons in dashboard components
- show the icon beside `insightSummary` text for all chart and metric components

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681ba5c858832e90e465dccc5d67d1