### PR TITLE
Update content analysis highlights

### DIFF
--- a/src/app/admin/creator-dashboard/components/FormatPerformanceRankingTable.tsx
+++ b/src/app/admin/creator-dashboard/components/FormatPerformanceRankingTable.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
+import { commaSeparatedIdsToLabels } from '../../../lib/classification';
+import { FullDataModal } from './FullDataModal';
+
+interface DataPoint {
+  name: string;
+  value: number;
+  postsCount: number;
+}
+
+const DEFAULT_METRIC = 'stats.total_interactions';
+
+const FormatPerformanceRankingTable: React.FC = () => {
+  const { timePeriod } = useGlobalTimePeriod();
+  const [data, setData] = useState<DataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const apiUrl = `/api/v1/platform/performance/average-engagement?timePeriod=${timePeriod}&groupBy=format&sortOrder=desc&engagementMetricField=${DEFAULT_METRIC}`;
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`Erro HTTP: ${res.status}`);
+      const result = await res.json();
+      const mapped: DataPoint[] = result.chartData.map((d: any) => ({
+        name: commaSeparatedIdsToLabels(d.name, 'format') || d.name,
+        value: d.value,
+        postsCount: d.postsCount,
+      }));
+      setData(mapped);
+    } catch (e: any) {
+      setError(e.message || 'Erro ao carregar ranking.');
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [timePeriod]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const totalPosts = data.reduce((sum, d) => sum + d.postsCount, 0);
+
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-md font-semibold text-gray-700">Ranking de Desempenho por Formato</h3>
+        <button onClick={() => setIsModalOpen(true)} className="text-sm font-semibold text-indigo-600 hover:text-indigo-800">
+          Ver Análise Completa
+        </button>
+      </div>
+      {loading && <p className="text-center py-6 text-gray-500">Carregando ranking...</p>}
+      {error && <p className="text-center py-6 text-red-500">Erro: {error}</p>}
+      {!loading && !error && data.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Formato</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Engajamento Médio</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Volume (% do Total)</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {data.map((item, index) => {
+                const pct = totalPosts > 0 ? (item.postsCount / totalPosts) * 100 : 0;
+                return (
+                  <tr key={item.name} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 text-center font-medium text-gray-700">{index + 1}</td>
+                    <td className="px-3 py-2 font-medium text-gray-800">{item.name}</td>
+                    <td className="px-3 py-2 text-right text-gray-700">{item.value.toLocaleString('pt-BR')}</td>
+                    <td className="px-3 py-2 text-right text-gray-700">
+                      <div className="flex items-center gap-2 justify-end">
+                        <span>{item.postsCount} ({pct.toFixed(1)}%)</span>
+                        <div className="w-24 h-2 bg-gray-200 rounded">
+                          <div className="h-2 bg-indigo-500 rounded" style={{ width: `${pct}%` }} />
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {!loading && !error && data.length === 0 && (
+        <p className="text-center py-6 text-gray-500">Nenhum dado disponível.</p>
+      )}
+
+      <FullDataModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        groupBy="format"
+        metricUsed={DEFAULT_METRIC}
+        chartTitle="Ranking de Desempenho por Formato"
+      />
+    </div>
+  );
+};
+
+export default FormatPerformanceRankingTable;

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -7,6 +7,7 @@ import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react';
 import HighlightCard from './HighlightCard';
 // CORREÇÃO: Importa a função para traduzir os IDs de contexto.
 import { commaSeparatedIdsToLabels } from '../../../lib/classification';
+import FormatPerformanceRankingTable from './FormatPerformanceRankingTable';
 
 interface PerformanceHighlightItem {
   name: string;
@@ -103,15 +104,18 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
               bgColorClass="bg-red-50"
               textColorClass="text-red-600"
             />
-          </div>
-          {summary.insightSummary && (
-            <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200 flex items-start">
-              <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
-              {summary.insightSummary}
-            </p>
-          )}
-        </>
-      )}
+        </div>
+        {summary.insightSummary && (
+          <p className="text-xs text-gray-600 mt-4 pt-3 border-t border-gray-200 flex items-start">
+            <LightBulbIcon className="w-4 h-4 text-yellow-500 mr-1 flex-shrink-0" />
+            {summary.insightSummary}
+          </p>
+        )}
+        <div className="mt-6">
+          <FormatPerformanceRankingTable />
+        </div>
+      </>
+    )}
        {!loading && !error && !summary && (
          <div className="text-center py-5"><p className="text-gray-500">Nenhum destaque de performance encontrado para a plataforma.</p></div>
       )}

--- a/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
@@ -3,12 +3,7 @@
 import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import PlatformPerformanceHighlights from "../PlatformPerformanceHighlights";
-import PlatformAverageEngagementChart from "../PlatformAverageEngagementChart";
-import PlatformPostDistributionChart from "../PlatformPostDistributionChart";
-import PlatformVideoPerformanceMetrics from "../PlatformVideoPerformanceMetrics";
-import PlatformMonthlyEngagementStackedChart from "../PlatformMonthlyEngagementStackedChart";
-import PlatformEngagementDistributionByFormatChart from "../PlatformEngagementDistributionByFormatChart";
-import ContentPerformanceByTypeChart from "../../ContentPerformanceByTypeChart";
+
 
 interface Props {
   startDate: string;
@@ -21,31 +16,9 @@ const PlatformContentAnalysisSection: React.FC<Props> = ({
 }) => (
   <section id="platform-content-analysis" className="mb-10">
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
-      Análise de Conteúdo da Plataforma <GlobalPeriodIndicator />
+      Destaques de Performance da Plataforma <GlobalPeriodIndicator />
     </h2>
-    <div className="mb-6 md:mb-8">
-      <PlatformPerformanceHighlights />
-    </div>
-
-    <div className="mb-6 md:mb-8">
-      <PlatformVideoPerformanceMetrics />
-    </div>
-
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-      <PlatformAverageEngagementChart
-        initialGroupBy="context"
-        chartTitle="Engajamento Médio da Plataforma"
-      />
-      <PlatformPostDistributionChart chartTitle="Distribuição de Posts por Formato" />
-    </div>
-    
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <PlatformMonthlyEngagementStackedChart />
-      <PlatformEngagementDistributionByFormatChart />
-    </div>
-    <div className="mt-6">
-      <ContentPerformanceByTypeChart dateRangeFilter={{ startDate, endDate }} />
-    </div>
+    <PlatformPerformanceHighlights />
   </section>
 );
 


### PR DESCRIPTION
## Summary
- add `FormatPerformanceRankingTable` for ranking posts by format
- embed ranking table inside performance highlights
- streamline Platform Content Analysis section to show new highlights only

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697d630e9c832ebae390196a588841