### PR TITLE
Implement agency payment integration

### DIFF
--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -18,7 +18,9 @@ export default function AgencySubscriptionPage() {
     const res = await fetch('/api/agency/subscription/create-checkout', { method: 'POST', body: JSON.stringify({ planId: 'basic' }) });
     if (res.ok) {
       const json = await res.json();
-      window.location.href = json.checkoutUrl;
+      if (json.initPoint) {
+        window.location.href = json.initPoint;
+      }
     }
   };
 

--- a/src/app/api/agency/subscription/cancel/route.ts
+++ b/src/app/api/agency/subscription/cancel/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/app/lib/logger';
+import { getAgencySession } from '@/lib/getAgencySession';
+import AgencyModel from '@/app/models/Agency';
+import mercadopago from '@/app/lib/mercadopago';
+
+export const runtime = 'nodejs';
+const SERVICE_TAG = '[api/agency/subscription/cancel]';
+
+export async function POST(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[POST]`;
+  try {
+    const session = await getAgencySession(req);
+    if (!session?.user?.agencyId) {
+      logger.warn(`${TAG} unauthorized attempt`);
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const agency = await AgencyModel.findById(session.user.agencyId);
+    if (!agency || !agency.paymentGatewaySubscriptionId) {
+      return NextResponse.json({ error: 'Subscription not found' }, { status: 404 });
+    }
+
+    await mercadopago.preapproval.update(agency.paymentGatewaySubscriptionId, { status: 'cancelled' });
+    agency.planStatus = 'canceled';
+    await agency.save();
+
+    logger.info(`${TAG} subscription cancelled for agency ${agency._id}`);
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    logger.error(`${TAG} unexpected error`, err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/subscription/create-checkout/route.ts
+++ b/src/app/api/agency/subscription/create-checkout/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { getAgencySession } from '@/lib/getAgencySession';
+import AgencyModel from '@/app/models/Agency';
+import mercadopago from '@/app/lib/mercadopago';
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/create-checkout]';
@@ -25,11 +27,33 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
     }
 
-    // TODO: Integrate with payment gateway (Stripe/Mercado Pago)
-    const checkoutUrl = `https://pagamento.exemplo.com/checkout?plan=${validation.data.planId}&agency=${session.user.agencyId}`;
+    const agency = await AgencyModel.findById(session.user.agencyId);
+    if (!agency) {
+      logger.warn(`${TAG} agency not found ${session.user.agencyId}`);
+      return NextResponse.json({ error: 'Agency not found' }, { status: 404 });
+    }
 
-    logger.info(`${TAG} checkout session created for agency ${session.user.agencyId}`);
-    return NextResponse.json({ checkoutUrl });
+    const preapprovalData = {
+      reason: 'Plano Agência Data2Content',
+      back_url: `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || ''}/agency/subscription`,
+      external_reference: agency._id.toString(),
+      payer_email: session.user.email || agency.contactEmail || undefined,
+      auto_recurring: {
+        frequency: 1,
+        frequency_type: 'months',
+        transaction_amount: Number(process.env.AGENCY_MONTHLY_PRICE || 99),
+        currency_id: 'BRL',
+      },
+    } as any;
+
+    const response = await mercadopago.preapproval.create(preapprovalData);
+    const initPoint = response.body.init_point;
+
+    agency.planStatus = 'pending';
+    await agency.save();
+
+    logger.info(`${TAG} checkout session created for agency ${agency._id}`);
+    return NextResponse.json({ initPoint });
   } catch (err: any) {
     logger.error(`${TAG} unexpected error`, err);
     return NextResponse.json({ error: 'Internal error' }, { status: 500 });

--- a/src/app/api/webhooks/payment/route.ts
+++ b/src/app/api/webhooks/payment/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import AgencyModel from '@/app/models/Agency';
 import { logger } from '@/app/lib/logger';
+import mercadopago from '@/app/lib/mercadopago';
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/webhooks/payment]';
 
 interface PaymentEvent {
   type: string;
+  action?: string;
   data?: {
+    id?: string;
     subscriptionId?: string;
   };
 }
@@ -18,31 +21,63 @@ export async function POST(req: NextRequest) {
     const body = (await req.json()) as PaymentEvent;
     logger.info(`${TAG} event received: ${body.type}`);
 
-    const subscriptionId = body.data?.subscriptionId;
-    if (!subscriptionId) {
-      logger.warn(`${TAG} missing subscriptionId`);
-      return NextResponse.json({ received: true });
-    }
+    if (body.type === 'preapproval') {
+      const preapprovalId = body.data?.id;
+      if (!preapprovalId) {
+        logger.warn(`${TAG} missing preapproval id`);
+        return NextResponse.json({ received: true });
+      }
 
-    const agency = await AgencyModel.findOne({ paymentGatewaySubscriptionId: subscriptionId });
-    if (!agency) {
-      logger.warn(`${TAG} agency not found for subscription ${subscriptionId}`);
-      return NextResponse.json({ received: true });
-    }
+      const { body: preapproval } = await mercadopago.preapproval.get(preapprovalId);
+      const agencyId = preapproval.external_reference;
+      if (!agencyId) {
+        logger.warn(`${TAG} preapproval ${preapprovalId} without external reference`);
+        return NextResponse.json({ received: true });
+      }
 
-    if (body.type === 'checkout.session.completed' || body.type === 'subscription.active') {
-      agency.planStatus = 'active';
-      agency.paymentGatewaySubscriptionId = subscriptionId;
+      const agency = await AgencyModel.findById(agencyId);
+      if (!agency) {
+        logger.warn(`${TAG} agency not found for preapproval ${preapprovalId}`);
+        return NextResponse.json({ received: true });
+      }
+
+      agency.paymentGatewaySubscriptionId = preapprovalId;
+      if (preapproval.status === 'authorized') {
+        agency.planStatus = 'active';
+      } else if (preapproval.status === 'cancelled') {
+        agency.planStatus = 'canceled';
+      } else if (preapproval.status === 'paused' || preapproval.status === 'suspended') {
+        agency.planStatus = 'past_due';
+      }
       await agency.save();
-      logger.info(`${TAG} agency ${agency._id} activated`);
-    } else if (body.type === 'invoice.payment_failed') {
-      agency.planStatus = 'past_due';
-      await agency.save();
-      logger.info(`${TAG} agency ${agency._id} marked past_due`);
-    } else if (body.type === 'customer.subscription.deleted') {
-      agency.planStatus = 'canceled';
-      await agency.save();
-      logger.info(`${TAG} agency ${agency._id} canceled`);
+      logger.info(`${TAG} agency ${agency._id} updated to ${agency.planStatus}`);
+    } else {
+      const subscriptionId = body.data?.subscriptionId;
+      if (!subscriptionId) {
+        logger.warn(`${TAG} missing subscriptionId`);
+        return NextResponse.json({ received: true });
+      }
+
+      const agency = await AgencyModel.findOne({ paymentGatewaySubscriptionId: subscriptionId });
+      if (!agency) {
+        logger.warn(`${TAG} agency not found for subscription ${subscriptionId}`);
+        return NextResponse.json({ received: true });
+      }
+
+      if (body.type === 'checkout.session.completed' || body.type === 'subscription.active') {
+        agency.planStatus = 'active';
+        agency.paymentGatewaySubscriptionId = subscriptionId;
+        await agency.save();
+        logger.info(`${TAG} agency ${agency._id} activated`);
+      } else if (body.type === 'invoice.payment_failed') {
+        agency.planStatus = 'past_due';
+        await agency.save();
+        logger.info(`${TAG} agency ${agency._id} marked past_due`);
+      } else if (body.type === 'customer.subscription.deleted') {
+        agency.planStatus = 'canceled';
+        await agency.save();
+        logger.info(`${TAG} agency ${agency._id} canceled`);
+      }
     }
 
     return NextResponse.json({ received: true });


### PR DESCRIPTION
## Summary
- integrate Mercado Pago preapproval creation for agencies
- handle preapproval events in payment webhook
- allow agency subscription cancellation
- update agency subscription UI to redirect to payment link

## Testing
- `npx jest --watchAll=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730af0da30832eba19d4050d9ff501