### PR TITLE
Fix Top Creators widget

### DIFF
--- a/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
@@ -7,6 +7,23 @@ import { useGlobalTimePeriod } from './components/filters/GlobalTimePeriodContex
 import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 import { TimePeriod } from '@/app/lib/constants/timePeriods';
 
+const InfoIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className || 'h-4 w-4'}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
+);
+
 interface TopCreatorsWidgetProps {
   title: string;
   context?: string;
@@ -15,6 +32,7 @@ interface TopCreatorsWidgetProps {
   limit?: number;
   metricLabel?: string;
   compositeRanking?: boolean;
+  tooltip?: string;
 }
 
 const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
@@ -25,6 +43,7 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
   limit = 5,
   metricLabel = '',
   compositeRanking = false,
+  tooltip,
 }) => {
   const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const effectiveTimePeriod: TimePeriod = timePeriod || (globalTimePeriod as TimePeriod);
@@ -98,9 +117,19 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
 
   return (
     <div className="bg-white p-4 rounded-lg shadow border border-gray-200 h-full flex flex-col">
-      <h4 className="text-md font-semibold text-gray-700 mb-3 truncate" title={title}>
-        {compositeRanking ? 'Top Criadores (Score)' : title}
-      </h4>
+      <div className="flex items-center justify-between mb-1">
+        <h4 className="text-md font-semibold text-gray-700 truncate" title={title}>
+          {compositeRanking ? 'Top Criadores (Score)' : title}
+        </h4>
+        {tooltip && (
+          <div className="relative group">
+            <InfoIcon className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-pointer" />
+            <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 w-max max-w-xs p-1.5 text-xs text-white bg-gray-700 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10">
+              {tooltip}
+            </div>
+          </div>
+        )}
+      </div>
       {isLoading && renderSkeleton()}
       {!isLoading && error && (
         <div className="text-center py-4 flex-grow flex flex-col justify-center items-center">

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -128,12 +128,13 @@ const CreatorRankingSection: React.FC<Props> = ({
             />
           </div>
           <div className="inline-flex md:block">
-            <TopCreatorsWidget
-              title="Top Criadores"
-              metric="total_interactions"
-              timePeriod={validatedTimePeriod}
-              limit={5}
-            />
+          <TopCreatorsWidget
+            title="Top Criadores"
+            metric="total_interactions"
+            timePeriod={validatedTimePeriod}
+            limit={5}
+            tooltip="Ranking geral com base em interações e alcance"
+          />
           </div>
         </div>
       </div>

--- a/src/app/api/admin/dashboard/rankings/top-creators/route.test.ts
+++ b/src/app/api/admin/dashboard/rankings/top-creators/route.test.ts
@@ -15,7 +15,14 @@ function mockRequest(params: Record<string, string>): NextRequest {
 }
 
 const sampleData = [
-  { creatorId: '1', creatorName: 'Alice', metricValue: 100, totalInteractions: 200, postCount: 10 },
+  {
+    creatorId: '1',
+    creatorName: 'Alice',
+    metricValue: 100,
+    totalInteractions: 200,
+    postCount: 10,
+    profilePictureUrl: 'https://example.com/alice.jpg',
+  },
 ];
 const sampleScoreData = [
   { creatorId: '1', creatorName: 'Alice', score: 90 },

--- a/src/app/lib/dataService/marketAnalysis/profilesService.ts
+++ b/src/app/lib/dataService/marketAnalysis/profilesService.ts
@@ -104,7 +104,17 @@ export async function fetchTopCreators(args: { context: string, metricToSortBy: 
       { $sort: { metricValue: -1 } },
       { $limit: limit },
       ...createBasePipeline(),
-      { $project: { _id: 0, creatorId: '$_id', creatorName: '$creatorInfo.name', totalInteractions: 1, metricValue: 1, postCount: 1 } },
+      {
+        $project: {
+          _id: 0,
+          creatorId: '$_id',
+          creatorName: '$creatorInfo.name',
+          profilePictureUrl: '$creatorInfo.profile_picture_url',
+          totalInteractions: 1,
+          metricValue: 1,
+          postCount: 1,
+        },
+      },
     ];
     return await MetricModel.aggregate(aggregationPipeline);
   } catch (error: any) {

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -58,6 +58,7 @@ export interface IMarketPerformanceResult {
 export interface ITopCreatorResult {
     creatorId: string;
     creatorName?: string;
+    profilePictureUrl?: string;
     metricValue: number;
     totalInteractions: number;
     postCount: number;


### PR DESCRIPTION
## Summary
- include profile picture in top creators ranking API
- add tooltip/InfoIcon to TopCreatorsWidget
- update CreatorRankingSection usage
- extend tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dab880e3c832e9196893c1bec2ff2