### PR TITLE
Improve time slot display

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -34,6 +34,27 @@ interface PlatformPerformanceHighlightsProps {
   sectionTitle?: string;
 }
 
+const DAY_NAMES = [
+  "Domingo",
+  "Segunda-feira",
+  "Terça-feira",
+  "Quarta-feira",
+  "Quinta-feira",
+  "Sexta-feira",
+  "Sábado",
+];
+
+function formatBestTimeSlot(slot: PerformanceSummaryResponse["bestTimeSlot"]): PerformanceHighlightItem | null {
+  if (!slot) return null;
+  const dayName = DAY_NAMES[slot.dayOfWeek] || `Dia ${slot.dayOfWeek}`;
+  return {
+    name: `${dayName}, ${slot.timeBlock}h`,
+    metricName: "Horário",
+    value: slot.average,
+    valueFormatted: slot.average.toFixed(1),
+  };
+}
+
 const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps> = ({
   sectionTitle = "Destaques de Performance da Plataforma"
 }) => {
@@ -132,7 +153,7 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
             />
             <HighlightCard
               title="Melhor Dia e Horário"
-              highlight={summary.bestTimeSlot ? { name: `${summary.bestTimeSlot.timeBlock} (Dia ${summary.bestTimeSlot.dayOfWeek})`, metricName: 'Horário', value: summary.bestTimeSlot.average, valueFormatted: summary.bestTimeSlot.average.toFixed(1) } : null}
+              highlight={formatBestTimeSlot(summary.bestTimeSlot)}
               icon={<TrendingUp size={18} className="mr-2 text-indigo-500"/>}
               bgColorClass="bg-indigo-50"
               textColorClass="text-indigo-600"

--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -53,6 +53,8 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
     return cell ? cell.average : 0;
   };
 
+  const maxValue = data?.buckets.reduce((max, c) => Math.max(max, c.average), 0) || 0;
+
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
       <h3 className="text-md font-semibold text-gray-700 mb-4">Análise de Performance por Horário</h3>
@@ -75,12 +77,15 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
                   <td className="px-2 py-1 font-medium text-gray-600">{d}</td>
                   {BLOCKS.map(b => {
                     const val = getCellValue(idx, b);
-                    const intensity = val === 0 ? 0 : Math.min(1, val / (data.bestSlots[0]?.average || val));
-                    const color = `rgba(59,130,246,${intensity})`;
+                    const intensity = maxValue === 0 ? 0 : val / maxValue;
+                    const style = val === 0 ? undefined : { backgroundColor: `rgba(79,70,229,${intensity})` };
                     return (
-                      <td key={b} className="px-2 py-1" style={{ backgroundColor: color }}>
-                        {val.toFixed(0)}
-                      </td>
+                      <td
+                        key={b}
+                        className="px-2 py-1"
+                        style={style}
+                        title={val.toFixed(1)}
+                      />
                     );
                   })}
                 </tr>


### PR DESCRIPTION
## Summary
- make best time slot readable by converting day index to weekday name
- show best day and hour in highlight card with proper format
- normalize heatmap values and color cells by intensity
- hide numbers in heatmap cells, showing exact values on hover

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c7e770a4832e9fee98aa5a87dd86