### PR TITLE
Refine dashboard services with agency filters

### DIFF
--- a/src/app/lib/dataService/marketAnalysis/dashboardService.ts
+++ b/src/app/lib/dataService/marketAnalysis/dashboardService.ts
@@ -192,9 +192,14 @@ export async function fetchDashboardOverallContentStats(
 
   try {
     await connectToDatabase();
-    const { dateRange } = params;
+    const { dateRange, agencyId } = params;
 
     const dateMatchStage: PipelineStage.Match['$match'] = {};
+    let agencyUserIds: Types.ObjectId[] | undefined;
+    if (agencyId) {
+      agencyUserIds = await UserModel.find({ agency: new Types.ObjectId(agencyId) }).distinct('_id');
+      dateMatchStage.user = { $in: agencyUserIds };
+    }
     if (dateRange?.startDate) {
       dateMatchStage.postDate = { ...dateMatchStage.postDate, $gte: dateRange.startDate };
     }

--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -161,6 +161,7 @@ export interface IFetchDashboardOverallContentStatsFilters {
     startDate?: Date;
     endDate?: Date;
   };
+  agencyId?: string;
 }
 
 export interface IDashboardOverallStats {

--- a/src/app/lib/dataService/marketAnalysisService.test.ts
+++ b/src/app/lib/dataService/marketAnalysisService.test.ts
@@ -181,6 +181,14 @@ describe('MarketAnalysisService', () => {
       const result = await marketAnalysisService.fetchDashboardOverallContentStats({});
       expect(result).toEqual(mockStatsData);
     });
+    it('should apply agencyId filter when provided', async () => {
+      (MetricModel.aggregate as jest.Mock).mockResolvedValueOnce([{ totalPlatformPosts: [], averagePlatformEngagementRate: [], totalContentCreators: [], breakdownByFormat: [], breakdownByProposal: [], breakdownByContext: [] }]);
+      const agencyId = new Types.ObjectId().toString();
+      await marketAnalysisService.fetchDashboardOverallContentStats({ agencyId });
+      const pipeline = (MetricModel.aggregate as jest.Mock).mock.calls[0][0];
+      const matchStage = pipeline.find((stage: any) => stage.$match);
+      expect(matchStage.$match.user).toBeDefined();
+    });
     it('should throw DatabaseError if aggregation fails', async () => {
       (MetricModel.aggregate as jest.Mock).mockRejectedValue(new Error('Stats Aggregation failed'));
       await expect(marketAnalysisService.fetchDashboardOverallContentStats({})).rejects.toThrow('Falha ao buscar estatísticas gerais de conteúdo: Stats Aggregation failed');


### PR DESCRIPTION
## Summary
- allow dashboard overall content stats to filter by `agencyId`
- expose `agencyId` in content stats filter types
- test agencyId filtering logic for overall stats

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest --version` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68743b3d82ec832e9c44db6f7d51e0c9