### PR TITLE
Add user time performance heatmap

### DIFF
--- a/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
+++ b/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
@@ -8,6 +8,7 @@ interface TimeSlotTopPostsModalProps {
   dayOfWeek: number;
   timeBlock: string;
   filters: { timePeriod: string; format?: string; proposal?: string; context?: string; metric: string };
+  userId?: string;
 }
 
 interface PostItem {
@@ -18,7 +19,7 @@ interface PostItem {
   metricValue: number;
 }
 
-const TimeSlotTopPostsModal: React.FC<TimeSlotTopPostsModalProps> = ({ isOpen, onClose, dayOfWeek, timeBlock, filters }) => {
+const TimeSlotTopPostsModal: React.FC<TimeSlotTopPostsModalProps> = ({ isOpen, onClose, dayOfWeek, timeBlock, filters, userId }) => {
   const [posts, setPosts] = useState<PostItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,7 +39,10 @@ const TimeSlotTopPostsModal: React.FC<TimeSlotTopPostsModalProps> = ({ isOpen, o
         if (filters.format) params.append('format', filters.format);
         if (filters.proposal) params.append('proposal', filters.proposal);
         if (filters.context) params.append('context', filters.context);
-        const res = await fetch(`/api/v1/platform/performance/time-distribution/posts?${params.toString()}`);
+        const base = userId
+          ? `/api/v1/users/${userId}/performance/time-distribution/posts`
+          : '/api/v1/platform/performance/time-distribution/posts';
+        const res = await fetch(`${base}?${params.toString()}`);
         if (!res.ok) throw new Error(`Erro HTTP ${res.status}`);
         const json = await res.json();
         setPosts(json.posts || []);

--- a/src/app/admin/creator-dashboard/components/UserTimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/UserTimePerformanceHeatmap.tsx
@@ -1,0 +1,298 @@
+/*
+================================================================================
+Componente: UserTimePerformanceHeatmap
+Função    : Heatmap de horários filtrado por usuário.
+Derivado  do TimePerformanceHeatmap.tsx original.
+================================================================================
+*/
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useGlobalTimePeriod } from "./filters/GlobalTimePeriodContext";
+import { formatCategories, proposalCategories, contextCategories } from "@/app/lib/classification";
+import TimeSlotTopPostsModal from './TimeSlotTopPostsModal';
+import { LightBulbIcon, CalendarDaysIcon, ChartBarIcon } from '@heroicons/react/24/solid';
+
+// --- Funções Auxiliares ---
+
+const getPortugueseWeekdayNameForList = (day: number): string => {
+    switch (day) {
+        case 1: return 'Domingo';
+        case 2: return 'Segunda';
+        case 3: return 'Terça';
+        case 4: return 'Quarta';
+        case 5: return 'Quinta';
+        case 6: return 'Sexta';
+        case 7: return 'Sábado';
+        default: return '';
+    }
+};
+
+// CORREÇÃO: Função auxiliar para converter a hora de volta para o formato de bloco.
+const hourToTimeBlock = (hour: number): string => {
+    if (hour <= 5) return "0-6";
+    if (hour <= 11) return "6-12";
+    if (hour <= 17) return "12-18";
+    return "18-24";
+};
+
+const createOptionsFromCategories = (categories: any[]) => {
+  const options: { value: string; label: string }[] = [];
+  const traverse = (cats: any[], prefix = '') => {
+    cats.forEach((cat) => {
+      const label = prefix ? `${prefix} > ${cat.label}` : cat.label;
+      options.push({ value: cat.id, label });
+      if (cat.subcategories && cat.subcategories.length) {
+        traverse(cat.subcategories, label);
+      }
+    });
+  };
+  traverse(categories);
+  return options;
+};
+
+const SkeletonLoader = () => (
+    <div className="animate-pulse">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4 p-4 bg-gray-50 rounded-lg border">
+            <div className="h-10 bg-gray-200 rounded-md"></div>
+            <div className="h-10 bg-gray-200 rounded-md"></div>
+            <div className="h-10 bg-gray-200 rounded-md"></div>
+            <div className="h-10 bg-gray-200 rounded-md"></div>
+        </div>
+        <div className="h-64 bg-gray-200 rounded-lg"></div>
+        <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="h-24 bg-gray-200 rounded-lg"></div>
+            <div className="h-24 bg-gray-200 rounded-lg"></div>
+        </div>
+    </div>
+);
+
+const EmptyState = ({ message }: { message: string }) => (
+    <div className="text-center py-10">
+        <ChartBarIcon className="mx-auto h-12 w-12 text-gray-300" />
+        <h3 className="mt-2 text-sm font-semibold text-gray-800">Nenhum dado encontrado</h3>
+        <p className="mt-1 text-sm text-gray-500">{message}</p>
+    </div>
+);
+
+
+// --- Tipos e Constantes ---
+interface HeatmapCell {
+  dayOfWeek: number;
+  hour: number;
+  average: number;
+  count: number;
+}
+
+interface TimePerformanceResponse {
+  buckets: HeatmapCell[];
+  bestSlots: HeatmapCell[];
+  worstSlots: HeatmapCell[];
+  insightSummary?: string;
+}
+
+const DAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+const metricOptions = [
+  { value: 'stats.total_interactions', label: 'Média de Engajamento por Post' },
+  { value: 'stats.engagement_rate_on_reach', label: 'Taxa de Engajamento Média' },
+];
+
+const formatOptions = createOptionsFromCategories(formatCategories);
+const proposalOptions = createOptionsFromCategories(proposalCategories);
+const contextOptions = createOptionsFromCategories(contextCategories);
+
+// --- Componente Principal ---
+interface UserTimePerformanceHeatmapProps {
+  userId: string | null;
+}
+
+const UserTimePerformanceHeatmap: React.FC<UserTimePerformanceHeatmapProps> = ({ userId }) => {
+  const { timePeriod } = useGlobalTimePeriod();
+  const [data, setData] = useState<TimePerformanceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  
+  const [format, setFormat] = useState('');
+  const [proposal, setProposal] = useState('');
+  const [context, setContext] = useState('');
+  const [metric, setMetric] = useState(metricOptions[0]!.value);
+  
+  const [selectedSlot, setSelectedSlot] = useState<{ dayOfWeek: number; hour: number } | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ timePeriod, metric });
+      if (format) params.set('format', format);
+      if (proposal) params.set('proposal', proposal);
+      if (context) params.set('context', context);
+
+      const res = await fetch(`/api/v1/users/${userId}/performance/time-distribution?${params.toString()}`);
+      if (!res.ok) throw new Error(`Erro ao buscar dados: ${res.statusText}`);
+      const json: TimePerformanceResponse = await res.json();
+      setData(json);
+    } catch (e: any) {
+      setError(e.message || 'Erro ao carregar dados');
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [timePeriod, format, proposal, context, metric]);
+
+  useEffect(() => {
+    if (userId) {
+      fetchData();
+    } else {
+      setData(null);
+      setLoading(false);
+    }
+  }, [fetchData, userId]);
+
+  const getCell = (day: number, hour: number) => {
+    return data?.buckets.find(b => b.dayOfWeek === day && b.hour === hour);
+  };
+
+  const maxValue = data?.buckets.reduce((max, c) => Math.max(max, c.average), 0) || 0;
+  const selectedMetricLabel = metricOptions.find(opt => opt.value === metric)?.label || '';
+
+  return (
+    <>
+      <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
+        <div className="flex items-center gap-3 mb-4">
+            <CalendarDaysIcon className="w-6 h-6 text-indigo-600" />
+            <h3 className="text-lg font-semibold text-gray-800">Análise de Performance por Horário</h3>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4 p-4 bg-gray-50 rounded-lg border">
+          <select value={format} onChange={(e) => setFormat(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+            <option value="">Todos Formatos</option>
+            {formatOptions.map((opt) => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+          </select>
+          <select value={proposal} onChange={(e) => setProposal(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+            <option value="">Todas Propostas</option>
+            {proposalOptions.map((opt) => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+          </select>
+          <select value={context} onChange={(e) => setContext(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+            <option value="">Todos Contextos</option>
+            {contextOptions.map((opt) => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+          </select>
+          <select value={metric} onChange={(e) => setMetric(e.target.value)} className="w-full p-2 border border-gray-300 rounded-md text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+            {metricOptions.map((opt) => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+          </select>
+        </div>
+
+        {loading && <SkeletonLoader />}
+        {error && <div className="text-center text-sm text-red-600 p-10">Erro: {error}</div>}
+        {!loading && !error && data && (
+          <div>
+            {data.buckets.length === 0 ? (
+                <EmptyState message="Tente ajustar os filtros ou o período de tempo." />
+            ) : (
+            <>
+                <div className="overflow-x-auto">
+                <table className="w-full text-center text-xs border-separate border-spacing-px table-fixed">
+                    <thead>
+                    <tr>
+                        <th className="p-1 w-10"></th> 
+                        {HOURS.map(h => (
+                        <th key={h} className="p-1 font-normal text-gray-500 text-[9px]">{h.toString().padStart(2, '0')}h</th>
+                        ))}
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {DAYS.map((d, idx) => (
+                        <tr key={d}>
+                        <td className="p-1 font-semibold text-gray-600 text-right">{d}</td>
+                        {HOURS.map(h => {
+                            const cell = getCell(idx + 1, h);
+                            const val = cell ? cell.average : 0;
+                            const intensity = maxValue === 0 ? 0 : 0.15 + (val / maxValue) * 0.85;
+                            const style = val === 0 ? { backgroundColor: '#f8fafc' } : { backgroundColor: `rgba(79, 70, 229, ${intensity})` };
+                            const tooltip = cell ? `${val.toLocaleString('pt-BR', {maximumFractionDigits: 1})} de média de engajamento (${cell.count} post${cell.count > 1 ? 's' : ''})` : 'Nenhum post';
+                            return (
+                            <td
+                                key={h}
+                                className="h-8 cursor-pointer rounded-sm transition-all duration-200 hover:scale-125 hover:shadow-lg hover:z-10"
+                                style={style}
+                                title={tooltip}
+                                onClick={() => cell && cell.count > 0 && setSelectedSlot({ dayOfWeek: cell.dayOfWeek, hour: cell.hour })}
+                            >
+                            </td>
+                            );
+                        })}
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+                </div>
+                
+                <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
+                {data.bestSlots.length > 0 && (
+                    <div className="bg-green-50 p-4 rounded-lg border border-green-200">
+                    <p className="font-semibold mb-1 text-green-800">✅ Melhores Horários</p>
+                    <p className="text-green-700 text-[11px] mb-2">{selectedMetricLabel}</p>
+                    <ul className="space-y-2">
+                        {data.bestSlots.slice(0,3).map((s, i) => (
+                        <li key={i} className="space-y-1">
+                            <div className="flex justify-between items-center">
+                            <span className="font-medium text-gray-700">{getPortugueseWeekdayNameForList(s.dayOfWeek)} • {s.hour.toString().padStart(2, '0')}:00h</span>
+                            <span className="font-bold text-gray-800">{s.average.toLocaleString('pt-BR', {maximumFractionDigits: 1})}</span>
+                            </div>
+                            <div className="w-full bg-green-200 rounded-full h-1.5">
+                            <div className="bg-green-500 h-1.5 rounded-full" style={{ width: `${(s.average / maxValue) * 100}%` }}></div>
+                            </div>
+                        </li>
+                        ))}
+                    </ul>
+                    </div>
+                )}
+                {data.worstSlots.length > 0 && (
+                    <div className="bg-red-50 p-4 rounded-lg border border-red-200">
+                    <p className="font-semibold mb-1 text-red-800">❌ Piores Horários</p>
+                    <p className="text-red-700 text-[11px] mb-2">{selectedMetricLabel}</p>
+                    <ul className="space-y-2">
+                        {data.worstSlots.slice(0,3).map((s, i) => (
+                        <li key={i} className="space-y-1">
+                            <div className="flex justify-between items-center">
+                            <span className="font-medium text-gray-700">{getPortugueseWeekdayNameForList(s.dayOfWeek)} • {s.hour.toString().padStart(2, '0')}:00h</span>
+                            <span className="font-bold text-gray-800">{s.average.toLocaleString('pt-BR', {maximumFractionDigits: 1})}</span>
+                            </div>
+                            <div className="w-full bg-red-200 rounded-full h-1.5">
+                            <div className="bg-red-500 h-1.5 rounded-full" style={{ width: `${(s.average / maxValue) * 100}%` }}></div>
+                            </div>
+                        </li>
+                        ))}
+                    </ul>
+                    </div>
+                )}
+                </div>
+                {data.insightSummary && (
+                    <div className="mt-4 p-3 text-xs text-yellow-800 bg-yellow-50 border border-yellow-200 rounded-lg flex items-start gap-2">
+                        <LightBulbIcon className="w-5 h-5 text-yellow-500 flex-shrink-0" />
+                        <span>{data.insightSummary}</span>
+                    </div>
+                )}
+            </>
+            )}
+          </div>
+        )}
+      </div>
+      <TimeSlotTopPostsModal
+        isOpen={!!selectedSlot}
+        onClose={() => setSelectedSlot(null)}
+        dayOfWeek={selectedSlot?.dayOfWeek || 0}
+        // CORREÇÃO: O modal ainda espera 'timeBlock'. Convertemos a hora para o formato de bloco.
+        // O ideal é refatorar o modal para aceitar 'hour' para uma filtragem precisa.
+        timeBlock={selectedSlot ? hourToTimeBlock(selectedSlot.hour) : '0-6'}
+        filters={{ timePeriod, format: format || undefined, proposal: proposal || undefined, context: context || undefined, metric }}
+        userId={userId || undefined}
+      />
+    </>
+  );
+};
+
+export default UserTimePerformanceHeatmap;

--- a/src/app/admin/creator-dashboard/components/__tests__/UserTimePerformanceHeatmap.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserTimePerformanceHeatmap.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserTimePerformanceHeatmap from '../UserTimePerformanceHeatmap';
+import { useGlobalTimePeriod } from '../filters/GlobalTimePeriodContext';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(),
+}));
+
+jest.mock('../TimeSlotTopPostsModal', () => () => null);
+
+const mockUseGlobalTimePeriod = useGlobalTimePeriod as jest.Mock;
+
+describe('UserTimePerformanceHeatmap', () => {
+  beforeEach(() => {
+    mockUseGlobalTimePeriod.mockReturnValue({ timePeriod: 'last_30_days' });
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ buckets: [], bestSlots: [], worstSlots: [] }),
+    });
+  });
+
+  it('fetches data for given user', async () => {
+    render(<UserTimePerformanceHeatmap userId="u1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/performance/time-distribution');
+  });
+});

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -16,6 +16,7 @@ import UserVideoPerformanceMetrics from "../UserVideoPerformanceMetrics";
 import UserMonthlyEngagementStackedChart from "../UserMonthlyEngagementStackedChart";
 import UserMonthlyComparisonChart from "../UserMonthlyComparisonChart";
 import UserPerformanceHighlights from "../UserPerformanceHighlights";
+import UserTimePerformanceHeatmap from "../UserTimePerformanceHeatmap";
 
 // User-specific components from Módulo 3 (Creator Detail)
 import UserRadarChartComparison from "../UserRadarChartComparison";
@@ -160,6 +161,9 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           userId={userId}
           sectionTitle="Destaques de Performance"
         />
+        <div className="mt-6">
+          <UserTimePerformanceHeatmap userId={userId} />
+        </div>
       </section>
 
       <section id={`user-advanced-analysis-${userId}`} className="mb-10">

--- a/src/app/api/v1/users/[userId]/performance/time-distribution/posts/route.test.ts
+++ b/src/app/api/v1/users/[userId]/performance/time-distribution/posts/route.test.ts
@@ -1,0 +1,37 @@
+import { GET } from './route';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+
+jest.mock('@/app/models/Metric', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = MetricModel.aggregate as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+const makeRequest = (userId: string, search = '') => new NextRequest(`http://localhost/api/v1/users/${userId}/performance/time-distribution/posts${search}`);
+
+describe('GET /api/v1/users/[userId]/performance/time-distribution/posts', () => {
+  const userId = new Types.ObjectId().toString();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('returns posts list', async () => {
+    mockAgg.mockResolvedValueOnce([{ _id: 'p1', metricValue: 10 }]);
+
+    const res = await GET(makeRequest(userId, '?dayOfWeek=1&timeBlock=6-12&timePeriod=last_30_days'), { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalled();
+    expect(body.posts[0].metricValue).toBe(10);
+  });
+});

--- a/src/app/api/v1/users/[userId]/performance/time-distribution/posts/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/time-distribution/posts/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import { Types } from 'mongoose';
+
+export const dynamic = 'force-dynamic';
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json(
+      { error: 'User ID inválido ou ausente.' },
+      { status: 400 }
+    );
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const format = searchParams.get('format') || undefined;
+  const proposal = searchParams.get('proposal') || undefined;
+  const context = searchParams.get('context') || undefined;
+  const metric = searchParams.get('metric') || 'stats.total_interactions';
+  const dayOfWeek = parseInt(searchParams.get('dayOfWeek') || '', 10);
+  const timeBlock = searchParams.get('timeBlock');
+  const limit = parseInt(searchParams.get('limit') || '5', 10);
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  if (!dayOfWeek || !timeBlock) {
+    return NextResponse.json({ error: 'Parâmetros dayOfWeek e timeBlock são obrigatórios.' }, { status: 400 });
+  }
+
+  try {
+    await connectToDatabase();
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+    const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+    const match: any = {
+      user: new Types.ObjectId(userId),
+      postDate: { $gte: startDate, $lte: endDate },
+    };
+    if (format) match.format = format;
+    if (proposal) match.proposal = proposal;
+    if (context) match.context = context;
+
+    const pipeline: any[] = [
+      { $match: match },
+      {
+        $addFields: {
+          dayOfWeek: { $dayOfWeek: '$postDate' },
+          hour: { $hour: '$postDate' },
+        },
+      },
+      {
+        $addFields: {
+          timeBlock: {
+            $switch: {
+              branches: [
+                { case: { $lte: ['$hour', 5] }, then: '0-6' },
+                { case: { $lte: ['$hour', 11] }, then: '6-12' },
+                { case: { $lte: ['$hour', 17] }, then: '12-18' },
+                { case: { $lte: ['$hour', 23] }, then: '18-24' },
+              ],
+              default: 'unknown',
+            },
+          },
+        },
+      },
+      { $match: { dayOfWeek, timeBlock } },
+      {
+        $project: {
+          description: 1,
+          postLink: 1,
+          coverUrl: 1,
+          metricValue: `$${metric}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      { $sort: { metricValue: -1 } },
+      { $limit: limit },
+    ];
+
+    const posts = await MetricModel.aggregate(pipeline).exec();
+
+    return NextResponse.json({ posts }, { status: 200 });
+  } catch (error: any) {
+    console.error('[API USER/TIME-DISTRIBUTION/POSTS] Error:', error);
+    return NextResponse.json({ error: 'Erro ao buscar posts.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/users/[userId]/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/users/[userId]/performance/time-distribution/route.test.ts
@@ -1,0 +1,43 @@
+import { GET } from './route';
+import aggregateUserTimePerformance from '@/utils/aggregateUserTimePerformance';
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+
+jest.mock('@/utils/aggregateUserTimePerformance');
+const mockAgg = aggregateUserTimePerformance as jest.Mock;
+
+const makeRequest = (userId: string, search = '') => new NextRequest(`http://localhost/api/v1/users/${userId}/performance/time-distribution${search}`);
+
+describe('GET /api/v1/users/[userId]/performance/time-distribution', () => {
+  const userId = new Types.ObjectId().toString();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns aggregated data', async () => {
+    mockAgg.mockResolvedValueOnce({
+      buckets: [{ dayOfWeek: 1, hour: 6, average: 10, count: 2 }],
+      bestSlots: [{ dayOfWeek: 1, hour: 6, average: 10, count: 2 }],
+      worstSlots: [{ dayOfWeek: 2, hour: 0, average: 1, count: 1 }],
+    });
+
+    const res = await GET(makeRequest(userId, '?timePeriod=last_30_days&format=reel'), { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalledWith(userId, 30, 'stats.total_interactions', {
+      format: 'reel',
+      proposal: undefined,
+      context: undefined,
+    }, expect.any(Date));
+    expect(body.buckets[0].hour).toBe(6);
+  });
+
+  it('returns 400 for invalid time period', async () => {
+    const res = await GET(makeRequest(userId, '?timePeriod=bad'), { params: { userId } });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Time period inválido');
+    expect(mockAgg).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/users/[userId]/performance/time-distribution/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/time-distribution/route.ts
@@ -1,0 +1,80 @@
+/*
+Endpoint: /api/v1/users/[userId]/performance/time-distribution
+Versão  : baseada no endpoint da plataforma, filtrando os posts pelo usuário.
+*/
+import { NextResponse as NextResponseForTime } from 'next/server';
+import { camelizeKeys as camelizeKeysForTime } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS as ALLOWED_TIME_PERIODS_FOR_TIME, TimePeriod as TimePeriodForTime } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays as timePeriodToDaysForTime } from '@/utils/timePeriodHelpers';
+import { Types } from 'mongoose';
+import { getCategoryById } from '@/app/lib/classification';
+import { aggregateUserTimePerformance as aggregateTimePerformance } from '@/utils/aggregateUserTimePerformance';
+
+function getPortugueseWeekdayNameForTime(day: number): string {
+    const days = ["Domingo", "Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira", "Sábado"];
+    return days[day - 1] || '';
+}
+
+function isAllowedTimePeriodForTime(period: any): period is TimePeriodForTime {
+  return ALLOWED_TIME_PERIODS_FOR_TIME.includes(period);
+}
+
+// CORREÇÃO: Nome da função corrigido para GET.
+export async function GET(
+  request: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponseForTime.json(
+      { error: 'User ID inválido ou ausente.' },
+      { status: 400 }
+    );
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
+
+  const timePeriod: TimePeriodForTime = isAllowedTimePeriodForTime(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriodForTime(timePeriodParam)) {
+    return NextResponseForTime.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS_FOR_TIME.join(', ')}` }, { status: 400 });
+  }
+
+  const periodInDaysValue = timePeriodToDaysForTime(timePeriod);
+  const metricField = metricParam || 'stats.total_interactions';
+
+  const result = await aggregateTimePerformance(userId, periodInDaysValue, metricField, {
+    format: formatParam || undefined,
+    proposal: proposalParam || undefined,
+    context: contextParam || undefined,
+  });
+
+  const best = result.bestSlots[0];
+  const worst = result.worstSlots[0];
+  let summary = '';
+  if (best) {
+    const dayName = getPortugueseWeekdayNameForTime(best.dayOfWeek).toLowerCase();
+    const bestAvg = best.average.toLocaleString('pt-BR', { maximumFractionDigits: 1 });
+    summary += `O pico de performance ocorre ${dayName} às ${best.hour}h, com uma média de ${bestAvg} de engajamento por post.`;
+  }
+  if (worst) {
+    const dayName = getPortugueseWeekdayNameForTime(worst.dayOfWeek).toLowerCase();
+    summary += ` O menor desempenho é ${dayName} às ${worst.hour}h.`;
+  }
+
+  const filterLabels: string[] = [];
+  if (formatParam) filterLabels.push(getCategoryById(formatParam, 'format')?.label || formatParam);
+  if (proposalParam) filterLabels.push(getCategoryById(proposalParam, 'proposal')?.label || proposalParam);
+  if (contextParam) filterLabels.push(getCategoryById(contextParam, 'context')?.label || contextParam);
+  if (filterLabels.length > 0 && summary) {
+    summary = `Para posts sobre ${filterLabels.join(' e ')}, ${summary.charAt(0).toLowerCase() + summary.slice(1)}`;
+  }
+
+  return NextResponseForTime.json(camelizeKeysForTime({ ...result, insightSummary: summary }), { status: 200 });
+}

--- a/src/utils/aggregateUserTimePerformance.ts
+++ b/src/utils/aggregateUserTimePerformance.ts
@@ -1,0 +1,129 @@
+/*
+==============================================================================
+Utilitário: aggregateUserTimePerformance
+Função   : Agrega métricas de desempenho por horário para um usuário específico.
+Baseado em aggregatePlatformTimePerformance.ts, com filtro adicional por userId.
+==============================================================================
+*/
+import MetricModel from "@/app/models/Metric";
+import { PipelineStage, Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface TimeBucket {
+  dayOfWeek: number;
+  hour: number; // ALTERADO: de timeBlock: string para hour: number
+  average: number;
+  count: number;
+}
+
+export interface UserTimePerformance {
+  buckets: TimeBucket[];
+  bestSlots: TimeBucket[];
+  worstSlots: TimeBucket[];
+}
+
+export interface PerformanceFilters {
+  format?: string;
+  proposal?: string;
+  context?: string;
+}
+
+export async function aggregateUserTimePerformance(
+  userId: string | Types.ObjectId,
+  periodInDays: number,
+  metricField: string,
+  filters: PerformanceFilters = {},
+  referenceDate: Date = new Date()
+): Promise<UserTimePerformance> {
+  const today = new Date(referenceDate);
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const result: UserTimePerformance = { buckets: [], bestSlots: [], worstSlots: [] };
+
+  try {
+    await connectToDatabase();
+
+    const resolvedUserId =
+      typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        user: resolvedUserId,
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    // Filtros usam regex para busca case-insensitive.
+    if (filters.format) {
+      (matchStage.$match as any).format = { $regex: `^${filters.format}$`, $options: 'i' };
+    }
+    if (filters.proposal) {
+      (matchStage.$match as any).proposal = { $regex: `^${filters.proposal}$`, $options: 'i' };
+    }
+    if (filters.context) {
+      (matchStage.$match as any).context = { $regex: `^${filters.context}$`, $options: 'i' };
+    }
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      {
+        $project: {
+          dayOfWeek: { $dayOfWeek: "$postDate" },
+          hour: { $hour: "$postDate" },
+          metricValue: `$${metricField}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      // REMOVIDO: O estágio que criava 'timeBlock' foi removido.
+      {
+        $group: {
+          // ALTERADO: Agrupamento agora é por hora individual.
+          _id: { dayOfWeek: "$dayOfWeek", hour: "$hour" },
+          total: { $sum: "$metricValue" },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $addFields: {
+          avg: {
+            $cond: {
+              if: { $eq: ["$count", 0] },
+              then: 0,
+              else: { $divide: ["$total", "$count"] },
+            },
+          },
+        },
+      },
+      { $sort: { avg: -1 } },
+    ];
+
+    const agg = await MetricModel.aggregate(pipeline);
+    result.buckets = agg.map((d: any) => ({
+      dayOfWeek: d._id.dayOfWeek,
+      hour: d._id.hour, // ALTERADO: Mapeando 'hour' em vez de 'timeBlock'.
+      average: d.avg,
+      count: d.count,
+    }));
+
+    result.bestSlots = result.buckets.slice(0, 3);
+    result.worstSlots = result.buckets.slice(-3).reverse();
+
+    return result;
+  } catch (error) {
+    logger.error("Error in aggregateUserTimePerformance:", error);
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- aggregate time performance by user ID
- expose new endpoints for user time distribution and posts
- add user time performance heatmap component
- make posts modal support optional userId
- render heatmap in user detail view
- tests for new endpoints and component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acf027b14832e93dc9cff246eda54