### PR TITLE
Fix agency login by storing password hash

### DIFF
--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -178,6 +178,7 @@ export interface IUser extends Document {
   _id: Types.ObjectId;
   name?: string;
   email: string;
+  password?: string;
   image?: string;
   googleId?: string;
   provider?: string;
@@ -291,6 +292,10 @@ const userSchema = new Schema<IUser>(
         unique: true,
         match: [/.+\@.+\..+/, 'Please fill a valid email address'],
         index: true,
+    },
+    password: {
+        type: String,
+        select: false
     },
     planStatus: { type: String, default: "inactive", index: true }, // OTIMIZAÇÃO: Mantido índice.
     inferredExpertiseLevel: {


### PR DESCRIPTION
## Summary
- add optional `password` field to `IUser`
- store hashed `password` in `userSchema` with `select: false`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687425acb8e0832eb033c4becdf079d1