### PR TITLE
Update CreatorQuickSearch search clearing

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -73,6 +73,7 @@ export default function CreatorQuickSearch({
     <div className="relative flex items-center" ref={containerRef}>
       <SearchBar
         initialValue=""
+        value={searchTerm}
         onSearchChange={(val) => {
           setSearchTerm(val);
           setShowDropdown(true);


### PR DESCRIPTION
## Summary
- bind `searchTerm` directly to the `SearchBar` value in `CreatorQuickSearch`
- ensure the search field clears after a creator selection

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b216c70e8832eadcf7384a957cca9