### PR TITLE
Fix placeholder for time period filter on mobile

### DIFF
--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
@@ -27,8 +27,14 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
   label = "Selecionar Período",
   disabled = false,
 }) => {
+  const selectedLabel =
+    options.find((o) => o.value === selectedTimePeriod)?.label || "";
   return (
     <div className="flex items-center">
+      {/* Placeholder text shown on small screens when the label is hidden */}
+      <span className="sm:hidden text-sm text-gray-500 mr-2" aria-hidden="true">
+        {selectedLabel}
+      </span>
       <label
         htmlFor="globalTimePeriodSelector"
         className="hidden sm:block text-sm font-medium text-gray-700 mr-2 whitespace-nowrap"
@@ -42,7 +48,7 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
         value={selectedTimePeriod}
         onChange={(e) => onTimePeriodChange(e.target.value)}
         disabled={disabled}
-        className="p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        className="p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed w-full sm:w-auto"
       >
         {options.map(option => (
           <option key={option.value} value={option.value}>{option.label}</option>


### PR DESCRIPTION
## Summary
- show selected period when the label is hidden on small screens
- make the select take the full width of its container

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681b83c030832e8182c65f40cebdf3