### PR TITLE
Improve metrics layout and readability

### DIFF
--- a/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
+++ b/src/app/admin/creator-dashboard/components/UserVideoPerformanceMetrics.tsx
@@ -231,7 +231,7 @@ const UserVideoPerformanceMetrics: React.FC<
 
       {!loading && !error && metrics && (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-7 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
             <div
               className="cursor-pointer"
               onClick={() => handleMetricClick("views")}

--- a/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
+++ b/src/app/admin/creator-dashboard/components/VideoDrillDownModal.tsx
@@ -55,10 +55,10 @@ const ClassificationTags: React.FC<{
   
   return (
     <div>
-      <h5 className="text-xs font-semibold text-gray-500 mb-1">{title}</h5>
-      <div className="flex flex-wrap gap-1">
+      <h5 className="text-sm font-semibold text-gray-500 mb-1">{title}</h5>
+      <div className="flex flex-wrap gap-1 text-sm">
         {labels.map(tag => (
-          <span key={tag} className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${colorClasses}`}>
+          <span key={tag} className={`inline-flex items-center px-2 py-0.5 rounded-md font-medium ${colorClasses}`}>
             {tag}
           </span>
         ))}
@@ -135,11 +135,11 @@ const VideoCard: React.FC<{ video: VideoListItem; index: number; readOnly?: bool
         <div className="col-span-12 md:col-span-4 flex items-start gap-4">
           <img src={video.thumbnailUrl || 'https://placehold.co/96x54/e2e8f0/a0aec0?text=Img'} alt={`Thumbnail para ${video.description || 'post'}`} width={96} height={54} className="rounded-md object-cover flex-shrink-0 mt-1" />
           <div className="flex-grow">
-            <p className="font-semibold text-sm text-gray-800 line-clamp-3" title={video.description}>
+            <p className="font-semibold text-base text-gray-800 line-clamp-3" title={video.description}>
               {readOnly && index === 0 && <FireIcon className="w-4 h-4 text-orange-400 inline-block mr-1.5 align-text-bottom" title="Top Performance"/>}
               {video.description || 'Sem legenda'}
             </p>
-            <p className="text-xs text-gray-500 mt-1">{formatDate(video.postDate)}</p>
+            <p className="text-sm text-gray-500 mt-1">{formatDate(video.postDate)}</p>
           </div>
         </div>
 
@@ -152,29 +152,29 @@ const VideoCard: React.FC<{ video: VideoListItem; index: number; readOnly?: bool
         </div>
 
         <div className="col-span-6 md:col-span-1 text-left md:text-center">
-            <h5 className="text-xs font-semibold text-gray-500 mb-1 md:hidden">Engaj.</h5>
+            <h5 className="text-sm font-semibold text-gray-500 mb-1 md:hidden">Engaj.</h5>
             <div className="font-bold text-base text-pink-600">{calculateEngagementRate(video.stats)}</div>
         </div>
 
         <div className="col-span-6 md:col-span-2">
-            <h5 className="text-xs font-semibold text-gray-500 mb-1 md:hidden">Performance</h5>
-            <div className="flex flex-col space-y-1.5 text-xs">
-                <span className="flex items-center gap-2 text-gray-700"><EyeIcon className="text-gray-400 w-3.5 h-3.5"/> {formatNumber(video.stats?.views)}</span>
-                <span className="flex items-center gap-2 text-gray-700"><HeartIcon className="text-gray-400 w-3.5 h-3.5"/> {formatNumber(video.stats?.likes)}</span>
-                <span className="flex items-center gap-2 text-gray-700"><ChatBubbleOvalLeftEllipsisIcon className="text-gray-400 w-3.5 h-3.5"/> {formatNumber(video.stats?.comments)}</span>
-                <span className="flex items-center gap-2 text-gray-700"><ShareIcon className="text-gray-400 w-3.5 h-3.5"/> {formatNumber(video.stats?.shares)}</span>
-                <span className="flex items-center gap-2 text-gray-700"><BookmarkIcon className="text-gray-400 w-3.5 h-3.5"/> {formatNumber(video.stats?.saves)}</span>
+            <h5 className="text-sm font-semibold text-gray-500 mb-1 md:hidden">Performance</h5>
+            <div className="flex flex-col space-y-1.5 text-sm font-semibold">
+                <span className="flex items-center gap-2 text-gray-700"><EyeIcon className="text-gray-400 w-4 h-4"/> {formatNumber(video.stats?.views)}</span>
+                <span className="flex items-center gap-2 text-gray-700"><HeartIcon className="text-gray-400 w-4 h-4"/> {formatNumber(video.stats?.likes)}</span>
+                <span className="flex items-center gap-2 text-gray-700"><ChatBubbleOvalLeftEllipsisIcon className="text-gray-400 w-4 h-4"/> {formatNumber(video.stats?.comments)}</span>
+                <span className="flex items-center gap-2 text-gray-700"><ShareIcon className="text-gray-400 w-4 h-4"/> {formatNumber(video.stats?.shares)}</span>
+                <span className="flex items-center gap-2 text-gray-700"><BookmarkIcon className="text-gray-400 w-4 h-4"/> {formatNumber(video.stats?.saves)}</span>
             </div>
         </div>
 
         <div className="col-span-12 md:col-span-2 flex flex-row sm:flex-col items-center justify-start sm:justify-center gap-2 pt-2 md:pt-0">
           {onRowClick && (
-            <button onClick={() => onRowClick(video._id)} title="Analisar Detalhes" className="flex items-center justify-center gap-2 w-full px-3 py-1.5 text-xs font-semibold text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 transition-colors">
+            <button onClick={() => onRowClick(video._id)} title="Analisar Detalhes" className="flex items-center justify-center gap-2 w-full px-3 py-1.5 text-sm font-semibold text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 transition-colors">
               <ChartBarIcon className="w-3.5 h-3.5" />
               <span>Analisar</span>
             </button>
           )}
-          <a href={video.permalink ?? '#'} target="_blank" rel="noopener noreferrer" title="Ver na Rede Social" className="flex items-center justify-center gap-2 w-full px-3 py-1.5 text-xs font-semibold text-white bg-gray-800 rounded-md shadow-sm hover:bg-gray-700 transition-colors">
+          <a href={video.permalink ?? '#'} target="_blank" rel="noopener noreferrer" title="Ver na Rede Social" className="flex items-center justify-center gap-2 w-full px-3 py-1.5 text-sm font-semibold text-white bg-gray-800 rounded-md shadow-sm hover:bg-gray-700 transition-colors">
             <InstagramIcon className="w-3.5 h-3.5" />
             <span>Ver Post</span>
           </a>
@@ -189,11 +189,11 @@ const VideosTable: React.FC<VideosTableProps> = ({ videos, ...props }) => {
   return (
     <div className="space-y-3">
       <div className="hidden md:grid md:grid-cols-12 md:gap-x-4 px-4 py-2 border-b border-gray-200">
-        <h4 className="md:col-span-4 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Conteúdo</h4>
-        <h4 className="md:col-span-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Classificação</h4>
-        <h4 className="md:col-span-1 text-center text-xs font-semibold text-gray-400 uppercase tracking-wider">Engaj.</h4>
-        <h4 className="md:col-span-2 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Performance</h4>
-        <h4 className="md:col-span-2 text-center text-xs font-semibold text-gray-400 uppercase tracking-wider">Ações</h4>
+        <h4 className="md:col-span-4 text-left text-sm font-semibold text-gray-400 uppercase tracking-wider">Conteúdo</h4>
+        <h4 className="md:col-span-3 text-left text-sm font-semibold text-gray-400 uppercase tracking-wider">Classificação</h4>
+        <h4 className="md:col-span-1 text-center text-sm font-semibold text-gray-400 uppercase tracking-wider">Engaj.</h4>
+        <h4 className="md:col-span-2 text-left text-sm font-semibold text-gray-400 uppercase tracking-wider">Performance</h4>
+        <h4 className="md:col-span-2 text-center text-sm font-semibold text-gray-400 uppercase tracking-wider">Ações</h4>
       </div>
       
       {videos.map((video, index) => (

--- a/src/app/admin/creator-dashboard/components/VideoListPreview.tsx
+++ b/src/app/admin/creator-dashboard/components/VideoListPreview.tsx
@@ -88,84 +88,82 @@ const VideoListPreview: React.FC<VideoListPreviewProps> = ({ userId, timePeriod,
             <div
               key={video._id}
               onClick={() => onRowClick && onRowClick(video._id)}
-              className="flex items-start gap-4 bg-white border border-gray-100 rounded-md p-2 cursor-pointer"
+              className="bg-white border border-gray-100 rounded-md p-3 cursor-pointer space-y-2"
             >
               <img
-                src={video.thumbnailUrl || "https://placehold.co/96x54/e2e8f0/a0aec0?text=Img"}
+                src={video.thumbnailUrl || "https://placehold.co/320x180/e2e8f0/a0aec0?text=Img"}
                 alt={video.caption || "thumbnail"}
-                width={96}
-                height={54}
-                className="rounded-md object-cover flex-shrink-0 mt-1"
+                className="w-full aspect-video object-cover rounded-md"
+                width={320}
+                height={180}
               />
-              <div className="flex-grow">
-                <p className="text-sm font-medium text-gray-700 line-clamp-2" title={video.caption}>
-                  {video.caption || "Sem legenda"}
-                </p>
-                <p className="text-xs text-gray-500 mt-0.5">{formatDate(video.postDate)}</p>
-                <div className="flex flex-wrap gap-1 mt-1 text-xs">
-                  {getLabels(video.format, "format").map((tag) => (
-                    <span
-                      key={tag}
-                      className="bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  {getLabels(video.proposal, "proposal").map((tag) => (
-                    <span
-                      key={tag}
-                      className="bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  {getLabels(video.context, "context").map((tag) => (
-                    <span
-                      key={tag}
-                      className="bg-purple-100 text-purple-800 px-1.5 py-0.5 rounded"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  {getLabels(video.tone, "tone").map((tag) => (
-                    <span
-                      key={tag}
-                      className="bg-yellow-100 text-yellow-800 px-1.5 py-0.5 rounded"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  {getLabels(video.references, "reference").map((tag) => (
-                    <span
-                      key={tag}
-                      className="bg-green-100 text-green-800 px-1.5 py-0.5 rounded"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs text-gray-600 mt-2">
-                  <span className="flex items-center gap-1">
-                    <EyeIcon className="w-3.5 h-3.5 text-gray-400" />
-                    {formatNumber(video.stats?.views)}
+              <p className="text-base font-medium text-gray-700 line-clamp-2" title={video.caption}>
+                {video.caption || "Sem legenda"}
+              </p>
+              <p className="text-sm text-gray-500">{formatDate(video.postDate)}</p>
+              <div className="flex flex-wrap gap-1 text-sm">
+                {getLabels(video.format, "format").map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded"
+                  >
+                    {tag}
                   </span>
-                  <span className="flex items-center gap-1">
-                    <HeartIcon className="w-3.5 h-3.5 text-gray-400" />
-                    {formatNumber(video.stats?.likes)}
+                ))}
+                {getLabels(video.proposal, "proposal").map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded"
+                  >
+                    {tag}
                   </span>
-                  <span className="flex items-center gap-1">
-                    <ChatBubbleOvalLeftEllipsisIcon className="w-3.5 h-3.5 text-gray-400" />
-                    {formatNumber(video.stats?.comments)}
+                ))}
+                {getLabels(video.context, "context").map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-purple-100 text-purple-800 px-2 py-0.5 rounded"
+                  >
+                    {tag}
                   </span>
-                  <span className="flex items-center gap-1">
-                    <ShareIcon className="w-3.5 h-3.5 text-gray-400" />
-                    {formatNumber(video.stats?.shares)}
+                ))}
+                {getLabels(video.tone, "tone").map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded"
+                  >
+                    {tag}
                   </span>
-                  <span className="flex items-center gap-1">
-                    <BookmarkIcon className="w-3.5 h-3.5 text-gray-400" />
-                    {formatNumber(video.stats?.saves)}
+                ))}
+                {getLabels(video.references, "reference").map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-green-100 text-green-800 px-2 py-0.5 rounded"
+                  >
+                    {tag}
                   </span>
-                </div>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-3 text-base text-gray-700 font-semibold">
+                <span className="flex items-center gap-1">
+                  <EyeIcon className="w-4 h-4 text-gray-500" />
+                  {formatNumber(video.stats?.views)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <HeartIcon className="w-4 h-4 text-gray-500" />
+                  {formatNumber(video.stats?.likes)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <ChatBubbleOvalLeftEllipsisIcon className="w-4 h-4 text-gray-500" />
+                  {formatNumber(video.stats?.comments)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <ShareIcon className="w-4 h-4 text-gray-500" />
+                  {formatNumber(video.stats?.shares)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <BookmarkIcon className="w-4 h-4 text-gray-500" />
+                  {formatNumber(video.stats?.saves)}
+                </span>
               </div>
             </div>
           ))}
@@ -181,5 +179,4 @@ const VideoListPreview: React.FC<VideoListPreviewProps> = ({ userId, timePeriod,
       )}
     </div>
   );
-};
-export default VideoListPreview;
+};export default VideoListPreview;


### PR DESCRIPTION
## Summary
- give video metrics more horizontal space in UserVideoPerformanceMetrics
- redesign VideoListPreview item as vertical card
- enlarge fonts and icons in VideoListPreview
- enlarge fonts and icons in VideoDrillDownModal and classification tags

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dad84c68c832eb0ea074f140bee40