### PR TITLE
Add agency dashboard endpoints

### DIFF
--- a/src/app/api/agency/creators/region-summary/route.ts
+++ b/src/app/api/agency/creators/region-summary/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getAgencySession } from '@/lib/getAgencySession';
+// Importa a função de agregação de audiência
+import aggregateAudienceByRegion from '@/utils/aggregateAudienceByRegion';
+
+export const dynamic = 'force-dynamic';
+
+// --- PASSO 1: Atualizar o schema de validação ---
+// Adicionamos os novos filtros opcionais para gênero e faixa etária.
+const querySchema = z.object({
+  region: z.enum(['Norte', 'Nordeste', 'Centro-Oeste', 'Sudeste', 'Sul']).optional(),
+  gender: z.enum(['F', 'M', 'U']).optional(),
+  ageRange: z.enum(['13-17', '18-24', '25-34', '35-44', '45-54', '55-64', '65+']).optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const TAG = '[api/agency/audience/region-summary]';
+  const session = await getAgencySession(req);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Acesso não autorizado.' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const params = Object.fromEntries(searchParams.entries());
+  
+  // Valida os novos parâmetros (região, gênero e idade)
+  const validated = querySchema.safeParse(params);
+  if (!validated.success) {
+    const message = validated.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+    return NextResponse.json({ error: `Parâmetros inválidos: ${message}` }, { status: 400 });
+  }
+
+  try {
+    logger.info(`${TAG} Filtros validados para agregação de audiência:`, validated.data);
+
+    // --- PASSO 2: Passar os filtros validados para a função ---
+    // A função aggregateAudienceByRegion agora receberá os filtros de gênero e idade.
+    const data = await aggregateAudienceByRegion(validated.data, session.user.agencyId);
+
+    logger.info(`${TAG} Resultado da agregação de audiência: ${data.length} estados.`);
+
+    return NextResponse.json({ states: data }, { status: 200 });
+  } catch (err) {
+    logger.error(`${TAG} erro inesperado`, err);
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.' }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/performance/average-engagement/route.ts
+++ b/src/app/api/agency/dashboard/performance/average-engagement/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import MetricModel, { IMetric } from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { getNestedValue } from '@/utils/dataAccessHelpers';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import {
+  ALLOWED_TIME_PERIODS,
+  ALLOWED_ENGAGEMENT_METRICS,
+  TimePeriod,
+  EngagementMetricField,
+} from '@/app/lib/constants/timePeriods';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+// Tipo local para agrupamento
+type GroupingType = 'format' | 'context' | 'proposal';
+
+// Constantes para validação e defaults
+const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context', 'proposal'];
+
+export async function GET(request: NextRequest) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod') as TimePeriod | null;
+  const engagementMetricParam = searchParams.get('engagementMetricField') as EngagementMetricField | null;
+  const groupByParam = searchParams.get('groupBy') as GroupingType | null;
+  // ✅ PASSO 1: LER O NOVO PARÂMETRO 'limit' DA URL
+  const limitParam = searchParams.get('limit');
+
+  // Validar timePeriod
+  const timePeriod: TimePeriod = timePeriodParam && ALLOWED_TIME_PERIODS.includes(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+  if (timePeriodParam && !ALLOWED_TIME_PERIODS.includes(timePeriodParam)) {
+    return NextResponse.json({ error: `timePeriod inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  // Validar engagementMetricField
+  const engagementMetric: EngagementMetricField = engagementMetricParam && ALLOWED_ENGAGEMENT_METRICS.includes(engagementMetricParam)
+    ? engagementMetricParam
+    : 'stats.total_interactions';
+  if (engagementMetricParam && !ALLOWED_ENGAGEMENT_METRICS.includes(engagementMetricParam)) {
+    return NextResponse.json({ error: `engagementMetricField inválido. Permitidos: ${ALLOWED_ENGAGEMENT_METRICS.join(', ')}` }, { status: 400 });
+  }
+
+  // Validar groupBy
+  const groupBy: GroupingType = groupByParam && ALLOWED_GROUPINGS.includes(groupByParam)
+    ? groupByParam
+    : 'format';
+  if (groupByParam && !ALLOWED_GROUPINGS.includes(groupByParam)) {
+    return NextResponse.json({ error: `groupBy inválido. Permitidos: ${ALLOWED_GROUPINGS.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    await connectToDatabase();
+
+    const activeUsers = await UserModel.find({ planStatus: 'active', agency: session.user.agencyId }).select('_id').lean();
+    const activeIds = activeUsers.map(u => u._id);
+
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+    const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+    const query: any = {};
+    if (activeIds.length > 0) {
+      query.user = { $in: activeIds };
+    }
+    if (timePeriod !== 'all_time') {
+      query.postDate = { $gte: startDate, $lte: endDate };
+    }
+
+    const posts: IMetric[] = await MetricModel.find(query).lean();
+
+    const performanceByGroup: Record<string, { sumPerformance: number; count: number }> = {};
+    for (const post of posts) {
+      const groupKey = groupBy === 'format' ? post.format : groupBy === 'context' ? post.context : post.proposal;
+      const metricValue = getNestedValue(post, engagementMetric);
+      if (groupKey && metricValue !== null) {
+        // Corrigido para lidar com arrays e strings
+        const keys = Array.isArray(groupKey) ? groupKey : [groupKey];
+        for (const key of keys) {
+            if (!performanceByGroup[key]) {
+                performanceByGroup[key] = { sumPerformance: 0, count: 0 };
+            }
+            performanceByGroup[key].sumPerformance += metricValue;
+            performanceByGroup[key].count += 1;
+        }
+      }
+    }
+
+    // ✅ Usamos 'let' para que a variável possa ser modificada
+    let results = Object.entries(performanceByGroup).map(([key, data]) => ({
+      name: key,
+      value: data.sumPerformance / data.count,
+      postsCount: data.count,
+    })).sort((a, b) => b.value - a.value);
+
+    // ✅ PASSO 2: APLICAR O LIMITE SE ELE FOI FORNECIDO
+    if (limitParam) {
+      const limit = parseInt(limitParam, 10);
+      // Garante que o limite é um número válido e positivo
+      if (!isNaN(limit) && limit > 0) {
+        // Usa slice() para pegar apenas os N primeiros itens do array já ordenado
+        results = results.slice(0, limit);
+      }
+    }
+
+    // Retorna dados
+    return NextResponse.json({ chartData: results, metricUsed: engagementMetric, groupBy }, { status: 200 });
+  } catch (error) {
+    logger.error('[API PLATFORM/PERFORMANCE/AVERAGE-ENGAGEMENT] Error:', error);
+    return NextResponse.json({ error: 'Erro ao processar engajamento médio agrupado.', details: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/api/agency/dashboard/platform-kpis/periodic-comparison/route.ts
+++ b/src/app/api/agency/dashboard/platform-kpis/periodic-comparison/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import AccountInsightModel from '@/app/models/AccountInsight';
+import MetricModel from '@/app/models/Metric'; // Importar MetricModel
+import calculateAverageEngagementPerPost from '@/utils/calculateAverageEngagementPerPost'; // Usado para engajamento
+import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneric } from '@/utils/dateHelpers';
+import { Types } from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { getAgencySession } from '@/lib/getAgencySession';
+
+// Tipos de dados para a resposta
+interface MiniChartDataPoint {
+  name: string; // Ex: "Anterior", "Atual"
+  value: number;
+  // periodKey?: string; // Opcional, se o frontend precisar para algo
+  // comparisonPair?: string; // Opcional
+}
+
+interface KPIComparisonData {
+  currentValue: number | null;
+  previousValue: number | null;
+  percentageChange: number | null;
+  chartData?: MiniChartDataPoint[];
+}
+
+interface PlatformPeriodicComparisonResponse {
+  platformFollowerGrowth: KPIComparisonData;
+  platformTotalEngagement: KPIComparisonData;
+  platformPostingFrequency: KPIComparisonData;
+  platformActiveCreators: KPIComparisonData;
+  insightSummary?: {
+    platformFollowerGrowth?: string;
+    platformTotalEngagement?: string;
+    platformPostingFrequency?: string;
+    platformActiveCreators?: string;
+  };
+}
+
+const ALLOWED_COMPARISON_PERIODS: { [key: string]: { currentPeriodDays: number, periodNameCurrent: string, periodNamePrevious: string } } = {
+  "month_vs_previous": { currentPeriodDays: 30, periodNameCurrent: "Este Mês", periodNamePrevious: "Mês Passado"},
+  "last_7d_vs_previous_7d": { currentPeriodDays: 7, periodNameCurrent: "Últimos 7 Dias", periodNamePrevious: "7 Dias Anteriores"},
+  "last_30d_vs_previous_30d": { currentPeriodDays: 30, periodNameCurrent: "Últimos 30 Dias", periodNamePrevious: "30 Dias Anteriores"},
+};
+
+function calculatePercentageChange(current: number | null, previous: number | null): number | null {
+  if (current === null || previous === null) return null;
+  if (previous === 0) {
+    return current > 0 ? 1.0 : (current === 0 ? 0.0 : -1.0);
+  }
+  return (current - previous) / previous;
+}
+
+async function getPlatformTotalFollowersAtDate(date: Date, userIds: Types.ObjectId[]): Promise<number> {
+    const userFollowerPromises = userIds.map(async (userId) => {
+        const snapshot = await AccountInsightModel.findOne({
+            user: userId,
+            recordedAt: { $lte: date }
+        }).sort({ recordedAt: -1 }).select('followersCount').lean();
+        return snapshot?.followersCount || 0;
+    });
+    const userFollowersCounts = await Promise.all(userFollowerPromises);
+    return userFollowersCounts.reduce((sum, count) => sum + count, 0);
+}
+
+async function getPlatformTotalPostsInPeriod(startDate: Date, endDate: Date, userIds: Types.ObjectId[]): Promise<number> {
+    // TODO: Considerar apenas posts de usuários ativos da plataforma
+    const count = await MetricModel.countDocuments({
+        user: { $in: userIds },
+        postDate: { $gte: startDate, $lte: endDate }
+    });
+    return count;
+}
+
+async function getTotalActiveCreatorsAtDate(date: Date, userIds: Types.ObjectId[]): Promise<number> {
+    if (userIds.length === 0) return 0;
+    return UserModel.countDocuments({ _id: { $in: userIds }, createdAt: { $lte: date } });
+}
+
+
+export async function GET(
+  request: NextRequest
+) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const comparisonPeriodParam = searchParams.get('comparisonPeriod');
+
+  const comparisonConfig = comparisonPeriodParam && ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]
+    ? ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]
+    : ALLOWED_COMPARISON_PERIODS["last_30d_vs_previous_30d"];
+
+  if (comparisonPeriodParam && !ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]) {
+     return NextResponse.json({ error: `Comparison period inválido. Permitidos: ${Object.keys(ALLOWED_COMPARISON_PERIODS).join(', ')}` }, { status: 400 });
+  }
+
+  const { currentPeriodDays, periodNameCurrent, periodNamePrevious } = comparisonConfig!; // Adicionado periodNameCurrent/Previous
+  const today = new Date();
+
+  const currentEndDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const currentStartDate = getStartDateFromTimePeriodGeneric(today, `last_${currentPeriodDays}_days`);
+
+  const previousEndDate = addDays(new Date(currentStartDate), -1);
+  previousEndDate.setHours(23,59,59,999);
+  const previousStartDate = addDays(new Date(previousEndDate), -(currentPeriodDays -1));
+  previousStartDate.setHours(0,0,0,0);
+
+  try {
+    await connectToDatabase();
+    const platformUsers = await UserModel.find({ agency: session.user.agencyId }).select('_id').lean();
+
+    if (!platformUsers || platformUsers.length === 0) {
+      const emptyKpi: KPIComparisonData = { currentValue: 0, previousValue: 0, percentageChange: 0, chartData: [{name: periodNamePrevious, value:0}, {name: periodNameCurrent, value:0}]};
+      return NextResponse.json({
+        platformFollowerGrowth: emptyKpi,
+        platformTotalEngagement: emptyKpi,
+        platformPostingFrequency: emptyKpi,
+        platformActiveCreators: emptyKpi,
+        insightSummary: {
+            platformFollowerGrowth: "Nenhum usuário na plataforma.",
+            platformTotalEngagement: "Nenhum usuário na plataforma.",
+            platformPostingFrequency: "Nenhum usuário na plataforma.",
+            platformActiveCreators: "Nenhum usuário na plataforma."
+        }
+      }, { status: 200 });
+    }
+    const userIds = platformUsers.map(user => user._id as Types.ObjectId);
+
+    // --- Platform Follower Growth ---
+    const followersT0 = await getPlatformTotalFollowersAtDate(currentEndDate, userIds);
+    const followersT1 = await getPlatformTotalFollowersAtDate(previousEndDate, userIds);
+    const dayBeforePreviousStartDate = addDays(new Date(previousStartDate), -1);
+    dayBeforePreviousStartDate.setHours(23,59,59,999);
+    const followersT2 = await getPlatformTotalFollowersAtDate(dayBeforePreviousStartDate, userIds);
+
+    const currentFollowerGainPlatform = followersT0 - followersT1;
+    const previousFollowerGainPlatform = followersT1 - followersT2;
+
+    const followerGrowthData: KPIComparisonData = {
+      currentValue: currentFollowerGainPlatform,
+      previousValue: previousFollowerGainPlatform,
+      percentageChange: calculatePercentageChange(currentFollowerGainPlatform, previousFollowerGainPlatform),
+      chartData: [
+        { name: periodNamePrevious, value: previousFollowerGainPlatform ?? 0 },
+        { name: periodNameCurrent, value: currentFollowerGainPlatform ?? 0 }
+      ]
+    };
+
+    // --- Platform Total Engagement ---
+    let currentPlatformTotalEngagement = 0;
+    let previousPlatformTotalEngagement = 0;
+
+    const engagementPromisesCurrent = userIds.map(uid =>
+        calculateAverageEngagementPerPost(uid, {startDate: currentStartDate, endDate: currentEndDate})
+    );
+    const engagementResultsCurrent = await Promise.allSettled(engagementPromisesCurrent);
+    engagementResultsCurrent.forEach(result => {
+        if (result.status === 'fulfilled') currentPlatformTotalEngagement += result.value.totalEngagement;
+        else console.error("Error fetching current engagement for a user:", result.reason);
+    });
+
+    const engagementPromisesPrevious = userIds.map(uid =>
+        calculateAverageEngagementPerPost(uid, {startDate: previousStartDate, endDate: previousEndDate})
+    );
+    const engagementResultsPrevious = await Promise.allSettled(engagementPromisesPrevious);
+    engagementResultsPrevious.forEach(result => {
+        if (result.status === 'fulfilled') previousPlatformTotalEngagement += result.value.totalEngagement;
+        else console.error("Error fetching previous engagement for a user:", result.reason);
+    });
+
+    const totalEngagementData: KPIComparisonData = {
+      currentValue: currentPlatformTotalEngagement,
+      previousValue: previousPlatformTotalEngagement,
+      percentageChange: calculatePercentageChange(currentPlatformTotalEngagement, previousPlatformTotalEngagement),
+      chartData: [
+        { name: periodNamePrevious, value: previousPlatformTotalEngagement ?? 0 },
+        { name: periodNameCurrent, value: currentPlatformTotalEngagement ?? 0 }
+      ]
+    };
+
+    // --- Platform Posting Frequency ---
+    const currentTotalPostsPlatform = await getPlatformTotalPostsInPeriod(currentStartDate, currentEndDate, userIds);
+    const previousTotalPostsPlatform = await getPlatformTotalPostsInPeriod(previousStartDate, previousEndDate, userIds);
+
+    // Número de dias nos períodos (deve ser currentPeriodDays para ambos, mas calcular para precisão)
+    const daysInCurrentPeriod = (currentEndDate.getTime() - currentStartDate.getTime()) / (1000 * 3600 * 24) + 1;
+    const daysInPreviousPeriod = (previousEndDate.getTime() - previousStartDate.getTime()) / (1000 * 3600 * 24) + 1;
+
+    const currentPlatformWeeklyFreq = daysInCurrentPeriod > 0 ? (currentTotalPostsPlatform / daysInCurrentPeriod) * 7 : 0;
+    const previousPlatformWeeklyFreq = daysInPreviousPeriod > 0 ? (previousTotalPostsPlatform / daysInPreviousPeriod) * 7 : 0;
+
+    const postingFrequencyData: KPIComparisonData = {
+        currentValue: currentPlatformWeeklyFreq,
+        previousValue: previousPlatformWeeklyFreq,
+        percentageChange: calculatePercentageChange(currentPlatformWeeklyFreq, previousPlatformWeeklyFreq),
+        chartData: [
+            { name: periodNamePrevious, value: previousPlatformWeeklyFreq ? parseFloat(previousPlatformWeeklyFreq.toFixed(1)) : 0 },
+            { name: periodNameCurrent, value: currentPlatformWeeklyFreq ? parseFloat(currentPlatformWeeklyFreq.toFixed(1)) : 0 }
+        ]
+    };
+
+    // --- Platform Active Creators ---
+    const currentActiveCreators = await getTotalActiveCreatorsAtDate(currentEndDate, userIds);
+    const previousActiveCreators = await getTotalActiveCreatorsAtDate(previousEndDate, userIds);
+
+    const activeCreatorsData: KPIComparisonData = {
+        currentValue: currentActiveCreators,
+        previousValue: previousActiveCreators,
+        percentageChange: calculatePercentageChange(currentActiveCreators, previousActiveCreators),
+        chartData: [
+            { name: periodNamePrevious, value: previousActiveCreators ?? 0 },
+            { name: periodNameCurrent, value: currentActiveCreators ?? 0 }
+        ]
+    };
+
+    const response: PlatformPeriodicComparisonResponse = {
+      platformFollowerGrowth: followerGrowthData,
+      platformTotalEngagement: totalEngagementData,
+      platformPostingFrequency: postingFrequencyData,
+      platformActiveCreators: activeCreatorsData,
+      insightSummary: {
+          platformFollowerGrowth: `Crescimento de seguidores da plataforma: ${followerGrowthData.currentValue?.toLocaleString() ?? 'N/A'} vs ${followerGrowthData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`,
+          platformTotalEngagement: `Engajamento total da plataforma: ${totalEngagementData.currentValue?.toLocaleString() ?? 'N/A'} vs ${totalEngagementData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`,
+          platformPostingFrequency: `Frequência de posts da plataforma: ${postingFrequencyData.currentValue?.toFixed(1) ?? 'N/A'} posts/sem vs ${postingFrequencyData.previousValue?.toFixed(1) ?? 'N/A'} no período anterior.`,
+          platformActiveCreators: `Criadores ativos na plataforma: ${activeCreatorsData.currentValue?.toLocaleString() ?? 'N/A'} vs ${activeCreatorsData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`
+      }
+    };
+
+    return NextResponse.json(response, { status: 200 });
+
+  } catch (error) {
+    console.error("[API PLATFORM/KPIS/PERIODIC] Error fetching platform periodic comparison KPIs:", error);
+    const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
+    const errorKpi: KPIComparisonData = { currentValue: null, previousValue: null, percentageChange: null, chartData: [{name: periodNamePrevious, value:0}, {name: periodNameCurrent, value:0}]};
+    return NextResponse.json({
+        error: "Erro ao processar sua solicitação de KPIs da plataforma.",
+        details: errorMessage,
+        platformFollowerGrowth: errorKpi,
+        platformTotalEngagement: errorKpi,
+        platformPostingFrequency: errorKpi,
+        platformActiveCreators: errorKpi,
+     }, { status: 500 });
+  }
+}
+

--- a/src/app/api/agency/dashboard/platform-kpis/summary/route.ts
+++ b/src/app/api/agency/dashboard/platform-kpis/summary/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User'; // Descomentado para contagem real
+import { connectToDatabase } from '@/app/lib/mongoose'; // Added
+import { logger } from '@/app/lib/logger'; // Added
+import { getAgencySession } from '@/lib/getAgencySession';
+
+// Interface para a resposta do endpoint
+interface PlatformKpisSummaryResponse {
+  totalActiveCreators: number;
+  // Adicionar outras KPIs de resumo da plataforma aqui no futuro, se necessário
+  // totalPostsLast30Days: number;
+  // totalEngagementLast30Days: number;
+  insightSummary?: string;
+}
+
+export async function GET(
+  request: NextRequest
+) {
+  const session = await getAgencySession(request);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    await connectToDatabase(); // Added
+
+    // Definição de "criador ativo" - pode ser ajustada conforme as regras de negócio
+    // Exemplo: status não é 'inactive' ou 'suspended', e teve atividade recente (não implementado aqui)
+    const activeCreatorCriteria = {
+      agency: session.user.agencyId,
+      // status: { $nin: ['inactive', 'suspended', 'pending_approval'] },
+    };
+
+    const activeCreatorsCount = await UserModel.countDocuments(activeCreatorCriteria);
+
+    const response: PlatformKpisSummaryResponse = {
+      totalActiveCreators: activeCreatorsCount,
+      insightSummary: `Total de ${activeCreatorsCount.toLocaleString()} criadores na plataforma.`
+                       // Poderia adicionar "ativos" se os critérios fossem mais específicos.
+    };
+    return NextResponse.json(response, { status: 200 });
+
+  } catch (error) {
+    logger.error("[API PLATFORM/KPIS/SUMMARY] Error fetching platform summary KPIs:", error); // Replaced console.error
+    const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
+    // Retornar um valor padrão ou um erro claro se a contagem falhar
+    return NextResponse.json({
+        error: "Erro ao buscar KPIs da plataforma.",
+        details: errorMessage,
+        totalActiveCreators: null, // Indicar que o valor não pôde ser obtido
+        insightSummary: "Não foi possível obter o número total de criadores."
+    }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- enable agency-specific data filtering
- implement agency routes for KPI summary, comparisons, average engagement, and region summaries

## Testing
- `npm test` *(fails: jest not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6874a0acbc08832e9e30731b95870588