### PR TITLE
Add category label validation

### DIFF
--- a/src/app/lib/classification.ts
+++ b/src/app/lib/classification.ts
@@ -176,24 +176,49 @@ const flatContextCategories = flattenCategories(contextCategories);
 const flatToneCategories = flattenCategories(toneCategories);
 const flatReferenceCategories = flattenCategories(referenceCategories);
 
-export const getCategoryById = (id: string, type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'): Category | undefined => {
-  let list: Category[];
+const getFlatCategoriesByType = (
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+): Category[] => {
   switch (type) {
-    case 'format': list = flatFormatCategories; break;
-    case 'proposal': list = flatProposalCategories; break;
-    case 'context': list = flatContextCategories; break;
-    case 'tone': list = flatToneCategories; break;
-    case 'reference': list = flatReferenceCategories; break;
-    default: return undefined;
+    case 'format':
+      return flatFormatCategories;
+    case 'proposal':
+      return flatProposalCategories;
+    case 'context':
+      return flatContextCategories;
+    case 'tone':
+      return flatToneCategories;
+    case 'reference':
+      return flatReferenceCategories;
+    default:
+      return [];
   }
-  return list.find(cat => cat.id === id);
+};
+
+export const getCategoryById = (
+  id: string,
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+): Category | undefined => {
+  return getFlatCategoriesByType(type).find((cat) => cat.id === id);
+};
+
+export const getCategoryByValue = (
+  value: string,
+  type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
+): Category | undefined => {
+  const list = getFlatCategoriesByType(type);
+  const byId = list.find((cat) => cat.id === value);
+  if (byId) return byId;
+  return list.find(
+    (cat) => cat.label.toLocaleLowerCase() === value.toLocaleLowerCase()
+  );
 };
 
 export const isValidCategoryId = (
   id: string,
   type: 'format' | 'proposal' | 'context' | 'tone' | 'reference'
 ): boolean => {
-  return Boolean(getCategoryById(id, type));
+  return Boolean(getCategoryByValue(id, type));
 };
 
 export function idsToLabels(ids: string[] | undefined, type: 'format'|'proposal'|'context'|'tone'|'reference'): string[] {

--- a/src/utils/getAverageEngagementByGrouping.test.ts
+++ b/src/utils/getAverageEngagementByGrouping.test.ts
@@ -3,6 +3,7 @@ import getAverageEngagementByGrouping, { GroupingType } from './getAverageEngage
 import MetricModel, { IMetric, FormatType, IMetricStats } from '@/app/models/Metric'; // Ajuste
 import { getNestedValue } from "./dataAccessHelpers"; // Importar para mock ou referência
 import { getStartDateFromTimePeriod } from "./dateHelpers"; // Para referência de datas
+import { isValidCategoryId } from '@/app/lib/classification';
 
 jest.mock('@/app/models/Metric', () => ({
   find: jest.fn(),
@@ -190,5 +191,13 @@ describe('getAverageEngagementByGrouping', () => {
     const result = await getAverageEngagementByGrouping(userId, timePeriod, performanceMetricField, "format");
     expect(result).toEqual([]);
     expect(console.error).toHaveBeenCalled();
+  });
+
+  test('Valores de formato por label continuam válidos', () => {
+    expect(isValidCategoryId('Reel', 'format')).toBe(true);
+    expect(isValidCategoryId('Foto', 'format')).toBe(true);
+    // também aceita variações em minúsculas
+    expect(isValidCategoryId('reel', 'format')).toBe(true);
+    expect(isValidCategoryId('foto', 'format')).toBe(true);
   });
 });

--- a/src/utils/getAverageEngagementByGrouping.ts
+++ b/src/utils/getAverageEngagementByGrouping.ts
@@ -3,6 +3,7 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { getNestedValue } from './dataAccessHelpers';
+// Validador agora aceita IDs ou labels (ex: "Reel", "Foto")
 import { isValidCategoryId } from '@/app/lib/classification';
 import { getStartDateFromTimePeriod } from './dateHelpers';
 


### PR DESCRIPTION
## Summary
- search category values by id or label with `getCategoryByValue`
- validate categories using the new search logic
- mention updated validator in average engagement helper
- test that `isValidCategoryId` accepts format labels such as "Reel" and "Foto"

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7965a5ac832eafafc228279e34a8