### PR TITLE
Fix total engagement KPI

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/UserComparativeKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/UserComparativeKpi.tsx
@@ -18,10 +18,12 @@ interface KPIComparisonData {
 interface UserPeriodicComparisonResponse {
   followerGrowth: KPIComparisonData;
   engagementRate: KPIComparisonData;
+  totalEngagement: KPIComparisonData;
   postingFrequency: KPIComparisonData;
   insightSummary?: {
     followerGrowth?: string;
     engagementRate?: string;
+    totalEngagement?: string;
     postingFrequency?: string;
   };
 }

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -141,7 +141,7 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
           />
           <UserComparativeKpi
             userId={userId}
-            kpiName="engagementRate"
+            kpiName="totalEngagement"
             title="Engajamento Total"
             comparisonPeriod={kpiComparisonPeriod}
             tooltip="Variação no total de interações em relação ao período anterior equivalente."

--- a/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
@@ -111,6 +111,12 @@ export async function GET(
     const currentEngagementRate = (engCurrentResult.totalEngagement !== null && fgT0 !== null && fgT0 > 0) ? (engCurrentResult.totalEngagement / fgT0) * 100 : null;
     const previousEngagementRate = (engPreviousResult.totalEngagement !== null && fgT1 !== null && fgT1 > 0) ? (engPreviousResult.totalEngagement / fgT1) * 100 : null;
     const engagementRateData = createKpiDataObject(currentEngagementRate, previousEngagementRate, { current: periodNameCurrent, previous: periodNamePrevious });
+
+    const totalEngagementData = createKpiDataObject(
+      engCurrentResult.totalEngagement,
+      engPreviousResult.totalEngagement,
+      { current: periodNameCurrent, previous: periodNamePrevious }
+    );
     
     const postingFrequencyData = createKpiDataObject(freqData.currentWeeklyFrequency, freqData.previousWeeklyFrequency, { current: periodNameCurrent, previous: periodNamePrevious });
     const periodNames = { current: periodNameCurrent, previous: periodNamePrevious };
@@ -127,6 +133,7 @@ export async function GET(
       comparisonPeriod: comparisonPeriodParam,
       followerGrowth: followerGrowthData,
       engagementRate: engagementRateData,
+      totalEngagement: totalEngagementData,
       postingFrequency: postingFrequencyData,
       avgViewsPerPost: avgViewsPerPostData,
       avgCommentsPerPost: avgCommentsPerPostData,
@@ -137,6 +144,7 @@ export async function GET(
       insightSummary: {
         followerGrowth: `Ganho de ${followerGrowthData.currentValue?.toLocaleString() ?? 'N/A'} seguidores.`,
         engagementRate: `Taxa de ${engagementRateData.currentValue?.toFixed(2) ?? 'N/A'}% por post.`,
+        totalEngagement: `${compactNumberFormat(totalEngagementData.currentValue)} interações no período.`,
         postingFrequency: `${postingFrequencyData.currentValue?.toFixed(1) ?? 'N/A'} posts por semana.`,
         avgViewsPerPost: `Média de ${compactNumberFormat(avgViewsPerPostData.currentValue)} views/post.`,
         avgCommentsPerPost: `Média de ${compactNumberFormat(avgCommentsPerPostData.currentValue)} comentários/post.`,
@@ -155,7 +163,7 @@ export async function GET(
     const errorKpi: KPIComparisonData = { currentValue: null, previousValue: null, percentageChange: null, chartData: [] };
     return NextResponse.json({
         error: "Erro ao processar sua solicitação de KPIs.", details: errorMessage,
-        followerGrowth: errorKpi, engagementRate: errorKpi, postingFrequency: errorKpi,
+        followerGrowth: errorKpi, engagementRate: errorKpi, totalEngagement: errorKpi, postingFrequency: errorKpi,
         avgViewsPerPost: errorKpi, avgCommentsPerPost: errorKpi, avgSharesPerPost: errorKpi, avgSavesPerPost: errorKpi,
         // NOVO: Adicionando o campo de alcance à resposta de erro
         avgReachPerPost: errorKpi

--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -45,6 +45,7 @@ export interface VideoListItem {
     comparisonPeriod?: string;
     followerGrowth: KPIComparisonData;
     engagementRate: KPIComparisonData;
+    totalEngagement: KPIComparisonData;
     postingFrequency: KPIComparisonData;
     avgViewsPerPost: KPIComparisonData;
     avgCommentsPerPost: KPIComparisonData;
@@ -54,6 +55,7 @@ export interface VideoListItem {
     insightSummary?: {
       followerGrowth?: string;
       engagementRate?: string;
+      totalEngagement?: string;
       postingFrequency?: string;
       avgViewsPerPost?: string;
       avgCommentsPerPost?: string;


### PR DESCRIPTION
## Summary
- add totalEngagement KPI to types
- expose total engagement in user periodic comparison API
- show totalEngagement KPI in user detail view
- update UserComparativeKpi component to handle new field

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686b2b3f6d9c832ead522c31c692076c