### PR TITLE
Fix context array handling in performance highlights

### DIFF
--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -194,10 +194,10 @@ export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'
 }
 
 // Novo helper para traduzir strings com IDs separados por vírgula
-export function commaSeparatedIdsToLabels(ids: string | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string {
+export function commaSeparatedIdsToLabels(ids: string | string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string {
   if (!ids) return '';
-  return ids
-    .split(',')
+  const idList = Array.isArray(ids) ? ids : ids.split(',');
+  return idList
     .map(id => id.trim())
     .filter(id => id.length > 0)
     .map(id => getCategoryById(id, type)?.label ?? id)

--- a/src/utils/__tests__/aggregatePlatformPerformanceHighlights.test.ts
+++ b/src/utils/__tests__/aggregatePlatformPerformanceHighlights.test.ts
@@ -40,6 +40,25 @@ describe('aggregatePlatformPerformanceHighlights', () => {
     expect(res.topContext).toEqual({ name: 'FEED', average: 5, count: 3 });
   });
 
+  it('joins array ids into comma separated strings', async () => {
+    mockAgg.mockResolvedValueOnce([
+      {
+        byFormat: [
+          { _id: ['VIDEO', 'LIVE'], avg: 8, count: 4 },
+          { _id: ['IMAGE'], avg: 2, count: 1 },
+        ],
+        byContext: [
+          { _id: ['FEED', 'STORIES'], avg: 7, count: 5 },
+        ],
+      },
+    ]);
+
+    const res = await aggregatePlatformPerformanceHighlights(30, 'stats.total_interactions');
+    expect(res.topFormat?.name).toBe('VIDEO,LIVE');
+    expect(res.lowFormat?.name).toBe('IMAGE');
+    expect(res.topContext?.name).toBe('FEED,STORIES');
+  });
+
   it('handles empty aggregation', async () => {
     mockAgg.mockResolvedValueOnce([{}]);
     const res = await aggregatePlatformPerformanceHighlights(30, 'stats.total_interactions');

--- a/src/utils/aggregatePerformanceHighlights.ts
+++ b/src/utils/aggregatePerformanceHighlights.ts
@@ -74,6 +74,7 @@ async function aggregatePerformanceHighlights(
       {
         $facet: {
           byFormat: [
+            { $unwind: "$format" },
             {
               $group: {
                 _id: "$format",
@@ -84,6 +85,7 @@ async function aggregatePerformanceHighlights(
             { $sort: { avg: -1 } },
           ],
           byContext: [
+            { $unwind: "$context" },
             {
               $group: {
                 _id: "$context",
@@ -102,13 +104,15 @@ async function aggregatePerformanceHighlights(
     if (agg?.byFormat?.length) {
       const topF = agg.byFormat[0];
       const lowF = agg.byFormat[agg.byFormat.length - 1];
+      const topFormatName = Array.isArray(topF._id) ? topF._id.join(',') : topF._id;
+      const lowFormatName = Array.isArray(lowF._id) ? lowF._id.join(',') : lowF._id;
       initial.topFormat = {
-        name: topF._id ?? null,
+        name: topFormatName ?? null,
         average: topF.avg ?? 0,
         count: topF.count ?? 0,
       };
       initial.lowFormat = {
-        name: lowF._id ?? null,
+        name: lowFormatName ?? null,
         average: lowF.avg ?? 0,
         count: lowF.count ?? 0,
       };
@@ -116,8 +120,9 @@ async function aggregatePerformanceHighlights(
 
     if (agg?.byContext?.length) {
       const topC = agg.byContext[0];
+      const topContextName = Array.isArray(topC._id) ? topC._id.join(',') : topC._id;
       initial.topContext = {
-        name: topC._id ?? null,
+        name: topContextName ?? null,
         average: topC.avg ?? 0,
         count: topC.count ?? 0,
       };

--- a/src/utils/aggregatePlatformPerformanceHighlights.ts
+++ b/src/utils/aggregatePlatformPerformanceHighlights.ts
@@ -70,6 +70,7 @@ async function aggregatePlatformPerformanceHighlights(
       {
         $facet: {
           byFormat: [
+            { $unwind: "$format" },
             {
               $group: {
                 _id: "$format",
@@ -80,6 +81,7 @@ async function aggregatePlatformPerformanceHighlights(
             { $sort: { avg: -1 } },
           ],
           byContext: [
+            { $unwind: "$context" },
             {
               $group: {
                 _id: "$context",
@@ -98,13 +100,15 @@ async function aggregatePlatformPerformanceHighlights(
     if (agg?.byFormat?.length) {
       const topF = agg.byFormat[0];
       const lowF = agg.byFormat[agg.byFormat.length - 1];
+      const topFormatName = Array.isArray(topF._id) ? topF._id.join(',') : topF._id;
+      const lowFormatName = Array.isArray(lowF._id) ? lowF._id.join(',') : lowF._id;
       initial.topFormat = {
-        name: topF._id ?? null,
+        name: topFormatName ?? null,
         average: topF.avg ?? 0,
         count: topF.count ?? 0,
       };
       initial.lowFormat = {
-        name: lowF._id ?? null,
+        name: lowFormatName ?? null,
         average: lowF.avg ?? 0,
         count: lowF.count ?? 0,
       };
@@ -112,8 +116,9 @@ async function aggregatePlatformPerformanceHighlights(
 
     if (agg?.byContext?.length) {
       const topC = agg.byContext[0];
+      const topContextName = Array.isArray(topC._id) ? topC._id.join(',') : topC._id;
       initial.topContext = {
-        name: topC._id ?? null,
+        name: topContextName ?? null,
         average: topC.avg ?? 0,
         count: topC.count ?? 0,
       };


### PR DESCRIPTION
## Summary
- support arrays in `commaSeparatedIdsToLabels`
- unwind arrays and join names in performance highlights aggregators
- test aggregator handling of array ids

## Testing
- `npx jest --watchAll=false` *(fails: `403 Forbidden`)*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868657eceb4832ebd8c47b35d5f9719