### PR TITLE
Fix views fallback for averages

### DIFF
--- a/src/app/lib/reportHelpers.ts
+++ b/src/app/lib/reportHelpers.ts
@@ -168,7 +168,7 @@ function addCommonAveragesToGroupStage(groupStage: any): any {
     groupStage.$group.avgSaved = { $avg: { $ifNull: ["$stats.saved", 0] } };
     groupStage.$group.avgReach = { $avg: { $ifNull: ["$stats.reach", 0] } };
     groupStage.$group.avgImpressions = { $avg: { $ifNull: ["$stats.impressions", 0] } };
-    groupStage.$group.avgViews = { $avg: { $ifNull: ["$stats.views", 0] } }; // Note: IMetricStats.views, não video_views
+    groupStage.$group.avgViews = { $avg: { $ifNull: ["$stats.views", "$stats.video_views", 0] } };
     groupStage.$group.avgFollows = { $avg: { $ifNull: ["$stats.follows", 0] } };
     groupStage.$group.avgProfileVisits = { $avg: { $ifNull: ["$stats.profile_visits", 0] } };
     groupStage.$group.avgTotalInteractions = { $avg: { $ifNull: ["$stats.total_interactions", 0] } };

--- a/src/utils/calculateAverageVideoMetrics.ts
+++ b/src/utils/calculateAverageVideoMetrics.ts
@@ -93,7 +93,7 @@ async function calculateAverageVideoMetrics(
             }
           }
           ,
-          views: '$stats.views',
+          views: { $ifNull: ['$stats.views', '$stats.video_views'] },
           likes: '$stats.likes',
           comments: '$stats.comments',
           shares: '$stats.shares',


### PR DESCRIPTION
## Summary
- support `video_views` when calculating average video metrics
- allow `avgViews` to fallback to `stats.video_views`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687038c657f4832eb9e1227191e0d7bd