### PR TITLE
Add time-based performance analysis

### DIFF
--- a/docs/plano-de-otimizacao-estrategica-v3.md
+++ b/docs/plano-de-otimizacao-estrategica-v3.md
@@ -1,0 +1,21 @@
+# Plano de Otimização Estratégica (Versão 3.0)
+
+Este documento descreve a consolidação das análises em duas seções principais: uma dedicada aos **destaques de performance** ("o quê" funciona) e outra voltada à **análise de performance por horário** ("quando" funciona).
+
+## 1. Destaques de Performance da Plataforma
+
+- **Grade de Destaques**: cards organizados em duas linhas de três.
+  - Linha 1: Formato, Proposta e Contexto com melhor desempenho.
+  - Linha 2: Tom, Referência e o novo "Melhor Dia/Horário".
+- **Tabela de Ranking**: ranking de desempenho por formato logo abaixo dos cards, justificando os destaques e apresentando o volume de posts.
+- **Acesso Completo**: botão "Ver Análise Completa" abre o modal de detalhes.
+
+## 2. Análise de Performance por Horário
+
+Seção dedicada a mostrar os dias e horários com maior engajamento, incluindo filtros por formato de conteúdo.
+
+- **Filtro de Formato**: dropdown para selecionar "Todos" ou um formato específico (Reel, Carrossel etc.).
+- **Heatmap de Engajamento**: dias na vertical e horários do dia na horizontal, com intensidade de cor representando o engajamento médio.
+- **Tabela de Detalhes**: lista com os três melhores e piores horários de postagem.
+
+Esta abordagem oferece uma visão completa e acionável, permitindo entender não apenas o que gera melhores resultados, mas também quando publicar para maximizar o engajamento.

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -22,11 +22,11 @@ interface PerformanceHighlightItem {
 
 interface PerformanceSummaryResponse {
   topPerformingFormat: PerformanceHighlightItem | null;
-  lowPerformingFormat: PerformanceHighlightItem | null;
   topPerformingContext: PerformanceHighlightItem | null;
   topPerformingProposal: PerformanceHighlightItem | null;
   topPerformingTone: PerformanceHighlightItem | null;
   topPerformingReference: PerformanceHighlightItem | null;
+  bestTimeSlot: { dayOfWeek: number; timeBlock: string; average: number } | null;
   insightSummary: string;
 }
 
@@ -94,7 +94,7 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
 
       {!loading && !error && summary && (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-3 gap-4">
             <HighlightCard
               title="Melhor Formato (Plataforma)"
               highlight={summary.topPerformingFormat}
@@ -108,13 +108,6 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
               icon={<Sparkles size={18} className="mr-2 text-blue-500"/>}
               bgColorClass="bg-blue-50"
               textColorClass="text-blue-600"
-            />
-            <HighlightCard
-              title="Formato de Pior Desempenho"
-              highlight={summary.lowPerformingFormat}
-              icon={<TrendingDown size={18} className="mr-2 text-red-500"/>}
-              bgColorClass="bg-red-50"
-              textColorClass="text-red-600"
             />
             <HighlightCard
               title="Melhor Proposta"
@@ -136,6 +129,13 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
               icon={<Sparkles size={18} className="mr-2 text-teal-500"/>}
               bgColorClass="bg-teal-50"
               textColorClass="text-teal-600"
+            />
+            <HighlightCard
+              title="Melhor Dia e Horário"
+              highlight={summary.bestTimeSlot ? { name: `${summary.bestTimeSlot.timeBlock} (Dia ${summary.bestTimeSlot.dayOfWeek})`, metricName: 'Horário', value: summary.bestTimeSlot.average, valueFormatted: summary.bestTimeSlot.average.toFixed(1) } : null}
+              icon={<TrendingUp size={18} className="mr-2 text-indigo-500"/>}
+              bgColorClass="bg-indigo-50"
+              textColorClass="text-indigo-600"
             />
         </div>
         {summary.insightSummary && (

--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+
+interface HeatmapCell {
+  dayOfWeek: number;
+  timeBlock: string;
+  average: number;
+  count: number;
+}
+
+interface TimePerformanceResponse {
+  buckets: HeatmapCell[];
+  bestSlots: HeatmapCell[];
+  worstSlots: HeatmapCell[];
+}
+
+const DAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+const BLOCKS = ["0-6", "6-12", "12-18", "18-24"];
+
+interface Props { formatFilter?: string; }
+
+const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
+  const { timePeriod } = useGlobalTimePeriod();
+  const [data, setData] = useState<TimePerformanceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      params.set("timePeriod", timePeriod);
+      if (formatFilter) params.set("format", formatFilter);
+      const res = await fetch(`/api/v1/platform/performance/time-distribution?${params.toString()}`);
+      if (!res.ok) throw new Error(`Erro HTTP ${res.status}`);
+      const json: TimePerformanceResponse = await res.json();
+      setData(json);
+    } catch (e: any) {
+      setError(e.message || "Erro ao carregar dados");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [timePeriod, formatFilter]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const getCellValue = (day: number, block: string) => {
+    const cell = data?.buckets.find(b => b.dayOfWeek === day && b.timeBlock === block);
+    return cell ? cell.average : 0;
+  };
+
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
+      <h3 className="text-md font-semibold text-gray-700 mb-4">Análise de Performance por Horário</h3>
+      {loading && <p className="text-center text-sm">Carregando...</p>}
+      {error && <p className="text-center text-sm text-red-600">Erro: {error}</p>}
+      {!loading && !error && data && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-center text-xs">
+            <thead>
+              <tr>
+                <th className="px-2 py-1"></th>
+                {BLOCKS.map(b => (
+                  <th key={b} className="px-2 py-1">{b}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {DAYS.map((d, idx) => (
+                <tr key={d}>
+                  <td className="px-2 py-1 font-medium text-gray-600">{d}</td>
+                  {BLOCKS.map(b => {
+                    const val = getCellValue(idx, b);
+                    const intensity = val === 0 ? 0 : Math.min(1, val / (data.bestSlots[0]?.average || val));
+                    const color = `rgba(59,130,246,${intensity})`;
+                    return (
+                      <td key={b} className="px-2 py-1" style={{ backgroundColor: color }}>
+                        {val.toFixed(0)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {data.bestSlots.length > 0 && (
+            <div className="mt-4 text-left text-xs">
+              <p className="font-semibold mb-1">Top Horários:</p>
+              <ul className="list-disc list-inside">
+                {data.bestSlots.slice(0,3).map((s, i) => (
+                  <li key={i}>{DAYS[s.dayOfWeek]} {s.timeBlock} - {s.average.toFixed(1)}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TimePerformanceHeatmap;

--- a/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import PlatformPerformanceHighlights from "../PlatformPerformanceHighlights";
+import TimePerformanceHeatmap from "../TimePerformanceHeatmap";
 
 
 interface Props {
@@ -19,6 +20,9 @@ const PlatformContentAnalysisSection: React.FC<Props> = ({
       Destaques de Performance da Plataforma <GlobalPeriodIndicator />
     </h2>
     <PlatformPerformanceHighlights />
+    <div className="mt-6">
+      <TimePerformanceHeatmap />
+    </div>
   </section>
 );
 

--- a/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
@@ -1,10 +1,13 @@
 import { GET } from './route';
 import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
+import aggregatePlatformTimePerformance from '@/utils/aggregatePlatformTimePerformance';
 import { NextRequest } from 'next/server';
 
 jest.mock('@/utils/aggregatePlatformPerformanceHighlights');
+jest.mock('@/utils/aggregatePlatformTimePerformance');
 
 const mockAgg = aggregatePlatformPerformanceHighlights as jest.Mock;
+const mockTimeAgg = aggregatePlatformTimePerformance as jest.Mock;
 
 const makeRequest = (search = '') => new NextRequest(`http://localhost/api/v1/platform/highlights/performance-summary${search}`);
 
@@ -22,18 +25,25 @@ describe('GET /api/v1/platform/highlights/performance-summary', () => {
       topTone: { name: 'humor', average: 7, count: 2 },
       topReference: { name: 'pop_culture', average: 6, count: 3 },
     });
+    mockTimeAgg.mockResolvedValueOnce({
+      buckets: [],
+      bestSlots: [{ dayOfWeek: 5, timeBlock: '18-24', average: 12, count: 4 }],
+      worstSlots: [],
+    });
 
     const res = await GET(makeRequest('?timePeriod=last_30_days'));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(mockAgg).toHaveBeenCalled();
+    expect(mockTimeAgg).toHaveBeenCalled();
     expect(body.topPerformingFormat.name).toBe('VIDEO');
     expect(body.lowPerformingFormat.name).toBe('IMAGE');
     expect(body.topPerformingContext.name).toBe('FEED');
     expect(body.topPerformingProposal.name).toBe('educational');
     expect(body.topPerformingTone.name).toBe('humor');
     expect(body.topPerformingReference.name).toBe('pop_culture');
+    expect(body.bestTimeSlot.timeBlock).toBe('18-24');
   });
 
   it('returns 400 for invalid timePeriod', async () => {

--- a/src/app/api/v1/platform/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.test.ts
@@ -1,0 +1,37 @@
+import { GET } from './route';
+import aggregatePlatformTimePerformance from '@/utils/aggregatePlatformTimePerformance';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/utils/aggregatePlatformTimePerformance');
+const mockAgg = aggregatePlatformTimePerformance as jest.Mock;
+
+const makeRequest = (search = '') => new NextRequest(`http://localhost/api/v1/platform/performance/time-distribution${search}`);
+
+describe('GET /api/v1/platform/performance/time-distribution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns aggregated data', async () => {
+    mockAgg.mockResolvedValueOnce({
+      buckets: [{ dayOfWeek: 1, timeBlock: '6-12', average: 10, count: 2 }],
+      bestSlots: [],
+      worstSlots: [],
+    });
+
+    const res = await GET(makeRequest('?timePeriod=last_30_days'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalled();
+    expect(body.buckets[0].timeBlock).toBe('6-12');
+  });
+
+  it('returns 400 for invalid time period', async () => {
+    const res = await GET(makeRequest('?timePeriod=bad'));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Time period inválido');
+    expect(mockAgg).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/platform/performance/time-distribution/route.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import aggregatePlatformTimePerformance from '@/utils/aggregatePlatformTimePerformance';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const formatParam = searchParams.get('format');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const metricField = 'stats.total_interactions';
+
+  const result = await aggregatePlatformTimePerformance(periodInDaysValue, metricField, formatParam || undefined);
+
+  return NextResponse.json(camelizeKeys(result), { status: 200 });
+}

--- a/src/utils/__tests__/aggregatePlatformTimePerformance.test.ts
+++ b/src/utils/__tests__/aggregatePlatformTimePerformance.test.ts
@@ -1,0 +1,43 @@
+import aggregatePlatformTimePerformance from '../aggregatePlatformTimePerformance';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = MetricModel.aggregate as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+describe('aggregatePlatformTimePerformance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('aggregates and sorts time buckets', async () => {
+    mockAgg.mockResolvedValueOnce([
+      { _id: { dayOfWeek: 2, timeBlock: '12-18' }, avg: 15, count: 4 },
+      { _id: { dayOfWeek: 5, timeBlock: '18-24' }, avg: 10, count: 2 },
+      { _id: { dayOfWeek: 1, timeBlock: '6-12' }, avg: 5, count: 3 },
+    ]);
+
+    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions');
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockAgg).toHaveBeenCalled();
+    expect(res.buckets.length).toBe(3);
+    expect(res.bestSlots[0].average).toBe(15);
+    expect(res.worstSlots[0].average).toBe(5);
+  });
+
+  it('handles empty aggregation', async () => {
+    mockAgg.mockResolvedValueOnce([]);
+    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions');
+    expect(res.buckets).toEqual([]);
+    expect(res.bestSlots).toEqual([]);
+  });
+});

--- a/src/utils/aggregatePlatformTimePerformance.ts
+++ b/src/utils/aggregatePlatformTimePerformance.ts
@@ -1,0 +1,109 @@
+import MetricModel from "@/app/models/Metric";
+import { PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface TimeBucket {
+  dayOfWeek: number;
+  timeBlock: string;
+  average: number;
+  count: number;
+}
+
+export interface PlatformTimePerformance {
+  buckets: TimeBucket[];
+  bestSlots: TimeBucket[];
+  worstSlots: TimeBucket[];
+}
+
+export async function aggregatePlatformTimePerformance(
+  periodInDays: number,
+  metricField: string,
+  formatFilter?: string,
+  referenceDate: Date = new Date()
+): Promise<PlatformTimePerformance> {
+  const today = new Date(referenceDate);
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const result: PlatformTimePerformance = { buckets: [], bestSlots: [], worstSlots: [] };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    if (formatFilter) {
+      (matchStage.$match as any).format = formatFilter;
+    }
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      {
+        $project: {
+          dayOfWeek: { $dayOfWeek: "$postDate" },
+          hour: { $hour: "$postDate" },
+          metricValue: `$${metricField}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      {
+        $addFields: {
+          timeBlock: {
+            $switch: {
+              branches: [
+                { case: { $lte: ["$hour", 5] }, then: "0-6" },
+                { case: { $lte: ["$hour", 11] }, then: "6-12" },
+                { case: { $lte: ["$hour", 17] }, then: "12-18" },
+                { case: { $lte: ["$hour", 23] }, then: "18-24" },
+              ],
+              default: "unknown",
+            },
+          },
+        },
+      },
+      {
+        $group: {
+          _id: { dayOfWeek: "$dayOfWeek", timeBlock: "$timeBlock" },
+          avg: { $avg: "$metricValue" },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { avg: -1 } },
+    ];
+
+    const agg = await MetricModel.aggregate(pipeline);
+    result.buckets = agg.map((d: any) => ({
+      dayOfWeek: d._id.dayOfWeek,
+      timeBlock: d._id.timeBlock,
+      average: d.avg,
+      count: d.count,
+    }));
+
+    result.bestSlots = result.buckets.slice(0, 3);
+    result.worstSlots = result.buckets.slice(-3).reverse();
+
+    return result;
+  } catch (error) {
+    logger.error("Error in aggregatePlatformTimePerformance:", error);
+    return result;
+  }
+}
+
+export default aggregatePlatformTimePerformance;


### PR DESCRIPTION
## Summary
- implement backend aggregation for best posting times
- expose new time distribution API
- extend performance highlights API with best time slot
- update platform highlights UI to show best time
- add heatmap component and integrate into analysis section
- include unit tests for new modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b5bc82c8832e9edff38e3c9992d2