### PR TITLE
Fix TopCreatorsWidget data

### DIFF
--- a/src/app/lib/dataService/marketAnalysis/helpers.ts
+++ b/src/app/lib/dataService/marketAnalysis/helpers.ts
@@ -8,13 +8,14 @@ import { PipelineStage } from 'mongoose';
 /**
  * @function createBasePipeline
  * @description Cria um pipeline de base para adicionar informações do criador (usuário) aos documentos de métricas.
+ * @param {string} [localField='user'] - Campo utilizado para correlacionar o usuário. Após agrupamentos costuma ser '_id'.
  * @returns {PipelineStage[]} Um array de estágios de pipeline do Mongoose.
  */
-export const createBasePipeline = (): PipelineStage[] => [
+export const createBasePipeline = (localField: string = 'user'): PipelineStage[] => [
     {
         $lookup: {
             from: 'users',
-            localField: 'user',
+            localField,
             foreignField: '_id',
             as: 'creatorInfo',
         },

--- a/src/app/lib/dataService/marketAnalysis/profilesService.ts
+++ b/src/app/lib/dataService/marketAnalysis/profilesService.ts
@@ -103,7 +103,7 @@ export async function fetchTopCreators(args: { context: string, metricToSortBy: 
       { $group: { _id: '$user', metricValue: { $avg: `$${sortField}` }, totalInteractions: { $sum: '$stats.total_interactions' }, postCount: { $sum: 1 } } },
       { $sort: { metricValue: -1 } },
       { $limit: limit },
-      ...createBasePipeline(),
+      ...createBasePipeline('_id'),
       {
         $project: {
           _id: 0,
@@ -169,7 +169,7 @@ export async function fetchTopCreatorsWithScore(args: { context?: string; days: 
         }
       },
       { $unwind: { path: '$followersData', preserveNullAndEmptyArrays: true } },
-      ...createBasePipeline(),
+      ...createBasePipeline('_id'),
       {
         $project: {
           _id: 0,


### PR DESCRIPTION
## Summary
- expose a localField option in `createBasePipeline`
- use `_id` for creator lookups in top creators queries

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dae98aeb0832eb6f161327e3a8a14