### PR TITLE
Update creator quick search input

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { SearchBar } from "@/app/components/SearchBar";
 import { UserAvatar } from "@/app/components/UserAvatar";
-import { XMarkIcon } from "@heroicons/react/24/solid";
 import type { AdminCreatorListItem } from "@/types/admin/creators";
 import { useCreatorSearch } from "@/hooks/useCreatorSearch";
 
@@ -78,22 +77,16 @@ export default function CreatorQuickSearch({
           setSearchTerm(val);
           setShowDropdown(true);
         }}
-        placeholder="Buscar criador..."
+        placeholder={selectedCreatorName || "Buscar criador..."}
         debounceMs={200}
         className="w-80 sm:w-96 flex-grow"
         ariaLabel="Buscar criador"
+        onClear={() => {
+          setSearchTerm("");
+          onClear && onClear();
+        }}
+        showClearWhenEmpty={!!selectedCreatorName}
       />
-      {selectedCreatorName && onClear && (
-        <span className="ml-2 flex items-center text-sm text-indigo-700">
-          <span className="mr-1">{selectedCreatorName}</span>
-          <button
-            onClick={onClear}
-            className="p-1 rounded-full bg-gray-200 hover:bg-gray-300"
-          >
-            <XMarkIcon className="w-4 h-4" />
-          </button>
-        </span>
-      )}
       {showDropdown && (searchTerm || isLoading) && (
         <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
           {isLoading && (

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -21,6 +21,11 @@ interface SearchBarProps {
   ariaLabel?: string;
   value?: string;
   onClear?: () => void;
+  /**
+   * When true, the clear button is displayed even if the input is empty.
+   * Useful for showing a selected value that can be cleared.
+   */
+  showClearWhenEmpty?: boolean;
 }
 
 /**
@@ -46,6 +51,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
       ariaLabel,
       value,
       onClear,
+      showClearWhenEmpty = false,
     }: SearchBarProps,
     ref,
   ) {
@@ -101,7 +107,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
                    focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-700
                    bg-white dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
         />
-        {onClear && inputValue && (
+        {onClear && (inputValue || showClearWhenEmpty) && (
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
## Summary
- add optional `showClearWhenEmpty` prop for `SearchBar`
- integrate clear behaviour directly in `CreatorQuickSearch`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b22d1bfc8832ea842e81c56f896e5