### PR TITLE
Fix post-login routing and agency subscription errors

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+const FullPageLoader = () => (
+  <div className="flex items-center justify-center h-screen">
+    <p>Redirecionando...</p>
+  </div>
+);
+
+export default function AuthCallbackPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'authenticated' && session?.user) {
+      const userRole = session.user.role;
+      if (userRole === 'admin') {
+        router.replace('/admin/creator-dashboard');
+      } else if (userRole === 'agency') {
+        router.replace('/agency/subscription');
+      } else {
+        router.replace('/dashboard');
+      }
+    } else if (status === 'unauthenticated') {
+      router.replace('/login');
+    }
+  }, [status, session, router]);
+
+  return <FullPageLoader />;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -36,9 +36,10 @@ export default function LoginPage() {
       console.error("Falha no login:", result.error);
       setIsLoading(false);
     } else {
-      // O redirecionamento será tratado pelo NextAuth se o login for bem-sucedido
-      // e o callbackUrl for válido, ou podemos forçar.
-      window.location.href = callbackUrlFromParams || "/agency/dashboard";
+      // Após um login bem-sucedido redirecionamos sempre para uma página de
+      // callback centralizada que irá decidir o destino final conforme o papel
+      // do usuário.
+      window.location.href = callbackUrlFromParams || "/auth/callback";
     }
   };
 


### PR DESCRIPTION
## Summary
- redirect credential login to a new callback page
- add `/auth/callback` smart router for role-based redirect
- improve Mercado Pago checkout error handling
- show toast feedback on agency subscription page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687429510ebc832ea3aaa2e64f4f4629