### PR TITLE
Add agency plan status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 Consulte o diretório `docs` para informações adicionais, incluindo o [plano de expanção dos rankings](docs/ranking-expansion.md) e o [plano de otimização estratégica v4](docs/plano-de-otimizacao-estrategica-v4.md).
 
 
+## Agency Dashboard
+
+Usuários com papel **agency** podem acessar `/agency/creator-dashboard` para acompanhar apenas os criadores vinculados à sua agência. Crie a conta de agência pelo painel admin e compartilhe o link de convite (`/assinar?codigo_agencia=<inviteCode>`). A assinatura do WhatsApp permanece do usuário mesmo que ele saia da agência. O dashboard só é liberado se o plano da agência estiver ativo.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/src/app/agency/components/AgencyAuthGuard.test.tsx
+++ b/src/app/agency/components/AgencyAuthGuard.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import AgencyAuthGuard from './AgencyAuthGuard';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+jest.mock('next-auth/react');
+const mockUseSession = useSession as jest.Mock;
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn().mockReturnValue('/agency/some-page'),
+}));
+const mockUseRouter = useRouter as jest.Mock;
+const mockRouterReplace = jest.fn();
+
+describe('AgencyAuthGuard', () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseRouter.mockReturnValue({ replace: mockRouterReplace });
+    mockRouterReplace.mockClear();
+  });
+
+  it('should render loading state initially', () => {
+    render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
+    expect(screen.getByText('Verificando autorização...')).toBeInTheDocument();
+  });
+
+  it('should redirect to /login if unauthenticated', async () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
+    await act(async () => {});
+    expect(mockRouterReplace).toHaveBeenCalledWith('/login?error=SessionRequired&callbackUrl=/agency/creator-dashboard');
+  });
+
+  it('should redirect to /unauthorized if authenticated but not agency', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { name: 'User' } }, status: 'authenticated' });
+    render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
+    await act(async () => {});
+    expect(mockRouterReplace).toHaveBeenCalledWith('/unauthorized?error=AgencyAccessRequired');
+  });
+
+  it('should redirect to /agency/subscription if plan inactive', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { name: 'Agent', role: 'agency', agencyPlanStatus: 'inactive' } }, status: 'authenticated' });
+    render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
+    await act(async () => {});
+    expect(mockRouterReplace).toHaveBeenCalledWith('/agency/subscription');
+  });
+
+  it('should render children if authenticated and agency with active plan', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { name: 'Agent', role: 'agency', agencyPlanStatus: 'active' } }, status: 'authenticated' });
+    render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
+    await act(async () => {});
+    expect(screen.getByText('Protected')).toBeInTheDocument();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/agency/components/AgencyAuthGuard.tsx
+++ b/src/app/agency/components/AgencyAuthGuard.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
+
+interface AgencyUser {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role?: string;
+  isAgency?: boolean;
+  agencyPlanStatus?: string | null;
+}
+
+interface ExtendedSession {
+  user?: AgencyUser;
+  expires: string;
+}
+
+export default function AgencyAuthGuard({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession() as { data: ExtendedSession | null, status: 'loading' | 'authenticated' | 'unauthenticated' };
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    if (status === 'unauthenticated') {
+      router.replace('/login?error=SessionRequired&callbackUrl=/agency/creator-dashboard');
+      return;
+    }
+
+    const userIsAgency = session?.user?.role === 'agency' || session?.user?.isAgency === true;
+    const planActive = session?.user?.agencyPlanStatus === 'active';
+    if (!userIsAgency) {
+      router.replace('/unauthorized?error=AgencyAccessRequired');
+    } else if (!planActive) {
+      router.replace('/agency/subscription');
+    }
+  }, [status, session, router]);
+
+  if (
+    status === 'loading' ||
+    status === 'unauthenticated' ||
+    (status === 'authenticated' && (
+      !(session?.user?.role === 'agency' || session?.user?.isAgency === true) ||
+      session?.user?.agencyPlanStatus !== 'active'
+    ))
+  ) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-brand-light">
+        <p className="text-lg text-gray-700">Verificando autorização...</p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/api/agency/dashboard/creators/route.ts
+++ b/src/app/api/agency/dashboard/creators/route.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview API Endpoint for fetching dashboard creators.
+ * @version 1.1.0
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getAgencySession } from '@/lib/getAgencySession';
+import { fetchDashboardCreatorsList } from '@/app/lib/dataService/marketAnalysis/dashboardService';
+import { IFetchDashboardCreatorsListParams } from '@/app/lib/dataService/marketAnalysis/types';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/creators]';
+
+// Schema para a validação dos parâmetros de consulta
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+  sortBy: z.string().optional().default('totalPosts'),
+  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
+  nameSearch: z.string().optional(),
+  planStatus: z.string().optional().transform(val => {
+    if (!val) return undefined;
+    return val.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  }).refine(val => val === undefined || (Array.isArray(val) && val.length > 0) ? true : false, {
+    message: "planStatus deve ser uma lista de strings separadas por vírgulas.",
+  }),
+  expertiseLevel: z.string().optional().transform(val => {
+    if (!val) return undefined;
+    return val.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  }).refine(val => val === undefined || (Array.isArray(val) && val.length > 0) ? true : false, {
+    message: "expertiseLevel deve ser uma lista de strings separadas por vírgulas.",
+  }),
+  minTotalPosts: z.coerce.number().int().min(0).optional(),
+  startDate: z.string().datetime({ offset: true, message: "Formato de startDate inválido." }).optional(),
+  endDate: z.string().datetime({ offset: true, message: "Formato de endDate inválido." }).optional(),
+}).refine(data => {
+  if (data.startDate && data.endDate) {
+    return new Date(data.startDate) <= new Date(data.endDate);
+  }
+  return true;
+}, { message: "startDate não pode ser posterior a endDate", path: ["endDate"] });
+
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+/**
+ * @handler GET
+ * @description Trata de pedidos GET para buscar uma lista de criadores do dashboard.
+ * @param {NextRequest} req - O objeto de pedido do Next.js.
+ * @returns {Promise<NextResponse>} Um objeto de resposta do Next.js.
+ */
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Pedido recebido para a lista de criadores do dashboard.`);
+
+  try {
+    const session = await getAgencySession(req);
+    // CORREÇÃO: Adicionada verificação explícita para session.user.
+    if (!session || !session.user) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+    logger.info(`${TAG} Sessão de agência validada para o utilizador: ${session.user.name}`);
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      logger.warn(`${TAG} Parâmetros de consulta inválidos: ${errorMessage}`);
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { nameSearch, planStatus, expertiseLevel, minTotalPosts, startDate, endDate, ...paginationAndSort } = validationResult.data;
+
+    const params: IFetchDashboardCreatorsListParams = {
+      ...paginationAndSort,
+      filters: {
+        nameSearch,
+        planStatus,
+        expertiseLevel,
+        minTotalPosts,
+        startDate,
+        endDate,
+      },
+    };
+    
+    // Remove filtros indefinidos para manter a chamada ao serviço limpa
+    Object.keys(params.filters!).forEach(key => {
+        const filterKey = key as keyof typeof params.filters;
+        if (params.filters![filterKey] === undefined) {
+            delete params.filters![filterKey];
+        }
+    });
+
+    logger.info(`${TAG} A chamar fetchDashboardCreatorsList com parâmetros: ${JSON.stringify(params)}`);
+    const { creators, totalCreators } = await fetchDashboardCreatorsList({ ...params, agencyId: session.user.agencyId });
+
+    logger.info(`${TAG} ${creators.length} criadores buscados com sucesso. Total disponível: ${totalCreators}.`);
+    return NextResponse.json({ creators, totalCreators, page: params.page, limit: params.limit }, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Erro inesperado:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(`Erro de base de dados: ${error.message}`, 500);
+    }
+    if (error instanceof z.ZodError) {
+        return apiError(`Erro de validação: ${error.errors.map(e => e.message).join(', ')}`, 400);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -10,7 +10,8 @@ import FacebookProvider from "next-auth/providers/facebook";
 import CredentialsProvider from "next-auth/providers/credentials";
 
 import { connectToDatabase } from "@/app/lib/mongoose";
-import DbUser, { IUser } from "@/app/models/User"; 
+import DbUser, { IUser } from "@/app/models/User";
+import AgencyModel, { IAgency } from "@/app/models/Agency";
 
 import { Types } from "mongoose";
 import type { JWT, DefaultJWT, JWTEncodeParams, JWTDecodeParams } from "next-auth/jwt";
@@ -482,6 +483,7 @@ export const authOptions: NextAuthOptions = {
                     (authUserFromProvider as NextAuthUserArg).planStatus = dbUserRecord.planStatus;
                     (authUserFromProvider as NextAuthUserArg).planExpiresAt = dbUserRecord.planExpiresAt;
                     (authUserFromProvider as NextAuthUserArg).affiliateCode = dbUserRecord.affiliateCode;
+                    (authUserFromProvider as NextAuthUserArg).agency = dbUserRecord.agency ? dbUserRecord.agency.toString() : undefined;
                     
                     logger.debug(`${TAG_SIGNIN} [${provider}] FINAL signIn. authUser.id (interno): '${authUserFromProvider.id}', name: '${authUserFromProvider.name}', provider (final): '${(authUserFromProvider as NextAuthUserArg).provider}', planStatus: ${(authUserFromProvider as NextAuthUserArg).planStatus}, igAccountsCount: ${(authUserFromProvider as NextAuthUserArg).availableIgAccounts?.length ?? 0}, igLlatSet: ${!!(authUserFromProvider as NextAuthUserArg).instagramAccessToken}`);
                     return true;
@@ -531,8 +533,23 @@ export const authOptions: NextAuthOptions = {
                 token.planStatus = (userFromSignIn as NextAuthUserArg).planStatus;
                 token.planExpiresAt = (userFromSignIn as NextAuthUserArg).planExpiresAt;
                 token.affiliateCode = (userFromSignIn as NextAuthUserArg).affiliateCode;
+                token.agencyId = (userFromSignIn as NextAuthUserArg).agency ?? null;
+                if ((userFromSignIn as NextAuthUserArg).agency) {
+                    try {
+                        await connectToDatabase();
+                        const agency = await AgencyModel.findById((userFromSignIn as NextAuthUserArg).agency)
+                            .select('planStatus')
+                            .lean<IAgency>();
+                        token.agencyPlanStatus = agency?.planStatus ?? 'inactive';
+                    } catch (err) {
+                        logger.error(`${TAG_JWT} Erro ao buscar agency durante signIn:`, err);
+                        token.agencyPlanStatus = 'inactive';
+                    }
+                } else {
+                    token.agencyPlanStatus = null;
+                }
 
-                logger.info(`${TAG_JWT} Token populado de userFromSignIn. ID: ${token.id}, Provider: ${token.provider}, planStatus: ${token.planStatus}, igAccounts: ${token.availableIgAccounts?.length}, igLlatSet: ${!!token.instagramAccessToken}`);
+                logger.info(`${TAG_JWT} Token populado de userFromSignIn. ID: ${token.id}, Provider: ${token.provider}, planStatus: ${token.planStatus}, agencyPlanStatus: ${token.agencyPlanStatus}, igAccounts: ${token.availableIgAccounts?.length}, igLlatSet: ${!!token.instagramAccessToken}`);
             }
 
             // For subsequent JWT reads (e.g., session creation, API calls) or updates
@@ -540,6 +557,7 @@ export const authOptions: NextAuthOptions = {
                 let needsDbRefresh = trigger === 'update' || // Explicit update
                                       !token.role ||  // Missing essential data
                                       typeof token.planStatus === 'undefined' ||
+                                      typeof token.agencyPlanStatus === 'undefined' ||
                                       typeof token.affiliateCode === 'undefined' ||
                                       (typeof token.isInstagramConnected === 'undefined' && typeof token.availableIgAccounts === 'undefined');
 
@@ -559,7 +577,7 @@ export const authOptions: NextAuthOptions = {
                     try {
                         await connectToDatabase();
                         const dbUser = await DbUser.findById(token.id)
-                            .select('name email image role provider providerAccountId facebookProviderAccountId isNewUserForOnboarding onboardingCompletedAt isInstagramConnected instagramAccountId username lastInstagramSyncAttempt lastInstagramSyncSuccess instagramSyncErrorMsg planStatus planExpiresAt affiliateCode availableIgAccounts instagramAccessToken')
+                            .select('name email image role agency provider providerAccountId facebookProviderAccountId isNewUserForOnboarding onboardingCompletedAt isInstagramConnected instagramAccountId username lastInstagramSyncAttempt lastInstagramSyncSuccess instagramSyncErrorMsg planStatus planExpiresAt affiliateCode availableIgAccounts instagramAccessToken')
                             .lean<IUser>(); // Use lean for performance
 
                         if (dbUser) {
@@ -588,6 +606,19 @@ export const authOptions: NextAuthOptions = {
                             token.planStatus = dbUser.planStatus ?? token.planStatus ?? 'inactive';
                             token.planExpiresAt = dbUser.planExpiresAt ?? token.planExpiresAt ?? null;
                             token.affiliateCode = dbUser.affiliateCode ?? token.affiliateCode ?? null;
+                            token.agencyId = dbUser.agency ? dbUser.agency.toString() : token.agencyId ?? null;
+                            if (dbUser.agency) {
+                                try {
+                                    const dbAgency = await AgencyModel.findById(dbUser.agency)
+                                        .select('planStatus')
+                                        .lean<IAgency>();
+                                    token.agencyPlanStatus = dbAgency?.planStatus ?? token.agencyPlanStatus ?? 'inactive';
+                                } catch (err) {
+                                    logger.error(`${TAG_JWT} Erro ao buscar agencia para token refresh:`, err);
+                                }
+                            } else {
+                                token.agencyPlanStatus = null;
+                            }
 
                             logger.info(`${TAG_JWT} Token enriquecido/atualizado do DB. ID: ${token.id}, Provider: ${token.provider}, planStatus: ${token.planStatus}, igAccounts: ${token.availableIgAccounts?.length}, igLlatSet: ${!!token.instagramAccessToken}, igErr: ${token.igConnectionError ? 'Sim ('+String(token.igConnectionError).substring(0,30)+'...)': 'Não'}`);
                         } else {
@@ -610,7 +641,7 @@ export const authOptions: NextAuthOptions = {
             // Ensure 'picture' is not in the final token if 'image' is used
             if (token.image && (token as any).picture) delete (token as any).picture; 
 
-            logger.debug(`${TAG_JWT} FINAL jwt. Token id: '${token.id}', name: '${token.name}', provider: '${token.provider}', planStatus: ${token.planStatus}, affiliateCode: ${token.affiliateCode}, igErr: ${token.igConnectionError ? 'Sim ('+String(token.igConnectionError).substring(0,30)+'...)': 'Não'}`);
+            logger.debug(`${TAG_JWT} FINAL jwt. Token id: '${token.id}', name: '${token.name}', provider: '${token.provider}', planStatus: ${token.planStatus}, agencyPlanStatus: ${token.agencyPlanStatus}, affiliateCode: ${token.affiliateCode}, agencyId: ${token.agencyId}, igErr: ${token.igConnectionError ? 'Sim ('+String(token.igConnectionError).substring(0,30)+'...)': 'Não'}`);
             return token;
         },
 
@@ -649,6 +680,8 @@ export const authOptions: NextAuthOptions = {
             session.user.planStatus = token.planStatus ?? 'inactive';
             session.user.planExpiresAt = token.planExpiresAt ? (typeof token.planExpiresAt === 'string' ? token.planExpiresAt : new Date(token.planExpiresAt).toISOString()) : null;
             session.user.affiliateCode = token.affiliateCode;
+            session.user.agencyId = token.agencyId ?? null;
+            session.user.agencyPlanStatus = token.agencyPlanStatus ?? null;
             
             // These fields might be populated from other sources or kept if already in session
             session.user.affiliateBalance = session.user.affiliateBalance ?? undefined; 
@@ -669,13 +702,23 @@ export const authOptions: NextAuthOptions = {
                     session.user.planStatus = dbUserCheck.planStatus ?? session.user.planStatus ?? 'inactive';
                     if (dbUserCheck.planExpiresAt instanceof Date) {
                         session.user.planExpiresAt = dbUserCheck.planExpiresAt.toISOString();
-                    } else if (dbUserCheck.planExpiresAt === null) { // Explicitly handle null
+                    } else if (dbUserCheck.planExpiresAt === null) {
                         session.user.planExpiresAt = null;
                     }
-                    // Ensure name, role, image are from the latest DB record if they exist
                     if (dbUserCheck.name) session.user.name = dbUserCheck.name;
                     if (dbUserCheck.role) session.user.role = dbUserCheck.role;
                     if (dbUserCheck.image) session.user.image = dbUserCheck.image;
+
+                    if (session.user.agencyId) {
+                        try {
+                            const agency = await AgencyModel.findById(session.user.agencyId)
+                                .select('planStatus')
+                                .lean<IAgency>();
+                            session.user.agencyPlanStatus = agency?.planStatus ?? session.user.agencyPlanStatus ?? 'inactive';
+                        } catch (err) {
+                            logger.error(`${TAG_SESSION} Erro ao revalidar agency para session ${token.id}:`, err);
+                        }
+                    }
 
                 } else if (!dbUserCheck) {
                     logger.warn(`${TAG_SESSION} Utilizador ${token.id} não encontrado no DB durante revalidação da sessão. Usando dados do token como estão.`);
@@ -684,7 +727,7 @@ export const authOptions: NextAuthOptions = {
                 logger.error(`${TAG_SESSION} Erro ao buscar dados do DB para revalidação da sessão ${token.id}:`, error);
             }
             
-            logger.debug(`${TAG_SESSION} Finalizado. Session.user ID: ${session.user?.id}, Name: ${session.user?.name}, Provider: ${session.user?.provider}, Session planStatus (final): ${session.user?.planStatus}, igAccounts: ${session.user?.availableIgAccounts?.length}, igErr: ${session.user?.igConnectionError ? 'Sim' : 'Não'}`);
+            logger.debug(`${TAG_SESSION} Finalizado. Session.user ID: ${session.user?.id}, Name: ${session.user?.name}, Provider: ${session.user?.provider}, Session planStatus (final): ${session.user?.planStatus}, agencyId: ${session.user?.agencyId}, agencyPlanStatus: ${session.user?.agencyPlanStatus}, igAccounts: ${session.user?.availableIgAccounts?.length}, igErr: ${session.user?.igConnectionError ? 'Sim' : 'Não'}`);
             return session;
          },
 

--- a/src/app/lib/dataService/marketAnalysis/dashboardService.ts
+++ b/src/app/lib/dataService/marketAnalysis/dashboardService.ts
@@ -4,7 +4,7 @@
  * @description Adicionadas anotações de otimização de performance.
  */
 
-import { PipelineStage } from 'mongoose';
+import { PipelineStage, Types } from 'mongoose';
 import { logger } from '@/app/lib/logger';
 import MetricModel from '@/app/models/Metric';
 import UserModel from '@/app/models/User';
@@ -53,6 +53,9 @@ export async function fetchDashboardCreatorsList(
     const userMatchStage: PipelineStage.Match['$match'] = {};
     if (filters.nameSearch) {
       userMatchStage.name = { $regex: filters.nameSearch, $options: 'i' };
+    }
+    if (params.agencyId) {
+      userMatchStage.agency = new Types.ObjectId(params.agencyId);
     }
     if (filters.planStatus && Array.isArray(filters.planStatus) && filters.planStatus.length > 0) {
       userMatchStage.planStatus = { $in: filters.planStatus };

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -129,6 +129,7 @@ export interface IFetchDashboardCreatorsListParams {
   limit?: number;
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
+  agencyId?: string;
   filters?: {
     nameSearch?: string;
     planStatus?: string[];

--- a/src/app/models/Agency.ts
+++ b/src/app/models/Agency.ts
@@ -1,0 +1,23 @@
+import { Schema, model, models, Document, Model } from 'mongoose';
+import { nanoid } from 'nanoid';
+
+export interface IAgency extends Document {
+  name: string;
+  contactEmail?: string;
+  inviteCode: string;
+  planStatus?: string;
+  paymentGatewaySubscriptionId?: string | null;
+}
+
+const agencySchema = new Schema<IAgency>({
+  name: { type: String, required: true },
+  contactEmail: { type: String },
+  inviteCode: { type: String, required: true, default: () => nanoid(10), unique: true },
+  planStatus: { type: String, default: 'inactive' },
+  paymentGatewaySubscriptionId: { type: String, default: null },
+}, { timestamps: true });
+
+agencySchema.index({ inviteCode: 1 }, { unique: true });
+
+const AgencyModel: Model<IAgency> = models.Agency || model<IAgency>('Agency', agencySchema);
+export default AgencyModel;

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -204,6 +204,7 @@ export interface IUser extends Document {
   mediaKitToken?: string;
   mediaKitSlug?: string;
   role: string;
+  agency?: Types.ObjectId | null;
   planStatus?: string;
   planExpiresAt?: Date | null;
   whatsappVerificationCode?: string | null;
@@ -324,6 +325,7 @@ const userSchema = new Schema<IUser>(
     mediaKitToken: { type: String, unique: true, sparse: true },
     mediaKitSlug: { type: String, unique: true, sparse: true },
     role: { type: String, default: "user" },
+    agency: { type: Schema.Types.ObjectId, ref: 'Agency', default: null },
     planExpiresAt: { type: Date, default: null },
     whatsappVerificationCode: { type: String, default: null, index: true },
     whatsappPhone: { type: String, default: null, index: true },

--- a/src/lib/getAgencySession.test.ts
+++ b/src/lib/getAgencySession.test.ts
@@ -1,0 +1,28 @@
+import { getServerSession } from 'next-auth/next';
+import { getAgencySession } from './getAgencySession';
+
+jest.mock('next-auth/next');
+const mockGetServerSession = getServerSession as jest.Mock;
+
+describe('getAgencySession', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns session when user is agency', async () => {
+    const session = { user: { role: 'agency' } } as any;
+    mockGetServerSession.mockResolvedValue(session);
+    const result = await getAgencySession({} as any);
+    expect(result).toBe(session);
+  });
+
+  it('returns null when role is not agency', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { role: 'user' } });
+    const result = await getAgencySession({} as any);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on error', async () => {
+    mockGetServerSession.mockRejectedValue(new Error('err'));
+    const result = await getAgencySession({} as any);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/getAgencySession.ts
+++ b/src/lib/getAgencySession.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { logger } from '@/app/lib/logger';
+
+export async function getAgencySession(_req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || session.user?.role !== 'agency') {
+      logger.warn('[getAgencySession] session invalid or user not agency');
+      return null;
+    }
+    return session;
+  } catch (err) {
+    logger.error('[getAgencySession] failed to get session', err);
+    return null;
+  }
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -17,6 +17,8 @@ declare module "next-auth" {
       image?: string | null;
       provider?: string | null; // Provider usado no login ATUAL ('google', 'facebook')
       role?: string;
+      agencyId?: string | null;
+      agencyPlanStatus?: string | null;
       planStatus?: string;
       planExpiresAt?: string | null; // Mantido como string (ISO) para o cliente
       affiliateCode?: string;
@@ -48,6 +50,7 @@ declare module "next-auth" {
   interface User extends DefaultUser { // DefaultUser já tem id, name, email, image
     id: string; // Garante que nosso ID (do DB) sobrescreva/seja o principal
     role?: string | null;
+    agency?: string | null;
     provider?: string | null; // Provider do primeiro login ou principal
     providerAccountId?: string | null; // ID do provider principal
     facebookProviderAccountId?: string | null; // ID específico do Facebook
@@ -84,6 +87,8 @@ declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT { // DefaultJWT já tem name, email, picture, sub
     id: string; // ID do usuário do seu DB (obrigatório)
     role?: string | null;
+    agencyId?: string | null;
+    agencyPlanStatus?: string | null;
     provider?: string | null;
     
     isNewUserForOnboarding?: boolean;


### PR DESCRIPTION
## Summary
- enforce agency dashboard access only with active plan
- propagate agency plan status through JWT and session
- update AgencyAuthGuard and its tests for subscription check
- document requirement in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6b56f5c832ea39e1ff799cda052