### PR TITLE
Add avg likes per post metric

### DIFF
--- a/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/users/[userId]/kpis/periodic-comparison/route.ts
@@ -91,6 +91,7 @@ export async function GET(
       engCurrentResult, engPreviousResult,
       freqData,
       currViews, prevViews,
+      currLikes, prevLikes,
       currComments, prevComments,
       currShares, prevShares,
       currSaves, prevSaves,
@@ -103,6 +104,7 @@ export async function GET(
       calculateAverageEngagementPerPost(resolvedUserId, {startDate: previousStartDate, endDate: previousEndDate}),
       calculateWeeklyPostingFrequency(resolvedUserId, currentPeriodDays),
       getAverageViews(currentStartDate, currentEndDate), getAverageViews(previousStartDate, previousEndDate),
+      getAverage('stats.likes', currentStartDate, currentEndDate), getAverage('stats.likes', previousStartDate, previousEndDate),
       getAverage('stats.comments', currentStartDate, currentEndDate), getAverage('stats.comments', previousStartDate, previousEndDate),
       getAverage('stats.shares', currentStartDate, currentEndDate), getAverage('stats.shares', previousStartDate, previousEndDate),
       getAverage('stats.saved', currentStartDate, currentEndDate), getAverage('stats.saved', previousStartDate, previousEndDate),
@@ -131,6 +133,7 @@ export async function GET(
     const postingFrequencyData = createKpiDataObject(freqData.currentWeeklyFrequency, freqData.previousWeeklyFrequency, { current: periodNameCurrent, previous: periodNamePrevious });
     const periodNames = { current: periodNameCurrent, previous: periodNamePrevious };
     const avgViewsPerPostData = createKpiDataObject(currViews, prevViews, periodNames);
+    const avgLikesPerPostData = createKpiDataObject(currLikes, prevLikes, periodNames);
     const avgCommentsPerPostData = createKpiDataObject(currComments, prevComments, periodNames);
     const avgSharesPerPostData = createKpiDataObject(currShares, prevShares, periodNames);
     const avgSavesPerPostData = createKpiDataObject(currSaves, prevSaves, periodNames);
@@ -146,6 +149,7 @@ export async function GET(
       totalEngagement: totalEngagementData,
       postingFrequency: postingFrequencyData,
       avgViewsPerPost: avgViewsPerPostData,
+      avgLikesPerPost: avgLikesPerPostData,
       avgCommentsPerPost: avgCommentsPerPostData,
       avgSharesPerPost: avgSharesPerPostData,
       avgSavesPerPost: avgSavesPerPostData,
@@ -157,6 +161,7 @@ export async function GET(
         totalEngagement: `${compactNumberFormat(totalEngagementData.currentValue)} interações no período.`,
         postingFrequency: `${postingFrequencyData.currentValue?.toFixed(1) ?? 'N/A'} posts por semana.`,
         avgViewsPerPost: `Média de ${compactNumberFormat(avgViewsPerPostData.currentValue)} views/post.`,
+        avgLikesPerPost: `Média de ${compactNumberFormat(avgLikesPerPostData.currentValue)} curtidas/post.`,
         avgCommentsPerPost: `Média de ${compactNumberFormat(avgCommentsPerPostData.currentValue)} comentários/post.`,
         avgSharesPerPost: `Média de ${compactNumberFormat(avgSharesPerPostData.currentValue)} compartilhamentos/post.`,
         avgSavesPerPost: `Média de ${compactNumberFormat(avgSavesPerPostData.currentValue)} salvamentos/post.`,
@@ -175,6 +180,7 @@ export async function GET(
         error: "Erro ao processar sua solicitação de KPIs.", details: errorMessage,
         followerGrowth: errorKpi, engagementRate: errorKpi, totalEngagement: errorKpi, postingFrequency: errorKpi,
         avgViewsPerPost: errorKpi, avgCommentsPerPost: errorKpi, avgSharesPerPost: errorKpi, avgSavesPerPost: errorKpi,
+        avgLikesPerPost: errorKpi,
         // NOVO: Adicionando o campo de alcance à resposta de erro
         avgReachPerPost: errorKpi
     }, { status: 500 });

--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -298,6 +298,7 @@ export default function MediaKitView({ user, summary, videos, kpis: initialKpis,
                     {isLoading ? <FaIcon path={ICONS.spinner} className="animate-spin text-pink-500 mx-auto my-10 h-6 w-6" /> : (
                       <div className="space-y-1">
                         <AverageMetricRow icon={<FaIcon path={ICONS.eye} className="w-4 h-4"/>} label="Visualizações" value={kpiData?.avgViewsPerPost?.currentValue} />
+                        <AverageMetricRow icon={<FaIcon path={ICONS.heart} className="w-4 h-4"/>} label="Curtidas" value={kpiData?.avgLikesPerPost?.currentValue} />
                         <AverageMetricRow icon={<FaIcon path={ICONS.comments} className="w-4 h-4"/>} label="Comentários" value={kpiData?.avgCommentsPerPost?.currentValue} />
                         <AverageMetricRow icon={<FaIcon path={ICONS.share} className="w-4 h-4"/>} label="Compartilhamentos" value={kpiData?.avgSharesPerPost?.currentValue} />
                         <AverageMetricRow icon={<FaIcon path={ICONS.bookmark} className="w-4 h-4"/>} label="Salvos" value={kpiData?.avgSavesPerPost?.currentValue} />

--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -38,6 +38,7 @@ export interface KpiComparison {
   totalEngagement: KPIComparisonData;
   postingFrequency: KPIComparisonData;
   avgViewsPerPost: KPIComparisonData;
+  avgLikesPerPost: KPIComparisonData;
   avgCommentsPerPost: KPIComparisonData;
   avgSharesPerPost: KPIComparisonData;
   avgSavesPerPost: KPIComparisonData;
@@ -48,6 +49,7 @@ export interface KpiComparison {
     totalEngagement?: string;
     postingFrequency?: string;
     avgViewsPerPost?: string;
+    avgLikesPerPost?: string;
     avgCommentsPerPost?: string;
     avgSharesPerPost?: string;
     avgSavesPerPost?: string;


### PR DESCRIPTION
## Summary
- expose avg likes per post KPI in API response and types
- display average likes in Media Kit view

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870424be88c832e9b73c5521e60186c