### PR TITLE
Use average engagement per post for time slots

### DIFF
--- a/src/utils/aggregatePlatformTimePerformance.ts
+++ b/src/utils/aggregatePlatformTimePerformance.ts
@@ -93,8 +93,19 @@ export async function aggregatePlatformTimePerformance(
       {
         $group: {
           _id: { dayOfWeek: "$dayOfWeek", timeBlock: "$timeBlock" },
-          avg: { $avg: "$metricValue" },
+          total: { $sum: "$metricValue" },
           count: { $sum: 1 },
+        },
+      },
+      {
+        $addFields: {
+          avg: {
+            $cond: {
+              if: { $eq: ["$count", 0] },
+              then: 0,
+              else: { $divide: ["$total", "$count"] },
+            },
+          },
         },
       },
       { $sort: { avg: -1 } },


### PR DESCRIPTION
## Summary
- calculate total interactions and derive the average per post when aggregating platform time performance

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a00591100832eb6c7d5bb29931215