### PR TITLE
Reorder Creator Dashboard sections

### DIFF
--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -184,18 +184,18 @@ const AdminCreatorDashboardContent: React.FC = () => {
                 rankingDateRange={rankingDateRange}
                 rankingDateLabel={rankingDateLabel}
               />
-              
-              {/* 2. Top Movers (Abaixo do Ranking) */}
-              <TopMoversSection />
 
-              {/* 3. Análise de Conteúdo */}
+              {/* 2. Destaques e Análise por Horário */}
               <PlatformContentAnalysisSection
                 startDate={startDate}
                 endDate={endDate}
               />
-              
-              {/* 4. Visão Geral da Plataforma */}
+
+              {/* 3. Visão Geral da Plataforma */}
               <PlatformOverviewSection />
+
+              {/* 4. Top Movers */}
+              <TopMoversSection />
 
               {/* 5. Explorador de Posts (Final) */}
               <section id="global-posts-explorer" className="mt-8">


### PR DESCRIPTION
## Summary
- rearrange the section order in `creator-dashboard/page.tsx` so performance highlights and heatmap appear right after the rankings
- move the Top Movers block to follow the platform overview

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa14973f8832ea7bccf099bfb9345