### PR TITLE
Remove duplicate navigation from creator dashboard

### DIFF
--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, memo } from 'react';
-import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
-import { MagnifyingGlassIcon, DocumentMagnifyingGlassIcon, ChartBarIcon, XMarkIcon, Bars3Icon } from '@heroicons/react/24/outline';
+import React, { useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 
@@ -119,15 +117,6 @@ const AdminCreatorDashboardContent: React.FC = () => {
   const endDateLabel = today.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric" });
   const rankingDateLabel = `${startDateLabel} - ${endDateLabel}`;
 
-  const sections = [
-    { id: 'platform-summary', label: 'Resumo' },
-    { id: 'creator-rankings', label: 'Rankings' },
-    { id: 'top-movers', label: 'Top Movers' },
-    { id: 'platform-content-analysis', label: 'Análise de Conteúdo' },
-    { id: 'platform-overview', label: 'Visão Geral' },
-    { id: 'global-posts-explorer', label: 'Posts' },
-  ];
-  const [navOpen, setNavOpen] = useState(false);
 
   const handleUserSelect = (userId: string, userName: string) => {
     setSelectedUserId(userId);
@@ -175,33 +164,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
           </div>
         </header>
 
-        <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8 lg:flex lg:gap-8">
-          <div className="lg:w-56 lg:flex-shrink-0">
-            <button
-              onClick={() => setNavOpen(prev => !prev)}
-              className="lg:hidden flex items-center gap-2 mb-4 text-brand-dark border px-3 py-2 rounded-md"
-            >
-              <Bars3Icon className="w-5 h-5" />
-              Menu
-            </button>
-            <nav
-              className={`${navOpen ? 'block' : 'hidden'} lg:block bg-white lg:bg-transparent border lg:border-none rounded-md p-4 lg:p-0`}
-            >
-              <ul className="space-y-2 text-sm lg:sticky lg:top-24">
-                {sections.map(sec => (
-                  <li key={sec.id}>
-                    <a
-                      href={`#${sec.id}`}
-                      className="block px-2 py-1 text-brand-dark hover:text-brand-pink"
-                      onClick={() => setNavOpen(false)}
-                    >
-                      {sec.label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </div>
+        <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
           <div className="flex-1">
             <h1 className="text-2xl md:text-3xl font-bold text-brand-dark mb-6">
               Dashboard Administrativo de Criadores

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -13,8 +13,27 @@ import {
 } from '@heroicons/react/24/outline';
 
 // --- Itens do Menu ---
-const menuItems = [
-  { label: 'Painel Criadores', href: '/admin/creator-dashboard', icon: ChartBarIcon },
+interface MenuItem {
+  label: string;
+  href: string;
+  icon: React.ElementType;
+  children?: { label: string; href: string }[];
+}
+
+const menuItems: MenuItem[] = [
+  {
+    label: 'Painel Criadores',
+    href: '/admin/creator-dashboard',
+    icon: ChartBarIcon,
+    children: [
+      { label: 'Resumo', href: '/admin/creator-dashboard#platform-summary' },
+      { label: 'Rankings', href: '/admin/creator-dashboard#creator-rankings' },
+      { label: 'Top Movers', href: '/admin/creator-dashboard#top-movers' },
+      { label: 'Análise de Conteúdo', href: '/admin/creator-dashboard#platform-content-analysis' },
+      { label: 'Visão Geral', href: '/admin/creator-dashboard#platform-overview' },
+      { label: 'Posts', href: '/admin/creator-dashboard#global-posts-explorer' },
+    ],
+  },
   { label: 'Afiliados', href: '/admin/affiliates', icon: UserGroupIcon },
   { label: 'Resgates', href: '/admin/redemptions', icon: CurrencyDollarIcon },
 ];
@@ -36,21 +55,37 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             const isActive = pathname === item.href;
             const Icon = item.icon;
             return (
-            <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setIsSidebarOpen(false)}
-                className={`
-                flex items-center gap-3 px-3 py-2 rounded-lg
-                transition-colors duration-150
-                ${isActive
-                    ? 'bg-indigo-100 text-indigo-700 font-semibold'
-                    : 'text-brand-dark hover:bg-brand-light hover:text-brand-dark'}
-                `}
-            >
-                <Icon className="w-5 h-5" />
-                <span>{item.label}</span>
-            </Link>
+            <div key={item.href}>
+              <Link
+                  href={item.href}
+                  onClick={() => setIsSidebarOpen(false)}
+                  className={`
+                  flex items-center gap-3 px-3 py-2 rounded-lg
+                  transition-colors duration-150
+                  ${isActive
+                      ? 'bg-indigo-100 text-indigo-700 font-semibold'
+                      : 'text-brand-dark hover:bg-brand-light hover:text-brand-dark'}
+                  `}
+              >
+                  <Icon className="w-5 h-5" />
+                  <span>{item.label}</span>
+              </Link>
+              {item.children && (
+                <ul className="mt-1 ml-8 space-y-1 text-sm">
+                  {item.children.map(child => (
+                    <li key={child.href}>
+                      <Link
+                        href={child.href}
+                        onClick={() => setIsSidebarOpen(false)}
+                        className="block px-2 py-1 text-brand-dark hover:text-brand-pink"
+                      >
+                        {child.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
             );
         })}
         </nav>


### PR DESCRIPTION
## Summary
- remove unused icons and section nav state
- drop creator dashboard internal navigation list

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682620c1ec832ea2127d1a6c4b39eb