### PR TITLE
Fix named import for user time performance test

### DIFF
--- a/src/app/api/v1/users/[userId]/performance/time-distribution/route.test.ts
+++ b/src/app/api/v1/users/[userId]/performance/time-distribution/route.test.ts
@@ -1,5 +1,5 @@
 import { GET } from './route';
-import aggregateUserTimePerformance from '@/utils/aggregateUserTimePerformance';
+import { aggregateUserTimePerformance } from '@/utils/aggregateUserTimePerformance';
 import { NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 


### PR DESCRIPTION
## Summary
- fix import statement for `aggregateUserTimePerformance` in `route.test.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad5911334832eb240aafbe5c246ef