### PR TITLE
Implement creator region heatmap

### DIFF
--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -10,6 +10,7 @@ import PlatformMovingAverageEngagementChart from "../PlatformMovingAverageEngage
 import TotalActiveCreatorsKpi from "../kpis/TotalActiveCreatorsKpi";
 import PlatformComparativeKpi from "../kpis/PlatformComparativeKpi";
 import PlatformDemographicsWidget from "../PlatformDemographicsWidget";
+import CreatorRegionHeatmap from "../CreatorRegionHeatmap";
 
 const TIME_PERIOD_TO_COMPARISON: Record<string, string> = {
   last_7_days: "last_7d_vs_previous_7d",
@@ -55,6 +56,10 @@ const PlatformOverviewSection: React.FC = () => {
 
     <div className="mt-6">
       <PlatformDemographicsWidget />
+    </div>
+
+    <div className="mt-6">
+      <CreatorRegionHeatmap />
     </div>
 
   </section>

--- a/src/app/api/admin/creators/region-summary/route.test.ts
+++ b/src/app/api/admin/creators/region-summary/route.test.ts
@@ -1,0 +1,43 @@
+import { GET } from './route';
+import aggregateCreatorsByRegion from '@/utils/aggregateCreatorsByRegion';
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+jest.mock('@/utils/aggregateCreatorsByRegion', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockAgg = aggregateCreatorsByRegion as jest.Mock;
+const mockSession = getServerSession as jest.Mock;
+
+function makeReq(params: string = ''): NextRequest {
+  const url = `http://localhost/api/admin/creators/region-summary${params}`;
+  return new NextRequest(url);
+}
+
+describe('GET /api/admin/creators/region-summary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSession.mockResolvedValue({ user: { role: 'admin' } });
+  });
+
+  it('returns aggregated data', async () => {
+    mockAgg.mockResolvedValueOnce([{ state: 'SP', count: 2, gender: {}, age: {}, cities: {} }]);
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.states[0].state).toBe('SP');
+  });
+
+  it('validates query params', async () => {
+    const res = await GET(makeReq('?minAge=abc'));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/admin/creators/region-summary/route.ts
+++ b/src/app/api/admin/creators/region-summary/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
+import aggregateCreatorsByRegion from '@/utils/aggregateCreatorsByRegion';
+
+export const dynamic = 'force-dynamic';
+
+const querySchema = z.object({
+  gender: z.enum(['male', 'female', 'other']).optional(),
+  minAge: z.coerce.number().int().positive().optional(),
+  maxAge: z.coerce.number().int().positive().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const TAG = '[api/admin/creators/region-summary]';
+  const session = await getAdminSession(req);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Acesso não autorizado.' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const params = Object.fromEntries(searchParams.entries());
+  const validated = querySchema.safeParse(params);
+  if (!validated.success) {
+    const message = validated.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+    return NextResponse.json({ error: `Par\u00E2metros inv\u00E1lidos: ${message}` }, { status: 400 });
+  }
+
+  try {
+    const data = await aggregateCreatorsByRegion(validated.data);
+    return NextResponse.json({ states: data }, { status: 200 });
+  } catch (err) {
+    logger.error(`${TAG} erro inesperado`, err);
+    return NextResponse.json({ error: 'Erro ao processar sua solicita\u00E7\u00E3o.' }, { status: 500 });
+  }
+}

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -155,6 +155,12 @@ export interface IUserKeyFact {
   fact: string;
   mentionedAt?: Date;
 }
+
+export interface IUserLocation {
+  country?: string;
+  state?: string;
+  city?: string;
+}
 export interface IAlertHistoryEntry {
   _id?: Types.ObjectId;
   type: string;
@@ -206,6 +212,9 @@ export interface IUser extends Document {
   profileTone?: string;
   hobbies?: string[];
   goal?: string;
+  gender?: 'male' | 'female' | 'other';
+  birthDate?: Date | null;
+  location?: IUserLocation;
   affiliateRank?: number;
   affiliateInvites?: number;
   affiliateCode?: string;
@@ -322,6 +331,13 @@ const userSchema = new Schema<IUser>(
     profileTone: { type: String, default: 'informal e prestativo' },
     hobbies: { type: [String], default: [] },
     goal: { type: String, default: null },
+    gender: { type: String, enum: ['male', 'female', 'other'], default: 'other', index: true },
+    birthDate: { type: Date, default: null },
+    location: {
+      country: { type: String, default: 'BR' },
+      state: { type: String, index: true },
+      city: { type: String },
+    },
     affiliateRank: { type: Number, default: 1 },
     affiliateInvites: { type: Number, default: 0 },
     affiliateCode: { type: String, unique: true, sparse: true },

--- a/src/data/brazilStateGrid.ts
+++ b/src/data/brazilStateGrid.ts
@@ -1,0 +1,38 @@
+export interface BrazilStateTile {
+  id: string;
+  name: string;
+  row: number;
+  col: number;
+}
+
+// Simplified tile grid layout of Brazil states for heatmap visualization
+// Coordinates roughly represent geographic position but are not to scale
+export const BRAZIL_STATE_GRID: BrazilStateTile[] = [
+  { id: 'RR', name: 'Roraima', row: 0, col: 4 },
+  { id: 'AP', name: 'Amap\u00E1', row: 1, col: 5 },
+  { id: 'AM', name: 'Amazonas', row: 2, col: 3 },
+  { id: 'PA', name: 'Par\u00E1', row: 2, col: 5 },
+  { id: 'AC', name: 'Acre', row: 3, col: 2 },
+  { id: 'RO', name: 'Rond\u00F4nia', row: 3, col: 3 },
+  { id: 'MT', name: 'Mato Grosso', row: 3, col: 4 },
+  { id: 'TO', name: 'Tocantins', row: 3, col: 5 },
+  { id: 'MA', name: 'Maranh\u00E3o', row: 3, col: 6 },
+  { id: 'PI', name: 'Piau\u00ED', row: 4, col: 6 },
+  { id: 'CE', name: 'Cear\u00E1', row: 4, col: 7 },
+  { id: 'RN', name: 'Rio Grande do Norte', row: 4, col: 8 },
+  { id: 'PB', name: 'Para\u00EDba', row: 5, col: 8 },
+  { id: 'PE', name: 'Pernambuco', row: 5, col: 7 },
+  { id: 'AL', name: 'Alagoas', row: 6, col: 8 },
+  { id: 'SE', name: 'Sergipe', row: 6, col: 7 },
+  { id: 'BA', name: 'Bahia', row: 6, col: 6 },
+  { id: 'DF', name: 'Distrito Federal', row: 5, col: 4 },
+  { id: 'GO', name: 'Goi\u00E1s', row: 5, col: 3 },
+  { id: 'MS', name: 'Mato Grosso do Sul', row: 4, col: 3 },
+  { id: 'MG', name: 'Minas Gerais', row: 6, col: 5 },
+  { id: 'ES', name: 'Esp\u00EDrito Santo', row: 7, col: 6 },
+  { id: 'RJ', name: 'Rio de Janeiro', row: 8, col: 5 },
+  { id: 'SP', name: 'S\u00E3o Paulo', row: 7, col: 4 },
+  { id: 'PR', name: 'Paran\u00E1', row: 8, col: 4 },
+  { id: 'SC', name: 'Santa Catarina', row: 9, col: 4 },
+  { id: 'RS', name: 'Rio Grande do Sul', row: 10, col: 4 },
+];

--- a/src/utils/__tests__/aggregateCreatorsByRegion.test.ts
+++ b/src/utils/__tests__/aggregateCreatorsByRegion.test.ts
@@ -1,0 +1,38 @@
+import aggregateCreatorsByRegion from '../aggregateCreatorsByRegion';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+jest.mock('@/app/models/User', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockFind = UserModel.find as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+
+describe('aggregateCreatorsByRegion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('aggregates creators by state with age and gender', async () => {
+    mockFind.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve([
+        { location: { state: 'SP', city: 'Sao Paulo' }, birthDate: new Date('1990-01-01'), gender: 'male' },
+        { location: { state: 'SP', city: 'Campinas' }, birthDate: new Date('1995-01-01'), gender: 'female' },
+        { location: { state: 'RJ', city: 'Rio de Janeiro' }, birthDate: new Date('1985-01-01'), gender: 'female' },
+      ]) })
+    });
+
+    const res = await aggregateCreatorsByRegion();
+    expect(mockConnect).toHaveBeenCalled();
+    expect(res.length).toBe(2);
+    const sp = res.find(r => r.state === 'SP')!;
+    expect(sp.count).toBe(2);
+    expect(sp.cities['Sao Paulo'].count).toBe(1);
+  });
+});

--- a/src/utils/aggregateCreatorsByRegion.ts
+++ b/src/utils/aggregateCreatorsByRegion.ts
@@ -1,0 +1,93 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { logger } from '@/app/lib/logger';
+
+export interface CityBreakdown {
+  count: number;
+  gender: Record<string, number>;
+  age: Record<string, number>;
+}
+
+export interface StateBreakdown {
+  state: string;
+  count: number;
+  gender: Record<string, number>;
+  age: Record<string, number>;
+  cities: Record<string, CityBreakdown>;
+}
+
+interface Filters {
+  gender?: string;
+  minAge?: number;
+  maxAge?: number;
+}
+
+function getAge(date: Date): number {
+  const diff = Date.now() - date.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24 * 365.25));
+}
+
+function getAgeGroup(age: number): string {
+  if (age < 18) return '0-17';
+  if (age <= 24) return '18-24';
+  if (age <= 34) return '25-34';
+  if (age <= 44) return '35-44';
+  return '45+';
+}
+
+export default async function aggregateCreatorsByRegion(filters: Filters = {}): Promise<StateBreakdown[]> {
+  const TAG = '[aggregateCreatorsByRegion]';
+  await connectToDatabase();
+
+  const query: any = { 'location.country': 'BR' };
+  if (filters.gender) {
+    query.gender = filters.gender;
+  }
+
+  const docs = await UserModel.find(query)
+    .select('location.state location.city birthDate gender')
+    .lean();
+
+  const result: Record<string, StateBreakdown> = {};
+
+  for (const u of docs) {
+    const state = u.location?.state;
+    if (!state) continue;
+
+    const gender = u.gender || 'other';
+
+    let ageGroup: string | null = null;
+    if (u.birthDate instanceof Date) {
+      const age = getAge(u.birthDate);
+      if (filters.minAge && age < filters.minAge) continue;
+      if (filters.maxAge && age > filters.maxAge) continue;
+      ageGroup = getAgeGroup(age);
+    } else if (filters.minAge || filters.maxAge) {
+      continue; // cannot satisfy age filter without birthDate
+    }
+
+    if (!result[state]) {
+      result[state] = { state, count: 0, gender: {}, age: {}, cities: {} };
+    }
+    const stateInfo = result[state];
+    stateInfo.count += 1;
+    stateInfo.gender[gender] = (stateInfo.gender[gender] || 0) + 1;
+    if (ageGroup) {
+      stateInfo.age[ageGroup] = (stateInfo.age[ageGroup] || 0) + 1;
+    }
+
+    const city = u.location?.city || 'Desconhecida';
+    if (!stateInfo.cities[city]) {
+      stateInfo.cities[city] = { count: 0, gender: {}, age: {} };
+    }
+    const cityInfo = stateInfo.cities[city];
+    cityInfo.count += 1;
+    cityInfo.gender[gender] = (cityInfo.gender[gender] || 0) + 1;
+    if (ageGroup) {
+      cityInfo.age[ageGroup] = (cityInfo.age[ageGroup] || 0) + 1;
+    }
+  }
+
+  logger.info(`${TAG} aggregated ${docs.length} users`);
+  return Object.values(result);
+}


### PR DESCRIPTION
## Summary
- store creator gender, birthDate and location
- aggregate creators by Brazilian state
- expose new `/api/admin/creators/region-summary` API
- show creator distribution heatmap on dashboard
- include dataset for Brazil state grid
- add tests for new utils and route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff7da2614832ea1ea1dfb9d97b6e6