### PR TITLE
Fix Top Creators widget to use composite ranking

### DIFF
--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -130,9 +130,9 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
           <TopCreatorsWidget
             title="Top Criadores"
-            metric="total_interactions"
             timePeriod={validatedTimePeriod}
             limit={5}
+            compositeRanking={true}
             tooltip="Ranking geral com base em interações e alcance"
           />
           </div>


### PR DESCRIPTION
## Summary
- enable composite ranking in the Top Creators card so the real score is shown

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db3844ef4832e8818a283b29937ca