### PR TITLE
Refactor agency dashboard endpoints

### DIFF
--- a/src/app/admin/creator-dashboard/GlobalPostsExplorer.tsx
+++ b/src/app/admin/creator-dashboard/GlobalPostsExplorer.tsx
@@ -76,7 +76,7 @@ const PostDetailModal = ({ isOpen, onClose, postId }: { isOpen: boolean; onClose
     const fetchDetails = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`/api/admin/dashboard/posts/${postId}/details`);
+        const res = await fetch(`${apiPrefix}/dashboard/posts/${postId}/details`);
         if (res.ok) {
           const json = await res.json();
           setData(json);
@@ -119,6 +119,7 @@ const PostDetailModal = ({ isOpen, onClose, postId }: { isOpen: boolean; onClose
 
 
 interface GlobalPostsExplorerProps {
+  apiPrefix?: string;
   dateRangeFilter?: {
     startDate: string;
     endDate: string;
@@ -142,7 +143,7 @@ interface ActiveFilters {
 }
 
 
-const GlobalPostsExplorer = memo(function GlobalPostsExplorer({ dateRangeFilter }: GlobalPostsExplorerProps) {
+const GlobalPostsExplorer = memo(function GlobalPostsExplorer({ apiPrefix = '/api/admin', dateRangeFilter }: GlobalPostsExplorerProps) {
   // ATUALIZADO: Estados para os novos filtros de UI
   const [selectedContext, setSelectedContext] = useState<string>('all');
   const [selectedProposal, setSelectedProposal] = useState<string>('all');
@@ -232,7 +233,7 @@ const GlobalPostsExplorer = memo(function GlobalPostsExplorer({ dateRangeFilter 
     if (dateRangeFilter?.endDate) params.append('endDate', new Date(dateRangeFilter.endDate).toISOString());
 
     try {
-      const response = await fetch(`/api/admin/dashboard/posts?${params.toString()}`);
+      const response = await fetch(`${apiPrefix}/dashboard/posts?${params.toString()}`);
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Failed to fetch posts: ${response.statusText}`);

--- a/src/app/admin/creator-dashboard/TopMoversWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopMoversWidget.tsx
@@ -75,7 +75,7 @@ const formatDisplayPercentageTM = (num?: number | null): string => {
 };
 
 
-export default function TopMoversWidget() {
+export default function TopMoversWidget({ apiPrefix = '/api/admin' }: { apiPrefix?: string }) {
   const [entityType, setEntityType] = useState<TopMoverEntityType>('content');
   const [metric, setMetric] = useState<TopMoverMetric>('cumulativeViews');
   const [previousPeriod, setPreviousPeriod] = useState<PeriodState>(initialPeriodState);
@@ -96,7 +96,7 @@ export default function TopMoversWidget() {
   useEffect(() => {
     async function loadContexts() {
       try {
-        const res = await fetch('/api/admin/dashboard/contexts');
+        const res = await fetch(`${apiPrefix}/dashboard/contexts`);
         if (res.ok) {
           const data = await res.json();
           setContextOptions(['', ...data.contexts]);
@@ -172,7 +172,7 @@ export default function TopMoversWidget() {
     }
 
     try {
-      const response = await fetch('/api/admin/dashboard/top-movers', {
+      const response = await fetch(`${apiPrefix}/dashboard/top-movers`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(apiPayload),

--- a/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorQuickSearch.tsx
@@ -83,6 +83,7 @@ interface CreatorQuickSearchProps {
   selectedCreatorName?: string | null;
   selectedCreatorPhotoUrl?: string | null;
   onClear: () => void;
+  apiPrefix?: string;
 }
 
 export default function CreatorQuickSearch({
@@ -90,9 +91,10 @@ export default function CreatorQuickSearch({
   selectedCreatorName,
   selectedCreatorPhotoUrl,
   onClear,
+  apiPrefix = '/api/admin',
 }: CreatorQuickSearchProps) {
   const [searchTerm, setSearchTerm] = useState("");
-  const { results: creators, isLoading, error } = useCreatorSearch(searchTerm, { minChars: 2 });
+  const { results: creators, isLoading, error } = useCreatorSearch(searchTerm, { minChars: 2, apiPrefix });
   const [showDropdown, setShowDropdown] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
@@ -19,11 +19,12 @@ interface PlatformSummaryData {
 }
 
 interface PlatformSummaryKpisProps {
+  apiPrefix?: string;
   startDate: string;
   endDate: string;
 }
 
-const PlatformSummaryKpis: React.FC<PlatformSummaryKpisProps> = ({ startDate, endDate }) => {
+const PlatformSummaryKpis: React.FC<PlatformSummaryKpisProps> = ({ apiPrefix = '/api/admin', startDate, endDate }) => {
   const [data, setData] = useState<PlatformSummaryData | null>(null);
   const [prevData, setPrevData] = useState<PlatformSummaryData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -47,8 +48,8 @@ const PlatformSummaryKpis: React.FC<PlatformSummaryKpisProps> = ({ startDate, en
         });
 
         const [response, prevResponse] = await Promise.all([
-          fetch(`/api/admin/dashboard/platform-summary?${params.toString()}`),
-          fetch(`/api/admin/dashboard/platform-summary?${prevParams.toString()}`),
+          fetch(`${apiPrefix}/dashboard/platform-summary?${params.toString()}`),
+          fetch(`${apiPrefix}/dashboard/platform-summary?${prevParams.toString()}`),
         ]);
 
         if (!response.ok) {

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -10,11 +10,13 @@ import { TimePeriod } from "@/app/lib/constants/timePeriods"; // Importa o tipo 
 interface Props {
   rankingDateRange: { startDate: string; endDate: string };
   rankingDateLabel: string;
+  apiPrefix?: string;
 }
 
 const CreatorRankingSection: React.FC<Props> = ({
   rankingDateRange,
   rankingDateLabel,
+  apiPrefix = '/api/admin',
 }) => {
   const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   
@@ -35,7 +37,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Maior Engajamento"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-engaging"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/top-engaging`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               metricLabel="%"
@@ -46,7 +48,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Mais Interações"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-interactions"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/top-interactions`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Soma de todas as interações (curtidas, comentários, etc.) no período."
@@ -56,7 +58,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Engajamento Médio/Post"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/avg-engagement-per-post"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/avg-engagement-per-post`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Média de interações por post; considera apenas criadores com 3 ou mais posts."
@@ -66,7 +68,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Variação de Engajamento"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/engagement-growth"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/engagement-growth`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               metricLabel="%"
@@ -77,7 +79,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Consistência de Performance"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/performance-consistency"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/performance-consistency`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Avalia a regularidade do engajamento por post; exige ao menos 5 posts relevantes."
@@ -90,7 +92,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Mais Posts"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/most-prolific"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/most-prolific`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Quantidade total de conteúdos publicados no período selecionado."
@@ -100,7 +102,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Mais Compartilhamentos"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/top-sharing"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/top-sharing`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Total de compartilhamentos obtidos pelos posts no período."
@@ -110,7 +112,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Alcance Médio/Post"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/avg-reach-per-post"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/avg-reach-per-post`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Média de alcance por post; inclui criadores com pelo menos 3 posts."
@@ -120,7 +122,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
             <CreatorRankingCard
               title="Alcance por Seguidor"
-              apiEndpoint="/api/admin/dashboard/rankings/creators/reach-per-follower"
+              apiEndpoint={`${apiPrefix}/dashboard/rankings/creators/reach-per-follower`}
               dateRangeFilter={rankingDateRange}
               dateRangeLabel={rankingDateLabel}
               tooltip="Relação entre alcance total e seguidores; mede eficiência de distribuição."

--- a/src/app/admin/creator-dashboard/components/views/TopMoversSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/TopMoversSection.tsx
@@ -4,12 +4,12 @@ import React from "react";
 import GlobalPeriodIndicator from "../GlobalPeriodIndicator";
 import TopMoversWidget from "../../TopMoversWidget";
 
-const TopMoversSection: React.FC = () => (
+const TopMoversSection: React.FC<{ apiPrefix?: string }> = ({ apiPrefix = '/api/admin' }) => (
   <section id="top-movers" className="mb-10">
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
       Top Movers <GlobalPeriodIndicator />
     </h2>
-    <TopMoversWidget />
+    <TopMoversWidget apiPrefix={apiPrefix} />
   </section>
 );
 

--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -18,26 +18,6 @@ import CreatorQuickSearch from '@/app/admin/creator-dashboard/components/Creator
 import ScrollToTopButton from '@/app/components/ScrollToTopButton';
 import GlobalPostsExplorer from '@/app/admin/creator-dashboard/GlobalPostsExplorer';
 
-function useAdminFetchRedirect() {
-  useEffect(() => {
-    const originalFetch = window.fetch;
-    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input.url;
-      if (typeof url === 'string' && url.startsWith('/api/admin/')) {
-        const newUrl = url.replace('/api/admin/', '/api/agency/');
-        if (typeof input === 'string') {
-          return originalFetch(newUrl, init);
-        }
-        const newRequest = new Request(newUrl, input as RequestInit);
-        return originalFetch(newRequest, init);
-      }
-      return originalFetch(input, init);
-    };
-    return () => {
-      window.fetch = originalFetch;
-    };
-  }, []);
-}
 
 const SkeletonBlock = ({ width = 'w-full', height = 'h-4', className = '' }) => (
   <div className={`bg-gray-200 animate-pulse rounded ${width} ${height} ${className}`}></div>
@@ -55,7 +35,6 @@ const getStartDateFromTimePeriod = (endDate: Date, timePeriod: TimePeriod): Date
 };
 
 const AgencyDashboardContent: React.FC = () => {
-  useAdminFetchRedirect();
 
   const [inviteCode, setInviteCode] = useState<string>('');
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -133,6 +112,7 @@ const AgencyDashboardContent: React.FC = () => {
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between py-4">
               <div className="flex-1 min-w-0 mb-2 sm:mb-0">
                 <CreatorQuickSearch
+                  apiPrefix="/api/agency"
                   onSelect={handleUserSelect}
                   selectedCreatorName={selectedUserName}
                   selectedCreatorPhotoUrl={selectedUserPhotoUrl}
@@ -162,17 +142,17 @@ const AgencyDashboardContent: React.FC = () => {
 
         <main className="max-w-full mx-auto py-8 px-4 sm:px-6 lg:px-8">
           <section id="platform-summary" className="mb-8">
-            <PlatformSummaryKpis startDate={startDate} endDate={endDate} />
+            <PlatformSummaryKpis apiPrefix="/api/agency" startDate={startDate} endDate={endDate} />
           </section>
 
           <AnimatePresence>
             {!selectedUserId && (
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-8">
-                <CreatorRankingSection rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
+                <CreatorRankingSection apiPrefix="/api/agency" rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
                 <PlatformContentAnalysisSection startDate={startDate} endDate={endDate} />
                 <PlatformOverviewSection />
-                <TopMoversSection />
-                <GlobalPostsExplorer dateRangeFilter={{ startDate, endDate }} />
+                <TopMoversSection apiPrefix="/api/agency" />
+                <GlobalPostsExplorer apiPrefix="/api/agency" dateRangeFilter={{ startDate, endDate }} />
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/app/api/agency/dashboard/contexts/route.ts
+++ b/src/app/api/agency/dashboard/contexts/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/app/lib/logger';
+import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
+import { DatabaseError } from '@/app/lib/errors';
+
+const SERVICE_TAG = '[api/agency/dashboard/contexts]';
+
+import { getAgencySession } from '@/lib/getAgencySession';
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request for available contexts.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado. Sessão de administrador inválida.', 401);
+    }
+    logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
+
+    const contexts = await getAvailableContexts();
+    logger.info(`${TAG} Retrieved ${contexts.length} contexts.`);
+    return NextResponse.json({ contexts }, { status: 200 });
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(`Erro de banco de dados: ${error.message}`, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/posts/[postId]/details/route.ts
+++ b/src/app/api/agency/dashboard/posts/[postId]/details/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import { logger } from '@/app/lib/logger';
+import { fetchPostDetails, IPostDetailsData } from '@/app/lib/dataService/marketAnalysis/postsService'; // Assuming IPostDetailsData is exported
+import { DatabaseError } from '@/app/lib/errors';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+const TAG = '/api/agency/dashboard/posts/[postId]/details';
+
+// Zod schema for path parameter
+const pathParamsSchema = z.object({
+  postId: z.string().refine((val) => Types.ObjectId.isValid(val), {
+    message: "Invalid MongoDB ObjectId format for postId.",
+  }),
+});
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { postId: string } } // Next.js dynamic route params
+) {
+  logger.info(`${TAG} Request received for postId: ${params.postId}`);
+
+  // 1. Agency Session Validation
+  const session = await getAgencySession(req);
+
+  if (!session || !session.user) {
+    logger.warn(`${TAG} Unauthorized access attempt for postId: ${params.postId}`);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  logger.info(`${TAG} Agency session validated for user: ${session.user.id}, postId: ${params.postId}`);
+
+  // 2. Validate Path Parameter
+  const validationResult = pathParamsSchema.safeParse(params);
+
+  if (!validationResult.success) {
+    logger.warn(`${TAG} Invalid postId: ${params.postId}`, validationResult.error.flatten());
+    return NextResponse.json({ error: 'Invalid postId format', details: validationResult.error.flatten() }, { status: 400 });
+  }
+
+  const { postId } = validationResult.data;
+  logger.info(`${TAG} Path parameter validated: ${postId}`);
+
+  try {
+    // 3. Call Service Function
+    logger.info(`${TAG} Calling fetchPostDetails service for postId: ${postId}`);
+    const postDetails: IPostDetailsData | null = await fetchPostDetails({ postId, agencyId: session.user.agencyId });
+
+    if (!postDetails) {
+      logger.warn(`${TAG} Post details not found for postId: ${postId}`);
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    }
+
+    logger.info(`${TAG} Successfully fetched post details for postId: ${postId}`);
+
+    // 4. Return Data
+    return NextResponse.json(postDetails, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Error in request handler for postId ${postId}:`, {
+      message: error.message,
+      stack: error.stack,
+    });
+
+    if (error instanceof DatabaseError) {
+      return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });
+    }
+    // Add any other specific error type checks if needed from the service layer
+
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/posts/route.ts
+++ b/src/app/api/agency/dashboard/posts/route.ts
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview API Endpoint for fetching dashboard posts for content exploration.
+ * @version 1.2.0 - Added support for 'tone' and 'references' filters.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getAgencySession } from '@/lib/getAgencySession';
+import { findGlobalPostsByCriteria, FindGlobalPostsArgs } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/posts v1.2.0]';
+
+// ATUALIZADO: Schema de validação para incluir os novos filtros de 'tone' e 'references'.
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+  sortBy: z.string().optional().default('stats.total_interactions'),
+  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
+  context: z.string().optional(),
+  proposal: z.string().optional(),
+  format: z.string().optional(),
+  tone: z.string().optional(), // NOVO: Filtro por tom
+  references: z.string().optional(), // NOVO: Filtro por referências
+  searchText: z.string().optional(),
+  minInteractions: z.coerce.number().int().min(0).optional(),
+  startDate: z.string().datetime({ offset: true }).optional().transform(val => val ? new Date(val) : undefined),
+  endDate: z.string().datetime({ offset: true }).optional().transform(val => val ? new Date(val) : undefined),
+}).refine(data => {
+    if (data.startDate && data.endDate && data.startDate > data.endDate) {
+        return false;
+    }
+    return true;
+}, { message: "startDate cannot be after endDate" });
+
+// Agency session validation
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+/**
+ * @handler GET
+ * @description Handles GET requests to fetch posts for content exploration.
+ * Validates query parameters, checks admin session, and calls `findGlobalPostsByCriteria`.
+ * @param {NextRequest} req - The incoming Next.js request object.
+ * @returns {Promise<NextResponse>} A Next.js response object.
+ */
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request for dashboard posts.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session || !session.user) {
+      return apiError('Acesso não autorizado. Sessão de administrador inválida.', 401);
+    }
+    logger.info(`${TAG} Agency session validated for user: ${session.user.name}`);
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      logger.warn(`${TAG} Invalid query parameters: ${errorMessage}`);
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, ...otherParams } = validationResult.data;
+
+    // Os novos parâmetros 'tone' e 'references' serão incluídos automaticamente em 'otherParams'
+    // e passados para o serviço de busca.
+    const serviceArgs: FindGlobalPostsArgs = { ...otherParams };
+    if (startDate || endDate) {
+        serviceArgs.dateRange = {};
+        if (startDate) serviceArgs.dateRange.startDate = startDate;
+        if (endDate) serviceArgs.dateRange.endDate = endDate;
+    }
+    
+    Object.keys(serviceArgs).forEach(key => {
+        if (serviceArgs[key as keyof FindGlobalPostsArgs] === undefined) {
+            delete serviceArgs[key as keyof FindGlobalPostsArgs];
+        }
+    });
+
+
+    logger.info(`${TAG} Calling findGlobalPostsByCriteria with args: ${JSON.stringify(serviceArgs)}`);
+    // NOTA: O serviço 'findGlobalPostsByCriteria' também precisa ser atualizado
+    // para aplicar os novos filtros na consulta ao banco de dados.
+    const result = await findGlobalPostsByCriteria(serviceArgs);
+
+    logger.info(`${TAG} Successfully fetched ${result.posts.length} posts. Total available: ${result.totalPosts}.`);
+    return NextResponse.json(result, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(`Erro de banco de dados: ${error.message}`, 500);
+    }
+    if (error instanceof z.ZodError) {
+        return apiError(`Erro de validação: ${error.errors.map(e => e.message).join(', ')}`, 400);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/avg-engagement-per-post/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/avg-engagement-per-post/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by average engagement per post.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchAvgEngagementPerPostCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/avg-engagement-per-post]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchAvgEngagementPerPostCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/avg-reach-per-post/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/avg-reach-per-post/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by average reach per post.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchAvgReachPerPostCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/avg-reach-per-post]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchAvgReachPerPostCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/engagement-growth/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/engagement-growth/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by engagement growth.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchEngagementVariationCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/engagement-growth]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchEngagementVariationCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/most-prolific/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/most-prolific/route.ts
@@ -1,0 +1,79 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching most prolific creators.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchMostProlificCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/most-prolific]';
+
+// Schema for query parameters validation
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: "startDate cannot be after endDate.",
+  path: ["endDate"],
+});
+
+// Agency session validation
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchMostProlificCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/performance-consistency/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/performance-consistency/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by performance consistency.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchPerformanceConsistencyCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/performance-consistency]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchPerformanceConsistencyCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/reach-per-follower/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/reach-per-follower/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching creators ranked by reach per follower.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchReachPerFollowerCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/reach-per-follower]';
+
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: 'Invalid startDate format.' }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: 'Invalid endDate format.' }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: 'startDate cannot be after endDate.',
+  path: ['endDate'],
+});
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}?: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchReachPerFollowerCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/top-engaging/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/top-engaging/route.ts
@@ -1,0 +1,77 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching top engaging creators.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopEngagingCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/top-engaging]';
+
+// Schema for query parameters validation
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: "startDate cannot be after endDate.",
+  path: ["endDate"],
+});
+
+// Agency session validation
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchTopEngagingCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/top-interactions/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/top-interactions/route.ts
@@ -1,0 +1,76 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+ * @fileoverview API Endpoint for fetching top interaction creators.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopInteractionCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/top-interactions]';
+
+// Schema for query parameters validation
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: "startDate cannot be after endDate.",
+  path: ["endDate"],
+});
+
+// Agency session validation
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchTopInteractionCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/rankings/creators/top-sharing/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/top-sharing/route.ts
@@ -1,0 +1,78 @@
+import { getAgencySession } from '@/lib/getAgencySession';
+/**
+ * @fileoverview API Endpoint for fetching top sharing creators.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { fetchTopSharingCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/top-sharing]';
+
+// Schema for query parameters validation
+const querySchema = z.object({
+  startDate: z.string().datetime({ message: "Invalid startDate format." }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: "Invalid endDate format." }).transform(val => new Date(val)),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(5),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).refine(data => data.startDate <= data.endDate, {
+  message: "startDate cannot be after endDate.",
+  path: ["endDate"],
+});
+
+// Agency session validation
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  logger.info(`${TAG} Received request.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session) {
+      return apiError('Acesso não autorizado.', 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+
+    const validationResult = querySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros de consulta inválidos: ${errorMessage}`, 400);
+    }
+
+    const { startDate, endDate, limit, offset } = validationResult.data;
+
+    const params: IFetchCreatorRankingParams = {
+      dateRange: { startDate, endDate },
+      limit,
+      offset,
+    };
+
+    const results = await fetchTopSharingCreators({ ...params, agencyId: session.user.agencyId });
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(error.message, 500);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/agency/dashboard/top-movers/route.ts
+++ b/src/app/api/agency/dashboard/top-movers/route.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview API Endpoint for fetching Top Movers data (content or creators).
+ * @version 2.0.0 - Updated to support 5-dimension classification.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import {
+  fetchTopMoversData,
+  IFetchTopMoversArgs,
+  ITopMoverResult,
+  TopMoverEntityType, // For Zod enum
+  TopMoverMetric,     // For Zod enum
+  TopMoverSortBy,     // For Zod enum
+} from '@/app/lib/dataService/marketAnalysisService';
+import { DatabaseError } from '@/app/lib/errors';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+const SERVICE_TAG = '[api/agency/dashboard/top-movers v2.0.0]';
+
+// --- Zod Schemas for Validation ---
+
+const periodSchema = z.object({
+  startDate: z.string().datetime({ message: "Invalid startDate format. Expected ISO datetime string." }).transform(val => new Date(val)),
+  endDate: z.string().datetime({ message: "Invalid endDate format. Expected ISO datetime string." }).transform(val => new Date(val))
+}).refine(data => data.startDate <= data.endDate, {
+    message: "startDate in a period cannot be after its endDate.",
+    path: ["endDate"],
+});
+
+// ATUALIZADO: Filtros de conteúdo agora incluem as 5 dimensões
+const contentFiltersSchema = z.object({
+  format: z.string().optional(),
+  proposal: z.string().optional(),
+  context: z.string().optional(),
+  tone: z.string().optional(),
+  references: z.string().optional(),
+}).optional();
+
+const creatorFiltersSchema = z.object({
+  planStatus: z.array(z.string()).optional(),
+  inferredExpertiseLevel: z.array(z.string()).optional()
+}).optional();
+
+const topMoverMetricLiterals: [TopMoverMetric, ...TopMoverMetric[]] = [
+  'cumulativeViews', 'cumulativeLikes', 'cumulativeShares', 'cumulativeComments',
+  'cumulativeSaved', 'cumulativeReach', 'cumulativeImpressions', 'cumulativeTotalInteractions'
+];
+const topMoverMetricEnum = z.enum(topMoverMetricLiterals);
+
+const topMoverSortByLiterals: [TopMoverSortBy, ...TopMoverSortBy[]] = [
+  'absoluteChange_increase', 'absoluteChange_decrease',
+  'percentageChange_increase', 'percentageChange_decrease'
+];
+const topMoverSortByEnum = z.enum(topMoverSortByLiterals);
+
+const entityTypeLiterals: [TopMoverEntityType, ...TopMoverEntityType[]] = ['content', 'creator'];
+const entityTypeEnum = z.enum(entityTypeLiterals);
+
+
+const requestBodySchema = z.object({
+  entityType: entityTypeEnum,
+  metric: topMoverMetricEnum,
+  currentPeriod: periodSchema,
+  previousPeriod: periodSchema,
+  topN: z.number().int().positive().min(1).max(50).optional(),
+  sortBy: topMoverSortByEnum.optional(),
+  contentFilters: contentFiltersSchema,
+  creatorFilters: creatorFiltersSchema
+}).refine(data => data.previousPeriod.endDate < data.currentPeriod.startDate, {
+  message: "Previous period must end before the current period starts.",
+  path: ["currentPeriod", "startDate"],
+});
+
+
+// --- Helper Functions ---
+
+async function getSession(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session || !session.user) {
+    logger.warn(`${SERVICE_TAG} Agency session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number): NextResponse {
+  logger.error(`${SERVICE_TAG} Erro ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+
+/**
+ * @handler POST
+ * @description Handles POST requests to fetch Top Movers data.
+ */
+export async function POST(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[POST]`;
+  logger.info(`${TAG} Received request for Top Movers data.`);
+
+  try {
+    const session = await getSession(req);
+    if (!session || !session.user) {
+      return apiError('Acesso não autorizado. Sessão de administrador inválida.', 401);
+    }
+    logger.info(`${TAG} Admin session validated for user: ${session.user.name}`);
+
+    const body = await req.json();
+    const validationResult = requestBodySchema.safeParse(body);
+
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ');
+      logger.warn(`${TAG} Invalid request body: ${errorMessage}`);
+      return apiError(`Corpo da requisição inválido: ${errorMessage}`, 400);
+    }
+
+    const validatedArgs = validationResult.data as IFetchTopMoversArgs;
+
+    logger.info(`${TAG} Calling fetchTopMoversData with validated args: ${JSON.stringify(validatedArgs)}`);
+    const results: ITopMoverResult[] = await fetchTopMoversData({ ...validatedArgs, agencyId: session.user.agencyId });
+
+    logger.info(`${TAG} Successfully fetched ${results.length} top movers.`);
+    return NextResponse.json(results, { status: 200 });
+
+  } catch (error: any) {
+    logger.error(`${TAG} Unexpected error:`, error);
+    if (error instanceof DatabaseError) {
+      return apiError(`Erro de banco de dados: ${error.message}`, 500);
+    } else if (error instanceof z.ZodError) {
+        return apiError(`Erro de validação Zod inesperado: ${error.message}`, 400);
+    }
+    return apiError('Ocorreu um erro interno no servidor.', 500);
+  }
+}

--- a/src/hooks/useCreatorSearch.ts
+++ b/src/hooks/useCreatorSearch.ts
@@ -18,7 +18,7 @@ const MAX_CACHE_SIZE = 50;
 
 export function useCreatorSearch(
   query: string,
-  { limit = 5, minChars = 2 }: UseCreatorSearchOptions = {}
+  { limit = 5, minChars = 2, apiPrefix = '/api/admin' }: UseCreatorSearchOptions & { apiPrefix?: string } = {}
 ) {
   const [results, setResults] = useState<AdminCreatorListItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -50,7 +50,7 @@ export function useCreatorSearch(
       try {
         const params = new URLSearchParams({ limit: String(limit), search: query });
         // Recomendação: O backend deve ser ajustado para ordenar por relevância (nome) em vez de data.
-        const resp = await fetch(`/api/admin/creators?${params.toString()}`, { signal: controller.signal });
+        const resp = await fetch(`${apiPrefix}/creators?${params.toString()}`, { signal: controller.signal });
         
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- remove admin fetch redirect
- add `apiPrefix` prop to dashboard components
- create agency versions of ranking and post endpoints
- update hooks and components to use new prefixes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687444ed4c68832ea25805b1fe7b0e56