### PR TITLE
Fix TimeSlot posts modal updates on user change

### DIFF
--- a/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
+++ b/src/app/admin/creator-dashboard/components/TimeSlotTopPostsModal.tsx
@@ -54,7 +54,7 @@ const TimeSlotTopPostsModal: React.FC<TimeSlotTopPostsModalProps> = ({ isOpen, o
       }
     };
     fetchPosts();
-  }, [isOpen, dayOfWeek, timeBlock, filters]);
+  }, [isOpen, dayOfWeek, timeBlock, filters, userId]);
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
- update `TimeSlotTopPostsModal` dependencies so posts reload when switching users

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad59febfc832e9c2bff6c4d1783de