### PR TITLE
Fix dashboard components to honor apiPrefix

### DIFF
--- a/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
+++ b/src/app/admin/creator-dashboard/TopCreatorsWidget.tsx
@@ -34,6 +34,7 @@ interface TopCreatorsWidgetProps {
   metricLabel?: string;
   compositeRanking?: boolean;
   tooltip?: string;
+  apiPrefix?: string;
 }
 
 const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
@@ -45,6 +46,7 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
   metricLabel = '',
   compositeRanking = false,
   tooltip,
+  apiPrefix = '/api/admin',
 }) => {
   const { timePeriod: globalTimePeriod } = useGlobalTimePeriod();
   const effectiveTimePeriod: TimePeriod = timePeriod || (globalTimePeriod as TimePeriod);
@@ -71,7 +73,7 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
     if (context) params.append('context', context);
 
     try {
-      const response = await fetch(`/api/admin/dashboard/rankings/top-creators?${params.toString()}`);
+      const response = await fetch(`${apiPrefix}/dashboard/rankings/top-creators?${params.toString()}`);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.error || 'Failed to fetch rankings');
@@ -84,7 +86,7 @@ const TopCreatorsWidget: React.FC<TopCreatorsWidgetProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [context, metric, days, limit, compositeRanking]);
+  }, [context, metric, days, limit, compositeRanking, apiPrefix]);
 
   useEffect(() => {
     fetchData();

--- a/src/app/admin/creator-dashboard/components/kpis/PlatformComparativeKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformComparativeKpi.tsx
@@ -40,6 +40,7 @@ interface PlatformComparativeKpiProps {
   title: string;
   comparisonPeriod: string;
   tooltip?: string;
+  apiPrefix?: string;
 }
 
 const PlatformComparativeKpi: React.FC<PlatformComparativeKpiProps> = ({
@@ -47,6 +48,7 @@ const PlatformComparativeKpi: React.FC<PlatformComparativeKpiProps> = ({
   title,
   comparisonPeriod,
   tooltip,
+  apiPrefix = '/api/admin',
 }) => {
   const [kpiData, setKpiData] = useState<KPIComparisonData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -57,7 +59,7 @@ const PlatformComparativeKpi: React.FC<PlatformComparativeKpiProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = `/api/v1/platform/kpis/periodic-comparison?comparisonPeriod=${comparisonPeriod}`;
+      const apiUrl = `${apiPrefix}/dashboard/platform-kpis/periodic-comparison?comparisonPeriod=${comparisonPeriod}`;
       const response = await fetch(apiUrl);
 
       if (!response.ok) {
@@ -87,7 +89,7 @@ const PlatformComparativeKpi: React.FC<PlatformComparativeKpiProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [comparisonPeriod, kpiName]);
+  }, [comparisonPeriod, kpiName, apiPrefix]);
 
   useEffect(() => {
     fetchData();

--- a/src/app/admin/creator-dashboard/components/kpis/TotalActiveCreatorsKpi.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/TotalActiveCreatorsKpi.tsx
@@ -13,12 +13,13 @@ const TIME_PERIOD_TO_COMPARISON: Record<string, string> = {
   all_time: "month_vs_previous",
 };
 
-const TotalActiveCreatorsKpi: React.FC = () => {
+const TotalActiveCreatorsKpi: React.FC<{ apiPrefix?: string }> = ({ apiPrefix = '/api/admin' }) => {
   const { timePeriod } = useGlobalTimePeriod();
   const comparisonPeriod = TIME_PERIOD_TO_COMPARISON[timePeriod] || "month_vs_previous";
 
   return (
     <PlatformComparativeKpi
+      apiPrefix={apiPrefix}
       kpiName="platformActiveCreators"
       title="Total de Criadores Ativos"
       comparisonPeriod={comparisonPeriod}

--- a/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/CreatorRankingSection.tsx
@@ -132,6 +132,7 @@ const CreatorRankingSection: React.FC<Props> = ({
           <div className="inline-flex md:block">
           <TopCreatorsWidget
             title="Top Criadores"
+            apiPrefix={apiPrefix}
             timePeriod={validatedTimePeriod}
             limit={5}
             compositeRanking={true}

--- a/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
+++ b/src/app/admin/creator-dashboard/components/views/PlatformOverviewSection.tsx
@@ -36,14 +36,16 @@ const PlatformOverviewSection: React.FC<Props> = ({ apiPrefix = '/api/admin', fo
       Visão Geral da Plataforma <GlobalPeriodIndicator />
     </h2>
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 mb-6 md:mb-8">
-      <TotalActiveCreatorsKpi />
+      <TotalActiveCreatorsKpi apiPrefix={apiPrefix} />
       <PlatformComparativeKpi
+        apiPrefix={apiPrefix}
         kpiName="platformFollowerGrowth"
         title="Crescimento de Seguidores"
         comparisonPeriod={comparisonPeriod}
         tooltip="Crescimento total de seguidores na plataforma comparado ao período anterior selecionado."
       />
       <PlatformComparativeKpi
+        apiPrefix={apiPrefix}
         kpiName="platformTotalEngagement"
         title="Engajamento Total"
         comparisonPeriod={comparisonPeriod}


### PR DESCRIPTION
## Summary
- use apiPrefix in TopCreatorsWidget fetches
- make PlatformComparativeKpi fetch from apiPrefix
- forward apiPrefix through TotalActiveCreatorsKpi
- pass apiPrefix through PlatformOverviewSection and CreatorRankingSection

## Testing
- `npx jest --watchAll=false` *(fails: npm 403 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6874719dc038832e8d1f71723f9af4bd