### PR TITLE
Adjust platform metrics to show average views

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformVideoPerformanceMetrics.tsx
@@ -6,7 +6,7 @@ import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 
 // Reutilizar as interfaces e componentes auxiliares
 interface VideoMetricsData {
-  averageRetentionRate: number | null;
+  averageViews: number | null;
   averageWatchTimeSeconds: number | null;
   numberOfVideoPosts: number | null;
 }
@@ -72,7 +72,7 @@ const PlatformVideoPerformanceMetrics: React.FC<PlatformVideoPerformanceMetricsP
       }
       const result: VideoMetricsResponse = await response.json();
       setMetrics({
-        averageRetentionRate: result.averageRetentionRate,
+        averageViews: result.averageViews,
         averageWatchTimeSeconds: result.averageWatchTimeSeconds,
         numberOfVideoPosts: result.numberOfVideoPosts,
       });
@@ -104,10 +104,9 @@ const PlatformVideoPerformanceMetrics: React.FC<PlatformVideoPerformanceMetricsP
         <>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <MetricDisplay
-                label="Retenção Média (Plataforma)"
-                value={metrics.averageRetentionRate !== null ? (metrics.averageRetentionRate).toFixed(1) : null}
-                unit="%"
-                tooltip="Média da porcentagem de vídeo que os espectadores assistem em toda a plataforma."
+                label="Média de Visualizações (Plataforma)"
+                value={metrics.averageViews !== null ? metrics.averageViews.toFixed(0) : null}
+                tooltip="Média de visualizações por vídeo na plataforma."
             />
             <MetricDisplay
                 label="Tempo Médio de Visualização (Plataforma)"

--- a/src/app/admin/creator-dashboard/components/__tests__/PlatformVideoPerformanceMetrics.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/PlatformVideoPerformanceMetrics.test.tsx
@@ -20,7 +20,7 @@ describe('PlatformVideoPerformanceMetrics', () => {
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        averageRetentionRate: 50,
+        averageViews: 200,
         averageWatchTimeSeconds: 120,
         numberOfVideoPosts: 10,
         insightSummary: 'Resumo',
@@ -29,7 +29,7 @@ describe('PlatformVideoPerformanceMetrics', () => {
 
     render(<PlatformVideoPerformanceMetrics />);
 
-    await waitFor(() => expect(screen.getByText('50.0%')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('200')).toBeInTheDocument());
     expect(screen.getByText('120s')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
     expect(screen.getByText('Resumo')).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('PlatformVideoPerformanceMetrics', () => {
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        averageRetentionRate: null,
+        averageViews: null,
         averageWatchTimeSeconds: null,
         numberOfVideoPosts: null,
       }),

--- a/src/app/api/v1/platform/performance/video-metrics/route.test.ts
+++ b/src/app/api/v1/platform/performance/video-metrics/route.test.ts
@@ -25,6 +25,8 @@ describe('GET /api/v1/platform/performance/video-metrics', () => {
         countRetentionValid: 2,
         totalWatchTimeSum: 300,
         countWatchTimeValid: 3,
+        totalViewsSum: 1000,
+        countViewsValid: 4,
         totalVideoPosts: 5,
       },
     ]);
@@ -35,6 +37,7 @@ describe('GET /api/v1/platform/performance/video-metrics', () => {
     expect(res.status).toBe(200);
     expect(body.averageRetentionRate).toBeCloseTo(100);
     expect(body.averageWatchTimeSeconds).toBeCloseTo(100);
+    expect(body.averageViews).toBeCloseTo(250);
     expect(body.numberOfVideoPosts).toBe(5);
     expect(body.insightSummary).toContain('last_30_days');
   });
@@ -48,6 +51,7 @@ describe('GET /api/v1/platform/performance/video-metrics', () => {
     expect(res.status).toBe(200);
     expect(body.averageRetentionRate).toBeNull();
     expect(body.averageWatchTimeSeconds).toBeNull();
+    expect(body.averageViews).toBeNull();
     expect(body.numberOfVideoPosts).toBe(0);
     expect(body.insightSummary).toContain('Nenhum post de vídeo encontrado');
   });


### PR DESCRIPTION
## Summary
- replace retention rate metric with average views metric in platform metrics
- compute average views in the API route
- update React component and tests for new metric

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type definition file 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686872277204832ea1bfcd07fbd0016f