### PR TITLE
Fix creator distribution filter handling

### DIFF
--- a/src/app/api/admin/creators/region-summary/route.ts
+++ b/src/app/api/admin/creators/region-summary/route.ts
@@ -6,10 +6,18 @@ import aggregateCreatorsByRegion from '@/utils/aggregateCreatorsByRegion';
 
 export const dynamic = 'force-dynamic';
 
+const parseAge = (val: unknown) => {
+  if (val === '' || val === undefined || val === null) {
+    return undefined;
+  }
+  const num = Number(val);
+  return Number.isFinite(num) ? num : undefined;
+};
+
 const querySchema = z.object({
   gender: z.enum(['male', 'female', 'other']).optional(),
-  minAge: z.coerce.number().int().positive().optional(),
-  maxAge: z.coerce.number().int().positive().optional(),
+  minAge: z.preprocess(parseAge, z.number().int().positive().optional()),
+  maxAge: z.preprocess(parseAge, z.number().int().positive().optional()),
   region: z.enum(['Norte', 'Nordeste', 'Centro-Oeste', 'Sudeste', 'Sul']).optional(),
 });
 

--- a/src/hooks/useCreatorRegionSummary.ts
+++ b/src/hooks/useCreatorRegionSummary.ts
@@ -42,7 +42,9 @@ export default function useCreatorRegionSummary(options: UseCreatorRegionSummary
 
   // Memoizar a função fetcher com useCallback.
   const fetcher = useCallback(async (): Promise<Record<string, StateBreakdown>> => {
-    const res = await fetch(`/api/admin/creators/region-summary?${queryString}`);
+    const res = await fetch(`/api/admin/creators/region-summary?${queryString}`, {
+      credentials: 'include',
+    });
     if (!res.ok) throw new Error(`Erro na API: ${res.statusText}`);
     const json: ApiResponse = await res.json();
     


### PR DESCRIPTION
## Summary
- ensure credentials are included when fetching creator distribution data
- handle empty age params safely in `region-summary` API route

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706d6feaf4832e8b9c56f8094463dd