### PR TITLE
Add user-specific performance highlights

### DIFF
--- a/src/app/admin/creator-dashboard/components/FullDataModal.tsx
+++ b/src/app/admin/creator-dashboard/components/FullDataModal.tsx
@@ -18,6 +18,7 @@ interface FullDataModalProps {
   groupBy: GroupingType;
   metricUsed: string;
   chartTitle: string;
+  userId?: string;
 }
 
 export const FullDataModal: React.FC<FullDataModalProps> = ({
@@ -25,7 +26,8 @@ export const FullDataModal: React.FC<FullDataModalProps> = ({
   onClose,
   groupBy,
   metricUsed,
-  chartTitle
+  chartTitle,
+  userId,
 }) => {
   const [allData, setAllData] = useState<DataPoint[]>([]);
   const [loading, setLoading] = useState(false);
@@ -36,7 +38,10 @@ export const FullDataModal: React.FC<FullDataModalProps> = ({
       setLoading(true);
       setError(null);
       // Busca TODOS os dados (sem o parâmetro 'limit') quando o modal é aberto
-      const apiUrl = `/api/v1/platform/performance/average-engagement?groupBy=${groupBy}&engagementMetricField=${metricUsed}&sortOrder=desc`;
+      const base = userId
+        ? `/api/v1/users/${userId}/performance/average-engagement`
+        : '/api/v1/platform/performance/average-engagement';
+      const apiUrl = `${base}?groupBy=${groupBy}&engagementMetricField=${metricUsed}&sortOrder=desc`;
       
       fetch(apiUrl)
         .then(res => {

--- a/src/app/admin/creator-dashboard/components/UserFormatPerformanceRankingTable.tsx
+++ b/src/app/admin/creator-dashboard/components/UserFormatPerformanceRankingTable.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useGlobalTimePeriod } from './filters/GlobalTimePeriodContext';
+import { commaSeparatedIdsToLabels } from '../../../lib/classification';
+import { FullDataModal } from './FullDataModal';
+
+interface DataPoint {
+  name: string;
+  value: number;
+  postsCount: number;
+}
+
+const DEFAULT_METRIC = 'stats.total_interactions';
+
+interface Props { userId: string | null; }
+
+const UserFormatPerformanceRankingTable: React.FC<Props> = ({ userId }) => {
+  const { timePeriod } = useGlobalTimePeriod();
+  const [data, setData] = useState<DataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (!userId) { setData([]); setLoading(false); return; }
+      const apiUrl = `/api/v1/users/${userId}/performance/average-engagement?timePeriod=${timePeriod}&groupBy=format&sortOrder=desc&engagementMetricField=${DEFAULT_METRIC}`;
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`Erro HTTP: ${res.status}`);
+      const result = await res.json();
+      const mapped: DataPoint[] = result.chartData.map((d: any) => ({
+        name: commaSeparatedIdsToLabels(d.name, 'format') || d.name,
+        value: d.value,
+        postsCount: d.postsCount,
+      }));
+      setData(mapped);
+    } catch (e: any) {
+      setError(e.message || 'Erro ao carregar ranking.');
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [timePeriod]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const totalPosts = data.reduce((sum, d) => sum + d.postsCount, 0);
+
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-md font-semibold text-gray-700">Ranking de Desempenho por Formato</h3>
+        <button onClick={() => setIsModalOpen(true)} className="text-sm font-semibold text-indigo-600 hover:text-indigo-800">
+          Ver Análise Completa
+        </button>
+      </div>
+      {loading && <p className="text-center py-6 text-gray-500">Carregando ranking...</p>}
+      {error && <p className="text-center py-6 text-red-500">Erro: {error}</p>}
+      {!loading && !error && data.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Formato</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Engajamento Médio</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Volume (% do Total)</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {data.map((item, index) => {
+                const pct = totalPosts > 0 ? (item.postsCount / totalPosts) * 100 : 0;
+                return (
+                  <tr key={item.name} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 text-center font-medium text-gray-700">{index + 1}</td>
+                    <td className="px-3 py-2 font-medium text-gray-800">{item.name}</td>
+                    <td className="px-3 py-2 text-right text-gray-700">{item.value.toLocaleString('pt-BR')}</td>
+                    <td className="px-3 py-2 text-right text-gray-700">
+                      <div className="flex items-center gap-2 justify-end">
+                        <span>{item.postsCount} ({pct.toFixed(1)}%)</span>
+                        <div className="w-24 h-2 bg-gray-200 rounded">
+                          <div className="h-2 bg-indigo-500 rounded" style={{ width: `${pct}%` }} />
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {!loading && !error && data.length === 0 && (
+        <p className="text-center py-6 text-gray-500">Nenhum dado disponível.</p>
+      )}
+
+      <FullDataModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        groupBy="format"
+        metricUsed={DEFAULT_METRIC}
+        chartTitle="Ranking de Desempenho por Formato"
+        userId={userId || undefined}
+      />
+    </div>
+  );
+};
+
+export default UserFormatPerformanceRankingTable;

--- a/src/app/api/v1/users/[userId]/highlights/performance-summary/route.test.ts
+++ b/src/app/api/v1/users/[userId]/highlights/performance-summary/route.test.ts
@@ -1,0 +1,54 @@
+import { GET } from './route';
+import aggregateUserPerformanceHighlights from '@/utils/aggregateUserPerformanceHighlights';
+import aggregateUserDayPerformance from '@/utils/aggregateUserDayPerformance';
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+
+jest.mock('@/utils/aggregateUserPerformanceHighlights');
+jest.mock('@/utils/aggregateUserDayPerformance');
+
+const mockAgg = aggregateUserPerformanceHighlights as jest.Mock;
+const mockDayAgg = aggregateUserDayPerformance as jest.Mock;
+
+const makeRequest = (userId: string, search = '') => new NextRequest(`http://localhost/api/v1/users/${userId}/highlights/performance-summary${search}`);
+
+describe('GET /api/v1/users/[userId]/highlights/performance-summary', () => {
+  const userId = new Types.ObjectId().toString();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns formatted highlights', async () => {
+    mockAgg.mockResolvedValueOnce({
+      topFormat: { name: 'VIDEO', average: 10, count: 2 },
+      lowFormat: { name: 'IMAGE', average: 2, count: 1 },
+      topContext: { name: 'FEED', average: 5, count: 3 },
+      topProposal: { name: 'educational', average: 8, count: 4 },
+      topTone: { name: 'humor', average: 7, count: 2 },
+      topReference: { name: 'pop_culture', average: 6, count: 3 },
+    });
+    mockDayAgg.mockResolvedValueOnce({
+      buckets: [],
+      bestDays: [{ dayOfWeek: 5, average: 12, count: 4 }],
+      worstDays: [],
+    });
+
+    const res = await GET(makeRequest(userId, '?timePeriod=last_30_days'), { params: { userId } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockAgg).toHaveBeenCalled();
+    expect(mockDayAgg).toHaveBeenCalled();
+    expect(body.topPerformingFormat.name).toBe('VIDEO');
+    expect(body.bestDay.dayOfWeek).toBe(5);
+  });
+
+  it('returns 400 for invalid timePeriod', async () => {
+    const res = await GET(makeRequest(userId, '?timePeriod=bad'), { params: { userId } });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Time period inválido');
+    expect(mockAgg).not.toHaveBeenCalled();
+    expect(mockDayAgg).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/aggregateUserDayPerformance.ts
+++ b/src/utils/aggregateUserDayPerformance.ts
@@ -1,0 +1,121 @@
+import MetricModel from "@/app/models/Metric";
+import { Types, PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface DayBucket {
+  dayOfWeek: number;
+  average: number;
+  count: number;
+}
+
+export interface UserDayPerformance {
+  buckets: DayBucket[];
+  bestDays: DayBucket[];
+  worstDays: DayBucket[];
+}
+
+export interface PerformanceFilters {
+  format?: string;
+  proposal?: string;
+  context?: string;
+}
+
+export async function aggregateUserDayPerformance(
+  userId: string | Types.ObjectId,
+  periodInDays: number,
+  metricField: string,
+  filters: PerformanceFilters = {},
+  referenceDate: Date = new Date()
+): Promise<UserDayPerformance> {
+  const resolvedUserId =
+    typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
+  const today = new Date(referenceDate);
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const result: UserDayPerformance = { buckets: [], bestDays: [], worstDays: [] };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        user: resolvedUserId,
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    if (filters.format) {
+      (matchStage.$match as any).format = { $regex: `^${filters.format}$`, $options: 'i' };
+    }
+    if (filters.proposal) {
+      (matchStage.$match as any).proposal = { $regex: `^${filters.proposal}$`, $options: 'i' };
+    }
+    if (filters.context) {
+      (matchStage.$match as any).context = { $regex: `^${filters.context}$`, $options: 'i' };
+    }
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      {
+        $project: {
+          dayOfWeek: { $dayOfWeek: "$postDate" },
+          metricValue: `$${metricField}`,
+        },
+      },
+      { $match: { metricValue: { $ne: null } } },
+      {
+        $group: {
+          _id: "$dayOfWeek",
+          total: { $sum: "$metricValue" },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $addFields: {
+          avg: {
+            $cond: {
+              if: { $eq: ["$count", 0] },
+              then: 0,
+              else: { $divide: ["$total", "$count"] },
+            },
+          },
+        },
+      },
+      { $sort: { avg: -1 } },
+    ];
+
+    const agg = await MetricModel.aggregate(pipeline);
+    result.buckets = agg.map((d: any) => ({
+      dayOfWeek: d._id,
+      average: d.avg,
+      count: d.count,
+    }));
+
+    result.bestDays = result.buckets.slice(0, 3);
+    result.worstDays = result.buckets.slice(-3).reverse();
+
+    return result;
+  } catch (error) {
+    logger.error(
+      `Error in aggregateUserDayPerformance for user ${resolvedUserId}:`,
+      error
+    );
+    return result;
+  }
+}
+
+export default aggregateUserDayPerformance;

--- a/src/utils/aggregateUserPerformanceHighlights.ts
+++ b/src/utils/aggregateUserPerformanceHighlights.ts
@@ -1,0 +1,213 @@
+import MetricModel from "@/app/models/Metric";
+import { Types, PipelineStage } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import { logger } from "@/app/lib/logger";
+import { getStartDateFromTimePeriod } from "./dateHelpers";
+
+export interface AggregatedHighlight {
+  name: string | null;
+  average: number;
+  count: number;
+}
+
+export interface UserPerformanceHighlightsAggregation {
+  topFormat: AggregatedHighlight | null;
+  lowFormat: AggregatedHighlight | null;
+  topContext: AggregatedHighlight | null;
+  topProposal: AggregatedHighlight | null;
+  topTone: AggregatedHighlight | null;
+  topReference: AggregatedHighlight | null;
+}
+
+async function aggregateUserPerformanceHighlights(
+  userId: string | Types.ObjectId,
+  periodInDays: number,
+  metricField: string,
+  referenceDate: Date = new Date()
+): Promise<UserPerformanceHighlightsAggregation> {
+  const resolvedUserId =
+    typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
+  const today = new Date(referenceDate);
+  const endDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  const startDate = getStartDateFromTimePeriod(
+    today,
+    `last_${periodInDays}_days`
+  );
+
+  const initial: UserPerformanceHighlightsAggregation = {
+    topFormat: null,
+    lowFormat: null,
+    topContext: null,
+    topProposal: null,
+    topTone: null,
+    topReference: null,
+  };
+
+  try {
+    await connectToDatabase();
+
+    const matchStage: PipelineStage.Match = {
+      $match: {
+        user: resolvedUserId,
+        postDate: { $gte: startDate, $lte: endDate },
+      },
+    };
+
+    const projectStage: PipelineStage.Project = {
+      $project: {
+        format: { $ifNull: ["$format", null] },
+        context: { $ifNull: ["$context", null] },
+        proposal: { $ifNull: ["$proposal", null] },
+        tone: { $ifNull: ["$tone", null] },
+        references: { $ifNull: ["$references", null] },
+        metricValue: `$${metricField}`,
+      },
+    };
+
+    const metricFilterStage: PipelineStage.Match = {
+      $match: { metricValue: { $ne: null } },
+    };
+
+    const pipeline: PipelineStage[] = [
+      matchStage,
+      projectStage,
+      metricFilterStage,
+      {
+        $facet: {
+          byFormat: [
+            { $unwind: "$format" },
+            {
+              $group: {
+                _id: "$format",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byContext: [
+            { $unwind: "$context" },
+            {
+              $group: {
+                _id: "$context",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byProposal: [
+            { $unwind: "$proposal" },
+            {
+              $group: {
+                _id: "$proposal",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byTone: [
+            { $unwind: "$tone" },
+            {
+              $group: {
+                _id: "$tone",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+          byReference: [
+            { $unwind: "$references" },
+            {
+              $group: {
+                _id: "$references",
+                avg: { $avg: "$metricValue" },
+                count: { $sum: 1 },
+              },
+            },
+            { $sort: { avg: -1 } },
+          ],
+        },
+      },
+    ];
+
+    const [agg] = await MetricModel.aggregate(pipeline);
+
+    if (agg?.byFormat?.length) {
+      const topF = agg.byFormat[0];
+      const lowF = agg.byFormat[agg.byFormat.length - 1];
+      const topFormatName = Array.isArray(topF._id) ? topF._id.join(',') : topF._id;
+      const lowFormatName = Array.isArray(lowF._id) ? lowF._id.join(',') : lowF._id;
+      initial.topFormat = {
+        name: topFormatName ?? null,
+        average: topF.avg ?? 0,
+        count: topF.count ?? 0,
+      };
+      initial.lowFormat = {
+        name: lowFormatName ?? null,
+        average: lowF.avg ?? 0,
+        count: lowF.count ?? 0,
+      };
+    }
+
+    if (agg?.byContext?.length) {
+      const topC = agg.byContext[0];
+      const topContextName = Array.isArray(topC._id) ? topC._id.join(',') : topC._id;
+      initial.topContext = {
+        name: topContextName ?? null,
+        average: topC.avg ?? 0,
+        count: topC.count ?? 0,
+      };
+    }
+
+    if (agg?.byProposal?.length) {
+      const topP = agg.byProposal[0];
+      const topProposalName = Array.isArray(topP._id) ? topP._id.join(',') : topP._id;
+      initial.topProposal = {
+        name: topProposalName ?? null,
+        average: topP.avg ?? 0,
+        count: topP.count ?? 0,
+      };
+    }
+
+    if (agg?.byTone?.length) {
+      const topT = agg.byTone[0];
+      const topToneName = Array.isArray(topT._id) ? topT._id.join(',') : topT._id;
+      initial.topTone = {
+        name: topToneName ?? null,
+        average: topT.avg ?? 0,
+        count: topT.count ?? 0,
+      };
+    }
+
+    if (agg?.byReference?.length) {
+      const topR = agg.byReference[0];
+      const topReferenceName = Array.isArray(topR._id) ? topR._id.join(',') : topR._id;
+      initial.topReference = {
+        name: topReferenceName ?? null,
+        average: topR.avg ?? 0,
+        count: topR.count ?? 0,
+      };
+    }
+
+    return initial;
+  } catch (error) {
+    logger.error(
+      `Error in aggregateUserPerformanceHighlights for user ${resolvedUserId}:`,
+      error
+    );
+    return initial;
+  }
+}
+
+export default aggregateUserPerformanceHighlights;


### PR DESCRIPTION
## Summary
- implement `aggregateUserPerformanceHighlights` and `aggregateUserDayPerformance`
- extend user highlights API with proposal, tone, reference and best day
- create component for user ranking table and update highlight UI
- support optional userId in `FullDataModal`
- add tests for new API endpoint
- translate classification labels in user highlights

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acdc2882c832ebba67d57fb175b32