### PR TITLE
Implement usage persistence cron and dashboard APIs

### DIFF
--- a/src/app/api/admin/dashboard/usage/history/[userId]/route.ts
+++ b/src/app/api/admin/dashboard/usage/history/[userId]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { fetchUserUsageTrend } from '@/app/lib/dataService';
+import { Types } from 'mongoose';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/usage/history]';
+
+const querySchema = z.object({
+  days: z.coerce.number().int().min(1).max(365).optional().default(30),
+});
+
+async function getAdminSession(_req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number) {
+  logger.error(`${SERVICE_TAG} Error ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest, { params }: { params: { userId: string } }) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  try {
+    const session = await getAdminSession(req);
+    if (!session || !session.user) return apiError('Acesso não autorizado.', 401);
+
+    const { userId } = params;
+    if (!userId || !Types.ObjectId.isValid(userId)) {
+      return apiError('UserId inválido.', 400);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validation = querySchema.safeParse(queryParams);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros inválidos: ${errorMessage}`, 400);
+    }
+    const { days } = validation.data;
+
+    const data = await fetchUserUsageTrend(userId, days);
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (err) {
+    logger.error(`${TAG} Unexpected error`, err);
+    return apiError('Erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/admin/dashboard/usage/top-users/route.ts
+++ b/src/app/api/admin/dashboard/usage/top-users/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { fetchTopActiveUsers } from '@/app/lib/dataService';
+
+export const dynamic = 'force-dynamic';
+
+const SERVICE_TAG = '[api/admin/dashboard/usage/top-users]';
+
+const querySchema = z.object({
+  since: z.string().datetime({ offset: true }).optional().transform(v => v ? new Date(v) : undefined),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+}).refine(data => {
+  return true;
+});
+
+async function getAdminSession(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') {
+    logger.warn(`${SERVICE_TAG} Admin session validation failed.`);
+    return null;
+  }
+  return session;
+}
+
+function apiError(message: string, status: number) {
+  logger.error(`${SERVICE_TAG} Error ${status}: ${message}`);
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  try {
+    const session = await getAdminSession(req);
+    if (!session || !session.user) return apiError('Acesso não autorizado.', 401);
+
+    const { searchParams } = new URL(req.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validation = querySchema.safeParse(queryParams);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      return apiError(`Parâmetros inválidos: ${errorMessage}`, 400);
+    }
+    const { since, limit } = validation.data;
+    const startDate = since || new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+    const results = await fetchTopActiveUsers(startDate, limit);
+    return NextResponse.json({ users: results }, { status: 200 });
+  } catch (err) {
+    logger.error(`${TAG} Unexpected error`, err);
+    return apiError('Erro interno no servidor.', 500);
+  }
+}

--- a/src/app/api/cron/persist-usage-counters/route.ts
+++ b/src/app/api/cron/persist-usage-counters/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Receiver } from '@upstash/qstash';
+import { logger } from '@/app/lib/logger';
+import persistUsageCounters from '@/cron/persistUsageCounters';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const currentSigningKey = process.env.QSTASH_CURRENT_SIGNING_KEY;
+const nextSigningKey = process.env.QSTASH_NEXT_SIGNING_KEY;
+
+let receiver: Receiver | null = null;
+let initError: string | null = null;
+
+if (!currentSigningKey || !nextSigningKey) {
+  initError = 'QStash signing keys not configured.';
+  logger.error(`[Cron PersistUsageCounters Init] ${initError}`);
+} else {
+  receiver = new Receiver({ currentSigningKey, nextSigningKey });
+}
+
+export async function POST(request: NextRequest) {
+  const TAG = '[Cron PersistUsageCounters]';
+
+  if (!receiver) {
+    logger.error(`${TAG} Receiver init error: ${initError}`);
+    return NextResponse.json({ error: initError }, { status: 500 });
+  }
+
+  try {
+    const signature = request.headers.get('upstash-signature');
+    if (!signature) {
+      logger.error(`${TAG} Missing signature header`);
+      return NextResponse.json({ error: 'Missing signature header' }, { status: 401 });
+    }
+    const bodyText = await request.text();
+    const isValid = await receiver.verify({ signature, body: bodyText });
+    if (!isValid) {
+      logger.error(`${TAG} Invalid signature`);
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+
+    await persistUsageCounters();
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    logger.error(`${TAG} Unexpected error`, error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/lib/dataService/index.ts
+++ b/src/app/lib/dataService/index.ts
@@ -61,4 +61,9 @@ export {
 } from './trendService';
 // -------------------------------------------------------------
 
+export {
+    fetchTopActiveUsers,
+    fetchUserUsageTrend
+} from './usageService';
+
 logger.info('[dataService][index] Módulos do dataService carregados e prontos para uso.')

--- a/src/app/lib/dataService/usageService.ts
+++ b/src/app/lib/dataService/usageService.ts
@@ -1,0 +1,43 @@
+import { PipelineStage, Types } from 'mongoose';
+import { connectToDatabase } from './connection';
+import UserUsageSnapshot from '@/app/models/UserUsageSnapshot';
+
+export async function fetchTopActiveUsers(since: Date, limit = 10) {
+  await connectToDatabase();
+
+  const pipeline: PipelineStage[] = [
+    { $match: { date: { $gte: since } } },
+    { $group: { _id: '$user', messageCount: { $sum: '$messageCount' } } },
+    { $sort: { messageCount: -1 } },
+    { $limit: limit },
+    { $lookup: { from: 'users', localField: '_id', foreignField: '_id', as: 'user' } },
+    { $unwind: '$user' },
+    {
+      $project: {
+        _id: 0,
+        userId: '$_id',
+        messageCount: 1,
+        name: '$user.name',
+        profilePictureUrl: '$user.profile_picture_url',
+      },
+    },
+  ];
+
+  return UserUsageSnapshot.aggregate(pipeline);
+}
+
+export async function fetchUserUsageTrend(userId: string, days = 30) {
+  await connectToDatabase();
+  const uid = new Types.ObjectId(userId);
+  const startDate = new Date();
+  startDate.setUTCDate(startDate.getUTCDate() - days);
+  startDate.setUTCHours(0, 0, 0, 0);
+
+  const pipeline: PipelineStage[] = [
+    { $match: { user: uid, date: { $gte: startDate } } },
+    { $sort: { date: 1 } },
+    { $project: { _id: 0, date: 1, messageCount: 1 } },
+  ];
+
+  return UserUsageSnapshot.aggregate(pipeline);
+}

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -367,6 +367,7 @@ const userSchema = new Schema<IUser>(
     userPreferences: { type: UserPreferencesSchema, default: () => ({}) },
     userLongTermGoals: { type: [UserLongTermGoalSchema], default: [] },
     userKeyFacts: { type: [UserKeyFactSchema], default: [] },
+    totalMessages: { type: Number, default: 0 },
     alertHistory: { type: [AlertHistoryEntrySchema], default: [] },
   },
   {

--- a/src/app/models/UserUsageSnapshot.ts
+++ b/src/app/models/UserUsageSnapshot.ts
@@ -1,0 +1,27 @@
+import { Schema, model, models, Document, Types, Model } from 'mongoose';
+
+export interface IUserUsageSnapshot extends Document {
+  user: Types.ObjectId;
+  date: Date;
+  messageCount: number;
+}
+
+const userUsageSnapshotSchema = new Schema<IUserUsageSnapshot>(
+  {
+    user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    date: { type: Date, required: true },
+    messageCount: { type: Number, required: true, default: 0 },
+  },
+  {
+    timestamps: true,
+    collection: 'user_usage_snapshots',
+  }
+);
+
+userUsageSnapshotSchema.index({ user: 1, date: -1 });
+
+const UserUsageSnapshotModel: Model<IUserUsageSnapshot> =
+  models.UserUsageSnapshot ||
+  model<IUserUsageSnapshot>('UserUsageSnapshot', userUsageSnapshotSchema);
+
+export default UserUsageSnapshotModel;

--- a/src/cron/persistUsageCounters.ts
+++ b/src/cron/persistUsageCounters.ts
@@ -1,0 +1,55 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { createClient } from 'redis';
+import { logger } from '@/app/lib/logger';
+import UserUsageSnapshot from '@/app/models/UserUsageSnapshot';
+import User from '@/app/models/User';
+
+const redisUrl = process.env.REDIS_URL || '';
+const redis = createClient({ url: redisUrl });
+redis.on('error', err => logger.error('[persistUsageCounters][Redis]', err));
+
+export async function persistUsageCounters() {
+  const TAG = '[cron persistUsageCounters]';
+  await connectToDatabase();
+  if (!redis.isReady) {
+    await redis.connect();
+  }
+  const keys = await redis.keys('usage:*');
+  logger.info(`${TAG} ${keys.length} usage keys found`);
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  for (const key of keys) {
+    const userId = key.split(':')[1];
+    try {
+      const countStr = await redis.get(key);
+      const count = parseInt(countStr || '0', 10);
+      if (!count || isNaN(count)) {
+        await redis.del(key);
+        continue;
+      }
+      await UserUsageSnapshot.updateOne(
+        { user: userId, date: today },
+        { $inc: { messageCount: count } },
+        { upsert: true }
+      );
+      await User.updateOne({ _id: userId }, { $inc: { totalMessages: count } });
+      await redis.del(key);
+      logger.info(`${TAG} Persisted ${count} messages for user ${userId}`);
+    } catch (e) {
+      logger.error(`${TAG} Error processing key ${key}`, e);
+    }
+  }
+}
+
+export default persistUsageCounters;
+
+if (process.argv[1] && process.argv[1].endsWith('persistUsageCounters.ts')) {
+  persistUsageCounters()
+    .catch(err => {
+      logger.error('[cron persistUsageCounters] unhandled error', err);
+    })
+    .finally(() => {
+      redis.quit();
+    });
+}


### PR DESCRIPTION
## Summary
- track daily message usage with new UserUsageSnapshot model
- store cumulative message counts in User
- cron job to persist usage counts from Redis to MongoDB
- endpoint `/api/cron/persist-usage-counters` to trigger persistence
- usage analytics service with top users and trends
- admin dashboard endpoints for usage

## Testing
- `npx jest` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_687681ccec64832eb56e41b5e9cca5b4