### PR TITLE
Add platform demographics aggregation

### DIFF
--- a/src/app/api/v1/platform/demographics/route.test.ts
+++ b/src/app/api/v1/platform/demographics/route.test.ts
@@ -1,0 +1,31 @@
+import { GET } from './route';
+import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/utils/aggregatePlatformDemographics');
+
+const mockAgg = aggregatePlatformDemographics as jest.Mock;
+const makeRequest = () => new NextRequest('http://localhost/api/v1/platform/demographics');
+
+describe('GET /api/v1/platform/demographics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns aggregated demographics', async () => {
+    mockAgg.mockResolvedValueOnce({ follower_demographics: { country: { BR: 10 } } });
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.follower_demographics.country.BR).toBe(10);
+    expect(mockAgg).toHaveBeenCalled();
+  });
+
+  it('returns 500 on error', async () => {
+    mockAgg.mockRejectedValueOnce(new Error('fail'));
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toContain('Erro ao processar');
+  });
+});

--- a/src/app/api/v1/platform/demographics/route.ts
+++ b/src/app/api/v1/platform/demographics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
+
+export async function GET(request: Request) {
+  try {
+    const data = await aggregatePlatformDemographics();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: message }, { status: 500 });
+  }
+}

--- a/src/utils/__tests__/aggregatePlatformDemographics.test.ts
+++ b/src/utils/__tests__/aggregatePlatformDemographics.test.ts
@@ -1,0 +1,50 @@
+import aggregatePlatformDemographics from '../aggregatePlatformDemographics';
+import AudienceDemographicSnapshotModel from '@/app/models/demographics/AudienceDemographicSnapshot';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/app/models/demographics/AudienceDemographicSnapshot', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockAgg = AudienceDemographicSnapshotModel.aggregate as jest.Mock;
+const mockFind = UserModel.find as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+describe('aggregatePlatformDemographics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('sums demographic data of latest snapshots', async () => {
+    mockFind.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([{ _id: 'u1' }, { _id: 'u2' }]) }) });
+    mockAgg.mockResolvedValueOnce([
+      { demographics: { follower_demographics: { country: { BR: 100 }, gender: { f: 60, m: 40 } } } },
+      { demographics: { follower_demographics: { country: { US: 50 }, gender: { f: 20, m: 30 } } } },
+    ]);
+
+    const res = await aggregatePlatformDemographics();
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockAgg).toHaveBeenCalled();
+    expect(res.follower_demographics.country.BR).toBe(100);
+    expect(res.follower_demographics.country.US).toBe(50);
+    expect(res.follower_demographics.gender.f).toBe(80);
+    expect(res.follower_demographics.gender.m).toBe(70);
+  });
+
+  it('returns empty maps when no active users', async () => {
+    mockFind.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([]) }) });
+    const res = await aggregatePlatformDemographics();
+    expect(res.follower_demographics.country).toEqual({});
+    expect(mockAgg).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/aggregatePlatformDemographics.ts
+++ b/src/utils/aggregatePlatformDemographics.ts
@@ -1,0 +1,65 @@
+import AudienceDemographicSnapshotModel, { IAudienceDemographics } from '@/app/models/demographics/AudienceDemographicSnapshot';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+
+export interface PlatformDemographicsAggregation {
+  follower_demographics: {
+    country: Record<string, number>;
+    city: Record<string, number>;
+    age: Record<string, number>;
+    gender: Record<string, number>;
+  };
+}
+
+export default async function aggregatePlatformDemographics(): Promise<PlatformDemographicsAggregation> {
+  const initial: PlatformDemographicsAggregation = {
+    follower_demographics: { country: {}, city: {}, age: {}, gender: {} },
+  };
+
+  try {
+    await connectToDatabase();
+    const activeUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    if (!activeUsers.length) return initial;
+
+    const userIds = activeUsers.map(u => u._id);
+
+    const pipeline = [
+      { $match: { user: { $in: userIds } } },
+      { $sort: { user: 1, recordedAt: -1 } },
+      { $group: { _id: '$user', doc: { $first: '$$ROOT' } } },
+      { $replaceRoot: { newRoot: '$doc' } },
+      { $project: { demographics: 1 } },
+    ];
+
+    const snapshots = await AudienceDemographicSnapshotModel.aggregate(pipeline);
+
+    const result = initial;
+
+    const addToMap = (map: Record<string, number>, data?: Record<string, number>) => {
+      if (!data) return;
+      for (const [k, v] of Object.entries(data)) {
+        map[k] = (map[k] || 0) + v;
+      }
+    };
+
+    for (const snap of snapshots) {
+      const follower = (snap.demographics as IAudienceDemographics)?.follower_demographics || {};
+      addToMap(result.follower_demographics.country, follower.country);
+      addToMap(result.follower_demographics.city, follower.city);
+      addToMap(result.follower_demographics.age, follower.age);
+      addToMap(result.follower_demographics.gender, follower.gender);
+    }
+
+    const sortMap = (m: Record<string, number>) => Object.fromEntries(Object.entries(m).sort((a, b) => b[1] - a[1]));
+    result.follower_demographics.country = sortMap(result.follower_demographics.country);
+    result.follower_demographics.city = sortMap(result.follower_demographics.city);
+    result.follower_demographics.age = sortMap(result.follower_demographics.age);
+    result.follower_demographics.gender = sortMap(result.follower_demographics.gender);
+
+    return result;
+  } catch (error) {
+    logger.error('Error aggregating platform demographics:', error);
+    return initial;
+  }
+}


### PR DESCRIPTION
## Summary
- aggregate follower demographics across creators
- expose `/api/v1/platform/demographics` endpoint
- add unit tests for the aggregator and API route

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686fec4b9dc4832ea5a67d7105aace9e