### PR TITLE
Fix heatmap fetch dependency

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserTimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/UserTimePerformanceHeatmap.tsx
@@ -141,7 +141,7 @@ const UserTimePerformanceHeatmap: React.FC<UserTimePerformanceHeatmapProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [timePeriod, format, proposal, context, metric]);
+  }, [timePeriod, format, proposal, context, metric, userId]);
 
   useEffect(() => {
     if (userId) {

--- a/src/app/admin/creator-dashboard/components/__tests__/UserTimePerformanceHeatmap.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserTimePerformanceHeatmap.test.tsx
@@ -26,4 +26,14 @@ describe('UserTimePerformanceHeatmap', () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/performance/time-distribution');
   });
+
+  it('refetches when userId changes', async () => {
+    const { rerender } = render(<UserTimePerformanceHeatmap userId="u1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/performance/time-distribution');
+
+    rerender(<UserTimePerformanceHeatmap userId="u2" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toContain('/api/v1/users/u2/performance/time-distribution');
+  });
 });


### PR DESCRIPTION
## Summary
- update the heatmap data fetching hook to depend on `userId`
- test that changing the selected creator triggers a new request

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad59dcf00832ea24a4f5b17056f8d