### PR TITLE
Add dedupe option for user alerts

### DIFF
--- a/src/app/api/v1/users/[userId]/alerts/active/route.ts
+++ b/src/app/api/v1/users/[userId]/alerts/active/route.ts
@@ -6,6 +6,7 @@ enum AlertTypeEnum {
   FOLLOWER_STAGNATION = "FollowerStagnation",
   FORGOTTEN_FORMAT = "ForgottenFormat",
   CONTENT_PERFORMANCE_DROP = "ContentPerformanceDrop",
+  NO_EVENT_FOUND_TODAY_WITH_INSIGHT = "no_event_found_today_with_insight",
 }
 
 interface AlertResponseItem {
@@ -38,6 +39,7 @@ export async function GET(
   const { searchParams } = new URL(request.url);
   const limitParam = searchParams.get('limit');
   const typesParam = searchParams.getAll('types');
+  const dedupeParam = searchParams.get('dedupeNoEventAlerts');
 
   let limit = 5;
   if (limitParam) {
@@ -51,8 +53,10 @@ export async function GET(
 
   const filterTypes = typesParam.filter(t => ALLOWED_ALERT_TYPES.includes(t as AlertTypeEnum));
 
+  const dedupeNoEventAlerts = dedupeParam === 'true';
+
   try {
-    const { alerts, totalAlerts } = await fetchUserAlerts(userId, { limit, types: filterTypes });
+    const { alerts, totalAlerts } = await fetchUserAlerts(userId, { limit, types: filterTypes, dedupeNoEventAlerts });
 
     const mappedAlerts: AlertResponseItem[] = alerts.map((a) => ({
       alertId: (a._id ?? new Types.ObjectId()).toString(),

--- a/src/app/lib/dataService/__tests__/userService.fetchUserAlerts.test.ts
+++ b/src/app/lib/dataService/__tests__/userService.fetchUserAlerts.test.ts
@@ -4,13 +4,13 @@ import User from '@/app/models/User';
 import { connectToDatabase } from '../connection';
 
 jest.mock('@/app/models/User', () => ({
-  findById: jest.fn(),
+  aggregate: jest.fn(),
 }));
 
 jest.mock('../connection');
 
 const mockConnect = connectToDatabase as jest.Mock;
-const mockFindById = User.findById as jest.Mock;
+const mockAggregate = User.aggregate as jest.Mock;
 
 describe('fetchUserAlerts - dataService', () => {
   const validUserId = new Types.ObjectId().toString();
@@ -27,10 +27,7 @@ describe('fetchUserAlerts - dataService', () => {
       { type: 'C', date: new Date('2024-02-01'), messageForAI: '', finalUserMessage: '', details: {} },
     ];
 
-    mockFindById.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue({ _id: validUserId, alertHistory: alerts }),
-    });
+    mockAggregate.mockResolvedValue([{ alerts, totalCount: [{ count: alerts.length }] }]);
 
     const { alerts: result } = await fetchUserAlerts(validUserId);
 
@@ -45,10 +42,7 @@ describe('fetchUserAlerts - dataService', () => {
       { type: 'C', date: new Date('2024-01-01'), messageForAI: '', finalUserMessage: '', details: {} },
     ];
 
-    mockFindById.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue({ _id: validUserId, alertHistory: alerts }),
-    });
+    mockAggregate.mockResolvedValue([{ alerts, totalCount: [{ count: alerts.length }] }]);
 
     const { alerts: result } = await fetchUserAlerts(validUserId, { limit: 2 });
 
@@ -63,14 +57,36 @@ describe('fetchUserAlerts - dataService', () => {
       { type: 'A', date: new Date('2024-01-01'), messageForAI: '', finalUserMessage: '', details: {} },
     ];
 
-    mockFindById.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue({ _id: validUserId, alertHistory: alerts }),
-    });
+    mockAggregate.mockResolvedValue([{ alerts, totalCount: [{ count: alerts.length }] }]);
 
     const { alerts: result } = await fetchUserAlerts(validUserId, { types: ['A'] });
 
     expect(result).toHaveLength(2);
     expect(result.every(a => a.type === 'A')).toBe(true);
+  });
+
+  test('deduplicates no_event_found_today_with_insight when option enabled', async () => {
+    const alerts = [
+      { type: 'no_event_found_today_with_insight', date: new Date('2024-04-01T10:00:00Z'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'no_event_found_today_with_insight', date: new Date('2024-04-01T09:00:00Z'), messageForAI: '', finalUserMessage: '', details: {} },
+      { type: 'A', date: new Date('2024-04-01T08:00:00Z'), messageForAI: '', finalUserMessage: '', details: {} },
+    ];
+
+    const deduped = [
+      alerts[0],
+      alerts[2],
+    ];
+
+    mockAggregate.mockResolvedValue([{ alerts: deduped, totalCount: [{ count: deduped.length }] }]);
+
+    const { alerts: result } = await fetchUserAlerts(validUserId, { dedupeNoEventAlerts: true });
+
+    expect(mockConnect).toHaveBeenCalled();
+    const pipeline = mockAggregate.mock.calls[0][0];
+    const hasGroupStage = pipeline.some((stage: any) => stage.$group && stage.$group._id === '$dedupeKey');
+    expect(hasGroupStage).toBe(true);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe('no_event_found_today_with_insight');
+    expect(result[1].type).toBe('A');
   });
 });


### PR DESCRIPTION
## Summary
- support deduplicating "no_event" alerts in `fetchUserAlerts`
- expose `dedupeNoEventAlerts` option in API route and widget
- allow hiding those alerts in the dashboard UI
- update unit tests for the new behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b39734530832e97d128c6c55c2a2f