### PR TITLE
Enable credential login with hashed passwords

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "swiper": "^11.2.6",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add `bcryptjs` dependency
- hash manager passwords on agency creation and update
- implement real credential login lookup via email and hashed password in NextAuth provider

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873e4814780832ea7764edf8d969b3f