### PR TITLE
Fix convertFollowerDemographics return type

### DIFF
--- a/src/utils/convertFollowerDemographics.ts
+++ b/src/utils/convertFollowerDemographics.ts
@@ -1,5 +1,5 @@
 import { FollowerDemographicsResult } from '@/services/instagramInsightsService';
-import { IAudienceDemographics, IDemographicBreakdown } from '@/app/models/demographics/AudienceDemographicSnapshot';
+import { IAudienceDemographics } from '@/app/models/demographics/AudienceDemographicSnapshot';
 
 /**
  * Converts the follower demographics returned by fetchFollowerDemographics
@@ -8,11 +8,11 @@ import { IAudienceDemographics, IDemographicBreakdown } from '@/app/models/demog
 export function convertFollowerDemographics(
   data: FollowerDemographicsResult
 ): IAudienceDemographics {
-  const convertMap = (m?: Record<string, number>): IDemographicBreakdown[] => {
-    if (!m) return [];
-    return Object.entries(m)
-      .map(([value, count]) => ({ value, count }))
-      .sort((a, b) => b.count - a.count);
+  const convertMap = (m?: Record<string, number>): Record<string, number> => {
+    if (!m) return {};
+    return Object.fromEntries(
+      Object.entries(m).sort((a, b) => b[1] - a[1])
+    );
   };
 
   const follower = data.follower_demographics || {};


### PR DESCRIPTION
## Summary
- fix type mismatch in `convertFollowerDemographics`

## Testing
- `npm test --silent`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686f410d2204832e9e42dd08f3eba016