### PR TITLE
Clean up leftover correction comments

### DIFF
--- a/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
+++ b/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
@@ -49,11 +49,9 @@ interface FinalPayload {
   suggestions: string[];
 }
 
-// --- INÍCIO DA CORREÇÃO 1: Adicionar a interface de props ---
 interface StandaloneChatInterfaceProps {
   initialPrompt?: string;
 }
-// --- FIM DA CORREÇÃO 1 ---
 
 // --- CONSTANTS ---
 const DATA_DELIMITER = '---JSON_DATA_PAYLOAD---';
@@ -345,14 +343,11 @@ const ChatInput: FC<{
 };
 
 // --- MAIN CHAT INTERFACE COMPONENT ---
-// --- INÍCIO DA CORREÇÃO 2: Alterar a assinatura do componente para aceitar props ---
 const StandaloneChatInterface: React.FC<StandaloneChatInterfaceProps> = ({ initialPrompt }) => {
-// --- FIM DA CORREÇÃO 2 ---
   const { messages, isLoading, error, visualizations, suggestions, startConversation, askRadarEffectiveness } = useIntelligenceChat();
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // --- INÍCIO DA CORREÇÃO 3: Adicionar useEffect para lidar com o initialPrompt ---
   useEffect(() => {
     // Inicia a conversa automaticamente se um prompt inicial for fornecido e não houver mensagens
     if (initialPrompt && messages.length === 0 && !isLoading) {
@@ -360,7 +355,6 @@ const StandaloneChatInterface: React.FC<StandaloneChatInterfaceProps> = ({ initi
     }
     // A dependência de 'startConversation' garante que a função mais recente seja usada.
   }, [initialPrompt, messages.length, isLoading, startConversation]);
-  // --- FIM DA CORREÇÃO 3 ---
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -45,12 +45,10 @@ export default function CreatorQuickSearch({
         setHighlightIndex((prev) => (prev - 1 + creators.length) % creators.length);
       } else if (e.key === 'Enter' && highlightIndex >= 0) {
         e.preventDefault();
-        // --- INÍCIO DA CORREÇÃO ---
         const selectedCreator = creators[highlightIndex];
         if (selectedCreator) {
           handleSelect(selectedCreator);
         }
-        // --- FIM DA CORREÇÃO ---
       } else if (e.key === 'Escape') {
         setShowDropdown(false);
       }

--- a/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
@@ -7,19 +7,16 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
 
-// ===== INÍCIO DA CORREÇÃO =====
-// A interface foi atualizada para corresponder à resposta da API
 interface ApiChartDataPoint {
   date: string;
   reach: number | null;
-  totalInteractions: number | null; // Alterado de engagedUsers
+  totalInteractions: number | null;
 }
 
 interface PlatformChartResponse {
   chartData: ApiChartDataPoint[];
   insightSummary?: string;
 }
-// ===== FIM DA CORREÇÃO =====
 
 const GRANULARITY_OPTIONS = [
   { value: "daily", label: "Diário" },

--- a/src/app/admin/widgets/CreatorTable.tsx
+++ b/src/app/admin/widgets/CreatorTable.tsx
@@ -100,9 +100,6 @@ const CreatorTable = memo(function CreatorTable({
       // Simula um delay de rede
       await new Promise(resolve => setTimeout(resolve, 1000));
       
-      // --- INÍCIO DA CORREÇÃO ---
-      // O objeto _id foi convertido para 'any' para satisfazer o tipo 'ObjectId' durante a simulação de dados.
-      // Isso resolve o erro de tipagem sem afetar a lógica de renderização que usa `_id.toString()`.
       const mockCreators: IDashboardCreator[] = Array.from({ length: limit }).map((_, i) => ({
         _id: { toString: () => `id_${currentPage}_${i}` } as any,
         name: `Criador da Tabela ${currentPage}-${i}`,
@@ -111,7 +108,6 @@ const CreatorTable = memo(function CreatorTable({
         lastActivityDate: new Date(Date.now() - Math.random() * 45 * 24 * 60 * 60 * 1000),
         planStatus: ['Free', 'Pro', 'Premium'][i % 3],
       }));
-      // --- FIM DA CORREÇÃO ---
 
       setCreators(mockCreators);
       setTotalCreators(50); // Total de mocks

--- a/src/app/admin/widgets/TopMoversWidget.tsx
+++ b/src/app/admin/widgets/TopMoversWidget.tsx
@@ -174,11 +174,7 @@ const TopMoversWidget = memo(function TopMoversWidget() {
           profilePictureUrl: entityType === 'creator' ? `https://i.pravatar.cc/40?u=${i}` : undefined,
       })).map(item => {
           item.absoluteChange = item.currentValue - item.previousValue;
-          // --- INÍCIO DA CORREÇÃO ---
-          // O erro de tipo ocorria aqui. `percentageChange` espera um `number`, mas `null` era fornecido.
-          // Alterado para `0` para casos de divisão por zero, garantindo a compatibilidade de tipo.
           item.percentageChange = item.previousValue !== 0 ? item.absoluteChange / item.previousValue : 0;
-          // --- FIM DA CORREÇÃO ---
           return item;
       }).sort((a, b) => {
           if (sortBy.includes('decrease')) return a.absoluteChange - b.absoluteChange;

--- a/src/app/api/admin/dashboard/content/performance-by-type/route.ts
+++ b/src/app/api/admin/dashboard/content/performance-by-type/route.ts
@@ -64,13 +64,10 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(performanceData, { status: 200 });
 
   } catch (error: any) {
-    // --- INÍCIO DA CORREÇÃO ---
-    // A propriedade 'details' foi removida do objeto de log porque ela não existe no tipo 'DatabaseError'.
     logger.error(`${TAG} Error in request handler:`, {
       message: error.message,
       stack: error.stack,
     });
-    // --- FIM DA CORREÇÃO ---
 
     if (error instanceof DatabaseError) {
       return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });

--- a/src/app/api/admin/dashboard/creators/route.ts
+++ b/src/app/api/admin/dashboard/creators/route.ts
@@ -11,12 +11,7 @@ import { fetchDashboardCreatorsList } from '@/app/lib/dataService/marketAnalysis
 import { IFetchDashboardCreatorsListParams } from '@/app/lib/dataService/marketAnalysis/types';
 import { DatabaseError } from '@/app/lib/errors';
 
-// ==================== INÍCIO DA CORREÇÃO ====================
-// Força a rota a ser sempre renderizada dinamicamente no servidor.
-// Isso é necessário porque a rota utiliza `req.url` para ler parâmetros de busca
-// e `getServerSession` para validação, o que impede a geração estática.
 export const dynamic = 'force-dynamic';
-// ==================== FIM DA CORREÇÃO ======================
 
 const SERVICE_TAG = '[api/admin/dashboard/creators]';
 

--- a/src/app/api/admin/dashboard/platform-summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.ts
@@ -89,13 +89,10 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(summaryData, { status: 200 });
 
   } catch (error: any) {
-    // --- INÍCIO DA CORREÇÃO ---
-    // A propriedade 'details' foi removida do objeto de log para corresponder à definição do tipo 'DatabaseError'.
     logger.error(`${TAG} Error in request handler:`, {
       message: error.message,
       stack: error.stack,
     });
-    // --- FIM DA CORREÇÃO ---
 
     if (error instanceof DatabaseError) {
       return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });

--- a/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
+++ b/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
@@ -58,13 +58,10 @@ export async function GET(
     return NextResponse.json(postDetails, { status: 200 });
 
   } catch (error: any) {
-    // --- INÍCIO DA CORREÇÃO ---
-    // A propriedade 'details' foi removida do objeto de log, pois não existe no tipo 'DatabaseError'.
     logger.error(`${TAG} Error in request handler for postId ${postId}:`, {
       message: error.message,
       stack: error.stack,
     });
-    // --- FIM DA CORREÇÃO ---
 
     if (error instanceof DatabaseError) {
       return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });

--- a/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
@@ -112,8 +112,6 @@ export async function GET(
         const sum = window.reduce((acc, curr) => acc + curr.totalDailyEngagement, 0);
         const average = sum / movingAverageWindowInDays;
         
-        // ===== INÍCIO DA CORREÇÃO =====
-        // Adicionada uma verificação para garantir que o ponto atual existe antes de acessá-lo.
         const currentPoint = completeDailyEngagements[i];
         if (currentPoint) {
             movingAverageSeries.push({
@@ -121,7 +119,6 @@ export async function GET(
                 movingAverageEngagement: average,
             });
         }
-        // ===== FIM DA CORREÇÃO =====
     }
 
     // 5. Filtrar a série final para corresponder à janela de dados solicitada

--- a/src/app/api/v1/platform/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/reach-engagement/route.ts
@@ -14,8 +14,6 @@ import {
   getYearWeek,
 } from '@/utils/dateHelpers';
 
-// ===== INÍCIO DA CORREÇÃO =====
-// Tipos atualizados para refletir a mudança de 'engagedUsers' para 'totalInteractions'
 interface ApiChartDataPoint {
   date: string;
   reach: number | null;
@@ -26,7 +24,6 @@ interface ChartResponse {
   chartData: ApiChartDataPoint[];
   insightSummary: string;
 }
-// ===== FIM DA CORREÇÃO =====
 
 const ALLOWED_GRANULARITIES: string[] = ["daily", "weekly"];
 

--- a/src/app/lib/dataService/marketAnalysis/segmentService.ts
+++ b/src/app/lib/dataService/marketAnalysis/segmentService.ts
@@ -162,10 +162,7 @@ export async function fetchContentPerformanceByType(
             $lte: endDate,
           },
           'stats.total_interactions': { $exists: true, $ne: null, $type: "number" }, // Ensure it's a number
-          // --- INÍCIO DA CORREÇÃO ---
-          // Substituído o uso duplicado de '$ne' por '$nin' (not in) para verificar múltiplos valores.
           type: { $exists: true, $nin: [null, ""] }
-          // --- FIM DA CORREÇÃO ---
         }
       },
       {

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -244,9 +244,6 @@ function generateAffiliateCode(): string {
 const commissionLogEntrySchema = new Schema<ICommissionLogEntry>({/*...*/}, {/*...*/}); // Placeholder for brevity
 const lastCommunityInspirationShownSchema = new Schema<ILastCommunityInspirationShown>({/*...*/}, {/*...*/}); // Placeholder for brevity
 
-// ========== INÍCIO DA CORREÇÃO ==========
-// O schema foi restaurado para a sua definição completa, garantindo que
-// os campos da conta do Instagram sejam salvos corretamente no banco de dados.
 const AvailableInstagramAccountSchema = new Schema<IAvailableInstagramAccount>({
     igAccountId: { type: String, required: true },
     pageId: { type: String, required: true },
@@ -254,7 +251,6 @@ const AvailableInstagramAccountSchema = new Schema<IAvailableInstagramAccount>({
     username: { type: String },
     profile_picture_url: { type: String },
 }, { _id: false });
-// ========== FIM DA CORREÇÃO ==========
 
 const UserPreferencesSchema = new Schema<IUserPreferences>({/*...*/}, {/*...*/}); // Placeholder for brevity
 const UserLongTermGoalSchema = new Schema<IUserLongTermGoal>({/*...*/}, {/*...*/}); // Placeholder for brevity

--- a/src/utils/platformMetricsHelpers.ts
+++ b/src/utils/platformMetricsHelpers.ts
@@ -62,15 +62,10 @@ export async function getPlatformMinMaxValues(
               );
               const latestFollowerCountsResults = await Promise.allSettled(latestFollowerCountsPromises);
               
-              // ==================== INÍCIO DA CORREÇÃO ====================
-              // 1. O primeiro .filter() agora apenas verifica o status da promessa, sem um type predicate complexo.
-              // 2. O .map() usa uma asserção de tipo (as) para informar ao TypeScript a "forma" do valor,
-              //    o que é seguro aqui porque já filtramos por status 'fulfilled' e valor não nulo.
               const validCounts = latestFollowerCountsResults
                   .filter(r => r.status === 'fulfilled' && r.value !== null)
                   .map(r => (r as PromiseFulfilledResult<FollowerCountResult>).value.followersCount)
                   .filter((count): count is number => typeof count === 'number');
-              // ==================== FIM DA CORREÇÃO ======================
 
               if (validCounts.length > 0) {
                   results[metricId] = {


### PR DESCRIPTION
## Summary
- strip `INÍCIO/FIM DA CORREÇÃO` comments from codebase
- keep functional code while removing explanatory notes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca2dc98fc832e892fe218d7d23293