### PR TITLE
Implement Instagram demographics service

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,7 @@ Consulte o diretório `docs` para informações adicionais, incluindo o [plano d
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Instagram Demographics Service
+
+The `src/services/instagramInsightsService.ts` module provides `fetchFollowerDemographics`, which sequentially calls the Instagram Graph API (v23.0) for each demographic breakdown and aggregates the results. A daily cron job (`src/cron/fetchDemographics.ts`) stores the values in Redis under `demographics:<igUserId>` with 24h TTL. The API endpoint `/api/instagram/[userId]/demographics` reads from this cache or fetches fresh data if missing.

--- a/src/app/api/instagram/[userId]/demographics/route.ts
+++ b/src/app/api/instagram/[userId]/demographics/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import { createClient } from 'redis';
+import { logger } from '@/app/lib/logger';
+import { fetchFollowerDemographics } from '@/services/instagramInsightsService';
+
+const redisUrl = process.env.REDIS_URL || '';
+const redis = createClient({ url: redisUrl });
+redis.on('error', err => logger.error('[demographics][Redis]', err));
+redis.connect().catch(err => logger.error('[demographics][Redis] connect', err));
+
+export async function GET(request: NextRequest, { params }: { params: { userId: string } }) {
+  const { userId } = params;
+  const TAG = '[API demographics]';
+
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json({ error: 'User ID inválido.' }, { status: 400 });
+  }
+
+  await connectToDatabase();
+  const user = await User.findById(userId)
+    .select('instagramAccountId instagramAccessToken')
+    .lean();
+
+  if (!user?.instagramAccountId || !user?.instagramAccessToken) {
+    return NextResponse.json({ error: 'Usuário não possui conta Instagram conectada.' }, { status: 404 });
+  }
+
+  const cacheKey = `demographics:${user.instagramAccountId}`;
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      await redis.quit();
+      return NextResponse.json(parsed, { status: 200 });
+    }
+  } catch (e) {
+    logger.warn(`${TAG} Falha ao ler cache:`, e);
+  }
+
+  try {
+    const data = await fetchFollowerDemographics(user.instagramAccountId, user.instagramAccessToken);
+    await redis.set(cacheKey, JSON.stringify(data), { EX: 60 * 60 * 24 });
+    await redis.quit();
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    await redis.quit();
+    logger.error(`${TAG} Erro ao obter demografia`, err);
+    return NextResponse.json({ error: 'Falha ao obter dados de demografia.' }, { status: 500 });
+  }
+}

--- a/src/cron/fetchDemographics.ts
+++ b/src/cron/fetchDemographics.ts
@@ -1,0 +1,39 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import { createClient } from 'redis';
+import { logger } from '@/app/lib/logger';
+import { fetchFollowerDemographics } from '@/services/instagramInsightsService';
+
+const redisUrl = process.env.REDIS_URL || '';
+const redis = createClient({ url: redisUrl });
+redis.on('error', err => logger.error('[fetchDemographics][Redis]', err));
+redis.connect().catch(err => logger.error('[fetchDemographics][Redis] connect', err));
+
+const TTL_SECONDS = 60 * 60 * 24; // 24h
+
+async function run() {
+  const TAG = '[cron fetchDemographics]';
+  await connectToDatabase();
+  const users = await User.find({ isInstagramConnected: true, instagramAccountId: { $ne: null }, instagramAccessToken: { $ne: null } })
+    .select('instagramAccountId instagramAccessToken')
+    .lean();
+  logger.info(`${TAG} ${users.length} contas encontradas`);
+  for (const u of users) {
+    const accountId = u.instagramAccountId as string;
+    const token = u.instagramAccessToken as string;
+    try {
+      const data = await fetchFollowerDemographics(accountId, token);
+      const key = `demographics:${accountId}`;
+      await redis.set(key, JSON.stringify(data), { EX: TTL_SECONDS });
+      logger.info(`${TAG} Dados salvos no cache para ${accountId}`);
+    } catch (e) {
+      logger.error(`${TAG} Falha ao obter demografia para ${accountId}`, e);
+    }
+  }
+  await redis.quit();
+}
+
+run().catch(err => {
+  logger.error('[cron fetchDemographics] erro não tratado', err);
+  redis.quit();
+});

--- a/src/services/instagramInsightsService.test.ts
+++ b/src/services/instagramInsightsService.test.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { fetchFollowerDemographics } from './instagramInsightsService';
+
+jest.mock('axios');
+const mockedGet = axios.get as jest.Mock;
+
+describe('fetchFollowerDemographics', () => {
+  const igUserId = '123';
+  const token = 'token';
+
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('aggregates breakdown responses', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { data: [{ name: 'age', values: [] }] } });
+    mockedGet.mockResolvedValueOnce({ data: { data: [{ name: 'gender', values: [] }] } });
+    mockedGet.mockResolvedValueOnce({ data: { data: [{ name: 'country', values: [] }] } });
+    mockedGet.mockResolvedValueOnce({ data: { data: [{ name: 'city', values: [] }] } });
+    const res = await fetchFollowerDemographics(igUserId, token);
+    expect(Object.keys(res.follower_demographics)).toEqual(['age', 'gender', 'country', 'city']);
+    expect(mockedGet).toHaveBeenCalledTimes(4);
+  });
+
+  it('handles 429 with retry', async () => {
+    mockedGet.mockRejectedValueOnce({ response: { status: 429, data: { error: { message: 'rate limit' } } } });
+    mockedGet.mockResolvedValueOnce({ data: { data: [] } });
+    mockedGet.mockResolvedValue({ data: { data: [] } });
+    const res = await fetchFollowerDemographics(igUserId, token);
+    expect(res.follower_demographics.age).toEqual([]);
+    expect(mockedGet).toHaveBeenCalled();
+  });
+});

--- a/src/services/instagramInsightsService.ts
+++ b/src/services/instagramInsightsService.ts
@@ -1,0 +1,84 @@
+import axios, { AxiosError } from 'axios';
+import { logger } from '@/app/lib/logger';
+
+const BREAKDOWNS = ['age', 'gender', 'country', 'city'] as const;
+const API_VERSION = 'v23.0';
+
+interface DemographicResponse {
+  data?: any[];
+  error?: { code: number; message: string; type?: string; error_subcode?: number };
+}
+
+export interface FollowerDemographicsResult {
+  follower_demographics: Record<string, any[]>;
+  retrieved_at: string;
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchFollowerDemographics(
+  igUserId: string,
+  accessToken: string
+): Promise<FollowerDemographicsResult> {
+  const TAG = '[fetchFollowerDemographics]';
+  const baseUrl = `https://graph.facebook.com/${API_VERSION}/${igUserId}/insights`;
+
+  const results: Record<string, any[]> = {};
+
+  for (const breakdown of BREAKDOWNS) {
+    let attempts = 0;
+    const maxAttempts = 3;
+    const params = {
+      metric: 'follower_demographics',
+      period: 'lifetime',
+      metric_type: 'total_value',
+      breakdown,
+      access_token: accessToken,
+    };
+
+    while (attempts < maxAttempts) {
+      try {
+        const start = Date.now();
+        const response = await axios.get<DemographicResponse>(baseUrl, { params });
+        const duration = Date.now() - start;
+        logger.info(`${TAG} ${breakdown} retornado em ${duration}ms`);
+        if (Array.isArray(response.data?.data)) {
+          results[breakdown] = response.data.data;
+        } else {
+          results[breakdown] = [];
+        }
+        break;
+      } catch (err) {
+        const error = err as AxiosError;
+        const status = error.response?.status;
+        const data: any = error.response?.data;
+        const message = data?.error?.message || error.message;
+        logger.warn(`${TAG} Erro para ${breakdown} (tentativa ${attempts + 1}): ${message}`);
+
+        if (status === 429) {
+          const backoff = 500 * Math.pow(2, attempts);
+          await sleep(backoff);
+        } else if (data?.error?.type === 'OAuthException') {
+          logger.error(`${TAG} OAuthException para ${breakdown}: ${message}`);
+          results[breakdown] = [];
+          break;
+        } else if (status && status >= 500) {
+          if (attempts >= maxAttempts - 1) {
+            throw new Error(`API error ${status} for ${breakdown}: ${message}`);
+          }
+          const backoff = 500 * Math.pow(2, attempts);
+          await sleep(backoff);
+        } else {
+          results[breakdown] = [];
+          break;
+        }
+      }
+      attempts++;
+    }
+  }
+
+  return { follower_demographics: results, retrieved_at: new Date().toISOString() };
+}
+


### PR DESCRIPTION
## Summary
- add new service `fetchFollowerDemographics` that loops breakdown API calls
- create cron job to cache demographics daily in Redis
- expose `/api/instagram/[userId]/demographics` endpoint
- document new service in README
- add basic unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eafabd6c0832e9f91cfa04455e34d