### PR TITLE
Implement agency dashboard endpoints

### DIFF
--- a/src/app/api/agency/dashboard/demographics/route.ts
+++ b/src/app/api/agency/dashboard/demographics/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const data = await aggregatePlatformDemographics(session.user.agencyId);
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: message }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/highlights/performance-summary/route.ts
+++ b/src/app/api/agency/dashboard/highlights/performance-summary/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { aggregatePlatformDayPerformance } from '@/utils/aggregatePlatformDayPerformance';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+interface PerformanceHighlight {
+  name: string;
+  metricName: string;
+  value: number;
+  valueFormatted: string;
+  postsCount?: number;
+}
+interface PlatformPerformanceSummaryResponse {
+  topPerformingFormat: PerformanceHighlight | null;
+  lowPerformingFormat: PerformanceHighlight | null;
+  topPerformingContext: PerformanceHighlight | null;
+  topPerformingProposal: PerformanceHighlight | null;
+  topPerformingTone: PerformanceHighlight | null;
+  topPerformingReference: PerformanceHighlight | null;
+  bestDay: { dayOfWeek: number; average: number } | null;
+  insightSummary: string;
+}
+const DEFAULT_PERFORMANCE_METRIC_LABEL = 'Interações (média por post)';
+
+function formatPerformanceValue(value: number, metricFieldId: string): string {
+  if (metricFieldId.includes('Rate') || metricFieldId.includes('percentage')) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
+  return value.toFixed(0);
+}
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+function getPortugueseWeekdayNameForSummary(day: number): string {
+  const days = ['Domingo','Segunda-feira','Terça-feira','Quarta-feira','Quinta-feira','Sexta-feira','Sábado'];
+  return days[day - 1] || '';
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_90_days';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  const performanceMetricField = 'stats.total_interactions';
+  const performanceMetricLabel = DEFAULT_PERFORMANCE_METRIC_LABEL;
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const [aggResult, dayAgg] = await Promise.all([
+    aggregatePlatformPerformanceHighlights(periodInDaysValue, performanceMetricField, session.user.agencyId),
+    aggregatePlatformDayPerformance(periodInDaysValue, performanceMetricField, {}, session.user.agencyId)
+  ]);
+  const bestDay = dayAgg.bestDays[0] || null;
+  const response: PlatformPerformanceSummaryResponse = {
+    topPerformingFormat: aggResult.topFormat ? { name: aggResult.topFormat.name as string, metricName: performanceMetricLabel, value: aggResult.topFormat.average, valueFormatted: formatPerformanceValue(aggResult.topFormat.average, performanceMetricField), postsCount: aggResult.topFormat.count } : null,
+    lowPerformingFormat: aggResult.lowFormat ? { name: aggResult.lowFormat.name as string, metricName: performanceMetricLabel, value: aggResult.lowFormat.average, valueFormatted: formatPerformanceValue(aggResult.lowFormat.average, performanceMetricField), postsCount: aggResult.lowFormat.count } : null,
+    topPerformingContext: aggResult.topContext ? { name: aggResult.topContext.name as string, metricName: performanceMetricLabel, value: aggResult.topContext.average, valueFormatted: formatPerformanceValue(aggResult.topContext.average, performanceMetricField), postsCount: aggResult.topContext.count } : null,
+    topPerformingProposal: aggResult.topProposal ? { name: aggResult.topProposal.name as string, metricName: performanceMetricLabel, value: aggResult.topProposal.average, valueFormatted: formatPerformanceValue(aggResult.topProposal.average, performanceMetricField), postsCount: aggResult.topProposal.count } : null,
+    topPerformingTone: aggResult.topTone ? { name: aggResult.topTone.name as string, metricName: performanceMetricLabel, value: aggResult.topTone.average, valueFormatted: formatPerformanceValue(aggResult.topTone.average, performanceMetricField), postsCount: aggResult.topTone.count } : null,
+    topPerformingReference: aggResult.topReference ? { name: aggResult.topReference.name as string, metricName: performanceMetricLabel, value: aggResult.topReference.average, valueFormatted: formatPerformanceValue(aggResult.topReference.average, performanceMetricField), postsCount: aggResult.topReference.count } : null,
+    bestDay: bestDay ? { dayOfWeek: bestDay.dayOfWeek, average: bestDay.average } : null,
+    insightSummary: ''
+  };
+  const insights: string[] = [];
+  if (response.topPerformingFormat) insights.push(`O formato de melhor performance é ${response.topPerformingFormat.name} (${response.topPerformingFormat.valueFormatted} de média).`);
+  if (response.topPerformingContext) insights.push(`${response.topPerformingContext.name} é o contexto de melhor performance (${response.topPerformingContext.valueFormatted} de média).`);
+  if (response.topPerformingProposal) insights.push(`${response.topPerformingProposal.name} é a proposta de melhor desempenho (${response.topPerformingProposal.valueFormatted} de média).`);
+  if (response.bestDay) {
+    const dayName = getPortugueseWeekdayNameForSummary(response.bestDay.dayOfWeek);
+    insights.push(`O melhor dia para postar é ${dayName}, com média de ${response.bestDay.average.toFixed(1)} interações por post.`);
+  }
+  if (response.lowPerformingFormat && response.lowPerformingFormat.name !== response.topPerformingFormat?.name) {
+    insights.push(`O formato ${response.lowPerformingFormat.name} tem performance mais baixa (${response.lowPerformingFormat.valueFormatted}).`);
+  }
+  response.insightSummary = insights.join(' ');
+  if (insights.length === 0) {
+    response.insightSummary = 'Não há dados suficientes para gerar insights de performance no período selecionado.';
+  }
+  return NextResponse.json(camelizeKeys(response), { status: 200 });
+}

--- a/src/app/api/agency/dashboard/trends/follower-change/route.ts
+++ b/src/app/api/agency/dashboard/trends/follower-change/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import getFollowerDailyChangeData from '@/charts/getFollowerDailyChangeData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+interface ApiChangePoint { date: string; change: number | null; }
+interface FollowerChangeResponse { chartData: ApiChangePoint[]; insightSummary?: string; }
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_30_days';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ agency: new Types.ObjectId(session.user.agencyId), planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers || agencyUsers.length === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum usuário encontrado na agência para agregar dados.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const BATCH_SIZE = 50;
+    const results: PromiseSettledResult<FollowerChangeResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batchIds.map(id => getFollowerDailyChangeData(id.toString(), timePeriod));
+      const batchRes = await Promise.allSettled(batchPromises);
+      results.push(...batchRes);
+    }
+    const aggregatedByDate = new Map<string, number>();
+    results.forEach(r => {
+      if (r.status === 'fulfilled' && r.value) {
+        r.value.chartData.forEach(p => {
+          if (p.change !== null) {
+            const curr = aggregatedByDate.get(p.date) || 0;
+            aggregatedByDate.set(p.date, curr + p.change);
+          }
+        });
+      } else if (r.status === 'rejected') {
+        logger.error('Erro ao buscar mudança de seguidores para um usuário:', r.reason);
+      }
+    });
+    if (aggregatedByDate.size === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum dado de seguidores encontrado para os usuários da agência no período.' }, { status: 200 });
+    }
+    const chartData: ApiChangePoint[] = Array.from(aggregatedByDate.entries())
+      .map(([date, change]) => ({ date, change }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+    let insight = 'Dados de variação diária de seguidores da agência.';
+    if (chartData.length > 0) {
+      const totalChange = chartData.reduce((acc, p) => acc + (p.change ?? 0), 0);
+      const periodText = timePeriod === 'all_time' ? 'todo o período' : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months', ' meses');
+      if (totalChange > 0) {
+        insight = `A agência ganhou ${totalChange.toLocaleString()} seguidores nos ${periodText}.`;
+      } else if (totalChange < 0) {
+        insight = `A agência perdeu ${Math.abs(totalChange).toLocaleString()} seguidores nos ${periodText}.`;
+      } else {
+        insight = `Sem mudança no total de seguidores da agência nos ${periodText}.`;
+      }
+    }
+    return NextResponse.json({ chartData, insightSummary: insight }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/FOLLOWER-CHANGE] Error aggregating agency follower change:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/trends/moving-average-engagement/route.ts
+++ b/src/app/api/agency/dashboard/trends/moving-average-engagement/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import MetricModel from '@/app/models/Metric';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { addDays, formatDateYYYYMMDD } from '@/utils/dateHelpers';
+import { Types } from 'mongoose';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+interface MovingAverageDataPoint { date: string; movingAverageEngagement: number | null; }
+interface ResponseData { series: MovingAverageDataPoint[]; insightSummary?: string; }
+const DEFAULT_DATA_WINDOW_DAYS = 30;
+const DEFAULT_MOVING_AVERAGE_WINDOW_DAYS = 7;
+const MAX_DATA_WINDOW_DAYS = 365;
+const MAX_MOVING_AVERAGE_WINDOW_DAYS = 90;
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  let dataWindowInDays = DEFAULT_DATA_WINDOW_DAYS;
+  const dwParam = searchParams.get('dataWindowInDays');
+  if (dwParam) {
+    const parsed = parseInt(dwParam,10);
+    if (isNaN(parsed) || parsed <= 0 || parsed > MAX_DATA_WINDOW_DAYS) {
+      return NextResponse.json({ error: `Parâmetro dataWindowInDays inválido. Deve ser um número positivo até ${MAX_DATA_WINDOW_DAYS}.` }, { status: 400 });
+    }
+    dataWindowInDays = parsed;
+  }
+  let movingWindow = DEFAULT_MOVING_AVERAGE_WINDOW_DAYS;
+  const mwParam = searchParams.get('movingAverageWindowInDays');
+  if (mwParam) {
+    const parsed = parseInt(mwParam,10);
+    if (isNaN(parsed) || parsed <= 0 || parsed > MAX_MOVING_AVERAGE_WINDOW_DAYS) {
+      return NextResponse.json({ error: `Parâmetro movingAverageWindowInDays inválido. Deve ser um número positivo até ${MAX_MOVING_AVERAGE_WINDOW_DAYS}.` }, { status: 400 });
+    }
+    movingWindow = parsed;
+  }
+  if (movingWindow > dataWindowInDays) {
+    return NextResponse.json({ error: 'movingAverageWindowInDays não pode ser maior que dataWindowInDays.' }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ agency: new Types.ObjectId(session.user.agencyId), planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers.length) {
+      return NextResponse.json({ series: [], insightSummary: 'Nenhum usuário encontrado para a agência.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23,59,59,999);
+    const startDateForQuery = new Date(today);
+    startDateForQuery.setDate(startDateForQuery.getDate() - (dataWindowInDays + movingWindow));
+    startDateForQuery.setHours(0,0,0,0);
+
+    const agg = await MetricModel.aggregate([
+      { $match: { user: { $in: userIds }, postDate: { $gte: startDateForQuery, $lte: endDate } } },
+      { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$postDate' } }, dailyEngagement: { $sum: { $add: [ { $ifNull: ['$stats.likes',0] }, { $ifNull: ['$stats.comments',0] }, { $ifNull: ['$stats.shares',0] }, { $ifNull: ['$stats.saved',0] } ] } } } },
+      { $sort: { _id: 1 } }
+    ]);
+    const map = new Map<string, number>(agg.map(it => [it._id, it.dailyEngagement]));
+    const complete: { date: string; total: number }[] = [];
+    let cursor = new Date(startDateForQuery);
+    while (cursor <= endDate) {
+      const key = formatDateYYYYMMDD(cursor);
+      complete.push({ date: key, total: map.get(key) || 0 });
+      cursor = addDays(cursor,1);
+    }
+    const series: MovingAverageDataPoint[] = [];
+    for (let i=movingWindow-1; i<complete.length; i++) {
+      const window = complete.slice(i-movingWindow+1, i+1);
+      const sum = window.reduce((a,b)=>a+b.total,0);
+      series.push({ date: complete[i].date, movingAverageEngagement: sum / movingWindow });
+    }
+    const displayStart = new Date(today); displayStart.setDate(displayStart.getDate()-dataWindowInDays+1); displayStart.setHours(0,0,0,0);
+    const finalSeries = series.filter(p => new Date(p.date) >= displayStart);
+    const insight = `Média móvel de ${movingWindow} dias do engajamento diário da agência nos últimos ${dataWindowInDays} dias.`;
+    return NextResponse.json({ series: finalSeries, insightSummary: finalSeries.length ? insight : 'Dados insuficientes para calcular a média móvel.' }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/MOVING-AVERAGE-ENGAGEMENT] Error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao calcular a média móvel.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/trends/reach-engagement/route.ts
+++ b/src/app/api/agency/dashboard/trends/reach-engagement/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import { getUserReachInteractionTrendChartData } from '@/charts/getReachInteractionTrendChartData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+interface ApiChartDataPoint { date: string; reach: number | null; totalInteractions: number | null; }
+interface ChartResponse { chartData: ApiChartDataPoint[]; insightSummary?: string; averageReach?: number; averageInteractions?: number; }
+const ALLOWED_GRANULARITIES: string[] = ['daily','weekly'];
+function isAllowedTimePeriod(period: any): period is TimePeriod { return ALLOWED_TIME_PERIODS.includes(period); }
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const granularityParam = searchParams.get('granularity');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_30_days';
+  const granularity = granularityParam && ALLOWED_GRANULARITIES.includes(granularityParam) ? (granularityParam as 'daily' | 'weekly') : 'daily';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  if (granularityParam && !ALLOWED_GRANULARITIES.includes(granularityParam)) {
+    return NextResponse.json({ error: `Granularity inválida. Permitidas: ${ALLOWED_GRANULARITIES.join(', ')}` }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ agency: new Types.ObjectId(session.user.agencyId), planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers || agencyUsers.length === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum usuário encontrado na agência para agregar dados.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const BATCH_SIZE = 30;
+    const results: PromiseSettledResult<ChartResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batch = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batch.map(id => getUserReachInteractionTrendChartData(id.toString(), timePeriod, granularity));
+      const batchResults = await Promise.allSettled(batchPromises);
+      results.push(...batchResults);
+    }
+    const aggregated = new Map<string,{ reachValues:number[]; interactionValues:number[] }>();
+    results.forEach(r => {
+      if (r.status === 'fulfilled' && r.value && r.value.chartData) {
+        r.value.chartData.forEach(p => {
+          const entry = aggregated.get(p.date) || { reachValues: [], interactionValues: [] };
+          if (p.reach !== null) entry.reachValues.push(p.reach);
+          if (p.totalInteractions !== null) entry.interactionValues.push(p.totalInteractions);
+          aggregated.set(p.date, entry);
+        });
+      } else if (r.status === 'rejected') {
+        logger.error('Erro ao buscar trend para usuário da agência:', r.reason);
+      }
+    });
+    if (aggregated.size === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum dado encontrado para os usuários da agência.' }, { status: 200 });
+    }
+    const chartData: ApiChartDataPoint[] = Array.from(aggregated.entries()).map(([date, data]) => {
+      const avgReach = data.reachValues.length ? data.reachValues.reduce((a,b)=>a+b,0)/data.reachValues.length : null;
+      const avgInt = data.interactionValues.length ? data.interactionValues.reduce((a,b)=>a+b,0)/data.interactionValues.length : null;
+      return { date, reach: avgReach, totalInteractions: avgInt };
+    }).sort((a,b)=>a.date.localeCompare(b.date));
+    const valid = chartData.filter(p => p.reach !== null || p.totalInteractions !== null);
+    let insight = 'Dados de tendência de alcance e interações da agência.';
+    if (valid.length) {
+      const avgReach = valid.reduce((s,p)=>s+(p.reach??0),0)/valid.length;
+      const avgInt = valid.reduce((s,p)=>s+(p.totalInteractions??0),0)/valid.length;
+      const periodText = timePeriod === 'all_time' ? 'todo o período' : timePeriod.replace('last_','últimos ').replace('_days',' dias').replace('_months',' meses');
+      insight = `Média de alcance: ${avgReach.toFixed(0)}, interações: ${avgInt.toFixed(0)} por ${granularity==='daily'?'dia':'semana'} nos ${periodText}.`;
+    }
+    return NextResponse.json({ chartData, insightSummary: insight }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/REACH-ENGAGEMENT] Error aggregating agency data:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/utils/aggregatePlatformPerformanceHighlights.ts
+++ b/src/utils/aggregatePlatformPerformanceHighlights.ts
@@ -1,5 +1,6 @@
 import MetricModel from "@/app/models/Metric";
-import { PipelineStage } from "mongoose";
+import UserModel from "@/app/models/User";
+import { PipelineStage, Types } from "mongoose";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import { logger } from "@/app/lib/logger";
 import { getStartDateFromTimePeriod } from "./dateHelpers";
@@ -22,6 +23,7 @@ export interface PlatformPerformanceHighlightsAggregation {
 async function aggregatePlatformPerformanceHighlights(
   periodInDays: number,
   metricField: string,
+  agencyId?: string,
   referenceDate: Date = new Date()
 ): Promise<PlatformPerformanceHighlightsAggregation> {
   const today = new Date(referenceDate);
@@ -51,9 +53,19 @@ async function aggregatePlatformPerformanceHighlights(
   try {
     await connectToDatabase();
 
+    let userFilter: any = {};
+    if (agencyId) {
+      const agencyUserIds = await UserModel.find({ agency: new Types.ObjectId(agencyId) }).distinct('_id');
+      if (!agencyUserIds.length) {
+        return initial;
+      }
+      userFilter = { user: { $in: agencyUserIds } };
+    }
+
     const matchStage: PipelineStage.Match = {
       $match: {
         postDate: { $gte: startDate, $lte: endDate },
+        ...userFilter,
       },
     };
 


### PR DESCRIPTION
## Summary
- support agency filter for platform performance utilities
- expose performance summary API for agencies
- add trend, demographics and moving-average routes for agency dashboards

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749b72ace4832e8938540842092e3d