### PR TITLE
Improve time slot display

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
-import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react';
+import { TrendingUp, TrendingDown, Sparkles, CalendarDays } from 'lucide-react';
 import HighlightCard from './HighlightCard';
 // CORREÇÃO: Importa a função para traduzir os IDs de contexto.
 import { commaSeparatedIdsToLabels } from '../../../lib/classification';
@@ -32,6 +32,27 @@ interface PerformanceSummaryResponse {
 
 interface PlatformPerformanceHighlightsProps {
   sectionTitle?: string;
+}
+
+const DAY_NAMES = [
+  "Domingo",
+  "Segunda-feira",
+  "Terça-feira",
+  "Quarta-feira",
+  "Quinta-feira",
+  "Sexta-feira",
+  "Sábado",
+];
+
+function formatBestTimeSlot(slot: PerformanceSummaryResponse["bestTimeSlot"]): PerformanceHighlightItem | null {
+  if (!slot) return null;
+  const dayName = DAY_NAMES[slot.dayOfWeek] || `Dia ${slot.dayOfWeek}`;
+  return {
+    name: `\uD83D\uDCC5 ${dayName}, ${slot.timeBlock}h`,
+    metricName: "Horário",
+    value: slot.average,
+    valueFormatted: slot.average.toFixed(1),
+  };
 }
 
 const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps> = ({
@@ -132,8 +153,8 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
             />
             <HighlightCard
               title="Melhor Dia e Horário"
-              highlight={summary.bestTimeSlot ? { name: `${summary.bestTimeSlot.timeBlock} (Dia ${summary.bestTimeSlot.dayOfWeek})`, metricName: 'Horário', value: summary.bestTimeSlot.average, valueFormatted: summary.bestTimeSlot.average.toFixed(1) } : null}
-              icon={<TrendingUp size={18} className="mr-2 text-indigo-500"/>}
+              highlight={formatBestTimeSlot(summary.bestTimeSlot)}
+              icon={<CalendarDays size={18} className="mr-2 text-indigo-500"/>}
               bgColorClass="bg-indigo-50"
               textColorClass="text-indigo-600"
             />

--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import {
+  formatCategories,
+  proposalCategories,
+  contextCategories,
+} from "../../../lib/classification";
 
 interface HeatmapCell {
   dayOfWeek: number;
@@ -21,11 +26,33 @@ const BLOCKS = ["0-6", "6-12", "12-18", "18-24"];
 
 interface Props { formatFilter?: string; }
 
+const createOptionsFromCategories = (categories: { id: string; label: string; subcategories?: any[] }[]) => {
+  const opts: { value: string; label: string }[] = [];
+  const traverse = (cats: typeof categories, prefix = '') => {
+    cats.forEach(cat => {
+      const label = prefix ? `${prefix} > ${cat.label}` : cat.label;
+      opts.push({ value: cat.id, label });
+      if (cat.subcategories && cat.subcategories.length) traverse(cat.subcategories, label);
+    });
+  };
+  traverse(categories);
+  return opts;
+};
+
 const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<TimePerformanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [format, setFormat] = useState<string>(formatFilter || "");
+  const [proposal, setProposal] = useState<string>("");
+  const [context, setContext] = useState<string>("");
+  const [metric, setMetric] = useState<string>("interactions");
+
+  const formatOptions = useMemo(() => createOptionsFromCategories(formatCategories), []);
+  const proposalOptions = useMemo(() => createOptionsFromCategories(proposalCategories), []);
+  const contextOptions = useMemo(() => createOptionsFromCategories(contextCategories), []);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -33,7 +60,10 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
     try {
       const params = new URLSearchParams();
       params.set("timePeriod", timePeriod);
-      if (formatFilter) params.set("format", formatFilter);
+      if (format) params.set("format", format);
+      if (proposal) params.set("proposal", proposal);
+      if (context) params.set("context", context);
+      params.set("metric", metric === "rate" ? "engagement_rate" : "interactions");
       const res = await fetch(`/api/v1/platform/performance/time-distribution?${params.toString()}`);
       if (!res.ok) throw new Error(`Erro HTTP ${res.status}`);
       const json: TimePerformanceResponse = await res.json();
@@ -44,7 +74,7 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
     } finally {
       setLoading(false);
     }
-  }, [timePeriod, formatFilter]);
+  }, [timePeriod, format, proposal, context, metric]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
@@ -53,6 +83,8 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
     return cell ? cell.average : 0;
   };
 
+  const maxValue = data?.buckets.reduce((max, c) => Math.max(max, c.average), 0) || 0;
+
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
       <h3 className="text-md font-semibold text-gray-700 mb-4">Análise de Performance por Horário</h3>
@@ -60,6 +92,25 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
       {error && <p className="text-center text-sm text-red-600">Erro: {error}</p>}
       {!loading && !error && data && (
         <div className="overflow-x-auto">
+          <div className="flex flex-wrap gap-2 mb-4 text-xs">
+            <select value={format} onChange={e => setFormat(e.target.value)} className="p-1 border rounded">
+              <option value="">Todos Formatos</option>
+              {formatOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+            <select value={proposal} onChange={e => setProposal(e.target.value)} className="p-1 border rounded">
+              <option value="">Todas Propostas</option>
+              {proposalOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+            <select value={context} onChange={e => setContext(e.target.value)} className="p-1 border rounded">
+              <option value="">Todos Contextos</option>
+              {contextOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+            <select value={metric} onChange={e => setMetric(e.target.value)} className="p-1 border rounded">
+              <option value="interactions">Volume de Engajamento</option>
+              <option value="rate">Taxa de Engajamento</option>
+            </select>
+            <button onClick={fetchData} className="px-2 py-1 border rounded bg-gray-50">Aplicar</button>
+          </div>
           <table className="min-w-full text-center text-xs">
             <thead>
               <tr>
@@ -75,26 +126,46 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
                   <td className="px-2 py-1 font-medium text-gray-600">{d}</td>
                   {BLOCKS.map(b => {
                     const val = getCellValue(idx, b);
-                    const intensity = val === 0 ? 0 : Math.min(1, val / (data.bestSlots[0]?.average || val));
-                    const color = `rgba(59,130,246,${intensity})`;
+                    const intensity = maxValue === 0 ? 0 : val / maxValue;
+                    const style = val === 0 ? undefined : { backgroundColor: `rgba(79,70,229,${intensity})` };
                     return (
-                      <td key={b} className="px-2 py-1" style={{ backgroundColor: color }}>
-                        {val.toFixed(0)}
-                      </td>
+                      <td
+                        key={b}
+                        className="px-2 py-1"
+                        style={style}
+                        title={val.toFixed(1)}
+                      />
                     );
                   })}
                 </tr>
               ))}
             </tbody>
           </table>
-          {data.bestSlots.length > 0 && (
-            <div className="mt-4 text-left text-xs">
-              <p className="font-semibold mb-1">Top Horários:</p>
-              <ul className="list-disc list-inside">
-                {data.bestSlots.slice(0,3).map((s, i) => (
-                  <li key={i}>{DAYS[s.dayOfWeek]} {s.timeBlock} - {s.average.toFixed(1)}</li>
-                ))}
-              </ul>
+          {(data.bestSlots.length > 0 || data.worstSlots.length > 0) && (
+            <div className="mt-4 text-left text-xs space-y-2">
+              {data.bestSlots.length > 0 && (
+                <div>
+                  <p className="font-semibold mb-1">Top Horários:</p>
+                  <ul className="list-disc list-inside">
+                    {data.bestSlots.slice(0,3).map((s, i) => (
+                      <li key={i}>{DAYS[s.dayOfWeek]} {s.timeBlock} - {s.average.toFixed(1)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {data.worstSlots.length > 0 && (
+                <div>
+                  <p className="font-semibold mb-1">Piores Horários:</p>
+                  <ul className="list-disc list-inside">
+                    {data.worstSlots.slice(0,3).map((s, i) => (
+                      <li key={i}>{DAYS[s.dayOfWeek]} {s.timeBlock} - {s.average.toFixed(1)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {data.bestSlots[0] && (
+                <p className="mt-2">Recomendação: priorize postagens em {DAYS[data.bestSlots[0].dayOfWeek]} {data.bestSlots[0].timeBlock}.</p>
+              )}
             </div>
           )}
         </div>

--- a/src/app/api/v1/platform/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.test.ts
@@ -27,6 +27,18 @@ describe('GET /api/v1/platform/performance/time-distribution', () => {
     expect(body.buckets[0].timeBlock).toBe('6-12');
   });
 
+  it('passes filters to aggregation', async () => {
+    mockAgg.mockResolvedValueOnce({ buckets: [], bestSlots: [], worstSlots: [] });
+    await GET(makeRequest('?timePeriod=last_30_days&format=reel&proposal=announcement&context=lifestyle&metric=engagement_rate'));
+    expect(mockAgg).toHaveBeenCalledWith(
+      expect.any(Number),
+      'stats.engagement_rate_on_reach',
+      'reel',
+      'announcement',
+      'lifestyle'
+    );
+  });
+
   it('returns 400 for invalid time period', async () => {
     const res = await GET(makeRequest('?timePeriod=bad'));
     const body = await res.json();

--- a/src/app/api/v1/platform/performance/time-distribution/route.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.ts
@@ -12,6 +12,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const timePeriodParam = searchParams.get('timePeriod');
   const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
 
   const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
     ? timePeriodParam
@@ -22,9 +25,17 @@ export async function GET(request: Request) {
   }
 
   const periodInDaysValue = timePeriodToDays(timePeriod);
-  const metricField = 'stats.total_interactions';
+  const metricField = metricParam === 'engagement_rate'
+    ? 'stats.engagement_rate_on_reach'
+    : 'stats.total_interactions';
 
-  const result = await aggregatePlatformTimePerformance(periodInDaysValue, metricField, formatParam || undefined);
+  const result = await aggregatePlatformTimePerformance(
+    periodInDaysValue,
+    metricField,
+    formatParam || undefined,
+    proposalParam || undefined,
+    contextParam || undefined
+  );
 
   return NextResponse.json(camelizeKeys(result), { status: 200 });
 }

--- a/src/utils/aggregatePlatformTimePerformance.ts
+++ b/src/utils/aggregatePlatformTimePerformance.ts
@@ -21,6 +21,8 @@ export async function aggregatePlatformTimePerformance(
   periodInDays: number,
   metricField: string,
   formatFilter?: string,
+  proposalFilter?: string,
+  contextFilter?: string,
   referenceDate: Date = new Date()
 ): Promise<PlatformTimePerformance> {
   const today = new Date(referenceDate);
@@ -51,6 +53,12 @@ export async function aggregatePlatformTimePerformance(
 
     if (formatFilter) {
       (matchStage.$match as any).format = formatFilter;
+    }
+    if (proposalFilter) {
+      (matchStage.$match as any).proposal = proposalFilter;
+    }
+    if (contextFilter) {
+      (matchStage.$match as any).context = contextFilter;
     }
 
     const pipeline: PipelineStage[] = [


### PR DESCRIPTION
## Summary
- make best time slot readable by converting day index to weekday name and adding a calendar icon
- allow heatmap filtering by format, proposal and context and switch between volume and rate metrics
- color heatmap cells with opacity and show top/worst slots with recommendation
- support new filters on backend time distribution route and aggregation
- test route with new filter parameters

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c7e770a4832e9fee98aa5a87dd86