### PR TITLE
Fix user reach trend naming

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/UserReachEngagementTrendChart.tsx
@@ -17,7 +17,7 @@ import {
 interface ApiReachEngagementDataPoint {
   date: string;
   reach: number | null;
-  engagedUsers: number | null;
+  totalInteractions: number | null;
 }
 
 interface UserReachEngagementTrendResponse {
@@ -265,8 +265,8 @@ const UserReachEngagementTrendChart: React.FC<
               <Line
                 yAxisId="left"
                 type="monotone"
-                dataKey="engagedUsers"
-                name="Contas Engajadas"
+                dataKey="totalInteractions"
+                name="Interações"
                 stroke="#82ca9d"
                 strokeWidth={2}
                 dot={{ r: 3 }}

--- a/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/users/[userId]/trends/reach-engagement/route.ts
@@ -8,7 +8,7 @@ import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriod
 interface ApiReachEngagementDataPoint {
   date: string;
   reach: number | null;
-  engagedUsers: number | null;
+  totalInteractions: number | null;
 }
 
 interface ReachEngagementChartResponse {
@@ -54,12 +54,19 @@ export async function GET(
   }
 
   try {
-    const data: ReachEngagementChartResponse =
-      await getReachInteractionTrendChartData(
-        userId,
-        timePeriod,
-        granularity
-      );
+    const rawData = await getReachInteractionTrendChartData(
+      userId,
+      timePeriod,
+      granularity
+    );
+    const data: ReachEngagementChartResponse = {
+      chartData: rawData.chartData.map((d) => ({
+        date: d.date,
+        reach: d.reach,
+        totalInteractions: d.totalInteractions,
+      })),
+      insightSummary: rawData.insightSummary,
+    };
 
     if (!data.chartData || data.chartData.length === 0) {
       data.insightSummary =

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -231,7 +231,7 @@ export interface FollowerTrendData {
 export interface ReachEngagementTrendPoint {
     date: string;
     reach: number | null;
-    engagedUsers: number | null;
+    totalInteractions: number | null;
 }
 
 export interface ReachEngagementTrendData {

--- a/src/charts/getReachEngagementTrendChartData.test.ts
+++ b/src/charts/getReachEngagementTrendChartData.test.ts
@@ -75,11 +75,11 @@ describe('getReachEngagementTrendChartData', () => {
       const result = await getReachEngagementTrendChartData(userId, period, "daily");
 
       expect(result.chartData.length).toBe(7); // 7 dias
-      expect(result.chartData[0]).toEqual({ date: formatDateYYYYMMDD(createDate(6, baseTestDate)), reach: 100, engagedUsers: 10 }); // Nov 9
-      expect(result.chartData[1]).toEqual({ date: formatDateYYYYMMDD(createDate(5, baseTestDate)), reach: null, engagedUsers: null });// Nov 10 (gap)
-      expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(createDate(4, baseTestDate)), reach: 120, engagedUsers: 12 });// Nov 11
-      expect(result.chartData[3]).toEqual({ date: formatDateYYYYMMDD(createDate(3, baseTestDate)), reach: null, engagedUsers: null });// Nov 12 (gap)
-      expect(result.chartData[6]).toEqual({ date: formatDateYYYYMMDD(createDate(0, baseTestDate)), reach: 150, engagedUsers: 15 });// Nov 15
+      expect(result.chartData[0]).toEqual({ date: formatDateYYYYMMDD(createDate(6, baseTestDate)), reach: 100, totalInteractions: 10 }); // Nov 9
+      expect(result.chartData[1]).toEqual({ date: formatDateYYYYMMDD(createDate(5, baseTestDate)), reach: null, totalInteractions: null });// Nov 10 (gap)
+      expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(createDate(4, baseTestDate)), reach: 120, totalInteractions: 12 });// Nov 11
+      expect(result.chartData[3]).toEqual({ date: formatDateYYYYMMDD(createDate(3, baseTestDate)), reach: null, totalInteractions: null });// Nov 12 (gap)
+      expect(result.chartData[6]).toEqual({ date: formatDateYYYYMMDD(createDate(0, baseTestDate)), reach: 150, totalInteractions: 15 });// Nov 15
       expect(result.insightSummary).toContain("Média de alcance");
     });
 
@@ -89,7 +89,7 @@ describe('getReachEngagementTrendChartData', () => {
       expect(result.chartData.length).toBe(3);
       result.chartData.forEach(dp => {
         expect(dp.reach).toBeNull();
-        expect(dp.engagedUsers).toBeNull();
+        expect(dp.totalInteractions).toBeNull();
       });
       expect(result.insightSummary).toBe("Nenhum dado de alcance ou engajamento encontrado para o período.");
     });
@@ -104,7 +104,7 @@ describe('getReachEngagementTrendChartData', () => {
         (AccountInsightModel.find as jest.Mock).mockResolvedValue(snapshots);
         const result = await getReachEngagementTrendChartData(userId, period, "daily");
         expect(result.chartData.length).toBe(3);
-        expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(createDate(0, baseTestDate)), reach: 100, engagedUsers: 10 });
+        expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(createDate(0, baseTestDate)), reach: 100, totalInteractions: 10 });
         expect(result.chartData[0].reach).toBeNull(); // Gaps para Nov 13, 14
         expect(result.chartData[1].reach).toBeNull();
     });
@@ -142,11 +142,11 @@ describe('getReachEngagementTrendChartData', () => {
       const weekForNov15 = getYearWeek(createDate(0, baseTestDate));  // 2023-46
       const weekForOct25 = getYearWeek(createDate(21, baseTestDate)); // 2023-43 (gap)
 
-      expect(result.chartData.find(p=>p.date === weekForOct18)).toEqual({ date: weekForOct18, reach: 700, engagedUsers: 70 });
-      expect(result.chartData.find(p=>p.date === weekForOct25)).toEqual({ date: weekForOct25, reach: null, engagedUsers: null });
-      expect(result.chartData.find(p=>p.date === weekForNov1)).toEqual({ date: weekForNov1, reach: 800, engagedUsers: 80 });
-      expect(result.chartData.find(p=>p.date === getYearWeek(createDate(7, baseTestDate)))).toEqual({ date: getYearWeek(createDate(7, baseTestDate)), reach: null, engagedUsers: null }); // 2023-45 (gap)
-      expect(result.chartData.find(p=>p.date === weekForNov15)).toEqual({ date: weekForNov15, reach: 900, engagedUsers: 90 });
+      expect(result.chartData.find(p=>p.date === weekForOct18)).toEqual({ date: weekForOct18, reach: 700, totalInteractions: 70 });
+      expect(result.chartData.find(p=>p.date === weekForOct25)).toEqual({ date: weekForOct25, reach: null, totalInteractions: null });
+      expect(result.chartData.find(p=>p.date === weekForNov1)).toEqual({ date: weekForNov1, reach: 800, totalInteractions: 80 });
+      expect(result.chartData.find(p=>p.date === getYearWeek(createDate(7, baseTestDate)))).toEqual({ date: getYearWeek(createDate(7, baseTestDate)), reach: null, totalInteractions: null }); // 2023-45 (gap)
+      expect(result.chartData.find(p=>p.date === weekForNov15)).toEqual({ date: weekForNov15, reach: 900, totalInteractions: 90 });
     });
      test('Sobrescreve com o último snapshot se múltiplos para a mesma semana/dia', async () => {
         const snapshots = [
@@ -157,7 +157,7 @@ describe('getReachEngagementTrendChartData', () => {
         const result = await getReachEngagementTrendChartData(userId, "last_7_days", "daily");
         const pointForNov9 = result.chartData.find(p=>p.date === formatDateYYYYMMDD(createDate(6, baseTestDate)));
         expect(pointForNov9?.reach).toBe(105); // Valor do último snapshot para o dia
-        expect(pointForNov9?.engagedUsers).toBe(11);
+        expect(pointForNov9?.totalInteractions).toBe(11);
     });
   });
 
@@ -167,7 +167,7 @@ describe('getReachEngagementTrendChartData', () => {
     expect(result.chartData.length).toBe(7); // Deve preencher com nulos
     result.chartData.forEach(dp => {
         expect(dp.reach).toBeNull();
-        expect(dp.engagedUsers).toBeNull();
+        expect(dp.totalInteractions).toBeNull();
     });
     expect(result.insightSummary).toBe("Erro ao buscar dados de alcance e engajamento.");
     expect(console.error).toHaveBeenCalled();

--- a/src/charts/getReachInteractionTrendChartData.test.ts
+++ b/src/charts/getReachInteractionTrendChartData.test.ts
@@ -58,10 +58,10 @@ describe('getReachInteractionTrendChartData', () => {
     const result = await getReachInteractionTrendChartData(userId, 'last_7_days', 'daily');
 
     expect(result.chartData.length).toBe(7);
-    expect(result.chartData[0]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -6)), reach: 100, engagedUsers: 10 });
-    expect(result.chartData[1]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -5)), reach: null, engagedUsers: null });
-    expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -4)), reach: 120, engagedUsers: 12 });
-    expect(result.chartData[6]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, 0)), reach: 150, engagedUsers: 15 });
+    expect(result.chartData[0]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -6)), reach: 100, totalInteractions: 10 });
+    expect(result.chartData[1]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -5)), reach: null, totalInteractions: null });
+    expect(result.chartData[2]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, -4)), reach: 120, totalInteractions: 12 });
+    expect(result.chartData[6]).toEqual({ date: formatDateYYYYMMDD(addDays(baseDate, 0)), reach: 150, totalInteractions: 15 });
   });
 
   test('Agrega posts semanais e preenche gaps', async () => {
@@ -82,9 +82,9 @@ describe('getReachInteractionTrendChartData', () => {
 
     expect(result.chartData.find(p => p.date === week1)?.reach).toBe(200);
     expect(result.chartData.find(p => p.date === week2)?.reach).toBeNull();
-    expect(result.chartData.find(p => p.date === week3)?.engagedUsers).toBe(30);
+    expect(result.chartData.find(p => p.date === week3)?.totalInteractions).toBe(30);
     expect(result.chartData.find(p => p.date === week4)?.reach).toBeNull();
-    expect(result.chartData.find(p => p.date === week5)?.engagedUsers).toBe(40);
+    expect(result.chartData.find(p => p.date === week5)?.totalInteractions).toBe(40);
   });
 
   test('Nenhum post retorna todos nulos', async () => {
@@ -93,7 +93,7 @@ describe('getReachInteractionTrendChartData', () => {
     expect(result.chartData.length).toBe(3);
     result.chartData.forEach(p => {
       expect(p.reach).toBeNull();
-      expect(p.engagedUsers).toBeNull();
+      expect(p.totalInteractions).toBeNull();
     });
   });
 

--- a/src/charts/getReachInteractionTrendChartData.ts
+++ b/src/charts/getReachInteractionTrendChartData.ts
@@ -14,7 +14,7 @@ import {
 interface ReachInteractionDataPoint {
   date: string;
   reach: number | null;
-  engagedUsers: number | null; // represents total_interactions
+  totalInteractions: number | null; // represents total_interactions
 }
 
 interface ReachInteractionChartResponse {
@@ -48,7 +48,7 @@ async function getReachInteractionTrendChartData(
       .sort({ postDate: 1 })
       .lean();
 
-    const dataMap = new Map<string, { reach: number; engagedUsers: number }>();
+    const dataMap = new Map<string, { reach: number; totalInteractions: number }>();
     for (const post of posts) {
       const stats = post.stats || {};
       const reach = typeof stats.reach === 'number' ? stats.reach : 0;
@@ -59,9 +59,9 @@ async function getReachInteractionTrendChartData(
         ? formatDateYYYYMMDD(post.postDate)
         : getYearWeek(post.postDate);
 
-      const agg = dataMap.get(key) || { reach: 0, engagedUsers: 0 };
+      const agg = dataMap.get(key) || { reach: 0, totalInteractions: 0 };
       agg.reach += reach;
-      agg.engagedUsers += interactions;
+      agg.totalInteractions += interactions;
       dataMap.set(key, agg);
     }
 
@@ -74,15 +74,15 @@ async function getReachInteractionTrendChartData(
       response.chartData.push({
         date: key,
         reach: entry ? entry.reach : null,
-        engagedUsers: entry ? entry.engagedUsers : null,
+        totalInteractions: entry ? entry.totalInteractions : null,
       });
       cursor = granularity === 'daily' ? addDays(cursor, 1) : addDays(cursor, 7);
     }
 
-    const valid = response.chartData.filter(p => p.reach !== null || p.engagedUsers !== null);
+    const valid = response.chartData.filter(p => p.reach !== null || p.totalInteractions !== null);
     if (valid.length) {
       const totalReach = valid.reduce((s, p) => s + (p.reach ?? 0), 0);
-      const totalInter = valid.reduce((s, p) => s + (p.engagedUsers ?? 0), 0);
+      const totalInter = valid.reduce((s, p) => s + (p.totalInteractions ?? 0), 0);
       const periodText = timePeriod === 'all_time'
         ? 'todo o período'
         : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months', ' meses');


### PR DESCRIPTION
## Summary
- align user reach/engagement trend APIs with platform naming
- rename `engagedUsers` to `totalInteractions` in user trend chart and service
- update API route mapping and associated tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c50246d20832e8bec5e9f951ebb9b