### PR TITLE
Fix search bar text color and dropdown placement

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -94,7 +94,7 @@ export default function CreatorQuickSearch({
         showClearWhenEmpty={!!selectedCreatorName}
       />
       {showDropdown && (searchTerm || isLoading) && (
-        <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+        <div className="absolute z-10 left-0 top-full mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
           {isLoading && (
             <p className="p-2 text-sm text-gray-500">Carregando...</p>
           )}

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -113,9 +113,9 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           aria-label={ariaLabel}
           ref={setRefs}
           autoFocus={autoFocus}
-          className={`block w-full pl-10 pr-8 py-2 sm:text-sm text-gray-700 dark:text-white focus:outline-none ${
+          className={`block w-full pl-10 pr-8 py-2 sm:text-sm text-black dark:text-white focus:outline-none ${
             variant === 'minimal'
-              ? 'bg-brand-light dark:bg-gray-800 border-0 border-b border-gray-200 rounded-none shadow-none focus:border-gray-400 focus:ring-0 placeholder-gray-500'
+              ? '!bg-brand-light dark:bg-gray-800 border-0 border-b border-gray-200 rounded-none shadow-none focus:border-gray-400 focus:ring-0 placeholder-gray-500'
               : 'border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-800 dark:border-gray-600'
           }`}
         />


### PR DESCRIPTION
## Summary
- ensure search bar text is black in light mode
- position creator search dropdown below input

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9b767cbc832e88c5f1f1664a6c79