### PR TITLE
Implement best day highlight

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -27,7 +27,7 @@ interface PerformanceSummaryResponse {
   topPerformingProposal: PerformanceHighlightItem | null;
   topPerformingTone: PerformanceHighlightItem | null;
   topPerformingReference: PerformanceHighlightItem | null;
-  bestTimeSlot: { dayOfWeek: number; timeBlock: string; average: number } | null;
+  bestDay: { dayOfWeek: number; average: number } | null;
   insightSummary: string;
 }
 
@@ -35,12 +35,12 @@ interface PlatformPerformanceHighlightsProps {
   sectionTitle?: string;
 }
 
-function formatBestTimeSlot(slot: PerformanceSummaryResponse["bestTimeSlot"]): PerformanceHighlightItem | null {
+function formatBestDay(slot: PerformanceSummaryResponse["bestDay"]): PerformanceHighlightItem | null {
   if (!slot) return null;
   const dayName = getPortugueseWeekdayName(slot.dayOfWeek);
   return {
-    name: `🗓️ ${dayName}, ${slot.timeBlock}h`,
-    metricName: "Horário",
+    name: `🗓️ ${dayName}`,
+    metricName: "Interações",
     value: slot.average,
     valueFormatted: slot.average.toFixed(1),
   };
@@ -143,8 +143,8 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
               textColorClass="text-teal-600"
             />
             <HighlightCard
-              title="Melhor Dia e Horário"
-              highlight={formatBestTimeSlot(summary.bestTimeSlot)}
+              title="Melhor Dia"
+              highlight={formatBestDay(summary.bestDay)}
               icon={<CalendarDays size={18} className="mr-2 text-indigo-500"/>}
               bgColorClass="bg-indigo-50"
               textColorClass="text-indigo-600"

--- a/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.test.ts
@@ -1,13 +1,13 @@
 import { GET } from './route';
 import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
-import aggregatePlatformTimePerformance from '@/utils/aggregatePlatformTimePerformance';
+import aggregatePlatformDayPerformance from '@/utils/aggregatePlatformDayPerformance';
 import { NextRequest } from 'next/server';
 
 jest.mock('@/utils/aggregatePlatformPerformanceHighlights');
-jest.mock('@/utils/aggregatePlatformTimePerformance');
+jest.mock('@/utils/aggregatePlatformDayPerformance');
 
 const mockAgg = aggregatePlatformPerformanceHighlights as jest.Mock;
-const mockTimeAgg = aggregatePlatformTimePerformance as jest.Mock;
+const mockDayAgg = aggregatePlatformDayPerformance as jest.Mock;
 
 const makeRequest = (search = '') => new NextRequest(`http://localhost/api/v1/platform/highlights/performance-summary${search}`);
 
@@ -25,10 +25,10 @@ describe('GET /api/v1/platform/highlights/performance-summary', () => {
       topTone: { name: 'humor', average: 7, count: 2 },
       topReference: { name: 'pop_culture', average: 6, count: 3 },
     });
-    mockTimeAgg.mockResolvedValueOnce({
+    mockDayAgg.mockResolvedValueOnce({
       buckets: [],
-      bestSlots: [{ dayOfWeek: 5, timeBlock: '18-24', average: 12, count: 4 }],
-      worstSlots: [],
+      bestDays: [{ dayOfWeek: 5, average: 12, count: 4 }],
+      worstDays: [],
     });
 
     const res = await GET(makeRequest('?timePeriod=last_30_days'));
@@ -36,14 +36,14 @@ describe('GET /api/v1/platform/highlights/performance-summary', () => {
 
     expect(res.status).toBe(200);
     expect(mockAgg).toHaveBeenCalled();
-    expect(mockTimeAgg).toHaveBeenCalled();
+    expect(mockDayAgg).toHaveBeenCalled();
     expect(body.topPerformingFormat.name).toBe('VIDEO');
     expect(body.lowPerformingFormat.name).toBe('IMAGE');
     expect(body.topPerformingContext.name).toBe('FEED');
     expect(body.topPerformingProposal.name).toBe('educational');
     expect(body.topPerformingTone.name).toBe('humor');
     expect(body.topPerformingReference.name).toBe('pop_culture');
-    expect(body.bestTimeSlot.timeBlock).toBe('18-24');
+    expect(body.bestDay.dayOfWeek).toBe(5);
   });
 
   it('returns 400 for invalid timePeriod', async () => {
@@ -52,5 +52,6 @@ describe('GET /api/v1/platform/highlights/performance-summary', () => {
     expect(res.status).toBe(400);
     expect(body.error).toContain('Time period inválido');
     expect(mockAgg).not.toHaveBeenCalled();
+    expect(mockDayAgg).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/__tests__/aggregatePlatformDayPerformance.test.ts
+++ b/src/utils/__tests__/aggregatePlatformDayPerformance.test.ts
@@ -1,0 +1,51 @@
+import aggregatePlatformDayPerformance from '../aggregatePlatformDayPerformance';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = MetricModel.aggregate as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+describe('aggregatePlatformDayPerformance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('aggregates and sorts day buckets', async () => {
+    mockAgg.mockResolvedValueOnce([
+      { _id: 2, avg: 15, count: 4 },
+      { _id: 5, avg: 10, count: 2 },
+      { _id: 1, avg: 5, count: 3 },
+    ]);
+
+    const res = await aggregatePlatformDayPerformance(30, 'stats.total_interactions', {});
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockAgg).toHaveBeenCalled();
+    expect(res.buckets.length).toBe(3);
+    expect(res.bestDays[0].average).toBe(15);
+    expect(res.worstDays[0].average).toBe(5);
+  });
+
+  it('handles empty aggregation', async () => {
+    mockAgg.mockResolvedValueOnce([]);
+    const res = await aggregatePlatformDayPerformance(30, 'stats.total_interactions', {});
+    expect(res.buckets).toEqual([]);
+    expect(res.bestDays).toEqual([]);
+  });
+
+  it('passes filters to aggregation', async () => {
+    mockAgg.mockResolvedValueOnce([]);
+    await aggregatePlatformDayPerformance(7, 'stats.total_interactions', { format: 'reel', context: 'tech' });
+    const pipeline = mockAgg.mock.calls[0][0];
+    expect(pipeline[0].$match.format).toBe('reel');
+    expect(pipeline[0].$match.context).toBe('tech');
+  });
+});

--- a/src/utils/aggregatePlatformDayPerformance.ts
+++ b/src/utils/aggregatePlatformDayPerformance.ts
@@ -1,0 +1,114 @@
+import MetricModel from "@/app/models/Metric";
+import { PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface DayBucket {
+  dayOfWeek: number;
+  average: number;
+  count: number;
+}
+
+export interface PlatformDayPerformance {
+  buckets: DayBucket[];
+  bestDays: DayBucket[];
+  worstDays: DayBucket[];
+}
+
+export interface PerformanceFilters {
+  format?: string;
+  proposal?: string;
+  context?: string;
+}
+
+export async function aggregatePlatformDayPerformance(
+  periodInDays: number,
+  metricField: string,
+  filters: PerformanceFilters = {},
+  referenceDate: Date = new Date()
+): Promise<PlatformDayPerformance> {
+  const today = new Date(referenceDate);
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const result: PlatformDayPerformance = { buckets: [], bestDays: [], worstDays: [] };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    if (filters.format) {
+      (matchStage.$match as any).format = { $regex: `^${filters.format}$`, $options: 'i' };
+    }
+    if (filters.proposal) {
+      (matchStage.$match as any).proposal = { $regex: `^${filters.proposal}$`, $options: 'i' };
+    }
+    if (filters.context) {
+      (matchStage.$match as any).context = { $regex: `^${filters.context}$`, $options: 'i' };
+    }
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      {
+        $project: {
+          dayOfWeek: { $dayOfWeek: "$postDate" },
+          metricValue: `$${metricField}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      {
+        $group: {
+          _id: "$dayOfWeek",
+          total: { $sum: "$metricValue" },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $addFields: {
+          avg: {
+            $cond: {
+              if: { $eq: ["$count", 0] },
+              then: 0,
+              else: { $divide: ["$total", "$count"] },
+            },
+          },
+        },
+      },
+      { $sort: { avg: -1 } },
+    ];
+
+    const agg = await MetricModel.aggregate(pipeline);
+    result.buckets = agg.map((d: any) => ({
+      dayOfWeek: d._id,
+      average: d.avg,
+      count: d.count,
+    }));
+
+    result.bestDays = result.buckets.slice(0, 3);
+    result.worstDays = result.buckets.slice(-3).reverse();
+
+    return result;
+  } catch (error) {
+    logger.error("Error in aggregatePlatformDayPerformance:", error);
+    return result;
+  }
+}
+
+export default aggregatePlatformDayPerformance;


### PR DESCRIPTION
## Summary
- add `aggregatePlatformDayPerformance` helper to compute best day of week
- update performance highlights API to return best day
- update dashboard component to show *Melhor Dia*
- test new helper and API changes
- fix metric label for best day highlight

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686a99cd7420832e8650d104e1a279c6