### PR TITLE
Fix missing views metric in media kit

### DIFF
--- a/src/app/lib/dataService/marketAnalysis/postsService.ts
+++ b/src/app/lib/dataService/marketAnalysis/postsService.ts
@@ -108,10 +108,16 @@ export async function fetchPostDetails(args: IPostDetailsArgs): Promise<IPostDet
         .find({ metric: new Types.ObjectId(postId) })
         .sort({ date: 1 })
         .lean<IDailyMetricSnapshot[]>();
+      const unifiedStats = {
+        ...postData.stats,
+        views:
+          postData.stats?.views ?? postData.stats?.video_views ?? null,
+      };
+
       const result: IPostDetailsData = {
         ...(postData as any),
         _id: postData._id,
-        stats: postData.stats,
+        stats: unifiedStats,
         dailySnapshots: fetchedDailySnapshots,
       };
       return result;


### PR DESCRIPTION
## Summary
- ensure post detail service returns a normalized `views` field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687045133558832eb80e2508cf7d48c1