### PR TITLE
Clarify highlights use average interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Basta fornecer o `userId` ao componente e ele renderizará um gráfico de coluna
 
 ### Platform Performance Highlights
 
-Na seção **Destaques de Performance da Plataforma** todo o resumo de conteúdo é consolidado em um único bloco. Os cards indicam o melhor e pior formato, além das propostas, tons e referências de maior desempenho. Logo abaixo, a tabela **Ranking de Desempenho por Formato** apresenta os dados completos e oferece acesso a uma análise detalhada.
+Na seção **Destaques de Performance da Plataforma** todo o resumo de conteúdo é consolidado em um único bloco. Os cards indicam o melhor e pior formato, além das propostas, tons e referências de maior desempenho. Todas as métricas exibidas representam a **média de interações por post**, acompanhadas do volume de publicações avaliadas. Logo abaixo, a tabela **Ranking de Desempenho por Formato** apresenta os dados completos e oferece acesso a uma análise detalhada.
 
 ### Populando o Banco para Desenvolvimento
 

--- a/src/app/api/v1/platform/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.ts
@@ -36,7 +36,10 @@ interface PlatformPerformanceSummaryResponse {
   insightSummary: string;
 }
 
-const DEFAULT_PERFORMANCE_METRIC_LABEL = "Interações Totais";
+// Use "Interações (média por post)" para deixar claro que os valores
+// retornados representam a média de interações por publicação, não o total
+// acumulado.
+const DEFAULT_PERFORMANCE_METRIC_LABEL = "Interações (média por post)";
 
 // Helpers
 function formatPerformanceValue(value: number, metricFieldId: string): string {

--- a/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/users/[userId]/highlights/performance-summary/route.ts
@@ -35,7 +35,9 @@ interface PerformanceSummaryResponse {
 }
 
 const DEFAULT_PERFORMANCE_METRIC = "stats.total_interactions";
-const DEFAULT_PERFORMANCE_METRIC_LABEL = "Interações Totais"; // Para o insightSummary
+// Indica explicitamente que os destaques utilizam a média por post,
+// evitando interpretações equivocadas sobre valores acumulados.
+const DEFAULT_PERFORMANCE_METRIC_LABEL = "Interações (média por post)"; // Para o insightSummary
 
 // --- Função de verificação de tipo (Type Guard) ---
 function isAllowedTimePeriod(period: any): period is TimePeriod {


### PR DESCRIPTION
## Summary
- clarify in documentation that platform highlight metrics display average interactions per post
- update platform and user highlight APIs to label metrics as average interactions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abe9c57d8832ea989beaf212bf2ae