### PR TITLE
Add Instagram link to WhatsApp alerts

### DIFF
--- a/src/app/api/whatsapp/__tests__/appendInstagramLinkIfMissing.test.ts
+++ b/src/app/api/whatsapp/__tests__/appendInstagramLinkIfMissing.test.ts
@@ -1,0 +1,10 @@
+import { appendInstagramLinkIfMissing } from '../process-response/dailyTipHandler';
+
+describe('appendInstagramLinkIfMissing', () => {
+  it('appends instagram link when message has no url and details has platformPostId', () => {
+    const msg = 'Check this out';
+    const details = { platformPostId: 'abc123' };
+    const result = appendInstagramLinkIfMissing(msg, details);
+    expect(result).toContain('https://www.instagram.com/p/abc123');
+  });
+});

--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -186,6 +186,31 @@ Pergunta instigante (ou "NO_QUESTION"):
     }
 }
 
+/**
+ * If the provided message has no URL, append an Instagram link derived from the
+ * alert details when available.
+ */
+export function appendInstagramLinkIfMissing(
+    message: string,
+    details: { [key: string]: any }
+): string {
+    if (/https?:\/\//.test(message)) {
+        return message;
+    }
+
+    const postLink: string | undefined =
+        (details && typeof details.postLink === 'string' && details.postLink.trim()) ||
+        (details && typeof details.platformPostId === 'string' && `https://www.instagram.com/p/${details.platformPostId}`) ||
+        (details && typeof details.originalPlatformPostId === 'string' && `https://www.instagram.com/p/${details.originalPlatformPostId}`) ||
+        undefined;
+
+    if (!postLink) {
+        return message;
+    }
+
+    return `${message}\n\n${postLink}`;
+}
+
 export async function handleDailyTip(payload: ProcessRequestBody): Promise<NextResponse> {
     console.log("!!!!!!!!!! EXECUTANDO handleDailyTip (v1.5.3) !!!!!!!!!! USER ID:", payload.userId, new Date().toISOString());
     
@@ -413,6 +438,8 @@ export async function handleDailyTip(payload: ProcessRequestBody): Promise<NextR
         if (instigatingQuestionForAlert) {
             fullAlertMessageToUser += `\n\n${instigatingQuestionForAlert}`;
         }
+
+        fullAlertMessageToUser = appendInstagramLinkIfMissing(fullAlertMessageToUser, detectedEvent.detailsForLog);
         
         let alertEntryDetails: AlertDetails & { whatsappMessageId?: string; sendStatus?: string; sendError?: string; } = { ...detectedEvent.detailsForLog };
 


### PR DESCRIPTION
## Summary
- add helper to append Instagram link when proactive alert details have post IDs
- use new helper when composing WhatsApp alerts
- test link appending behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767c47816c832e902a5a3c6096332f