### PR TITLE
Add agency follower trend endpoint and dashboard props

### DIFF
--- a/src/app/admin/creator-dashboard/components/CreatorBrazilMap.tsx
+++ b/src/app/admin/creator-dashboard/components/CreatorBrazilMap.tsx
@@ -36,7 +36,7 @@ const MapLegend: React.FC<{ mode: 'count' | 'density' }> = ({ mode }) => (
   </div>
 );
 
-export default function CreatorBrazilMap() {
+export default function CreatorBrazilMap({ apiPrefix = '/api/admin' }: { apiPrefix?: string }) {
   // --- PASSO 1: Adicionar estados para os novos filtros ---
   const [region, setRegion] = useState<string>("");
   const [gender, setGender] = useState<string>("");
@@ -51,6 +51,7 @@ export default function CreatorBrazilMap() {
     region,
     gender,
     ageRange,
+    apiPrefix,
   });
 
   const { maxCount, maxDensity } = useMemo(() => {

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerTrendChart.tsx
@@ -27,10 +27,14 @@ const GRANULARITY_OPTIONS = [
 
 interface PlatformFollowerTrendChartProps {
   initialGranularity?: string;
+  apiPrefix?: string;
+  title?: string;
 }
 
 const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
-  initialGranularity = GRANULARITY_OPTIONS[0]?.value || "daily"
+  initialGranularity = GRANULARITY_OPTIONS[0]?.value || "daily",
+  apiPrefix = '/api/admin',
+  title = 'Evolução de Seguidores da Plataforma'
 }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformFollowerTrendResponse['chartData']>([]);
@@ -45,7 +49,7 @@ const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
     setError(null);
     try {
       // Usa timePeriod do contexto e granularity do estado local
-      const apiUrl = `/api/v1/platform/trends/followers?timePeriod=${timePeriod}&granularity=${granularity}`;
+      const apiUrl = `${apiPrefix}/dashboard/trends/followers?timePeriod=${timePeriod}&granularity=${granularity}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -87,7 +91,7 @@ const PlatformFollowerTrendChart: React.FC<PlatformFollowerTrendChartProps> = ({
     <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
       <div className="flex flex-col sm:flex-row justify-between sm:items-center mb-4">
         <h2 className="text-lg md:text-xl font-semibold text-gray-700 mb-2 sm:mb-0">
-          Evolução de Seguidores da Plataforma
+          {title}
         </h2>
         {/* Seletor de timePeriod removido */}
         <div>

--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -21,7 +21,12 @@ const TIME_PERIOD_TO_COMPARISON: Record<string, string> = {
   all_time: "month_vs_previous",
 };
 
-const PlatformOverviewSection: React.FC = () => {
+interface Props {
+  apiPrefix?: string;
+  followerTrendTitle?: string;
+}
+
+const PlatformOverviewSection: React.FC<Props> = ({ apiPrefix = '/api/admin', followerTrendTitle = 'Evolução de Seguidores da Plataforma' }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const comparisonPeriod = TIME_PERIOD_TO_COMPARISON[timePeriod] || "month_vs_previous";
 
@@ -46,7 +51,7 @@ const PlatformOverviewSection: React.FC = () => {
       />
     </div>
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-      <PlatformFollowerTrendChart />
+      <PlatformFollowerTrendChart apiPrefix={apiPrefix} title={followerTrendTitle} />
       <PlatformFollowerChangeChart />
     </div>
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
@@ -58,7 +63,7 @@ const PlatformOverviewSection: React.FC = () => {
     {/* Colocamos o widget de demografia e o mapa lado a lado em um grid para controlar o tamanho. */}
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
       <PlatformDemographicsWidget />
-      <CreatorBrazilMap />
+      <CreatorBrazilMap apiPrefix={apiPrefix} />
     </div>
 
   </section>

--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -150,7 +150,7 @@ const AgencyDashboardContent: React.FC = () => {
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-8">
                 <CreatorRankingSection apiPrefix="/api/agency" rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
                 <PlatformContentAnalysisSection startDate={startDate} endDate={endDate} />
-                <PlatformOverviewSection />
+                <PlatformOverviewSection apiPrefix="/api/agency" followerTrendTitle="Evolução de Seguidores da Agência" />
                 <TopMoversSection apiPrefix="/api/agency" />
                 <GlobalPostsExplorer apiPrefix="/api/agency" dateRangeFilter={{ startDate, endDate }} />
               </motion.div>

--- a/src/app/api/agency/dashboard/trends/followers/route.ts
+++ b/src/app/api/agency/dashboard/trends/followers/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import getFollowerTrendChartData from '@/charts/getFollowerTrendChartData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+interface ApiChartDataPoint {
+  date: string;
+  value: number | null;
+}
+
+interface FollowerTrendChartResponse {
+  chartData: ApiChartDataPoint[];
+  insightSummary?: string;
+}
+
+const ALLOWED_GRANULARITIES = ['daily', 'monthly'];
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const granularityParam = searchParams.get('granularity');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+  const granularity =
+    granularityParam && ALLOWED_GRANULARITIES.includes(granularityParam)
+      ? (granularityParam as 'daily' | 'monthly')
+      : 'daily';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json(
+      { error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  if (granularityParam && !ALLOWED_GRANULARITIES.includes(granularityParam)) {
+    return NextResponse.json(
+      { error: `Granularity inválida. Permitidas: ${ALLOWED_GRANULARITIES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await connectToDatabase();
+    const session = await getAgencySession(request as any);
+    if (!session || !session.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const agencyUsers = await UserModel.find({
+      agency: new Types.ObjectId(session.user.agencyId),
+      planStatus: 'active',
+    })
+      .select('_id')
+      .lean();
+
+    if (!agencyUsers || agencyUsers.length === 0) {
+      return NextResponse.json(
+        {
+          chartData: [],
+          insightSummary: 'Nenhum usuário encontrado na agência para agregar dados.',
+        },
+        { status: 200 }
+      );
+    }
+
+    const userIds = agencyUsers.map((u) => u._id);
+
+    const BATCH_SIZE = 50;
+    const userTrendResults: PromiseSettledResult<FollowerTrendChartResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batchIds.map((id) =>
+        getFollowerTrendChartData(id.toString(), timePeriod, granularity)
+      );
+      const batchResults = await Promise.allSettled(batchPromises);
+      userTrendResults.push(...batchResults);
+    }
+
+    const aggregatedFollowersByDate = new Map<string, number>();
+    userTrendResults.forEach((result) => {
+      if (result.status === 'fulfilled' && result.value && result.value.chartData) {
+        result.value.chartData.forEach((d) => {
+          if (d.value !== null && d.date) {
+            const current = aggregatedFollowersByDate.get(d.date) || 0;
+            aggregatedFollowersByDate.set(d.date, current + d.value);
+          }
+        });
+      } else if (result.status === 'rejected') {
+        logger.error('Erro ao buscar dados de tendência para um usuário da agência:', result.reason);
+      }
+    });
+
+    if (aggregatedFollowersByDate.size === 0) {
+      return NextResponse.json(
+        {
+          chartData: [],
+          insightSummary: 'Nenhum dado de seguidores encontrado para os usuários da agência no período.',
+        },
+        { status: 200 }
+      );
+    }
+
+    const chartData: ApiChartDataPoint[] = Array.from(aggregatedFollowersByDate.entries())
+      .map(([date, total]) => ({ date, value: total }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let insight = 'Dados de tendência de seguidores da agência.';
+    if (chartData.length > 0) {
+      const first = chartData[0];
+      const last = chartData[chartData.length - 1];
+      if (first && last && first.value !== null && last.value !== null) {
+        const diff = last.value - first.value;
+        const periodText = timePeriod
+          .replace('last_', 'últimos ')
+          .replace('_days', ' dias')
+          .replace('_months', ' meses');
+        const displayPeriod = timePeriod === 'all_time' ? 'todo o período' : `nos ${periodText}`;
+        if (diff > 0) {
+          insight = `A agência ganhou ${diff.toLocaleString()} seguidores ${displayPeriod}.`;
+        } else if (diff < 0) {
+          insight = `A agência perdeu ${Math.abs(diff).toLocaleString()} seguidores ${displayPeriod}.`;
+        } else {
+          insight = `Sem mudança no total de seguidores da agência ${displayPeriod}.`;
+        }
+      } else if (last && last.value !== null) {
+        insight = `Total de ${last.value.toLocaleString()} seguidores na agência no final do período.`;
+      }
+    }
+
+    const response: FollowerTrendChartResponse = {
+      chartData,
+      insightSummary: insight,
+    };
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/FOLLOWERS] Error aggregating agency follower trend:', error);
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: message }, { status: 500 });
+  }
+}

--- a/src/hooks/useCreatorRegionSummary.ts
+++ b/src/hooks/useCreatorRegionSummary.ts
@@ -33,7 +33,8 @@ export interface UseAudienceRegionSummaryOptions {
 }
 
 // O nome da função foi atualizado para refletir o seu propósito
-export default function useAudienceRegionSummary(options: UseAudienceRegionSummaryOptions) {
+export default function useAudienceRegionSummary(options: UseAudienceRegionSummaryOptions & { apiPrefix?: string }) {
+  const { apiPrefix = '/api/admin' } = options;
   // --- ATUALIZAÇÃO: Incluir os novos filtros na query string ---
   const queryString = useMemo(() => {
     const query = new URLSearchParams();
@@ -43,10 +44,10 @@ export default function useAudienceRegionSummary(options: UseAudienceRegionSumma
     return query.toString();
   }, [options.region, options.gender, options.ageRange]);
 
-  const key = `audience_region_summary_${queryString}`;
+  const key = `audience_region_summary_${apiPrefix}_${queryString}`;
 
   const fetcher = useCallback(async (): Promise<Record<string, StateBreakdown>> => {
-    const res = await fetch(`/api/admin/creators/region-summary?${queryString}`, {
+    const res = await fetch(`${apiPrefix}/creators/region-summary?${queryString}`, {
       credentials: 'include',
     });
     if (!res.ok) throw new Error(`Erro na API: ${res.statusText}`);
@@ -57,7 +58,7 @@ export default function useAudienceRegionSummary(options: UseAudienceRegionSumma
       return acc;
     }, {} as Record<string, StateBreakdown>);
 
-  }, [queryString]);
+  }, [queryString, apiPrefix]);
 
   return useCachedFetch<Record<string, StateBreakdown>>(key, fetcher);
 }


### PR DESCRIPTION
## Summary
- create `/api/agency/dashboard/trends/followers` endpoint using agency session
- allow PlatformFollowerTrendChart to target admin or agency API
- support apiPrefix and custom title in PlatformOverviewSection
- pass agency prefix to charts and Brazil map on agency dashboard
- make region summary hook configurable with apiPrefix

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687459e93748832eb5fa43b05f8f1faa