### PR TITLE
Add clear button to SearchBar and simplify CreatorQuickSearch

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { SearchBar } from "@/app/components/SearchBar";
 import { UserAvatar } from "@/app/components/UserAvatar";
-import { XMarkIcon } from "@heroicons/react/24/solid";
 import type { AdminCreatorListItem } from "@/types/admin/creators";
 import { useCreatorSearch } from "@/hooks/useCreatorSearch";
 
@@ -77,22 +76,12 @@ export default function CreatorQuickSearch({
           setSearchTerm(val);
           setShowDropdown(true);
         }}
-        placeholder="Buscar criador..."
+        placeholder={selectedCreatorName || "Buscar criador..."}
         debounceMs={200}
         className="w-60 sm:w-72"
         ariaLabel="Buscar criador"
+        onClear={selectedCreatorName ? onClear : undefined}
       />
-      {selectedCreatorName && onClear && (
-        <span className="ml-2 flex items-center text-sm text-indigo-700">
-          <span className="mr-1">{selectedCreatorName}</span>
-          <button
-            onClick={onClear}
-            className="p-1 rounded-full bg-gray-200 hover:bg-gray-300"
-          >
-            <XMarkIcon className="w-4 h-4" />
-          </button>
-        </span>
-      )}
       {showDropdown && (searchTerm || isLoading) && (
         <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
           {isLoading && (

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useMemo, forwardRef } from "react";
 import { debounce } from "lodash";
 import { FaSearch } from "react-icons/fa"; // Usando react-icons para o ícone
+import { XMarkIcon } from "@heroicons/react/24/solid";
 
 interface SearchBarProps {
   initialValue?: string;
@@ -12,6 +13,11 @@ interface SearchBarProps {
   className?: string;
   autoFocus?: boolean;
   ariaLabel?: string;
+  /**
+   * Optional callback executed when the clear button is pressed. If not
+   * provided, the input will simply be emptied.
+   */
+  onClear?: () => void;
 }
 
 /**
@@ -35,6 +41,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
       className = "",
       autoFocus = false,
       ariaLabel,
+      onClear,
     }: SearchBarProps,
     ref,
   ) {
@@ -64,6 +71,18 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <FaSearch className="h-4 w-4 text-gray-400" />
         </div>
+        {(inputValue || onClear) && (
+          <button
+            type="button"
+            onClick={() => {
+              setInputValue("");
+              onClear?.();
+            }}
+            className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        )}
         <input
           type="text"
           value={inputValue}
@@ -72,7 +91,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           aria-label={ariaLabel}
           ref={ref}
           autoFocus={autoFocus}
-          className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm
+          className="block w-full pl-10 pr-8 py-2 border border-gray-300 rounded-md shadow-sm
                    focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-700
                    dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
         />


### PR DESCRIPTION
## Summary
- add optional `onClear` to `SearchBar` and render a clear button
- use the new clear button in `CreatorQuickSearch`
- show selected creator name as the search placeholder

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686b21720244832eaef177ae95f2fa3b