### PR TITLE
Implement agency dashboard endpoints

### DIFF
--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -1,79 +1,205 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import Head from 'next/head';
+import { AnimatePresence, motion } from 'framer-motion';
+
 import AgencyAuthGuard from '../components/AgencyAuthGuard';
-import CreatorTable from '@/app/admin/creator-dashboard/CreatorTable';
+import GlobalTimePeriodFilter from '@/app/admin/creator-dashboard/components/filters/GlobalTimePeriodFilter';
+import { GlobalTimePeriodProvider, useGlobalTimePeriod } from '@/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext';
+import PlatformSummaryKpis from '@/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis';
+import PlatformOverviewSection from '@/app/admin/creator-dashboard/components/views/PlatformOverviewSection';
+import PlatformContentAnalysisSection from '@/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection';
+import CreatorRankingSection from '@/app/admin/creator-dashboard/components/views/CreatorRankingSection';
+import TopMoversSection from '@/app/admin/creator-dashboard/components/views/TopMoversSection';
+import UserDetailView from '@/app/admin/creator-dashboard/components/views/UserDetailView';
+import CreatorQuickSearch from '@/app/admin/creator-dashboard/CreatorQuickSearch';
+import ScrollToTopButton from '@/app/components/ScrollToTopButton';
+import GlobalPostsExplorer from '@/app/admin/creator-dashboard/GlobalPostsExplorer';
 
-export default function AgencyDashboardPage() {
-  const [inviteCode, setInviteCode] = useState<string>('');
-  const [creators, setCreators] = useState<any[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
+function useAdminFetchRedirect() {
   useEffect(() => {
-    fetch('/api/agency/invite-code').then(res => res.json()).then(data => {
-      if (data.inviteCode) setInviteCode(data.inviteCode);
-    }).catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    const fetchCreators = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        const response = await fetch('/api/agency/dashboard/creators');
-        if (!response.ok) {
-          throw new Error('Falha ao buscar os dados dos criadores.');
+    const originalFetch = window.fetch;
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (typeof url === 'string' && url.startsWith('/api/admin/')) {
+        const newUrl = url.replace('/api/admin/', '/api/agency/');
+        if (typeof input === 'string') {
+          return originalFetch(newUrl, init);
         }
-        const data = await response.json();
-        setCreators(data.creators);
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setIsLoading(false);
+        const newRequest = new Request(newUrl, input as RequestInit);
+        return originalFetch(newRequest, init);
       }
+      return originalFetch(input, init);
     };
-
-    fetchCreators();
+    return () => {
+      window.fetch = originalFetch;
+    };
   }, []);
+}
+
+const SkeletonBlock = ({ width = 'w-full', height = 'h-4', className = '' }) => (
+  <div className={`bg-gray-200 animate-pulse rounded ${width} ${height} ${className}`}></div>
+);
+
+type TimePeriod = 'last_7_days' | 'last_30_days' | 'last_90_days';
+const getStartDateFromTimePeriod = (endDate: Date, timePeriod: TimePeriod): Date => {
+  const startDate = new Date(endDate);
+  switch (timePeriod) {
+    case 'last_7_days': startDate.setDate(startDate.getDate() - 7); break;
+    case 'last_30_days': startDate.setMonth(startDate.getMonth() - 1); break;
+    case 'last_90_days': startDate.setMonth(startDate.getMonth() - 3); break;
+  }
+  return startDate;
+};
+
+const AgencyDashboardContent: React.FC = () => {
+  useAdminFetchRedirect();
+
+  const [inviteCode, setInviteCode] = useState<string>('');
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
+  const [selectedUserPhotoUrl, setSelectedUserPhotoUrl] = useState<string | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const { timePeriod: globalTimePeriod, setTimePeriod: setGlobalTimePeriod } = useGlobalTimePeriod();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const nameCache = useRef<Record<string, string>>({});
+  const photoCache = useRef<Record<string, string | null>>({});
+
+  useEffect(() => {
+    fetch('/api/agency/invite-code')
+      .then(res => res.json())
+      .then(data => { if (data.inviteCode) setInviteCode(data.inviteCode); })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const userIdFromUrl = searchParams.get('userId');
+
+    if (userIdFromUrl) {
+      const knownName = nameCache.current[userIdFromUrl];
+      const knownPhoto = photoCache.current[userIdFromUrl];
+      const finalName = knownName || `Criador ID: ...${userIdFromUrl.slice(-4)}`;
+
+      setSelectedUserId(userIdFromUrl);
+      setSelectedUserName(finalName);
+      setSelectedUserPhotoUrl(knownPhoto ?? null);
+    } else {
+      setSelectedUserId(null);
+      setSelectedUserName(null);
+      setSelectedUserPhotoUrl(null);
+    }
+    setIsInitializing(false);
+  }, [searchParams]);
+
+  const today = new Date();
+  const startDateObj = getStartDateFromTimePeriod(today, globalTimePeriod as TimePeriod);
+  const startDate = startDateObj.toISOString();
+  const endDate = today.toISOString();
+  const rankingDateRange = { startDate, endDate };
+  const rankingDateLabel = `${startDateObj.toLocaleDateString('pt-BR')} - ${today.toLocaleDateString('pt-BR')}`;
+
+  const handleUserSelect = useCallback((creator: { id: string; name: string; profilePictureUrl?: string | null }) => {
+    nameCache.current[creator.id] = creator.name;
+    photoCache.current[creator.id] = creator.profilePictureUrl ?? null;
+    router.push(`${pathname}?userId=${creator.id}`, { scroll: false });
+    setSelectedUserPhotoUrl(creator.profilePictureUrl ?? null);
+  }, [pathname, router]);
+
+  const handleClearSelection = useCallback(() => {
+    router.push(pathname, { scroll: false });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [pathname, router]);
 
   const inviteLink = inviteCode ? `${typeof window !== 'undefined' ? window.location.origin : ''}/assinar?codigo_agencia=${inviteCode}` : '';
 
-  const copy = () => {
-    if (inviteLink) navigator.clipboard.writeText(inviteLink);
-  };
+  const copy = () => { if (inviteLink) navigator.clipboard.writeText(inviteLink); };
+
+  if (isInitializing) {
+    return <div className="flex justify-center items-center h-screen"><SkeletonBlock height="h-12" width="w-12" /></div>;
+  }
 
   return (
-    <AgencyAuthGuard>
-      <div className="p-6 space-y-8">
-        <div>
-          <h1 className="text-2xl font-bold">Dashboard da Agência</h1>
-          {inviteCode && (
-            <div className="bg-white p-4 rounded shadow inline-flex items-center gap-2 mt-2">
-              <span className="text-sm break-all">{inviteLink}</span>
-              <button className="px-2 py-1 text-sm bg-brand-pink text-white rounded" onClick={copy}>Copiar</button>
+    <>
+      <Head>
+        <title>Dashboard da Agência - Data2Content</title>
+      </Head>
+      <div className="min-h-screen bg-gray-50">
+        <header className="bg-white sticky top-0 z-40 border-b border-gray-200">
+          <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between py-4">
+              <div className="flex-1 min-w-0 mb-2 sm:mb-0">
+                <CreatorQuickSearch
+                  onSelect={handleUserSelect}
+                  selectedCreatorName={selectedUserName}
+                  selectedCreatorPhotoUrl={selectedUserPhotoUrl}
+                  onClear={handleClearSelection}
+                />
+              </div>
+              <div className="flex items-center gap-4 ml-0 sm:ml-4">
+                <GlobalTimePeriodFilter
+                  selectedTimePeriod={globalTimePeriod}
+                  onTimePeriodChange={setGlobalTimePeriod}
+                  options={[
+                    { value: 'last_7_days', label: 'Últimos 7 dias' },
+                    { value: 'last_30_days', label: 'Últimos 30 dias' },
+                    { value: 'last_90_days', label: 'Últimos 90 dias' },
+                  ]}
+                />
+              </div>
             </div>
-          )}
-        </div>
+            {inviteCode && (
+              <div className="bg-white p-2 rounded shadow inline-flex items-center gap-2 mt-2">
+                <span className="text-sm break-all">{inviteLink}</span>
+                <button className="px-2 py-1 text-sm bg-brand-pink text-white rounded" onClick={copy}>Copiar</button>
+              </div>
+            )}
+          </div>
+        </header>
 
-        <div className="mt-8">
-          <h2 className="text-xl font-semibold mb-4">Visão Geral dos Seus Criadores</h2>
+        <main className="max-w-full mx-auto py-8 px-4 sm:px-6 lg:px-8">
+          <section id="platform-summary" className="mb-8">
+            <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
+          </section>
 
-          {isLoading && <p>Carregando criadores...</p>}
+          <AnimatePresence>
+            {!selectedUserId && (
+              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-8">
+                <CreatorRankingSection rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
+                <PlatformContentAnalysisSection startDate={startDate} endDate={endDate} />
+                <PlatformOverviewSection />
+                <TopMoversSection />
+                <GlobalPostsExplorer dateRangeFilter={{ startDate, endDate }} />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
-          {error && <p className="text-red-500">{error}</p>}
-
-          {!isLoading && !error && creators.length > 0 && (
-            <CreatorTable data={creators} />
-          )}
-
-          {!isLoading && !error && creators.length === 0 && (
-            <div className="text-center py-10 bg-gray-50 rounded-lg">
-              <p>Nenhum criador encontrado para esta agência.</p>
-              <p className="text-sm text-gray-600">Use o link de convite acima para começar a adicionar seus talentos!</p>
-            </div>
-          )}
-        </div>
+          <div id="user-detail-view-container">
+            {selectedUserId && (
+              <UserDetailView
+                userId={selectedUserId}
+                userName={selectedUserName ?? undefined}
+                userPhotoUrl={selectedUserPhotoUrl ?? undefined}
+                onClear={handleClearSelection}
+              />
+            )}
+          </div>
+          <ScrollToTopButton />
+        </main>
       </div>
-    </AgencyAuthGuard>
+    </>
   );
-}
+};
+
+const AgencyDashboardPage: React.FC = () => (
+  <AgencyAuthGuard>
+    <GlobalTimePeriodProvider>
+      <AgencyDashboardContent />
+    </GlobalTimePeriodProvider>
+  </AgencyAuthGuard>
+);
+
+export default AgencyDashboardPage;

--- a/src/app/api/agency/dashboard/platform-summary/route.ts
+++ b/src/app/api/agency/dashboard/platform-summary/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+const TAG = '/api/agency/dashboard/platform-summary';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid start date format. Expected ISO 8601 string.' }).optional(),
+  endDate: z.string().datetime({ message: 'Invalid end date format. Expected ISO 8601 string.' }).optional(),
+}).superRefine((data, ctx) => {
+  if (data.startDate && !data.endDate) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'endDate is required if startDate is provided.', path: ['endDate'] });
+  }
+  if (!data.startDate && data.endDate) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'startDate is required if endDate is provided.', path: ['startDate'] });
+  }
+  if (data.startDate && data.endDate && new Date(data.startDate) > new Date(data.endDate)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'endDate cannot be earlier than startDate.', path: ['endDate'] });
+  }
+});
+
+export async function GET(req: NextRequest) {
+  logger.info(`${TAG} Request received`);
+
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${TAG} Unauthorized access attempt.`);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const queryParamsFromUrl = {
+    startDate: searchParams.get('startDate') || undefined,
+    endDate: searchParams.get('endDate') || undefined,
+  };
+  const definedQueryParams: any = {};
+  if (queryParamsFromUrl.startDate) definedQueryParams.startDate = queryParamsFromUrl.startDate;
+  if (queryParamsFromUrl.endDate) definedQueryParams.endDate = queryParamsFromUrl.endDate;
+
+  const validationResult = querySchema.safeParse(definedQueryParams);
+  if (!validationResult.success) {
+    logger.warn(`${TAG} Invalid query parameters:`, validationResult.error.flatten());
+    return NextResponse.json({ error: 'Invalid query parameters', details: validationResult.error.flatten() }, { status: 400 });
+  }
+
+  let dateRange;
+  if (validationResult.data.startDate && validationResult.data.endDate) {
+    dateRange = { startDate: new Date(validationResult.data.startDate), endDate: new Date(validationResult.data.endDate) };
+  }
+
+  logger.info(`${TAG} Query parameters validated. Date range: ${dateRange ? JSON.stringify(dateRange) : 'Not provided'}`);
+
+  try {
+    const summaryData = await fetchPlatformSummary({ dateRange, agencyId: session.user.agencyId });
+    return NextResponse.json(summaryData, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Error in request handler:`, { message: error.message, stack: error.stack });
+    if (error instanceof DatabaseError) {
+      return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/top-creators/route.ts
+++ b/src/app/api/agency/dashboard/rankings/top-creators/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopCreators, fetchTopCreatorsWithScore, TopCreatorMetricEnum } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/top-creators]';
+
+const querySchema = z.object({
+  context: z.string().optional(),
+  metric: TopCreatorMetricEnum.optional().default('total_interactions'),
+  days: z.coerce.number().int().positive().max(365).optional().default(30),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  composite: z.coerce.boolean().optional().default(false),
+});
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getAgencySession(req);
+    if (!session || !session.user) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors
+        .map(e => `${e.path.join('.')}?: ${e.message}`)
+        .join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { context, metric, days, limit, composite } = validationResult.data;
+    let results;
+    if (composite) {
+      results = await fetchTopCreatorsWithScore({
+        context: context ?? 'geral',
+        days,
+        limit,
+        agencyId: session.user.agencyId,
+      });
+    } else {
+      results = await fetchTopCreators({
+        context: context ?? 'geral',
+        metricToSortBy: metric,
+        days,
+        limit,
+        agencyId: session.user.agencyId,
+      });
+    }
+
+    return NextResponse.json(results, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- create agency dashboard page replicating admin dashboard
- intercept admin API calls and redirect them to agency endpoints
- add backend routes for agency platform summary and top creators rankings
- support agency filtering in dashboardService and profilesService

## Testing
- `npx jest --watchAll=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6874374e48c4832eaf62b88e228e9e4c