### PR TITLE
Add region filter to creator heatmap

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorRegionHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorRegionHeatmap.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { BRAZIL_STATE_GRID, BrazilStateTile } from "@/data/brazilStateGrid";
+import { BRAZIL_REGION_STATES } from "@/data/brazilRegions";
 
 interface CityBreakdown {
   count: number;
@@ -33,6 +34,7 @@ function getColor(value: number, max: number) {
 export default function CreatorRegionHeatmap() {
   const [data, setData] = useState<Record<string, StateBreakdown>>({});
   const [gender, setGender] = useState("");
+  const [region, setRegion] = useState("");
   const [minAge, setMinAge] = useState("");
   const [maxAge, setMaxAge] = useState("");
   const [tooltip, setTooltip] = useState<{ x: number; y: number; state: StateBreakdown } | null>(null);
@@ -40,6 +42,7 @@ export default function CreatorRegionHeatmap() {
   const fetchData = useCallback(async () => {
     const params = new URLSearchParams();
     if (gender) params.set("gender", gender);
+    if (region) params.set("region", region);
     if (minAge) params.set("minAge", minAge);
     if (maxAge) params.set("maxAge", maxAge);
     const res = await fetch(`/api/admin/creators/region-summary?${params.toString()}`);
@@ -51,7 +54,7 @@ export default function CreatorRegionHeatmap() {
     } else {
       setData({});
     }
-  }, [gender, minAge, maxAge]);
+  }, [gender, region, minAge, maxAge]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
@@ -61,6 +64,12 @@ export default function CreatorRegionHeatmap() {
     <div className="bg-white p-4 rounded-lg shadow-md border border-gray-200">
       <h3 className="text-md font-semibold text-gray-700 mb-2">Distribui\u00E7\u00E3o de Criadores</h3>
       <div className="flex items-end space-x-2 mb-4">
+        <select className="border p-1 text-sm" value={region} onChange={e => setRegion(e.target.value)}>
+          <option value="">Todas as Regiões</option>
+          {Object.keys(BRAZIL_REGION_STATES).map(r => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
         <select className="border p-1 text-sm" value={gender} onChange={e => setGender(e.target.value)}>
           <option value="">Todos os G\u00EAneros</option>
           <option value="male">Masculino</option>
@@ -107,7 +116,15 @@ export default function CreatorRegionHeatmap() {
           <div className="font-semibold mb-1">{tooltip.state.state}</div>
           <div>Total: {tooltip.state.count}</div>
           {Object.entries(tooltip.state.cities).slice(0, 5).map(([city, info]) => (
-            <div key={city}>{city}: {info.count}</div>
+            <div key={city} className="mt-1">
+              <div className="font-semibold">{city}: {info.count}</div>
+              <div className="pl-2">{`M: ${info.gender.male || 0} F: ${info.gender.female || 0} O: ${info.gender.other || 0}`}</div>
+              <div className="pl-2 flex flex-wrap gap-1">
+                {Object.entries(info.age).map(([group, c]) => (
+                  <span key={group}>{group}:{c}</span>
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       )}

--- a/src/app/api/admin/creators/region-summary/route.ts
+++ b/src/app/api/admin/creators/region-summary/route.ts
@@ -10,6 +10,7 @@ const querySchema = z.object({
   gender: z.enum(['male', 'female', 'other']).optional(),
   minAge: z.coerce.number().int().positive().optional(),
   maxAge: z.coerce.number().int().positive().optional(),
+  region: z.enum(['Norte', 'Nordeste', 'Centro-Oeste', 'Sudeste', 'Sul']).optional(),
 });
 
 export async function GET(req: NextRequest) {

--- a/src/data/brazilRegions.ts
+++ b/src/data/brazilRegions.ts
@@ -1,0 +1,11 @@
+export const BRAZIL_REGION_STATES: Record<string, string[]> = {
+  'Norte': ['AC', 'AP', 'AM', 'PA', 'RO', 'RR', 'TO'],
+  'Nordeste': ['AL', 'BA', 'CE', 'MA', 'PB', 'PE', 'PI', 'RN', 'SE'],
+  'Centro-Oeste': ['DF', 'GO', 'MT', 'MS'],
+  'Sudeste': ['ES', 'MG', 'RJ', 'SP'],
+  'Sul': ['PR', 'RS', 'SC'],
+};
+
+export function getStatesByRegion(region: string): string[] {
+  return BRAZIL_REGION_STATES[region] || [];
+}

--- a/src/utils/__tests__/aggregateCreatorsByRegion.test.ts
+++ b/src/utils/__tests__/aggregateCreatorsByRegion.test.ts
@@ -35,4 +35,17 @@ describe('aggregateCreatorsByRegion', () => {
     expect(sp.count).toBe(2);
     expect(sp.cities['Sao Paulo'].count).toBe(1);
   });
+
+  it('applies region filter when provided', async () => {
+    mockFind.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve([]) })
+    });
+
+    await aggregateCreatorsByRegion({ region: 'Sudeste' });
+
+    expect(mockFind).toHaveBeenCalledWith({
+      'location.country': 'BR',
+      'location.state': { $in: ['ES', 'MG', 'RJ', 'SP'] },
+    });
+  });
 });

--- a/src/utils/aggregateCreatorsByRegion.ts
+++ b/src/utils/aggregateCreatorsByRegion.ts
@@ -1,6 +1,7 @@
 import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { logger } from '@/app/lib/logger';
+import { getStatesByRegion } from '@/data/brazilRegions';
 
 export interface CityBreakdown {
   count: number;
@@ -20,6 +21,7 @@ interface Filters {
   gender?: string;
   minAge?: number;
   maxAge?: number;
+  region?: string;
 }
 
 function getAge(date: Date): number {
@@ -42,6 +44,12 @@ export default async function aggregateCreatorsByRegion(filters: Filters = {}): 
   const query: any = { 'location.country': 'BR' };
   if (filters.gender) {
     query.gender = filters.gender;
+  }
+  if (filters.region) {
+    const states = getStatesByRegion(filters.region);
+    if (states.length > 0) {
+      query['location.state'] = { $in: states };
+    }
   }
 
   const docs = await UserModel.find(query)


### PR DESCRIPTION
## Summary
- add Brazil region dataset
- filter creators by region in aggregate utility and API
- support region filter on CreatorRegionHeatmap
- show city age/gender breakdown in tooltip
- test region filter logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffbecd410832e9a614d9f041313a1