### PR TITLE
Fix API routes compile errors

### DIFF
--- a/src/app/api/agency/dashboard/rankings/creators/most-prolific/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/most-prolific/route.ts
@@ -7,8 +7,6 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchMostProlificCreators, IFetchCreatorRankingParams } from '@/app/lib/dataService/marketAnalysisService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getAgencySession } from '@/lib/getAgencySession';
-
 export const dynamic = 'force-dynamic';
 
 const SERVICE_TAG = '[api/agency/dashboard/rankings/creators/most-prolific]';

--- a/src/app/api/agency/dashboard/rankings/creators/top-interactions/route.ts
+++ b/src/app/api/agency/dashboard/rankings/creators/top-interactions/route.ts
@@ -1,4 +1,5 @@
 import { getAgencySession } from '@/lib/getAgencySession';
+/**
  * @fileoverview API Endpoint for fetching top interaction creators.
  */
 import { NextRequest, NextResponse } from 'next/server';


### PR DESCRIPTION
## Summary
- fix malformed JSDoc comment in `top-interactions` route
- remove duplicate import in `most-prolific` route

## Testing
- `npm install` *(fails: unable to access registry.npmjs.org)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744b5a8ae8832e9080643025c42e0c