### PR TITLE
Adjust dashboard search styling

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -74,7 +74,7 @@ export default function CreatorQuickSearch({
   };
 
   return (
-    <div className="relative flex items-center" ref={containerRef}>
+    <div className="relative flex items-center bg-brand-light" ref={containerRef}>
       <SearchBar
         initialValue=""
         value={searchTerm}

--- a/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
+++ b/src/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter.tsx
@@ -48,7 +48,7 @@ const GlobalTimePeriodFilter: React.FC<GlobalTimePeriodFilterProps> = ({
         value={selectedTimePeriod}
         onChange={(e) => onTimePeriodChange(e.target.value)}
         disabled={disabled}
-        className="p-2 bg-brand-light border-0 border-b border-gray-200 rounded-none shadow-none focus:outline-none focus:border-gray-400 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed w-full sm:w-auto"
+        className="p-2 pr-8 bg-brand-light border-0 border-b border-gray-200 rounded-none shadow-none focus:outline-none focus:border-gray-400 text-sm text-gray-700 disabled:bg-gray-100 disabled:cursor-not-allowed w-full sm:w-auto"
       >
         {options.map(option => (
           <option key={option.value} value={option.value}>{option.label}</option>

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -134,8 +134,8 @@ const AdminCreatorDashboardContent: React.FC = () => {
       </Head>
       <div className="min-h-screen bg-brand-light">
         <header className="bg-brand-light sticky top-0 z-40 border-b border-gray-200">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex items-center gap-4 h-16">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="flex items-end gap-4">
               <CreatorQuickSearch
                 onSelect={(creator) => handleUserSelect(creator.id, creator.name)}
                 selectedCreatorName={selectedUserName}

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -115,7 +115,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           autoFocus={autoFocus}
           className={`block w-full pl-10 pr-8 py-2 sm:text-sm text-gray-700 dark:text-white focus:outline-none ${
             variant === 'minimal'
-              ? 'bg-brand-light dark:bg-gray-800 border-0 border-b border-gray-200 rounded-none shadow-none focus:border-gray-400 focus:ring-0'
+              ? '!bg-brand-light dark:bg-gray-800 border-0 border-b border-gray-200 rounded-none shadow-none focus:border-gray-400 focus:ring-0 placeholder-gray-500'
               : 'border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-800 dark:border-gray-600'
           }`}
         />


### PR DESCRIPTION
## Summary
- tweak minimal search input style to better blend with dashboard
- give time filter more right padding
- align header bottom border with sidebar divider
- match quick search container color to page background

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c97b75fa8832e9b42d5ed22cd79ce