### PR TITLE
Improve search bar layout

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -79,7 +79,7 @@ export default function CreatorQuickSearch({
         }}
         placeholder="Buscar criador..."
         debounceMs={200}
-        className="w-60 sm:w-72"
+        className="w-80 sm:w-96 flex-grow"
         ariaLabel="Buscar criador"
       />
       {selectedCreatorName && onClear && (

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -135,7 +135,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
       <div className="min-h-screen bg-brand-light">
         <header className="bg-white shadow-sm sticky top-0 z-40 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center h-16 gap-4">
+            <div className="flex items-center gap-4 h-16">
               <Link href="/admin/creator-dashboard" className="flex-shrink-0 flex items-center gap-2 group">
                 <span className="text-brand-pink text-3xl font-bold group-hover:opacity-80 transition-opacity">[2]</span>
               </Link>
@@ -148,18 +148,20 @@ const AdminCreatorDashboardContent: React.FC = () => {
                   window.scrollTo({ top: 0, behavior: 'smooth' });
                 }}
               />
-              <GlobalTimePeriodFilter
-                selectedTimePeriod={globalTimePeriod}
-                onTimePeriodChange={setGlobalTimePeriod}
-                options={[
-                  { value: "last_7_days", label: "Últimos 7 dias" },
-                  { value: "last_30_days", label: "Últimos 30 dias" },
-                  { value: "last_90_days", label: "Últimos 90 dias" },
-                  { value: "last_6_months", label: "Últimos 6 meses" },
-                  { value: "last_12_months", label: "Últimos 12 meses" },
-                  { value: "all_time", label: "Todo o período" },
-                ]}
-              />
+              <div className="ml-auto">
+                <GlobalTimePeriodFilter
+                  selectedTimePeriod={globalTimePeriod}
+                  onTimePeriodChange={setGlobalTimePeriod}
+                  options={[
+                    { value: "last_7_days", label: "Últimos 7 dias" },
+                    { value: "last_30_days", label: "Últimos 30 dias" },
+                    { value: "last_90_days", label: "Últimos 90 dias" },
+                    { value: "last_6_months", label: "Últimos 6 meses" },
+                    { value: "last_12_months", label: "Últimos 12 meses" },
+                    { value: "all_time", label: "Todo o período" },
+                  ]}
+                />
+              </div>
             </div>
           </div>
         </header>

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           autoFocus={autoFocus}
           className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm
                    focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-700
-                   dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+                   bg-white dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- enlarge CreatorQuickSearch width and allow flex-grow
- keep SearchBar input white in light mode
- tweak creator dashboard header layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b21705264832e909b8b880aaaa03b