### PR TITLE
Fix missing DemographicsData export

### DIFF
--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -1,74 +1,76 @@
-// src/types/mediakit.ts
+// @/types/mediakit.ts
 
-// Tipos compartilhados para o Mídia Kit
-
-// Para a tabela de vídeos
+// Tipo para os itens da tabela de vídeos
 export interface VideoListItem {
-    _id: string;
-    thumbnailUrl?: string | null;
-    caption?: string;
-    permalink?: string | null;
-    postDate?: string | Date;
-    // Classificação de conteúdo
-    // Todos os campos são arrays para acomodar múltiplas tags
-    format?: string[];
-    proposal?: string[];
-    context?: string[];
-    tone?: string[];
-    references?: string[];
-    stats?: {
-      views?: number;
-      likes?: number;
-      comments?: number;
-      shares?: number;
-      saves?: number;
-      reach?: number; // NOVO: Adicionado para o cálculo de alcance
-    };
-  }
-  
-  // Para os cards de destaque
-  export interface PerformanceSummary {
-    topPerformingFormat?: { name: string; metricName: string; valueFormatted: string } | null;
-    topPerformingContext?: { name: string; metricName: string; valueFormatted: string } | null;
-  }
-  
-  // Para cada KPI individual
-  export interface KPIComparisonData {
-    currentValue: number | null;
-    previousValue: number | null;
-    percentageChange: number | null;
-    chartData?: { name: string; value: number }[];
-  }
-  
-  // Para o objeto completo de KPIs da API
-  export interface KpiComparison {
-    comparisonPeriod?: string;
-    followerGrowth: KPIComparisonData;
-    engagementRate: KPIComparisonData;
-    totalEngagement: KPIComparisonData;
-    postingFrequency: KPIComparisonData;
-    avgViewsPerPost: KPIComparisonData;
-    avgCommentsPerPost: KPIComparisonData;
-    avgSharesPerPost: KPIComparisonData;
-    avgSavesPerPost: KPIComparisonData;
-    avgReachPerPost: KPIComparisonData;
-    insightSummary?: {
-      followerGrowth?: string;
-      engagementRate?: string;
-      totalEngagement?: string;
-      postingFrequency?: string;
-      avgViewsPerPost?: string;
-      avgCommentsPerPost?: string;
-      avgSharesPerPost?: string;
-      avgSavesPerPost?: string;
-      avgReachPerPost?: string;
-    };
-  }
-  
-  // Para as props do componente MediaKitView
-  export interface MediaKitViewProps {
-    user: any;
-    summary: PerformanceSummary | null;
-    videos: VideoListItem[];
-    kpis: KpiComparison | null; // Dados iniciais
-  }
+  _id: string;
+  thumbnailUrl?: string | null;
+  caption?: string;
+  description?: string;
+  permalink?: string | null;
+  postDate?: string | Date;
+  stats?: {
+    views?: number;
+    likes?: number;
+    comments?: number;
+    shares?: number;
+  };
+}
+
+// Tipo para o resumo de performance (cards de destaque)
+export interface PerformanceSummary {
+  topPerformingFormat?: { name: string; metricName: string; valueFormatted: string } | null;
+  topPerformingContext?: { name: string; metricName: string; valueFormatted: string } | null;
+}
+
+// Tipo para os dados de cada KPI individual
+export interface KPIComparisonData {
+  currentValue: number | null;
+  previousValue: number | null;
+  percentageChange: number | null;
+  chartData?: { name: string; value: number }[];
+}
+
+// Tipo para o objeto completo de KPIs que vem da API
+export interface KpiComparison {
+  followerGrowth: KPIComparisonData;
+  engagementRate: KPIComparisonData;
+  postingFrequency: KPIComparisonData;
+  avgReachPerPost?: KPIComparisonData;
+  avgViewsPerPost?: KPIComparisonData;
+  avgCommentsPerPost?: KPIComparisonData;
+  avgSharesPerPost?: KPIComparisonData;
+  avgSavesPerPost?: KPIComparisonData;
+  insightSummary?: {
+    followerGrowth?: string;
+    engagementRate?: string;
+    postingFrequency?: string;
+  };
+  comparisonPeriod: string;
+}
+
+// --- NOVOS TIPOS PARA DEMOGRAFIA ---
+
+// CORREÇÃO: Renomeado de AudienceDemographics para DemographicsData para corresponder ao uso.
+export interface DemographicsData {
+  follower_demographics?: {
+    gender?: Record<string, number>;
+    age?: Record<string, number>;
+    city?: Record<string, number>;
+    country?: Record<string, number>;
+  };
+  engaged_audience_demographics?: {
+    gender?: Record<string, number>;
+    age?: Record<string, number>;
+    city?: Record<string, number>;
+    country?: Record<string, number>;
+  };
+}
+
+// Props para o componente MediaKitView
+export interface MediaKitViewProps {
+  user: any;
+  summary: PerformanceSummary | null;
+  videos: VideoListItem[];
+  kpis: KpiComparison | null;
+  demographics: DemographicsData | null;
+}


### PR DESCRIPTION
## Summary
- update `src/types/mediakit.ts` to export `DemographicsData`
- include `demographics` in `MediaKitViewProps`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2a604a2c832e991fe7a1233078da