### PR TITLE
Fix metric label for best day performance card

### DIFF
--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -40,7 +40,8 @@ function formatBestDay(slot: PerformanceSummaryResponse["bestDay"]): Performance
   const dayName = getPortugueseWeekdayName(slot.dayOfWeek);
   return {
     name: `🗓️ ${dayName}`,
-    metricName: "Dia",
+    // Exibir claramente que o valor representa a média de interações
+    metricName: "Interações (média)",
     value: slot.average,
     valueFormatted: slot.average.toFixed(1),
   };


### PR DESCRIPTION
## Summary
- show the average number of interactions on the "Melhor Dia" card

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9ec6bafc832e9a371a582c636892