### PR TITLE
Fix user trend filtering

### DIFF
--- a/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
@@ -1,6 +1,5 @@
 // src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
 import { NextResponse } from 'next/server';
-import getReachEngagementTrendChartData from '@/charts/getReachEngagementTrendChartData';
 import getReachInteractionTrendChartData from '@/charts/getReachInteractionTrendChartData';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
@@ -58,23 +57,11 @@ export async function GET(
     // CORREÇÃO: A variável 'data' não é mais estritamente tipada na declaração.
     // Em vez disso, usamos uma asserção de tipo ('as') para garantir que os dados
     // sejam tratados como 'ReachEngagementChartResponse', resolvendo o erro de tipo.
-    let data = await getReachEngagementTrendChartData(
+    const data = await getReachInteractionTrendChartData(
       userId,
       timePeriod,
       granularity
     ) as unknown as ReachEngagementChartResponse;
-
-    const noInsightData =
-      !data.chartData || data.chartData.every(p => p.reach === null && p.engagedUsers === null);
-
-    if (noInsightData) {
-      // A asserção também é aplicada aqui para manter a consistência do tipo da variável 'data'.
-      data = await getReachInteractionTrendChartData(
-          userId, 
-          timePeriod, 
-          granularity
-      ) as unknown as ReachEngagementChartResponse;
-    }
 
     if (!data.chartData || data.chartData.length === 0) {
       data.insightSummary =

--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -189,6 +189,13 @@ export const getCategoryById = (id: string, type: 'format' | 'proposal' | 'conte
   return list.find(cat => cat.id === id);
 };
 
+export const isValidCategoryId = (
+  id: string,
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+): boolean => {
+  return Boolean(getCategoryById(id, type));
+};
+
 export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string[] {
   return (ids ?? []).map(id => getCategoryById(id, type)?.label ?? id);
 }

--- a/src/utils/getAverageEngagementByGrouping.ts
+++ b/src/utils/getAverageEngagementByGrouping.ts
@@ -3,6 +3,7 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { getNestedValue } from './dataAccessHelpers';
+import { isValidCategoryId } from '@/app/lib/classification';
 import { getStartDateFromTimePeriod } from './dateHelpers';
 
 export type GroupingType = 'format' | 'context' | 'proposal';
@@ -59,6 +60,7 @@ async function getAverageEngagementByGrouping(
       if (Array.isArray(keys)) {
         for (const key of keys) {
           if (!key) continue; // Pula chaves nulas ou vazias dentro do array
+          if (!isValidCategoryId(key, groupBy)) continue; // ignora IDs desconhecidos
 
           if (!aggregation[key]) {
             aggregation[key] = { sum: 0, count: 0 };


### PR DESCRIPTION
## Summary
- add category validation helper
- skip invalid categories when aggregating averages
- ensure reach/engagement trend for creators uses user-filtered data only

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c01d69ab0832e911c281fc14743fe