### PR TITLE
Fix comparative KPI and add month comparison

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/UserComparativeKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/UserComparativeKpi.tsx
@@ -17,11 +17,11 @@ interface KPIComparisonData {
 
 interface UserPeriodicComparisonResponse {
   followerGrowth: KPIComparisonData;
-  totalEngagement: KPIComparisonData;
+  engagementRate: KPIComparisonData;
   postingFrequency: KPIComparisonData;
   insightSummary?: {
     followerGrowth?: string;
-    totalEngagement?: string;
+    engagementRate?: string;
     postingFrequency?: string;
   };
 }

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -141,7 +141,7 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           />
           <UserComparativeKpi
             userId={userId}
-            kpiName="totalEngagement"
+            kpiName="engagementRate"
             title="Engajamento Total"
             comparisonPeriod={kpiComparisonPeriod}
             tooltip="Variação no total de interações em relação ao período anterior equivalente."

--- a/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
@@ -11,6 +11,7 @@ import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneri
 
 // Períodos de comparação permitidos
 const ALLOWED_COMPARISON_PERIODS: { [key: string]: { currentPeriodDays: number, periodNameCurrent: string, periodNamePrevious: string } } = {
+  "month_vs_previous": { currentPeriodDays: 30, periodNameCurrent: "Este Mês", periodNamePrevious: "Mês Passado"},
   "last_7d_vs_previous_7d": { currentPeriodDays: 7, periodNameCurrent: "Últimos 7 Dias", periodNamePrevious: "7 Dias Anteriores"},
   "last_30d_vs_previous_30d": { currentPeriodDays: 30, periodNameCurrent: "Últimos 30 Dias", periodNamePrevious: "30 Dias Anteriores"},
 };


### PR DESCRIPTION
## Summary
- allow month comparison period on user KPI API
- match user KPI prop names with API response
- update KPI selection in detail view

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2679fd74832e8418e89e1721c561