### PR TITLE
Add agency user performance time distribution API

### DIFF
--- a/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
+++ b/src/app/admin/creator-dashboard/components/TimePerformanceHeatmap.tsx
@@ -136,6 +136,7 @@ const TimePerformanceHeatmap: React.FC<TimePerformanceHeatmapProps> = ({ userId,
       const baseUrl = userId
         ? `${apiPrefix}/dashboard/users/${userId}/performance/time-distribution`
         : `${apiPrefix}/dashboard/performance/time-distribution`;
+      console.log("URL da API sendo chamada:", baseUrl);
       const res = await fetch(`${baseUrl}?${params.toString()}`);
       if (!res.ok) throw new Error(`Erro ao buscar dados: ${res.statusText}`);
       const json: TimePerformanceResponse = await res.json();

--- a/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
+++ b/src/app/admin/creator-dashboard/components/views/UserDetailView.tsx
@@ -26,6 +26,7 @@ interface UserDetailViewProps {
   userName?: string;
   userPhotoUrl?: string | null;
   onClear?: () => void;
+  apiPrefix?: string;
 }
 
 const KPI_COMPARISON_PERIOD_OPTIONS = [
@@ -39,6 +40,7 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
   userName,
   userPhotoUrl,
   onClear,
+  apiPrefix = '/api/admin',
 }) => {
   const [kpiComparisonPeriod, setKpiComparisonPeriod] = useState<string>(
     KPI_COMPARISON_PERIOD_OPTIONS[0]!.value,
@@ -128,7 +130,7 @@ const UserDetailView: React.FC<UserDetailViewProps> = ({
         <section id={`user-performance-highlights-${userId}`} className="mb-10">
           <UserPerformanceHighlights userId={userId} sectionTitle="Destaques de Desempenho" />
           <h4 className="text-lg font-semibold text-gray-700 mt-6 mb-4">Análise por Horário</h4>
-          <TimePerformanceHeatmap userId={userId} />
+          <TimePerformanceHeatmap userId={userId} apiPrefix={apiPrefix} />
         </section>
 
         <section id={`user-demographics-${userId}`} className="mb-10">

--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -166,6 +166,7 @@ const AgencyDashboardContent: React.FC = () => {
                 userName={selectedUserName ?? undefined}
                 userPhotoUrl={selectedUserPhotoUrl ?? undefined}
                 onClear={handleClearSelection}
+                apiPrefix={apiPrefix}
               />
             )}
           </div>

--- a/src/app/api/agency/dashboard/users/[userId]/performance/time-distribution/route.ts
+++ b/src/app/api/agency/dashboard/users/[userId]/performance/time-distribution/route.ts
@@ -1,0 +1,98 @@
+/*
+================================================================================
+ARQUIVO 2/4: .../performance/time-distribution/route.ts
+FUNÇÃO: Rota da API que recebe a requisição do front-end.
+STATUS: Nenhuma alteração necessária. O arquivo já extrai os parâmetros
+corretamente da requisição e os repassa para a função de agregação.
+================================================================================
+*/
+import { NextRequest, NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { Types } from 'mongoose';
+import { getCategoryById } from '@/app/lib/classification';
+import { aggregateUserTimePerformance } from '@/utils/aggregateUserTimePerformance';
+import { getAgencySession } from '@/lib/getAgencySession';
+import UserModel from '@/app/models/User';
+
+function getPortugueseWeekdayName(day: number): string {
+    const days = ["Domingo", "Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira", "Sábado"];
+    return days[day - 1] || '';
+}
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json(
+      { error: 'User ID inválido ou ausente.' },
+      { status: 400 }
+    );
+  }
+  const session = await getAgencySession(req);
+  if (!session || !session.user || !session.user.agencyId) {
+    return NextResponse.json({ error: 'Acesso não autorizado' }, { status: 401 });
+  }
+
+  const creator = await UserModel.findOne({ _id: userId, agency: session.user.agencyId }).lean();
+  if (!creator) {
+    return NextResponse.json(
+      { error: 'Criador não encontrado ou não pertence a esta agência' },
+      { status: 403 }
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const metricField = metricParam || 'stats.total_interactions';
+
+  const result = await aggregateUserTimePerformance(userId, periodInDaysValue, metricField, {
+    format: formatParam || undefined,
+    proposal: proposalParam || undefined,
+    context: contextParam || undefined,
+  });
+
+  const best = result.bestSlots[0];
+  const worst = result.worstSlots[0];
+  let summary = '';
+  if (best) {
+    const dayName = getPortugueseWeekdayName(best.dayOfWeek).toLowerCase();
+    const bestAvg = best.average.toLocaleString('pt-BR', { maximumFractionDigits: 1 });
+    summary += `O pico de performance ocorre ${dayName} às ${best.hour}h, com uma média de ${bestAvg} de engajamento por post.`;
+  }
+  if (worst) {
+    const dayName = getPortugueseWeekdayName(worst.dayOfWeek).toLowerCase();
+    summary += ` O menor desempenho é ${dayName} às ${worst.hour}h.`;
+  }
+
+  const filterLabels: string[] = [];
+  if (formatParam) filterLabels.push(getCategoryById(formatParam, 'format')?.label || formatParam);
+  if (proposalParam) filterLabels.push(getCategoryById(proposalParam, 'proposal')?.label || proposalParam);
+  if (contextParam) filterLabels.push(getCategoryById(contextParam, 'context')?.label || contextParam);
+  if (filterLabels.length > 0 && summary) {
+    summary = `Para posts sobre ${filterLabels.join(' e ')}, ${summary.charAt(0).toLowerCase() + summary.slice(1)}`;
+  }
+
+  return NextResponse.json(camelizeKeys({ ...result, insightSummary: summary }), { status: 200 });
+}


### PR DESCRIPTION
## Summary
- create agency endpoint to analyze performance per hour for an individual creator
- log the fetched API URL in time heatmap for debugging
- allow passing apiPrefix to user detail view and use agency prefix on agency dashboard

## Testing
- `npx next lint` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6875215f6bd8832eb03eac12030aa029