### PR TITLE
Remove white header from creator dashboard

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -85,6 +85,7 @@ export default function CreatorQuickSearch({
         placeholder={selectedCreatorName || "Buscar criador..."}
         debounceMs={200}
         className="w-80 sm:w-96 flex-grow"
+        variant="minimal"
         ariaLabel="Buscar criador"
         onClear={() => {
           setSearchTerm("");

--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
@@ -48,7 +48,7 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
         value={selectedTimePeriod}
         onChange={(e) => onTimePeriodChange(e.target.value)}
         disabled={disabled}
-        className="p-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed w-full sm:w-auto"
+        className="p-2 bg-brand-light border-0 border-b border-gray-200 rounded-none shadow-none focus:outline-none focus:border-gray-400 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed w-full sm:w-auto"
       >
         {options.map(option => (
           <option key={option.value} value={option.value}>{option.label}</option>

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -133,12 +133,9 @@ const AdminCreatorDashboardContent: React.FC = () => {
         <title>Dashboard Admin - Data2Content</title>
       </Head>
       <div className="min-h-screen bg-brand-light">
-        <header className="bg-white shadow-sm sticky top-0 z-40 border-b border-gray-200">
+        <header className="bg-brand-light sticky top-0 z-40 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-4 h-16">
-              <Link href="/admin/creator-dashboard" className="flex-shrink-0 flex items-center gap-2 group">
-                <span className="text-brand-pink text-3xl font-bold group-hover:opacity-80 transition-opacity">[2]</span>
-              </Link>
               <CreatorQuickSearch
                 onSelect={(creator) => handleUserSelect(creator.id, creator.name)}
                 selectedCreatorName={selectedUserName}

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -26,6 +26,11 @@ interface SearchBarProps {
    * Useful for showing a selected value that can be cleared.
    */
   showClearWhenEmpty?: boolean;
+  /**
+   * Visual variant of the input. Default keeps the bordered style while
+   * 'minimal' removes the box and uses only a bottom border.
+   */
+  variant?: 'default' | 'minimal';
 }
 
 /**
@@ -52,6 +57,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
       value,
       onClear,
       showClearWhenEmpty = false,
+      variant = 'default',
     }: SearchBarProps,
     ref,
   ) {
@@ -107,9 +113,11 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           aria-label={ariaLabel}
           ref={setRefs}
           autoFocus={autoFocus}
-          className="block w-full pl-10 pr-8 py-2 border border-gray-300 rounded-md shadow-sm
-                   focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-700
-                   bg-white dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+          className={`block w-full pl-10 pr-8 py-2 sm:text-sm text-gray-700 dark:text-white focus:outline-none ${
+            variant === 'minimal'
+              ? 'bg-brand-light dark:bg-gray-800 border-0 border-b border-gray-200 rounded-none shadow-none focus:border-gray-400 focus:ring-0'
+              : 'border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-800 dark:border-gray-600'
+          }`}
         />
         {onClear && (inputValue || showClearWhenEmpty) && (
           <button


### PR DESCRIPTION
## Summary
- match header background color to page
- simplify search bar and filter style
- remove numeric logo from creator dashboard

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8ef45fb8832eac1def126e23fb62