### PR TITLE
Add advanced time slot filters and highlight improvements

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -3,7 +3,8 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
-import { TrendingUp, TrendingDown, Sparkles } from 'lucide-react';
+import { TrendingUp, TrendingDown, Sparkles, CalendarDays } from 'lucide-react';
+import { getPortugueseWeekdayName } from '@/utils/weekdays';
 import HighlightCard from './HighlightCard';
 // CORREÇÃO: Importa a função para traduzir os IDs de contexto.
 import { commaSeparatedIdsToLabels } from '../../../lib/classification';
@@ -34,21 +35,11 @@ interface PlatformPerformanceHighlightsProps {
   sectionTitle?: string;
 }
 
-const DAY_NAMES = [
-  "Domingo",
-  "Segunda-feira",
-  "Terça-feira",
-  "Quarta-feira",
-  "Quinta-feira",
-  "Sexta-feira",
-  "Sábado",
-];
-
 function formatBestTimeSlot(slot: PerformanceSummaryResponse["bestTimeSlot"]): PerformanceHighlightItem | null {
   if (!slot) return null;
-  const dayName = DAY_NAMES[slot.dayOfWeek] || `Dia ${slot.dayOfWeek}`;
+  const dayName = getPortugueseWeekdayName(slot.dayOfWeek);
   return {
-    name: `${dayName}, ${slot.timeBlock}h`,
+    name: `🗓️ ${dayName}, ${slot.timeBlock}h`,
     metricName: "Horário",
     value: slot.average,
     valueFormatted: slot.average.toFixed(1),
@@ -154,7 +145,7 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
             <HighlightCard
               title="Melhor Dia e Horário"
               highlight={formatBestTimeSlot(summary.bestTimeSlot)}
-              icon={<TrendingUp size={18} className="mr-2 text-indigo-500"/>}
+              icon={<CalendarDays size={18} className="mr-2 text-indigo-500"/>}
               bgColorClass="bg-indigo-50"
               textColorClass="text-indigo-600"
             />

--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -2,6 +2,23 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import { formatCategories, proposalCategories, contextCategories } from "@/app/lib/classification";
+import { getPortugueseWeekdayName } from '@/utils/weekdays';
+
+const createOptionsFromCategories = (categories: any[]) => {
+  const options: { value: string; label: string }[] = [];
+  const traverse = (cats: any[], prefix = '') => {
+    cats.forEach((cat) => {
+      const label = prefix ? `${prefix} > ${cat.label}` : cat.label;
+      options.push({ value: cat.id, label });
+      if (cat.subcategories && cat.subcategories.length) {
+        traverse(cat.subcategories, label);
+      }
+    });
+  };
+  traverse(categories);
+  return options;
+};
 
 interface HeatmapCell {
   dayOfWeek: number;
@@ -19,37 +36,51 @@ interface TimePerformanceResponse {
 const DAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
 const BLOCKS = ["0-6", "6-12", "12-18", "18-24"];
 
-interface Props { formatFilter?: string; }
+const metricOptions = [
+  { value: 'stats.total_interactions', label: 'Volume de Engajamento' },
+  { value: 'stats.engagement_rate_on_reach', label: 'Taxa de Engajamento' },
+];
 
-const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
+const formatOptions = createOptionsFromCategories(formatCategories);
+const proposalOptions = createOptionsFromCategories(proposalCategories);
+const contextOptions = createOptionsFromCategories(contextCategories);
+
+const TimePerformanceHeatmap: React.FC = () => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<TimePerformanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [format, setFormat] = useState('');
+  const [proposal, setProposal] = useState('');
+  const [context, setContext] = useState('');
+  const [metric, setMetric] = useState(metricOptions[0]!.value);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = async () => {
     setLoading(true);
     setError(null);
     try {
       const params = new URLSearchParams();
-      params.set("timePeriod", timePeriod);
-      if (formatFilter) params.set("format", formatFilter);
+      params.set('timePeriod', timePeriod);
+      if (format) params.set('format', format);
+      if (proposal) params.set('proposal', proposal);
+      if (context) params.set('context', context);
+      if (metric) params.set('metric', metric);
       const res = await fetch(`/api/v1/platform/performance/time-distribution?${params.toString()}`);
       if (!res.ok) throw new Error(`Erro HTTP ${res.status}`);
       const json: TimePerformanceResponse = await res.json();
       setData(json);
     } catch (e: any) {
-      setError(e.message || "Erro ao carregar dados");
+      setError(e.message || 'Erro ao carregar dados');
       setData(null);
     } finally {
       setLoading(false);
     }
-  }, [timePeriod, formatFilter]);
+  };
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => { fetchData(); }, [timePeriod]);
 
   const getCellValue = (day: number, block: string) => {
-    const cell = data?.buckets.find(b => b.dayOfWeek === day && b.timeBlock === block);
+    const cell = data?.buckets.find(b => b.dayOfWeek === day + 1 && b.timeBlock === block);
     return cell ? cell.average : 0;
   };
 
@@ -58,6 +89,49 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
       <h3 className="text-md font-semibold text-gray-700 mb-4">Análise de Performance por Horário</h3>
+
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mb-4">
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">Formato</label>
+          <select value={format} onChange={(e) => setFormat(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-xs">
+            <option value="">Todos</option>
+            {formatOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">Proposta</label>
+          <select value={proposal} onChange={(e) => setProposal(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-xs">
+            <option value="">Todas</option>
+            {proposalOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">Contexto</label>
+          <select value={context} onChange={(e) => setContext(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-xs">
+            <option value="">Todos</option>
+            {contextOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">Métrica</label>
+          <select value={metric} onChange={(e) => setMetric(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-xs">
+            {metricOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="mb-4 text-right">
+        <button onClick={fetchData} className="px-3 py-1 text-xs font-semibold text-white bg-indigo-600 rounded">Aplicar</button>
+      </div>
+
       {loading && <p className="text-center text-sm">Carregando...</p>}
       {error && <p className="text-center text-sm text-red-600">Erro: {error}</p>}
       {!loading && !error && data && (
@@ -92,14 +166,29 @@ const TimePerformanceHeatmap: React.FC<Props> = ({ formatFilter }) => {
               ))}
             </tbody>
           </table>
-          {data.bestSlots.length > 0 && (
-            <div className="mt-4 text-left text-xs">
-              <p className="font-semibold mb-1">Top Horários:</p>
-              <ul className="list-disc list-inside">
-                {data.bestSlots.slice(0,3).map((s, i) => (
-                  <li key={i}>{DAYS[s.dayOfWeek]} {s.timeBlock} - {s.average.toFixed(1)}</li>
-                ))}
-              </ul>
+          {(data.bestSlots.length > 0 || data.worstSlots.length > 0) && (
+            <div className="mt-4 text-left text-xs space-y-2">
+              {data.bestSlots.length > 0 && (
+                <div>
+                  <p className="font-semibold mb-1">Melhores Horários:</p>
+                  <ul className="list-disc list-inside">
+                    {data.bestSlots.slice(0,3).map((s, i) => (
+                      <li key={i}>{getPortugueseWeekdayName(s.dayOfWeek)} {s.timeBlock} - {s.average.toFixed(1)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {data.worstSlots.length > 0 && (
+                <div>
+                  <p className="font-semibold mb-1">Piores Horários:</p>
+                  <ul className="list-disc list-inside">
+                    {data.worstSlots.slice(0,3).map((s, i) => (
+                      <li key={i}>{getPortugueseWeekdayName(s.dayOfWeek)} {s.timeBlock} - {s.average.toFixed(1)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <p className="mt-2">Recomendação: priorize os melhores horários e evite os piores.</p>
             </div>
           )}
         </div>

--- a/src/app/api/v1/platform/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.test.ts
@@ -19,11 +19,15 @@ describe('GET /api/v1/platform/performance/time-distribution', () => {
       worstSlots: [],
     });
 
-    const res = await GET(makeRequest('?timePeriod=last_30_days'));
+    const res = await GET(makeRequest('?timePeriod=last_30_days&format=reel&metric=stats.total_interactions'));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockAgg).toHaveBeenCalled();
+    expect(mockAgg).toHaveBeenCalledWith(30, 'stats.total_interactions', {
+      format: 'reel',
+      proposal: undefined,
+      context: undefined,
+    }, expect.any(Date));
     expect(body.buckets[0].timeBlock).toBe('6-12');
   });
 

--- a/src/app/api/v1/platform/performance/time-distribution/route.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.ts
@@ -12,6 +12,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const timePeriodParam = searchParams.get('timePeriod');
   const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
 
   const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
     ? timePeriodParam
@@ -22,9 +25,13 @@ export async function GET(request: Request) {
   }
 
   const periodInDaysValue = timePeriodToDays(timePeriod);
-  const metricField = 'stats.total_interactions';
+  const metricField = metricParam || 'stats.total_interactions';
 
-  const result = await aggregatePlatformTimePerformance(periodInDaysValue, metricField, formatParam || undefined);
+  const result = await aggregatePlatformTimePerformance(periodInDaysValue, metricField, {
+    format: formatParam || undefined,
+    proposal: proposalParam || undefined,
+    context: contextParam || undefined,
+  });
 
   return NextResponse.json(camelizeKeys(result), { status: 200 });
 }

--- a/src/utils/__tests__/aggregatePlatformTimePerformance.test.ts
+++ b/src/utils/__tests__/aggregatePlatformTimePerformance.test.ts
@@ -26,7 +26,7 @@ describe('aggregatePlatformTimePerformance', () => {
       { _id: { dayOfWeek: 1, timeBlock: '6-12' }, avg: 5, count: 3 },
     ]);
 
-    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions');
+    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions', {});
     expect(mockConnect).toHaveBeenCalled();
     expect(mockAgg).toHaveBeenCalled();
     expect(res.buckets.length).toBe(3);
@@ -36,8 +36,16 @@ describe('aggregatePlatformTimePerformance', () => {
 
   it('handles empty aggregation', async () => {
     mockAgg.mockResolvedValueOnce([]);
-    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions');
+    const res = await aggregatePlatformTimePerformance(30, 'stats.total_interactions', {});
     expect(res.buckets).toEqual([]);
     expect(res.bestSlots).toEqual([]);
+  });
+
+  it('passes filters to aggregation', async () => {
+    mockAgg.mockResolvedValueOnce([]);
+    await aggregatePlatformTimePerformance(7, 'stats.total_interactions', { format: 'reel', context: 'tech' });
+    const pipeline = mockAgg.mock.calls[0][0];
+    expect(pipeline[0].$match.format).toBe('reel');
+    expect(pipeline[0].$match.context).toBe('tech');
   });
 });

--- a/src/utils/aggregatePlatformTimePerformance.ts
+++ b/src/utils/aggregatePlatformTimePerformance.ts
@@ -17,10 +17,16 @@ export interface PlatformTimePerformance {
   worstSlots: TimeBucket[];
 }
 
+export interface PerformanceFilters {
+  format?: string;
+  proposal?: string;
+  context?: string;
+}
+
 export async function aggregatePlatformTimePerformance(
   periodInDays: number,
   metricField: string,
-  formatFilter?: string,
+  filters: PerformanceFilters = {},
   referenceDate: Date = new Date()
 ): Promise<PlatformTimePerformance> {
   const today = new Date(referenceDate);
@@ -49,8 +55,14 @@ export async function aggregatePlatformTimePerformance(
       },
     };
 
-    if (formatFilter) {
-      (matchStage.$match as any).format = formatFilter;
+    if (filters.format) {
+      (matchStage.$match as any).format = filters.format;
+    }
+    if (filters.proposal) {
+      (matchStage.$match as any).proposal = filters.proposal;
+    }
+    if (filters.context) {
+      (matchStage.$match as any).context = filters.context;
     }
 
     const pipeline: PipelineStage[] = [

--- a/src/utils/weekdays.ts
+++ b/src/utils/weekdays.ts
@@ -1,0 +1,14 @@
+export function getPortugueseWeekdayName(day: number): string {
+  const names = [
+    'Domingo',
+    'Segunda-feira',
+    'Terça-feira',
+    'Quarta-feira',
+    'Quinta-feira',
+    'Sexta-feira',
+    'Sábado',
+  ];
+  if (day >= 0 && day <= 6) return names[day];
+  if (day >= 1 && day <= 7) return names[day - 1];
+  return `Dia ${day}`;
+}


### PR DESCRIPTION
## Summary
- show best time slot with weekday helper and emoji
- add calendar icon to highlight card
- allow metric, format, context and proposal filters on time performance heatmap
- display best/worst slot summaries with recommendation
- extend backend time-distribution endpoint with new parameters
- support filters in aggregation util
- update related tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ccaf9f5c832ea60ceb1531d52218