### PR TITLE
Fix creator ranking labels

### DIFF
--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -32,11 +32,11 @@ const CreatorRankingSection: React.FC<Props> = ({
         limit={5}
       />
       <CreatorRankingCard
-        title="Mais Interações"
+        title="Interações Totais"
         apiEndpoint="/api/admin/dashboard/rankings/creators/top-interactions"
         dateRangeFilter={rankingDateRange}
         dateRangeLabel={rankingDateLabel}
-        tooltip="Soma de todas as interações (curtidas, comentários, etc.) no período."
+        tooltip="Soma de todas as interações obtidas no período selecionado."
         limit={5}
       />
       <CreatorRankingCard
@@ -97,7 +97,7 @@ const CreatorRankingSection: React.FC<Props> = ({
         limit={5}
       />
       <TopCreatorsWidget
-        title="Top Criadores"
+        title="Média de Interações/Post"
         metric="total_interactions"
         timePeriod={globalTimePeriod}
         limit={5}


### PR DESCRIPTION
## Summary
- clarify that the `top-interactions` card is showing total interactions
- rename widget to show it displays average interactions per post

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681b965174832eaa2d004f9b3f93a2