### PR TITLE
Add postLink to PostObject mappings

### DIFF
--- a/src/app/lib/dataService/reportService.ts
+++ b/src/app/lib/dataService/reportService.ts
@@ -212,7 +212,7 @@ export async function getRecentPostObjects(
         }
 
         const postsFromMetrics: IMetric[] = await MetricModel.find(query)
-            .select('_id user instagramMediaId type description postDate stats format proposal context')
+            .select('_id user postLink instagramMediaId type description postDate stats format proposal context')
             .sort({ postDate: -1 })
             .limit(100)
             .lean();
@@ -239,6 +239,7 @@ export async function getRecentPostObjects(
             return {
                 _id: metric._id.toString(),
                 userId: metric.user.toString(),
+                postLink: metric.postLink,
                 instagramMediaId: metric.instagramMediaId, // PADRONIZADO
                 type: metric.type as PostObject['type'],
                 description: metric.description,
@@ -278,7 +279,7 @@ export async function getRecentPostObjectsWithAggregatedMetrics(
             user: new Types.ObjectId(userId),
             postDate: { $gte: sinceDate }
         })
-        .select('_id user instagramMediaId type description postDate stats format proposal context')
+        .select('_id user postLink instagramMediaId type description postDate stats format proposal context')
         .sort({ postDate: -1 })
         .limit(150)
         .lean();
@@ -306,6 +307,7 @@ export async function getRecentPostObjectsWithAggregatedMetrics(
             return {
                 _id: metric._id.toString(),
                 userId: metric.user.toString(),
+                postLink: metric.postLink,
                 instagramMediaId: metric.instagramMediaId,
                 type: metric.type as PostObject['type'],
                 description: metric.description,

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -156,6 +156,7 @@ export interface CommunityInspirationFilters {
 export interface PostObject {
     _id: string;
     userId: string;
+    postLink?: string;
     platformPostId?: string; // Pode coexistir se necessário, ou ser removido se instagramMediaId for o padrão nesta camada
     instagramMediaId?: string; // <-- ADICIONADO PARA CORRIGIR O ERRO EM reportService.ts
     type: string; 

--- a/src/app/lib/utils.ts
+++ b/src/app/lib/utils.ts
@@ -18,6 +18,7 @@ const UTILS_TAG = '[Utils v3.1]'; // Versão atualizada
  */
 export interface PostObjectForAverage {
     _id: string; // ID interno da métrica/post
+    postLink?: string;
     instagramMediaId?: string; // NOVO: ID da mídia no Instagram (fonte para platformPostId)
     type?: 'IMAGE' | 'CAROUSEL' | 'REEL' | 'VIDEO' | 'STORY' | string;
     postDate: Date | string;


### PR DESCRIPTION
## Summary
- store postLink on PostObject and PostObjectForAverage
- fetch postLink in reportService queries and map it to PostObject

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e94eb4fc4832eb7f3a4febb36fa0f