### PR TITLE
Fix agency dashboard API routing

### DIFF
--- a/src/app/admin/creator-dashboard/components/FormatPerformanceRankingTable.tsx
+++ b/src/app/admin/creator-dashboard/components/FormatPerformanceRankingTable.tsx
@@ -11,7 +11,11 @@ interface DataPoint {
 
 const DEFAULT_METRIC = 'stats.total_interactions';
 
-const FormatPerformanceRankingTable: React.FC = () => {
+interface FormatPerformanceRankingTableProps {
+  apiPrefix?: string;
+}
+
+const FormatPerformanceRankingTable: React.FC<FormatPerformanceRankingTableProps> = ({ apiPrefix = '/api/admin' }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<DataPoint[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +26,7 @@ const FormatPerformanceRankingTable: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = `/api/v1/platform/performance/average-engagement?timePeriod=${timePeriod}&groupBy=format&sortOrder=desc&engagementMetricField=${DEFAULT_METRIC}`;
+      const apiUrl = `${apiPrefix}/dashboard/performance/average-engagement?timePeriod=${timePeriod}&groupBy=format&sortOrder=desc&engagementMetricField=${DEFAULT_METRIC}`;
       const res = await fetch(apiUrl);
       if (!res.ok) throw new Error(`Erro HTTP: ${res.status}`);
       const result = await res.json();
@@ -98,6 +102,7 @@ const FormatPerformanceRankingTable: React.FC = () => {
         groupBy="format"
         metricUsed={DEFAULT_METRIC}
         chartTitle="Ranking de Desempenho por Formato"
+        apiPrefix={apiPrefix}
       />
     </div>
   );

--- a/src/app/admin/creator-dashboard/components/FullDataModal.tsx
+++ b/src/app/admin/creator-dashboard/components/FullDataModal.tsx
@@ -19,6 +19,7 @@ interface FullDataModalProps {
   metricUsed: string;
   chartTitle: string;
   userId?: string;
+  apiPrefix?: string;
 }
 
 export const FullDataModal: React.FC<FullDataModalProps> = ({
@@ -28,6 +29,7 @@ export const FullDataModal: React.FC<FullDataModalProps> = ({
   metricUsed,
   chartTitle,
   userId,
+  apiPrefix = '/api/admin',
 }) => {
   const [allData, setAllData] = useState<DataPoint[]>([]);
   const [loading, setLoading] = useState(false);
@@ -39,8 +41,8 @@ export const FullDataModal: React.FC<FullDataModalProps> = ({
       setError(null);
       // Busca TODOS os dados (sem o parâmetro 'limit') quando o modal é aberto
       const base = userId
-        ? `/api/v1/users/${userId}/performance/average-engagement`
-        : '/api/v1/platform/performance/average-engagement';
+        ? `${apiPrefix}/dashboard/users/${userId}/performance/average-engagement`
+        : `${apiPrefix}/dashboard/performance/average-engagement`;
       const apiUrl = `${base}?groupBy=${groupBy}&engagementMetricField=${metricUsed}&sortOrder=desc`;
       
       fetch(apiUrl)

--- a/src/app/admin/creator-dashboard/components/PlatformDemographicsWidget.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformDemographicsWidget.tsx
@@ -74,8 +74,8 @@ const MODAL_TITLES: Record<ModalType, string> = {
   gender: "Seguidores por Gênero",
 };
 
-const PlatformDemographicsWidget: React.FC = () => {
-  const { data, loading, error, refresh } = usePlatformDemographics();
+const PlatformDemographicsWidget: React.FC<{ apiPrefix?: string }> = ({ apiPrefix = '/api/v1/platform' }) => {
+  const { data, loading, error, refresh } = usePlatformDemographics(apiPrefix);
   const [modalType, setModalType] = useState<ModalType | null>(null);
 
   const handleCloseModal = useCallback(() => setModalType(null), []);

--- a/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformFollowerChangeChart.tsx
@@ -17,9 +17,11 @@ interface PlatformFollowerChangeResponse {
   insightSummary?: string;
 }
 
-interface PlatformFollowerChangeChartProps {}
+interface PlatformFollowerChangeChartProps {
+  apiPrefix?: string;
+}
 
-const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = () => {
+const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = ({ apiPrefix = '/api/admin' }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformFollowerChangeResponse['chartData']>([]);
   const [insightSummary, setInsightSummary] = useState<string | undefined>(undefined);
@@ -30,7 +32,7 @@ const PlatformFollowerChangeChart: React.FC<PlatformFollowerChangeChartProps> = 
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = `/api/v1/platform/trends/follower-change?timePeriod=${timePeriod}`;
+      const apiUrl = `${apiPrefix}/dashboard/trends/follower-change?timePeriod=${timePeriod}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformMovingAverageEngagementChart.tsx
@@ -38,10 +38,12 @@ const timePeriodToDataWindowDays = (timePeriod: string): number => {
 
 interface PlatformMovingAverageEngagementChartProps {
   initialAvgWindow?: string;
+  apiPrefix?: string;
 }
 
 const PlatformMovingAverageEngagementChart: React.FC<PlatformMovingAverageEngagementChartProps> = ({
-  initialAvgWindow = MOVING_AVERAGE_WINDOW_OPTIONS[0]?.value ?? "7"
+  initialAvgWindow = MOVING_AVERAGE_WINDOW_OPTIONS[0]?.value ?? "7",
+  apiPrefix = '/api/admin'
 }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformMovingAverageResponse['series']>([]);
@@ -66,7 +68,7 @@ const PlatformMovingAverageEngagementChart: React.FC<PlatformMovingAverageEngage
     }
 
     try {
-      const apiUrl = `/api/v1/platform/trends/moving-average-engagement?dataWindowInDays=${dataWindowInDays}&movingAverageWindowInDays=${currentAvgWindowDays}`;
+      const apiUrl = `${apiPrefix}/dashboard/trends/moving-average-engagement?dataWindowInDays=${dataWindowInDays}&movingAverageWindowInDays=${currentAvgWindowDays}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformPerformanceHighlights.tsx
@@ -33,6 +33,7 @@ interface PerformanceSummaryResponse {
 
 interface PlatformPerformanceHighlightsProps {
   sectionTitle?: string;
+  apiPrefix?: string;
 }
 
 function formatBestDay(slot: PerformanceSummaryResponse["bestDay"]): PerformanceHighlightItem | null {
@@ -48,7 +49,8 @@ function formatBestDay(slot: PerformanceSummaryResponse["bestDay"]): Performance
 }
 
 const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps> = ({
-  sectionTitle = "Destaques de Performance da Plataforma"
+  sectionTitle = "Destaques de Performance da Plataforma",
+  apiPrefix = '/api/admin'
 }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [summary, setSummary] = useState<PerformanceSummaryResponse | null>(null);
@@ -59,7 +61,7 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = `/api/v1/platform/highlights/performance-summary?timePeriod=${timePeriod}`;
+      const apiUrl = `${apiPrefix}/dashboard/highlights/performance-summary?timePeriod=${timePeriod}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -158,7 +160,7 @@ const PlatformPerformanceHighlights: React.FC<PlatformPerformanceHighlightsProps
           </p>
         )}
         <div className="mt-6">
-          <FormatPerformanceRankingTable />
+          <FormatPerformanceRankingTable apiPrefix={apiPrefix} />
         </div>
       </>
     )}

--- a/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/components/PlatformReachEngagementTrendChart.tsx
@@ -25,10 +25,12 @@ const GRANULARITY_OPTIONS = [
 
 interface PlatformReachEngagementTrendChartProps {
   initialGranularity?: string;
+  apiPrefix?: string;
 }
 
 const PlatformReachEngagementTrendChart: React.FC<PlatformReachEngagementTrendChartProps> = ({
-  initialGranularity = GRANULARITY_OPTIONS[0]!.value
+  initialGranularity = GRANULARITY_OPTIONS[0]!.value,
+  apiPrefix = '/api/admin'
 }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<PlatformChartResponse['chartData']>([]);
@@ -41,7 +43,7 @@ const PlatformReachEngagementTrendChart: React.FC<PlatformReachEngagementTrendCh
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = `/api/v1/platform/trends/reach-engagement?timePeriod=${timePeriod}&granularity=${granularity}`;
+      const apiUrl = `${apiPrefix}/dashboard/trends/reach-engagement?timePeriod=${timePeriod}&granularity=${granularity}`;
       const response = await fetch(apiUrl);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -108,9 +108,10 @@ const contextOptions = createOptionsFromCategories(contextCategories);
 interface TimePerformanceHeatmapProps {
   /** Se fornecido, filtra os dados para o usuário indicado */
   userId?: string | null;
+  apiPrefix?: string;
 }
 
-const TimePerformanceHeatmap: React.FC<TimePerformanceHeatmapProps> = ({ userId }) => {
+const TimePerformanceHeatmap: React.FC<TimePerformanceHeatmapProps> = ({ userId, apiPrefix = '/api/admin' }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const [data, setData] = useState<TimePerformanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -133,8 +134,8 @@ const TimePerformanceHeatmap: React.FC<TimePerformanceHeatmapProps> = ({ userId 
       if (context) params.set('context', context);
 
       const baseUrl = userId
-        ? `/api/v1/users/${userId}/performance/time-distribution`
-        : '/api/v1/platform/performance/time-distribution';
+        ? `${apiPrefix}/dashboard/users/${userId}/performance/time-distribution`
+        : `${apiPrefix}/dashboard/performance/time-distribution`;
       const res = await fetch(`${baseUrl}?${params.toString()}`);
       if (!res.ok) throw new Error(`Erro ao buscar dados: ${res.statusText}`);
       const json: TimePerformanceResponse = await res.json();

--- a/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformContentAnalysisSection.tsx
@@ -9,19 +9,21 @@ import TimePerformanceHeatmap from "../TimePerformanceHeatmap";
 interface Props {
   startDate: string;
   endDate: string;
+  apiPrefix?: string;
 }
 
 const PlatformContentAnalysisSection: React.FC<Props> = ({
   startDate,
   endDate,
+  apiPrefix = '/api/admin'
 }) => (
   <section id="platform-content-analysis" className="mb-10">
     <h2 className="text-xl md:text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
       Destaques de Performance da Plataforma <GlobalPeriodIndicator />
     </h2>
-    <PlatformPerformanceHighlights />
+    <PlatformPerformanceHighlights apiPrefix={apiPrefix} />
     <div className="mt-6">
-      <TimePerformanceHeatmap />
+      <TimePerformanceHeatmap apiPrefix={apiPrefix} />
     </div>
   </section>
 );

--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -52,17 +52,17 @@ const PlatformOverviewSection: React.FC<Props> = ({ apiPrefix = '/api/admin', fo
     </div>
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
       <PlatformFollowerTrendChart apiPrefix={apiPrefix} title={followerTrendTitle} />
-      <PlatformFollowerChangeChart />
+      <PlatformFollowerChangeChart apiPrefix={apiPrefix} />
     </div>
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 md:mb-8">
-      <PlatformReachEngagementTrendChart />
-      <PlatformMovingAverageEngagementChart />
+      <PlatformReachEngagementTrendChart apiPrefix={apiPrefix} />
+      <PlatformMovingAverageEngagementChart apiPrefix={apiPrefix} />
     </div>
 
     {/* --- CORREÇÃO APLICADA AQUI --- */}
     {/* Colocamos o widget de demografia e o mapa lado a lado em um grid para controlar o tamanho. */}
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
-      <PlatformDemographicsWidget />
+      <PlatformDemographicsWidget apiPrefix={apiPrefix} />
       <CreatorBrazilMap apiPrefix={apiPrefix} />
     </div>
 

--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -36,6 +36,8 @@ const getStartDateFromTimePeriod = (endDate: Date, timePeriod: TimePeriod): Date
 
 const AgencyDashboardContent: React.FC = () => {
 
+  const apiPrefix = '/api/agency';
+
   const [inviteCode, setInviteCode] = useState<string>('');
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
@@ -112,7 +114,7 @@ const AgencyDashboardContent: React.FC = () => {
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between py-4">
               <div className="flex-1 min-w-0 mb-2 sm:mb-0">
                 <CreatorQuickSearch
-                  apiPrefix="/api/agency"
+                  apiPrefix={apiPrefix}
                   onSelect={handleUserSelect}
                   selectedCreatorName={selectedUserName}
                   selectedCreatorPhotoUrl={selectedUserPhotoUrl}
@@ -142,17 +144,17 @@ const AgencyDashboardContent: React.FC = () => {
 
         <main className="max-w-full mx-auto py-8 px-4 sm:px-6 lg:px-8">
           <section id="platform-summary" className="mb-8">
-            <PlatformSummaryKpis apiPrefix="/api/agency" startDate={startDate} endDate={endDate} />
+            <PlatformSummaryKpis apiPrefix={apiPrefix} startDate={startDate} endDate={endDate} />
           </section>
 
           <AnimatePresence>
             {!selectedUserId && (
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-8">
-                <CreatorRankingSection apiPrefix="/api/agency" rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
-                <PlatformContentAnalysisSection startDate={startDate} endDate={endDate} />
-                <PlatformOverviewSection apiPrefix="/api/agency" followerTrendTitle="Evolução de Seguidores da Agência" />
-                <TopMoversSection apiPrefix="/api/agency" />
-                <GlobalPostsExplorer apiPrefix="/api/agency" dateRangeFilter={{ startDate, endDate }} />
+                <CreatorRankingSection apiPrefix={apiPrefix} rankingDateRange={rankingDateRange} rankingDateLabel={rankingDateLabel} />
+                <PlatformContentAnalysisSection apiPrefix={apiPrefix} startDate={startDate} endDate={endDate} />
+                <PlatformOverviewSection apiPrefix={apiPrefix} followerTrendTitle="Evolução de Seguidores da Agência" />
+                <TopMoversSection apiPrefix={apiPrefix} />
+                <GlobalPostsExplorer apiPrefix={apiPrefix} dateRangeFilter={{ startDate, endDate }} />
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/hooks/usePlatformDemographics.ts
+++ b/src/hooks/usePlatformDemographics.ts
@@ -13,9 +13,9 @@ export interface DemographicsData {
 const CACHE_KEY = "platform_demographics_cache";
 const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 
-export default function usePlatformDemographics(): UseCachedFetchReturn<DemographicsData> {
+export default function usePlatformDemographics(apiPrefix: string = '/api/v1/platform'): UseCachedFetchReturn<DemographicsData> {
   const fetcher = useCallback(async (): Promise<DemographicsData> => {
-    const res = await fetch("/api/v1/platform/demographics");
+    const res = await fetch(`${apiPrefix}/demographics`);
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.error || res.statusText);


### PR DESCRIPTION
## Summary
- allow agency dashboard components to specify an API prefix
- wire up agency dashboard page to use `/api/agency`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68746a0da39c832e9546972e2e0e28e6