### PR TITLE
Add shares/saves metrics and extended classifications

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -11,6 +11,8 @@ interface VideoMetricsData {
   averageRetentionRate: number | null;
   averageWatchTimeSeconds: number | null;
   numberOfVideoPosts: number | null;
+  averageShares: number | null;
+  averageSaves: number | null;
 }
 
 interface VideoMetricsResponse extends VideoMetricsData {
@@ -129,6 +131,8 @@ const UserVideoPerformanceMetrics: React.FC<
         averageRetentionRate: result.averageRetentionRate,
         averageWatchTimeSeconds: result.averageWatchTimeSeconds,
         numberOfVideoPosts: result.numberOfVideoPosts,
+        averageShares: result.averageShares ?? null,
+        averageSaves: result.averageSaves ?? null,
       });
       setInsightSummary(result.insightSummary);
     } catch (err) {
@@ -213,7 +217,7 @@ const UserVideoPerformanceMetrics: React.FC<
 
       {!loading && !error && metrics && (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-5 gap-3">
             <div
               className="cursor-pointer"
               onClick={() => handleMetricClick("retention_rate")}
@@ -251,6 +255,26 @@ const UserVideoPerformanceMetrics: React.FC<
                 label="Total de Vídeos Analisados"
                 value={metrics.numberOfVideoPosts}
                 tooltip="Número de posts de vídeo considerados para estas métricas no período."
+              />
+            </div>
+            <div
+              className="cursor-pointer"
+              onClick={() => handleMetricClick("shares")}
+            >
+              <MetricDisplay
+                label="Compartilhamentos Médios"
+                value={metrics.averageShares !== null ? metrics.averageShares.toFixed(1) : null}
+                tooltip="Média de compartilhamentos por vídeo."
+              />
+            </div>
+            <div
+              className="cursor-pointer"
+              onClick={() => handleMetricClick("saves")}
+            >
+              <MetricDisplay
+                label="Salvamentos Médios"
+                value={metrics.averageSaves !== null ? metrics.averageSaves.toFixed(1) : null}
+                tooltip="Média de salvamentos por vídeo."
               />
             </div>
           </div>

--- a/src/app/admin/creator-dashboard/components/VideoListPreview.tsx
+++ b/src/app/admin/creator-dashboard/components/VideoListPreview.tsx
@@ -5,6 +5,8 @@ import {
   EyeIcon,
   HeartIcon,
   ChatBubbleOvalLeftEllipsisIcon,
+  ShareIcon,
+  BookmarkIcon,
 } from "@heroicons/react/24/solid";
 import { VideoListItem } from "@/types/mediakit";
 import { idsToLabels } from "@/app/lib/classification";
@@ -24,7 +26,7 @@ const formatNumber = (n?: number) =>
 
 const getLabels = (
   tags: string | string[] | undefined,
-  type: "format" | "proposal" | "context"
+  type: "format" | "proposal" | "context" | "tone" | "reference"
 ): string[] => {
   if (!tags) {
     return [];
@@ -125,6 +127,22 @@ const VideoListPreview: React.FC<VideoListPreviewProps> = ({ userId, timePeriod,
                       {tag}
                     </span>
                   ))}
+                  {getLabels(video.tone, "tone").map((tag) => (
+                    <span
+                      key={tag}
+                      className="bg-yellow-100 text-yellow-800 px-1.5 py-0.5 rounded text-[10px]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                  {getLabels(video.references, "reference").map((tag) => (
+                    <span
+                      key={tag}
+                      className="bg-green-100 text-green-800 px-1.5 py-0.5 rounded text-[10px]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
                 </div>
               </div>
               <div className="flex flex-col text-xs text-gray-600 gap-1 pr-2">
@@ -139,6 +157,14 @@ const VideoListPreview: React.FC<VideoListPreviewProps> = ({ userId, timePeriod,
                 <span className="flex items-center gap-1">
                   <ChatBubbleOvalLeftEllipsisIcon className="w-3.5 h-3.5 text-gray-400" />
                   {formatNumber(video.stats?.comments)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <ShareIcon className="w-3.5 h-3.5 text-gray-400" />
+                  {formatNumber(video.stats?.shares)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <BookmarkIcon className="w-3.5 h-3.5 text-gray-400" />
+                  {formatNumber(video.stats?.saves)}
                 </span>
               </div>
             </div>

--- a/src/app/admin/creator-dashboard/components/VideosTable.tsx
+++ b/src/app/admin/creator-dashboard/components/VideosTable.tsx
@@ -22,7 +22,7 @@ interface VideosTableProps {
 // ✅ CORREÇÃO FINAL: A função agora processa os itens *dentro* do array.
 const getTranslatedLabels = (
   tags: string | string[] | undefined,
-  type: 'format' | 'proposal' | 'context'
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
 ): string[] => {
   if (!tags) {
     return [];
@@ -94,6 +94,12 @@ const VideoCard: React.FC<{ video: VideoListItem; index: number; readOnly?: bool
           ))}
           {getTranslatedLabels(video.context, 'context').map(tag => (
             <span key={tag} className={`${tagBaseClasses} bg-purple-100 text-purple-800`}>{tag}</span>
+          ))}
+          {getTranslatedLabels(video.tone, 'tone').map(tag => (
+            <span key={tag} className={`${tagBaseClasses} bg-yellow-100 text-yellow-800`}>{tag}</span>
+          ))}
+          {getTranslatedLabels(video.references, 'reference').map(tag => (
+            <span key={tag} className={`${tagBaseClasses} bg-green-100 text-green-800`}>{tag}</span>
           ))}
         </div>
 

--- a/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserVideoPerformanceMetrics.test.tsx
@@ -32,6 +32,8 @@ describe('UserVideoPerformanceMetrics', () => {
           averageRetentionRate: 50,
           averageWatchTimeSeconds: 120,
           numberOfVideoPosts: 10,
+          averageShares: 5,
+          averageSaves: 3,
         }),
       })
       .mockResolvedValueOnce({

--- a/src/app/api/v1/users/[userId]/performance/video-metrics/route.ts
+++ b/src/app/api/v1/users/[userId]/performance/video-metrics/route.ts
@@ -8,6 +8,8 @@ interface AverageVideoMetricsData {
   averageRetentionRate: number;
   averageWatchTimeSeconds: number;
   numberOfVideoPosts: number;
+  averageShares: number;
+  averageSaves: number;
 }
 
 interface UserVideoMetricsResponse extends Omit<Awaited<ReturnType<typeof calculateAverageVideoMetrics>>, 'startDate' | 'endDate'> {
@@ -55,6 +57,8 @@ export async function GET(
       averageRetentionRate: videoMetrics.averageRetentionRate,
       averageWatchTimeSeconds: videoMetrics.averageWatchTimeSeconds,
       numberOfVideoPosts: videoMetrics.numberOfVideoPosts,
+      averageShares: videoMetrics.averageShares,
+      averageSaves: videoMetrics.averageSaves,
       insightSummary: `Nos ${timePeriod.replace("last_","").replace("_"," ")}, a retenção média dos seus vídeos é de ${videoMetrics.averageRetentionRate.toFixed(1)}% e o tempo médio de visualização é de ${videoMetrics.averageWatchTimeSeconds.toFixed(0)}s, baseado em ${videoMetrics.numberOfVideoPosts} vídeos.`
     };
     if (videoMetrics.numberOfVideoPosts === 0) {


### PR DESCRIPTION
## Summary
- compute average shares and saves in `calculateAverageVideoMetrics`
- expose the new metrics through the user video metrics API
- show shares and saves in creator dashboard video metrics
- expand preview and table to display tone and reference tags
- adjust test mocks for new fields

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686b5e0dc568832e86fb93eb1397ca42