### PR TITLE
Add interactive heatmap with post volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Documentação
 
-Consulte o diretório `docs` para informações adicionais, incluindo o [plano de expanção dos rankings](docs/ranking-expansion.md).
+Consulte o diretório `docs` para informações adicionais, incluindo o [plano de expanção dos rankings](docs/ranking-expansion.md) e o [plano de otimização estratégica v4](docs/plano-de-otimizacao-estrategica-v4.md).
 
 
 ## Deploy on Vercel

--- a/docs/plano-de-otimizacao-estrategica-v4.md
+++ b/docs/plano-de-otimizacao-estrategica-v4.md
@@ -1,0 +1,19 @@
+# Plano de Otimização Estratégica (Versão 4.0)
+
+Esta versão evolui a "Análise de Performance por Horário" para torná‑la interativa e contextual.
+
+## 1. Heatmap com Volume de Posts
+
+O tooltip de cada célula do heatmap exibe o engajamento médio e o número de posts considerados. Assim o usuário entende se o bom desempenho é consistente ou fruto de um post isolado.
+
+Exemplo: `Engajamento Médio: 786k (n=5 posts)`.
+
+## 2. Exploração de Posts por Horário
+
+Cada célula do heatmap é clicável. Ao clicar, abre‑se um modal listando os principais posts daquele dia e bloco de horário. Isso conecta o insight ao conteúdo real.
+
+## 3. Recomendação Dinâmica
+
+O endpoint do heatmap retorna um resumo textual contextualizado com os filtros ativos. A recomendação apresentada abaixo da tabela agora reflete esses filtros, indicando melhores e piores horários de forma personalizada.
+
+Com essas melhorias a análise de horário deixa de ser estática e passa a orientar ações práticas com base no conteúdo que gerou os resultados.

--- a/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
+++ b/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
@@ -1,0 +1,87 @@
+"use client";
+import React, { useEffect, useState } from 'react';
+import { getPortugueseWeekdayName } from '@/utils/weekdays';
+
+interface TimeSlotTopPostsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  dayOfWeek: number;
+  timeBlock: string;
+  filters: { timePeriod: string; format?: string; proposal?: string; context?: string; metric: string };
+}
+
+interface PostItem {
+  _id: string;
+  description?: string;
+  postLink?: string;
+  coverUrl?: string;
+  metricValue: number;
+}
+
+const TimeSlotTopPostsModal: React.FC<TimeSlotTopPostsModalProps> = ({ isOpen, onClose, dayOfWeek, timeBlock, filters }) => {
+  const [posts, setPosts] = useState<PostItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const fetchPosts = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({
+          dayOfWeek: String(dayOfWeek),
+          timeBlock,
+          timePeriod: filters.timePeriod,
+          metric: filters.metric,
+        });
+        if (filters.format) params.append('format', filters.format);
+        if (filters.proposal) params.append('proposal', filters.proposal);
+        if (filters.context) params.append('context', filters.context);
+        const res = await fetch(`/api/v1/platform/performance/time-distribution/posts?${params.toString()}`);
+        if (!res.ok) throw new Error(`Erro HTTP ${res.status}`);
+        const json = await res.json();
+        setPosts(json.posts || []);
+      } catch (e: any) {
+        setError(e.message || 'Erro ao carregar posts');
+        setPosts([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPosts();
+  }, [isOpen, dayOfWeek, timeBlock, filters]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white w-full max-w-md rounded-lg shadow-lg relative p-4 space-y-3 max-h-[80vh] overflow-y-auto">
+        <button onClick={onClose} className="absolute top-2 right-2 text-gray-500" aria-label="Fechar">x</button>
+        <h4 className="text-sm font-semibold">
+          Top Posts: {getPortugueseWeekdayName(dayOfWeek)} ({timeBlock}h)
+        </h4>
+        {loading && <p className="text-sm">Carregando...</p>}
+        {error && <p className="text-sm text-red-600">Erro: {error}</p>}
+        {!loading && !error && posts.length === 0 && <p className="text-sm">Nenhum post encontrado.</p>}
+        {!loading && !error && posts.length > 0 && (
+          <ul className="space-y-2 text-sm">
+            {posts.map((p) => (
+              <li key={p._id} className="border-b pb-1">
+                {p.coverUrl && (
+                  <img src={p.coverUrl} alt="capa" className="w-full h-32 object-cover rounded mb-1" />
+                )}
+                <a href={p.postLink} target="_blank" rel="noopener" className="font-medium text-indigo-600 hover:underline">
+                  {p.description || p.postLink || 'Post'}
+                </a>
+                <div className="text-gray-600">{p.metricValue.toLocaleString('pt-BR')}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TimeSlotTopPostsModal;

--- a/src/app/api/v1/platform/performance/time-distribution/posts/route.test.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/posts/route.test.ts
@@ -1,0 +1,35 @@
+import { GET } from './route';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = MetricModel.aggregate as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+const makeRequest = (search = '') => new NextRequest(`http://localhost/api/v1/platform/performance/time-distribution/posts${search}`);
+
+describe('GET /api/v1/platform/performance/time-distribution/posts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('returns posts list', async () => {
+    mockAgg.mockResolvedValueOnce([{ _id: 'p1', metricValue: 10 }]);
+
+    const res = await GET(makeRequest('?dayOfWeek=1&timeBlock=6-12&timePeriod=last_30_days'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalled();
+    expect(body.posts[0].metricValue).toBe(10);
+  });
+});

--- a/src/app/api/v1/platform/performance/time-distribution/posts/route.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/posts/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from 'next/server';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+
+export const dynamic = 'force-dynamic';
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const format = searchParams.get('format') || undefined;
+  const proposal = searchParams.get('proposal') || undefined;
+  const context = searchParams.get('context') || undefined;
+  const metric = searchParams.get('metric') || 'stats.total_interactions';
+  const dayOfWeek = parseInt(searchParams.get('dayOfWeek') || '', 10);
+  const timeBlock = searchParams.get('timeBlock');
+  const limit = parseInt(searchParams.get('limit') || '5', 10);
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  if (!dayOfWeek || !timeBlock) {
+    return NextResponse.json({ error: 'Parâmetros dayOfWeek e timeBlock são obrigatórios.' }, { status: 400 });
+  }
+
+  try {
+    await connectToDatabase();
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+    const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+    const match: any = {
+      postDate: { $gte: startDate, $lte: endDate },
+    };
+    if (format) match.format = format;
+    if (proposal) match.proposal = proposal;
+    if (context) match.context = context;
+
+    const pipeline: any[] = [
+      { $match: match },
+      {
+        $addFields: {
+          dayOfWeek: { $dayOfWeek: '$postDate' },
+          hour: { $hour: '$postDate' },
+        },
+      },
+      {
+        $addFields: {
+          timeBlock: {
+            $switch: {
+              branches: [
+                { case: { $lte: ['$hour', 5] }, then: '0-6' },
+                { case: { $lte: ['$hour', 11] }, then: '6-12' },
+                { case: { $lte: ['$hour', 17] }, then: '12-18' },
+                { case: { $lte: ['$hour', 23] }, then: '18-24' },
+              ],
+              default: 'unknown',
+            },
+          },
+        },
+      },
+      { $match: { dayOfWeek, timeBlock } },
+      {
+        $project: {
+          description: 1,
+          postLink: 1,
+          coverUrl: 1,
+          metricValue: `$${metric}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      { $sort: { metricValue: -1 } },
+      { $limit: limit },
+    ];
+
+    const posts = await MetricModel.aggregate(pipeline).exec();
+
+    return NextResponse.json({ posts }, { status: 200 });
+  } catch (error: any) {
+    console.error('[API PLATFORM/TIME-DISTRIBUTION/POSTS] Error:', error);
+    return NextResponse.json({ error: 'Erro ao buscar posts.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/platform/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.test.ts
@@ -15,8 +15,8 @@ describe('GET /api/v1/platform/performance/time-distribution', () => {
   it('returns aggregated data', async () => {
     mockAgg.mockResolvedValueOnce({
       buckets: [{ dayOfWeek: 1, timeBlock: '6-12', average: 10, count: 2 }],
-      bestSlots: [],
-      worstSlots: [],
+      bestSlots: [{ dayOfWeek: 1, timeBlock: '6-12', average: 10, count: 2 }],
+      worstSlots: [{ dayOfWeek: 2, timeBlock: '0-6', average: 1, count: 1 }],
     });
 
     const res = await GET(makeRequest('?timePeriod=last_30_days&format=reel&metric=stats.total_interactions'));
@@ -29,6 +29,7 @@ describe('GET /api/v1/platform/performance/time-distribution', () => {
       context: undefined,
     }, expect.any(Date));
     expect(body.buckets[0].timeBlock).toBe('6-12');
+    expect(body.insightSummary).toContain('pico de engajamento');
   });
 
   it('returns 400 for invalid time period', async () => {


### PR DESCRIPTION
## Summary
- add doc for optimization plan v4
- link doc from README
- include insight summary in time distribution API
- expose posts for specific time slots
- create modal to show top posts for heatmap cells
- make heatmap cells clickable with post volume tooltip
- update tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d54c0e1c832e9a2b8f455eb29fc5