### PR TITLE
Add demographic query intent

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -151,6 +151,12 @@ export const GetConsultingKnowledgeArgsSchema = z.object({
 export const GetLatestAccountInsightsArgsSchema = z.object({
 }).strict().describe("Busca os insights de conta e dados demográficos mais recentes disponíveis para o usuário.");
 
+// Schema para getLatestAudienceDemographics
+export const GetLatestAudienceDemographicsArgsSchema = z
+  .object({})
+  .strict()
+  .describe('Busca apenas o snapshot demográfico mais recente do usuário.');
+
 
 // Schema para FetchCommunityInspirationsArgsSchema
 export const FetchCommunityInspirationsArgsSchema = z.object({
@@ -197,5 +203,6 @@ export const functionValidators: ValidatorMap = {
   getFpcTrendHistory: GetFpcTrendHistoryArgsSchema,
   getConsultingKnowledge: GetConsultingKnowledgeArgsSchema,
   getLatestAccountInsights: GetLatestAccountInsightsArgsSchema,
+  getLatestAudienceDemographics: GetLatestAudienceDemographicsArgsSchema,
   fetchCommunityInspirations: FetchCommunityInspirationsArgsSchema,
 };

--- a/src/app/lib/dataService/demographicService.ts
+++ b/src/app/lib/dataService/demographicService.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Serviço para operações de demografia de audiência.
+ * @version 1.0.0
+ */
+import mongoose, { Types } from 'mongoose';
+import { logger } from '@/app/lib/logger';
+import { DatabaseError } from '@/app/lib/errors';
+import AudienceDemographicSnapshotModel, { IAudienceDemographics } from '@/app/models/demographics/AudienceDemographicSnapshot';
+import { connectToDatabase } from './connection';
+
+/**
+ * Busca o snapshot demográfico mais recente de um usuário.
+ * @param userId - ID do usuário.
+ * @returns Objeto de demografia ou null se não encontrado.
+ * @throws {DatabaseError} Em caso de erro de banco de dados.
+ */
+export async function getLatestAudienceDemographics(userId: string): Promise<IAudienceDemographics | null> {
+  const TAG = '[dataService][demographicService][getLatestAudienceDemographics]';
+  logger.debug(`${TAG} Buscando snapshot demográfico mais recente para ${userId}`);
+
+  if (!mongoose.isValidObjectId(userId)) {
+    logger.error(`${TAG} ID de usuário inválido: ${userId}`);
+    return null;
+  }
+
+  try {
+    await connectToDatabase();
+    const snap = await AudienceDemographicSnapshotModel.findOne({ user: new Types.ObjectId(userId) })
+      .sort({ recordedAt: -1 })
+      .lean();
+
+    if (!snap) {
+      logger.info(`${TAG} Nenhum snapshot demográfico encontrado para ${userId}`);
+      return null;
+    }
+
+    logger.info(`${TAG} Snapshot demográfico encontrado para ${userId} registrado em ${snap.recordedAt}`);
+    return snap.demographics;
+  } catch (err: any) {
+    logger.error(`${TAG} Erro ao buscar demografia para ${userId}:`, err);
+    throw new DatabaseError(`Erro ao buscar dados demográficos: ${err.message}`);
+  }
+}

--- a/src/app/lib/dataService/index.ts
+++ b/src/app/lib/dataService/index.ts
@@ -43,6 +43,8 @@ export * from './adDealService';
 
 // Funções relacionadas com AccountInsights (Insights da Conta)
 export * from './accountInsightService';
+// Funções relacionadas com dados demográficos da audiência
+export * from './demographicService';
 
 // --- (NOVO) Funções relacionadas com Rankings de Categorias ---
 // Adicionando a exportação da nossa nova função para torná-la visível.

--- a/src/app/lib/intentService.ts
+++ b/src/app/lib/intentService.ts
@@ -70,6 +70,7 @@ export type DeterminedIntent =
   | 'generate_proactive_alert'
   | 'ask_community_inspiration'
   | 'user_stated_preference'
+  | 'demographic_query'
   | 'user_shared_goal'
   | 'user_mentioned_key_fact'
   | 'user_requests_memory_update'
@@ -215,6 +216,12 @@ const METRIC_DETAILS_KEYWORDS: string[] = [
     'me da a media', 'e os numeros', 'qual foi o resultado', 'mostra os detalhes disso', 'aprofundar nisso',
     'quero ver os detalhes', 'quais foram as medias', 'detalha essa metrica', 'me mostre os dados', 'quais os numeros'
 ];
+/** Palavras-chave para identificar perguntas sobre demografia do público. */
+const DEMOGRAPHICS_KEYWORDS: string[] = [
+  'demografia', 'demográfico', 'demograficos', 'perfil do público',
+  'idade do público', 'faixa etária', 'idade média', 'gênero dos seguidores',
+  'publico feminino', 'publico masculino', 'onde moram', 'quais países', 'quais cidades'
+];
 /** Palavras-chave que indicam que o usuário deseja continuar ou aprofundar o tópico anterior. */
 const CONTINUE_TOPIC_KEYWORDS: string[] = [
     'e sobre isso', 'continuando', 'voltando ao assunto', 'sobre o que falamos', 'mais sobre isso',
@@ -252,6 +259,7 @@ const N_CLARIFICATION_KW = toNormSet(CLARIFICATION_KEYWORDS);
 const N_DATA_SOURCE_KW   = toNormSet(DATA_SOURCE_KEYWORDS);
 const N_METRIC_DETAILS_KW = toNormSet(METRIC_DETAILS_KEYWORDS);
 const N_CONTINUE_TOPIC_KW = toNormSet(CONTINUE_TOPIC_KEYWORDS);
+const N_DEMOGRAPHICS_KW = toNormSet(DEMOGRAPHICS_KEYWORDS);
 
 const includesKw = (txt: string, kwSet: Set<string>) =>
   [...kwSet].some((kw) => txt.includes(kw));
@@ -292,6 +300,7 @@ const isClarificationRequest = (txt: string) => includesKw(txt, N_CLARIFICATION_
 const isDataSourceRequest    = (txt: string) => includesKw(txt, N_DATA_SOURCE_KW);
 const isMetricDetailsRequest = (txt: string) => includesKw(txt, N_METRIC_DETAILS_KW);
 const isContinueTopicRequest = (txt: string) => includesKw(txt, N_CONTINUE_TOPIC_KW);
+const isDemographicsRequest = (txt: string) => includesKw(txt, N_DEMOGRAPHICS_KW);
 
 /** Verifica se a mensagem é apenas uma saudação curta. */
 function isGreetingOnly(norm: string): boolean {
@@ -738,6 +747,7 @@ export async function determineIntent(
   else if (isPlanRequest(normalizedText))        intent = 'content_plan';
   else if (isScriptRequest(normalizedText))      intent = 'script_request';
   else if (isBestPerfRequest(normalizedText))    intent = 'ASK_BEST_PERFORMER';
+  else if (isDemographicsRequest(normalizedText)) intent = 'demographic_query';
   else if (isCommunityInspirationRequest(normalizedText)) intent = 'ask_community_inspiration';
   else if (isIdeasRequest(normalizedText))       intent = 'content_ideas';
   else if (isRankingRequest(normalizedText))     intent = 'ranking_request';

--- a/src/app/lib/promptSystemFC.ts
+++ b/src/app/lib/promptSystemFC.ts
@@ -6,6 +6,7 @@ export function getSystemPrompt(userName: string = 'usuário'): string { // user
     // Nomes das funções
     const GET_AGGREGATED_REPORT_FUNC_NAME = 'getAggregatedReport';
     const GET_LATEST_ACCOUNT_INSIGHTS_FUNC_NAME = 'getLatestAccountInsights';
+    const GET_LATEST_AUDIENCE_DEMOGRAPHICS_FUNC_NAME = 'getLatestAudienceDemographics';
     const FETCH_COMMUNITY_INSPIRATIONS_FUNC_NAME = 'fetchCommunityInspirations';
     const GET_TOP_POSTS_FUNC_NAME = 'getTopPosts';
     const GET_CATEGORY_RANKING_FUNC_NAME = 'getCategoryRanking'; // (NOVO)
@@ -82,7 +83,8 @@ Regras Gerais de Operação
 
     * **ANÚNCIO DA BUSCA DE DADOS (v2.32.6):** ...
     * **DADOS DE POSTS (RELATÓRIO AGREGADO - \`${GET_AGGREGATED_REPORT_FUNC_NAME}\`):** ...
-    * **DADOS DA CONTA E AUDIÊNCIA (\`${GET_LATEST_ACCOUNT_INSIGHTS_FUNC_NAME}\`):** ...
+    * **DADOS DA CONTA (\`${GET_LATEST_ACCOUNT_INSIGHTS_FUNC_NAME}\`):** Use para retornar estatísticas gerais como alcance e impressões da conta.
+    * **DADOS DEMOGRÁFICOS DA AUDIÊNCIA (\`${GET_LATEST_AUDIENCE_DEMOGRAPHICS_FUNC_NAME}\`):** Use esta função para obter a distribuição de idade, gênero, país e cidade dos seguidores sempre que o usuário pedir detalhes do público.
     * **BUSCANDO INSPIRAÇÕES NA COMUNIDADE (\`${FETCH_COMMUNITY_INSPIRATIONS_FUNC_NAME}\`):** ...
     * **FALHA AO BUSCAR DADOS / DADOS INSUFICIENTES (ATUALIZADO - v2.32.13):** ...
     * **APRESENTANDO DADOS QUANDO ENCONTRADOS (NOVO - v2.32.13, REFORÇADO v2.33.4):**


### PR DESCRIPTION
## Summary
- expand system prompt to clarify how to fetch follower demographics
- detect demographic questions in the intent service
- fetch latest audience demographics via new function and dataService

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719f107d58832e8be46271de89a798