### PR TITLE
Restrict dashboard rankings to agency creators

### DIFF
--- a/src/app/lib/dataService/marketAnalysis/types.ts
+++ b/src/app/lib/dataService/marketAnalysis/types.ts
@@ -224,6 +224,7 @@ export interface IFetchCreatorRankingParams {
   };
   limit?: number;
   offset?: number;
+  agencyId?: string;
 }
 
 export interface IFetchCreatorTimeSeriesArgs {


### PR DESCRIPTION
## Summary
- update ranking service types to accept agencyId
- filter all ranking aggregation queries by agency when provided

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744f69b270832ead3b317e5f4ac6b3