### PR TITLE
Enable pagination for creator rankings and filter Instagram users

### DIFF
--- a/src/app/admin/creator-dashboard/CreatorRankingModal.tsx
+++ b/src/app/admin/creator-dashboard/CreatorRankingModal.tsx
@@ -30,6 +30,7 @@ const CreatorRankingModal: React.FC<CreatorRankingModalProps> = ({
   const [rankingData, setRankingData] = useState<ICreatorMetricRankItem[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
 
   const fetchData = useCallback(async () => {
     if (!dateRangeFilter?.startDate || !dateRangeFilter?.endDate) {
@@ -40,7 +41,10 @@ const CreatorRankingModal: React.FC<CreatorRankingModalProps> = ({
     setIsLoading(true);
     setError(null);
 
-    const params = new URLSearchParams({ limit: String(limit) });
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(page * limit),
+    });
 
     if (dateRangeFilter.startDate) {
       const ls = new Date(dateRangeFilter.startDate);
@@ -67,13 +71,17 @@ const CreatorRankingModal: React.FC<CreatorRankingModalProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [apiEndpoint, dateRangeFilter, limit, title]);
+  }, [apiEndpoint, dateRangeFilter, limit, title, page]);
 
   useEffect(() => {
     if (isOpen) {
       fetchData();
     }
   }, [isOpen, fetchData]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [dateRangeFilter]);
 
   const formatMetricValue = (value: number): string => {
     if (Number.isInteger(value)) {
@@ -164,7 +172,23 @@ const CreatorRankingModal: React.FC<CreatorRankingModalProps> = ({
             </div>
           )}
         </div>
-        <footer className="p-4 border-t text-right">
+        <footer className="p-4 border-t flex items-center justify-between space-x-2">
+          <div className="space-x-2">
+            <button
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={page === 0 || isLoading}
+              className="px-3 py-1 text-sm bg-gray-100 rounded-md disabled:opacity-50"
+            >
+              Anterior
+            </button>
+            <button
+              onClick={() => setPage(p => p + 1)}
+              disabled={isLoading || (rankingData && rankingData.length < limit)}
+              className="px-3 py-1 text-sm bg-gray-100 rounded-md disabled:opacity-50"
+            >
+              Próximo
+            </button>
+          </div>
           <button onClick={onClose} className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md">
             Fechar
           </button>

--- a/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-engagement-per-post/route.ts
@@ -16,6 +16,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: 'startDate cannot be after endDate.',
   path: ['endDate'],
@@ -54,11 +55,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchAvgEngagementPerPostCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/avg-reach-per-post/route.ts
@@ -16,6 +16,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: 'startDate cannot be after endDate.',
   path: ['endDate'],
@@ -54,11 +55,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchAvgReachPerPostCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/engagement-growth/route.ts
@@ -16,6 +16,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: 'startDate cannot be after endDate.',
   path: ['endDate'],
@@ -54,11 +55,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchEngagementVariationCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/most-prolific/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/most-prolific/route.ts
@@ -17,6 +17,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: "startDate cannot be after endDate.",
   path: ["endDate"],
@@ -56,11 +57,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchMostProlificCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/performance-consistency/route.ts
@@ -16,6 +16,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: 'startDate cannot be after endDate.',
   path: ['endDate'],
@@ -54,11 +55,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchPerformanceConsistencyCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/reach-per-follower/route.ts
@@ -16,6 +16,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: 'startDate cannot be after endDate.',
   path: ['endDate'],
@@ -54,11 +55,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchReachPerFollowerCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/top-engaging/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-engaging/route.ts
@@ -17,6 +17,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: "startDate cannot be after endDate.",
   path: ["endDate"],
@@ -56,11 +57,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchTopEngagingCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/top-interactions/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-interactions/route.ts
@@ -17,6 +17,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: "startDate cannot be after endDate.",
   path: ["endDate"],
@@ -56,11 +57,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchTopInteractionCreators(params);

--- a/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
+++ b/src/app/api/admin/dashboard/rankings/creators/top-sharing/route.ts
@@ -17,6 +17,7 @@ const querySchema = z.object({
   startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
   endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
   limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
 }).refine(data => data.startDate <= data.endDate, {
   message: "startDate cannot be after endDate.",
   path: ["endDate"],
@@ -56,11 +57,12 @@ export async function GET(req: NextRequest) {
       return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
     }
 
-    const { startDate, endDate, limit } = validationResult.data;
+    const { startDate, endDate, limit, offset } = validationResult.data;
 
     const params: IFetchCreatorRankingParams = {
       dateRange: { startDate, endDate },
       limit,
+      offset,
     };
 
     const results = await fetchTopSharingCreators(params);

--- a/src/app/lib/dataService/marketAnalysis/rankingsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/rankingsService.ts
@@ -31,7 +31,7 @@ export async function fetchTopEngagingCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchTopEngagingCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -58,6 +58,7 @@ export async function fetchTopEngagingCreators(
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -65,10 +66,11 @@ export async function fetchTopEngagingCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -98,7 +100,7 @@ export async function fetchMostProlificCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchMostProlificCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
    logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -107,6 +109,7 @@ export async function fetchMostProlificCreators(
       { $match: { postDate: { $gte: dateRange.startDate, $lte: dateRange.endDate } } },
       { $group: { _id: '$user', metricValue: { $sum: 1 } }},
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -114,10 +117,11 @@ export async function fetchMostProlificCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -147,7 +151,7 @@ export async function fetchTopInteractionCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
     const TAG = `${SERVICE_TAG}[fetchTopInteractionCreators]`;
-    const { dateRange, limit = 5 } = params;
+    const { dateRange, limit = 5, offset = 0 } = params;
     logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -161,6 +165,7 @@ export async function fetchTopInteractionCreators(
       },
       { $group: { _id: '$user', metricValue: { $sum: '$stats.total_interactions' } }},
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -168,10 +173,11 @@ export async function fetchTopInteractionCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -201,7 +207,7 @@ export async function fetchTopSharingCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
     const TAG = `${SERVICE_TAG}[fetchTopSharingCreators]`;
-    const { dateRange, limit = 5 } = params;
+    const { dateRange, limit = 5, offset = 0 } = params;
     logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -215,6 +221,7 @@ export async function fetchTopSharingCreators(
       },
       { $group: { _id: '$user', metricValue: { $sum: '$stats.shares' } }},
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -222,10 +229,11 @@ export async function fetchTopSharingCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -253,7 +261,7 @@ export async function fetchAvgEngagementPerPostCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchAvgEngagementPerPostCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -279,6 +287,7 @@ export async function fetchAvgEngagementPerPostCreators(
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -286,10 +295,11 @@ export async function fetchAvgEngagementPerPostCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -317,7 +327,7 @@ export async function fetchAvgReachPerPostCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchAvgReachPerPostCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -343,6 +353,7 @@ export async function fetchAvgReachPerPostCreators(
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -350,10 +361,11 @@ export async function fetchAvgReachPerPostCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -381,7 +393,7 @@ export async function fetchEngagementVariationCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchEngagementVariationCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   const periodMs = dateRange.endDate.getTime() - dateRange.startDate.getTime();
@@ -429,6 +441,7 @@ export async function fetchEngagementVariationCreators(
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -436,10 +449,11 @@ export async function fetchEngagementVariationCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -467,7 +481,7 @@ export async function fetchPerformanceConsistencyCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchPerformanceConsistencyCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -499,6 +513,7 @@ export async function fetchPerformanceConsistencyCreators(
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $lookup: {
@@ -506,10 +521,11 @@ export async function fetchPerformanceConsistencyCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
+      { $match: { 'creatorDetails.isInstagramConnected': true } },
       {
         $project: {
           _id: 0,
@@ -537,7 +553,7 @@ export async function fetchReachPerFollowerCreators(
   params: IFetchCreatorRankingParams
 ): Promise<ICreatorMetricRankItem[]> {
   const TAG = `${SERVICE_TAG}[fetchReachPerFollowerCreators]`;
-  const { dateRange, limit = 5 } = params;
+  const { dateRange, limit = 5, offset = 0 } = params;
   logger.info(`${TAG} Fetching for period: ${dateRange.startDate} - ${dateRange.endDate}`);
 
   try {
@@ -563,17 +579,18 @@ export async function fetchReachPerFollowerCreators(
           localField: '_id',
           foreignField: '_id',
           as: 'creatorDetails',
-          pipeline: [{ $project: { name: 1, profile_picture_url: 1, followers_count: 1 } }]
+          pipeline: [{ $project: { name: 1, profile_picture_url: 1, followers_count: 1, isInstagramConnected: 1 } }]
         }
       },
       { $unwind: { path: '$creatorDetails', preserveNullAndEmptyArrays: true } },
-      { $match: { 'creatorDetails.followers_count': { $gte: 1000 } } },
+      { $match: { 'creatorDetails.followers_count': { $gte: 1000 }, 'creatorDetails.isInstagramConnected': true } },
       {
         $addFields: {
           metricValue: { $divide: ['$totalReach', '$creatorDetails.followers_count'] }
         }
       },
       { $sort: { metricValue: -1 } },
+      { $skip: offset },
       { $limit: limit },
       {
         $project: {

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -220,6 +220,7 @@ export interface IFetchCreatorRankingParams {
     endDate: Date;
   };
   limit?: number;
+  offset?: number;
 }
 
 export interface IFetchCreatorTimeSeriesArgs {


### PR DESCRIPTION
## Summary
- add `offset` to ranking request types and API routes
- filter only Instagram-connected creators in ranking service
- add pagination support with previous/next controls in the modal

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d98720028832e962d0663edb54ab8