### PR TITLE
Fix KPI save metric path

### DIFF
--- a/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
@@ -105,7 +105,7 @@ export async function GET(
       getAverageViews(currentStartDate, currentEndDate), getAverageViews(previousStartDate, previousEndDate),
       getAverage('stats.comments', currentStartDate, currentEndDate), getAverage('stats.comments', previousStartDate, previousEndDate),
       getAverage('stats.shares', currentStartDate, currentEndDate), getAverage('stats.shares', previousStartDate, previousEndDate),
-      getAverage('stats.saves', currentStartDate, currentEndDate), getAverage('stats.saves', previousStartDate, previousEndDate),
+      getAverage('stats.saved', currentStartDate, currentEndDate), getAverage('stats.saved', previousStartDate, previousEndDate),
       // NOVO: Chamada para a nova métrica de alcance
       getAverage('stats.reach', currentStartDate, currentEndDate), getAverage('stats.reach', previousStartDate, previousEndDate),
     ]);


### PR DESCRIPTION
## Summary
- update 'stats.saves' references to 'stats.saved'

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703be40d54832e999187e1edbdad2c