### PR TITLE
Fix format label mapping for platform charts

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformEngagementDistributionByFormatChart.tsx
@@ -6,6 +6,31 @@ import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { getCategoryById, commaSeparatedIdsToLabels } from "../../../lib/classification";
 
+const FORMAT_LABEL_MAP: Record<string, string> = {
+  IMAGE: 'photo',
+  IMAGEM: 'photo',
+  PHOTO: 'photo',
+  FOTO: 'photo',
+  VIDEO: 'long_video',
+  REEL: 'reel',
+  CAROUSEL_ALBUM: 'carousel',
+  CAROUSEL: 'carousel',
+  CARROSSEL: 'carousel',
+  STORY: 'story',
+  LIVE: 'live',
+  LONG_VIDEO: 'long_video',
+};
+
+function toFormatLabel(raw: string): string {
+  const key = raw.trim().toUpperCase();
+  const mappedId = FORMAT_LABEL_MAP[key];
+  return (
+    (mappedId && getCategoryById(mappedId, 'format')?.label) ||
+    getCategoryById(raw.trim().toLowerCase(), 'format')?.label ||
+    raw.trim()
+  );
+}
+
 interface ApiEngagementDistributionDataPoint {
   name: string;
   value: number;
@@ -71,7 +96,7 @@ const PlatformEngagementDistributionByFormatChart: React.FC<PlatformEngagementDi
       const result: PlatformEngagementDistributionApiResponse = await response.json();
       const mapped = result.chartData.map(d => ({
         ...d,
-        name: commaSeparatedIdsToLabels(d.name, 'format') || d.name,
+        name: commaSeparatedIdsToLabels(d.name, 'format') || toFormatLabel(d.name),
       }));
       setData(mapped);
       setInsightSummary(result.insightSummary);

--- a/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPostDistributionChart.tsx
@@ -6,6 +6,31 @@ import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { getCategoryById } from "../../../lib/classification";
 
+const FORMAT_LABEL_MAP: Record<string, string> = {
+  IMAGE: 'photo',
+  IMAGEM: 'photo',
+  PHOTO: 'photo',
+  FOTO: 'photo',
+  VIDEO: 'long_video',
+  REEL: 'reel',
+  CAROUSEL_ALBUM: 'carousel',
+  CAROUSEL: 'carousel',
+  CARROSSEL: 'carousel',
+  STORY: 'story',
+  LIVE: 'live',
+  LONG_VIDEO: 'long_video',
+};
+
+function toFormatLabel(raw: string): string {
+  const key = raw.trim().toUpperCase();
+  const mappedId = FORMAT_LABEL_MAP[key];
+  return (
+    (mappedId && getCategoryById(mappedId, 'format')?.label) ||
+    getCategoryById(raw.trim().toLowerCase(), 'format')?.label ||
+    raw.trim()
+  );
+}
+
 interface ApiPostDistributionDataPoint {
   name: string;
   value: number; // Agora representa contagem de posts
@@ -61,7 +86,7 @@ const PlatformPostDistributionChart: React.FC<PlatformPostDistributionChartProps
       const result: PlatformPostDistributionResponse = await response.json();
       const mapped = result.chartData.map(d => ({
         ...d,
-        name: getCategoryById(d.name, 'format')?.label ?? d.name,
+        name: toFormatLabel(d.name),
       }));
       setData(mapped);
       setInsightSummary(result.insightSummary);


### PR DESCRIPTION
## Summary
- normalize format names for platform post and engagement distribution charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687847833c832ebb4b68fe1345bda1