### PR TITLE
Fix API prefix on post details

### DIFF
--- a/src/app/admin/creator-dashboard/ContentTrendChart.tsx
+++ b/src/app/admin/creator-dashboard/ContentTrendChart.tsx
@@ -35,6 +35,7 @@ interface PostDetailResponse {
 
 interface ContentTrendChartProps {
   postId: string;
+  apiPrefix?: string;
 }
 
 const metricOptions: { key: keyof DailySnapshot; label: string; color: string }[] = [
@@ -45,7 +46,7 @@ const metricOptions: { key: keyof DailySnapshot; label: string; color: string }[
 
 // --- Componente Principal ---
 
-const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
+const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId, apiPrefix = '/api/admin' }) => {
   const [data, setData] = useState<DailySnapshot[]>([]);
   // ATUALIZADO: Estado de metadados para armazenar as 5 dimensões
   const [meta, setMeta] = useState<{
@@ -64,7 +65,7 @@ const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/dashboard/posts/${postId}/details`);
+      const res = await fetch(`${apiPrefix}/dashboard/posts/${postId}/details`);
       if (!res.ok) {
         const err = await res.json();
         throw new Error(err.error || 'Erro ao buscar dados');
@@ -94,7 +95,7 @@ const ContentTrendChart: React.FC<ContentTrendChartProps> = ({ postId }) => {
     } finally {
       setIsLoading(false);
     }
-  }, [postId]);
+  }, [postId, apiPrefix]);
 
   useEffect(() => {
     fetchData();

--- a/src/app/admin/creator-dashboard/PostDetailModal.tsx
+++ b/src/app/admin/creator-dashboard/PostDetailModal.tsx
@@ -90,9 +90,10 @@ interface PostDetailModalProps {
   onClose: () => void;
   postId: string | null;
   publicMode?: boolean;
+  apiPrefix?: string;
 }
 
-const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, postId, publicMode = false }) => {
+const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, postId, publicMode = false, apiPrefix = '/api/admin' }) => {
   const [postData, setPostData] = useState<IPostDetailsData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -107,7 +108,7 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, post
 
       const apiUrl = publicMode
         ? `/api/v1/posts/${postId}/details`
-        : `/api/admin/dashboard/posts/${postId}/details`;
+        : `${apiPrefix}/dashboard/posts/${postId}/details`;
 
       try {
         const response = await fetch(apiUrl);
@@ -147,7 +148,7 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({ isOpen, onClose, post
       setIsLoading(false);
       setError(null);
     }
-  }, [isOpen, postId, publicMode]); // Adicionado publicMode às dependências
+  }, [isOpen, postId, publicMode, apiPrefix]); // Adicionado publicMode e apiPrefix às dependências
 
   if (!isOpen || !postId) {
     return null;


### PR DESCRIPTION
## Summary
- honor `apiPrefix` when fetching post details
- ensure detailed charts use passed API prefix

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874757ae950832e9213b933a39f68b3