### PR TITLE
Show avatar in filtered creator view

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -8,7 +8,15 @@ import { useCreatorSearch } from "@/hooks/useCreatorSearch";
 import { XMarkIcon, MagnifyingGlassIcon } from "@heroicons/react/24/solid";
 import { AnimatePresence, motion } from "framer-motion";
 
-const CreatorBadge = ({ name, onClear }: { name: string; onClear: () => void; }) => (
+const CreatorBadge = ({
+  name,
+  photoUrl,
+  onClear,
+}: {
+  name: string;
+  photoUrl?: string | null;
+  onClear: () => void;
+}) => (
   <motion.div
     layoutId="creatorBadge"
     initial={{ opacity: 0, scale: 0.8 }}
@@ -17,6 +25,7 @@ const CreatorBadge = ({ name, onClear }: { name: string; onClear: () => void; })
     transition={{ type: "spring", stiffness: 300, damping: 30 }}
     className="flex items-center gap-2 bg-indigo-100 text-indigo-800 text-sm font-medium px-2 py-1 rounded-full"
   >
+    <UserAvatar name={name} src={photoUrl} size={24} />
     <span>{name}</span>
     <button onClick={onClear} className="p-0.5 rounded-full hover:bg-indigo-200">
       <XMarkIcon className="w-4 h-4" />
@@ -70,14 +79,16 @@ const HighlightMatch = ({ text, highlight }: { text: string; highlight: string }
 };
 
 interface CreatorQuickSearchProps {
-  onSelect: (creator: { id: string; name: string }) => void;
+  onSelect: (creator: { id: string; name: string; profilePictureUrl?: string | null }) => void;
   selectedCreatorName?: string | null;
+  selectedCreatorPhotoUrl?: string | null;
   onClear: () => void;
 }
 
 export default function CreatorQuickSearch({
   onSelect,
   selectedCreatorName,
+  selectedCreatorPhotoUrl,
   onClear,
 }: CreatorQuickSearchProps) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -116,7 +127,7 @@ export default function CreatorQuickSearch({
   }, [showDropdown, creators, highlightIndex, isLoading]);
 
   const handleSelect = (creator: AdminCreatorListItem) => {
-    onSelect({ id: creator._id, name: creator.name });
+    onSelect({ id: creator._id, name: creator.name, profilePictureUrl: creator.profilePictureUrl });
     setSearchTerm("");
     setShowDropdown(false);
   };
@@ -141,7 +152,13 @@ export default function CreatorQuickSearch({
         disabled={!!selectedCreatorName}
       >
         <AnimatePresence>
-          {selectedCreatorName && <CreatorBadge name={selectedCreatorName} onClear={onClear} />}
+          {selectedCreatorName && (
+            <CreatorBadge
+              name={selectedCreatorName}
+              photoUrl={selectedCreatorPhotoUrl}
+              onClear={onClear}
+            />
+          )}
         </AnimatePresence>
       </SearchBar>
 

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import { ArrowLeftIcon } from '@heroicons/react/24/solid';
+import { UserAvatar } from "@/app/components/UserAvatar";
 
 
 // User-specific charts & metrics
@@ -22,6 +23,7 @@ import UserComparativeKpi from "../kpis/UserComparativeKpi";
 interface UserDetailViewProps {
   userId: string | null;
   userName?: string;
+  userPhotoUrl?: string | null;
   onClear?: () => void;
 }
 
@@ -34,6 +36,7 @@ const KPI_COMPARISON_PERIOD_OPTIONS = [
 const UserDetailView: React.FC<UserDetailViewProps> = ({
   userId,
   userName,
+  userPhotoUrl,
   onClear,
 }) => {
   const [kpiComparisonPeriod, setKpiComparisonPeriod] = useState<string>(
@@ -81,7 +84,9 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
                     </button>
                 )}
                 <h2 className="text-2xl md:text-3xl font-bold text-indigo-700 flex items-center gap-2">
-                  Análise Detalhada: {displayName} <GlobalPeriodIndicator />
+                  <UserAvatar name={displayName} src={userPhotoUrl ?? undefined} size={36} />
+                  <span>{displayName}</span>
+                  <GlobalPeriodIndicator />
                 </h2>
               </div>
           </div>

--- a/src/app/admin/creator-dashboard/page.tsx
+++ b/src/app/admin/creator-dashboard/page.tsx
@@ -35,26 +35,31 @@ const SkeletonBlock = ({ width = 'w-full', height = 'h-4', className = '' }) => 
 const AdminCreatorDashboardContent: React.FC = () => {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
+  const [selectedUserPhotoUrl, setSelectedUserPhotoUrl] = useState<string | null>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } = useGlobalTimePeriod();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const nameCache = useRef<Record<string, string>>({});
+  const photoCache = useRef<Record<string, string | null>>({});
 
   // ===== CORREÇÃO APLICADA: useEffect segue a recomendação do desenvolvedor =====
   useEffect(() => {
     const userIdFromUrl = searchParams.get('userId');
-    
+
     if (userIdFromUrl) {
         const knownName = nameCache.current[userIdFromUrl];
+        const knownPhoto = photoCache.current[userIdFromUrl];
         const finalName = knownName || `Criador ID: ...${userIdFromUrl.slice(-4)}`;
-        
+
         setSelectedUserId(userIdFromUrl);
         setSelectedUserName(finalName);
+        setSelectedUserPhotoUrl(knownPhoto ?? null);
     } else {
         setSelectedUserId(null);
         setSelectedUserName(null);
+        setSelectedUserPhotoUrl(null);
     }
     setIsInitializing(false);
   }, [searchParams]); // A dependência agora é APENAS a URL, como recomendado.
@@ -67,9 +72,11 @@ const AdminCreatorDashboardContent: React.FC = () => {
   const rankingDateLabel = `${startDateObj.toLocaleDateString("pt-BR")} - ${today.toLocaleDateString("pt-BR")}`;
   
   // ===== CORREÇÃO APLICADA: Handlers apenas modificam a URL =====
-  const handleUserSelect = useCallback((creator: { id: string; name: string }) => {
+  const handleUserSelect = useCallback((creator: { id: string; name: string; profilePictureUrl?: string | null }) => {
     nameCache.current[creator.id] = creator.name; // Salva o nome no cache para UX
+    photoCache.current[creator.id] = creator.profilePictureUrl ?? null;
     router.push(`${pathname}?userId=${creator.id}`, { scroll: false });
+    setSelectedUserPhotoUrl(creator.profilePictureUrl ?? null);
   }, [pathname, router]);
 
   const handleClearSelection = useCallback(() => {
@@ -94,6 +101,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
                 <CreatorQuickSearch
                     onSelect={handleUserSelect}
                     selectedCreatorName={selectedUserName}
+                    selectedCreatorPhotoUrl={selectedUserPhotoUrl}
                     onClear={handleClearSelection}
                 />
               </div>
@@ -139,6 +147,7 @@ const AdminCreatorDashboardContent: React.FC = () => {
                 <UserDetailView
                   userId={selectedUserId}
                   userName={selectedUserName ?? undefined}
+                  userPhotoUrl={selectedUserPhotoUrl ?? undefined}
                   onClear={handleClearSelection}
                 />
               )}
@@ -155,5 +164,4 @@ const AdminCreatorDashboardPage: React.FC = () => (
     <AdminCreatorDashboardContent />
   </GlobalTimePeriodProvider>
 );
-
 export default AdminCreatorDashboardPage;


### PR DESCRIPTION
## Summary
- pass profile picture through CreatorQuickSearch
- store user photo in dashboard state
- render user avatar beside filtered creator name in header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686debdf3780832e9ad0c171be4da5aa