### PR TITLE
Add integration tests for user endpoints

### DIFF
--- a/src/app/admin/creator-dashboard/components/__tests__/UserAverageEngagementChart.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserAverageEngagementChart.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserAverageEngagementChart from '../UserAverageEngagementChart';
+import { useGlobalTimePeriod } from '../filters/GlobalTimePeriodContext';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(),
+}));
+
+const mockUseGlobalTimePeriod = useGlobalTimePeriod as jest.Mock;
+
+describe('UserAverageEngagementChart', () => {
+  beforeEach(() => {
+    mockUseGlobalTimePeriod.mockReturnValue({ timePeriod: 'last_30_days' });
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ chartData: [], insightSummary: '' }),
+    });
+  });
+
+  it('calls user endpoint', async () => {
+    render(<UserAverageEngagementChart userId="u1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/performance/average-engagement');
+  });
+});

--- a/src/app/admin/creator-dashboard/components/__tests__/UserMonthlyComparisonChart.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserMonthlyComparisonChart.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserMonthlyComparisonChart from '../UserMonthlyComparisonChart';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(() => ({ timePeriod: 'last_3_months' })),
+}));
+
+describe('UserMonthlyComparisonChart', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ chartData: [], metricCompared: 'totalPosts' }),
+    });
+  });
+
+  it('calls user endpoint', async () => {
+    render(<UserMonthlyComparisonChart userId="u1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/charts/monthly-comparison');
+  });
+});

--- a/src/app/admin/creator-dashboard/components/__tests__/UserMonthlyEngagementStackedChart.test.tsx
+++ b/src/app/admin/creator-dashboard/components/__tests__/UserMonthlyEngagementStackedChart.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserMonthlyEngagementStackedChart from '../UserMonthlyEngagementStackedChart';
+import { useGlobalTimePeriod } from '../filters/GlobalTimePeriodContext';
+
+jest.mock('../filters/GlobalTimePeriodContext', () => ({
+  useGlobalTimePeriod: jest.fn(),
+}));
+
+const mockUseGlobalTimePeriod = useGlobalTimePeriod as jest.Mock;
+
+describe('UserMonthlyEngagementStackedChart', () => {
+  beforeEach(() => {
+    mockUseGlobalTimePeriod.mockReturnValue({ timePeriod: 'last_6_months' });
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ chartData: [], insightSummary: '' }),
+    });
+  });
+
+  it('calls user endpoint', async () => {
+    render(<UserMonthlyEngagementStackedChart userId="u1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/v1/users/u1/charts/monthly-engagement-stacked');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure user charts use `/api/v1/users/...` routes
- add tests for user average engagement, monthly stacked engagement, and monthly comparison charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4ee99de0832e94f22d22112c74dd