### PR TITLE
Restore admin dashboard endpoints

### DIFF
--- a/src/app/api/admin/dashboard/audience/region-summary/route.ts
+++ b/src/app/api/admin/dashboard/audience/region-summary/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/app/lib/logger';
+import { getAdminSession } from '@/lib/getAdminSession';
+// Importa a função de agregação de audiência
+import aggregateAudienceByRegion from '@/utils/aggregateAudienceByRegion';
+
+export const dynamic = 'force-dynamic';
+
+// --- PASSO 1: Atualizar o schema de validação ---
+// Adicionamos os novos filtros opcionais para gênero e faixa etária.
+const querySchema = z.object({
+  region: z.enum(['Norte', 'Nordeste', 'Centro-Oeste', 'Sudeste', 'Sul']).optional(),
+  gender: z.enum(['F', 'M', 'U']).optional(),
+  ageRange: z.enum(['13-17', '18-24', '25-34', '35-44', '45-54', '55-64', '65+']).optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const TAG = '[api/admin/audience/region-summary]';
+  const session = await getAdminSession(req);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Acesso não autorizado.' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const params = Object.fromEntries(searchParams.entries());
+  
+  // Valida os novos parâmetros (região, gênero e idade)
+  const validated = querySchema.safeParse(params);
+  if (!validated.success) {
+    const message = validated.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+    return NextResponse.json({ error: `Parâmetros inválidos: ${message}` }, { status: 400 });
+  }
+
+  try {
+    logger.info(`${TAG} Filtros validados para agregação de audiência:`, validated.data);
+
+    // --- PASSO 2: Passar os filtros validados para a função ---
+    // A função aggregateAudienceByRegion agora receberá os filtros de gênero e idade.
+    const data = await aggregateAudienceByRegion(validated.data);
+
+    logger.info(`${TAG} Resultado da agregação de audiência: ${data.length} estados.`);
+
+    return NextResponse.json({ states: data }, { status: 200 });
+  } catch (err) {
+    logger.error(`${TAG} erro inesperado`, err);
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/demographics/route.ts
+++ b/src/app/api/admin/dashboard/demographics/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const data = await aggregatePlatformDemographics();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/highlights/performance-summary/route.ts
+++ b/src/app/api/admin/dashboard/highlights/performance-summary/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPerformanceHighlights';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { aggregatePlatformDayPerformance } from '@/utils/aggregatePlatformDayPerformance';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+interface PerformanceHighlight {
+  name: string;
+  metricName: string;
+  value: number;
+  valueFormatted: string;
+  postsCount?: number;
+}
+interface PlatformPerformanceSummaryResponse {
+  topPerformingFormat: PerformanceHighlight | null;
+  lowPerformingFormat: PerformanceHighlight | null;
+  topPerformingContext: PerformanceHighlight | null;
+  topPerformingProposal: PerformanceHighlight | null;
+  topPerformingTone: PerformanceHighlight | null;
+  topPerformingReference: PerformanceHighlight | null;
+  bestDay: { dayOfWeek: number; average: number } | null;
+  insightSummary: string;
+}
+const DEFAULT_PERFORMANCE_METRIC_LABEL = 'Interações (média por post)';
+
+function formatPerformanceValue(value: number, metricFieldId: string): string {
+  if (metricFieldId.includes('Rate') || metricFieldId.includes('percentage')) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
+  return value.toFixed(0);
+}
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+function getPortugueseWeekdayNameForSummary(day: number): string {
+  const days = ['Domingo','Segunda-feira','Terça-feira','Quarta-feira','Quinta-feira','Sexta-feira','Sábado'];
+  return days[day - 1] || '';
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_90_days';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  const performanceMetricField = 'stats.total_interactions';
+  const performanceMetricLabel = DEFAULT_PERFORMANCE_METRIC_LABEL;
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const [aggResult, dayAgg] = await Promise.all([
+    aggregatePlatformPerformanceHighlights(periodInDaysValue, performanceMetricField),
+    aggregatePlatformDayPerformance(periodInDaysValue, performanceMetricField, {})
+  ]);
+  const bestDay = dayAgg.bestDays[0] || null;
+  const response: PlatformPerformanceSummaryResponse = {
+    topPerformingFormat: aggResult.topFormat ? { name: aggResult.topFormat.name as string, metricName: performanceMetricLabel, value: aggResult.topFormat.average, valueFormatted: formatPerformanceValue(aggResult.topFormat.average, performanceMetricField), postsCount: aggResult.topFormat.count } : null,
+    lowPerformingFormat: aggResult.lowFormat ? { name: aggResult.lowFormat.name as string, metricName: performanceMetricLabel, value: aggResult.lowFormat.average, valueFormatted: formatPerformanceValue(aggResult.lowFormat.average, performanceMetricField), postsCount: aggResult.lowFormat.count } : null,
+    topPerformingContext: aggResult.topContext ? { name: aggResult.topContext.name as string, metricName: performanceMetricLabel, value: aggResult.topContext.average, valueFormatted: formatPerformanceValue(aggResult.topContext.average, performanceMetricField), postsCount: aggResult.topContext.count } : null,
+    topPerformingProposal: aggResult.topProposal ? { name: aggResult.topProposal.name as string, metricName: performanceMetricLabel, value: aggResult.topProposal.average, valueFormatted: formatPerformanceValue(aggResult.topProposal.average, performanceMetricField), postsCount: aggResult.topProposal.count } : null,
+    topPerformingTone: aggResult.topTone ? { name: aggResult.topTone.name as string, metricName: performanceMetricLabel, value: aggResult.topTone.average, valueFormatted: formatPerformanceValue(aggResult.topTone.average, performanceMetricField), postsCount: aggResult.topTone.count } : null,
+    topPerformingReference: aggResult.topReference ? { name: aggResult.topReference.name as string, metricName: performanceMetricLabel, value: aggResult.topReference.average, valueFormatted: formatPerformanceValue(aggResult.topReference.average, performanceMetricField), postsCount: aggResult.topReference.count } : null,
+    bestDay: bestDay ? { dayOfWeek: bestDay.dayOfWeek, average: bestDay.average } : null,
+    insightSummary: ''
+  };
+  const insights: string[] = [];
+  if (response.topPerformingFormat) insights.push(`O formato de melhor performance é ${response.topPerformingFormat.name} (${response.topPerformingFormat.valueFormatted} de média).`);
+  if (response.topPerformingContext) insights.push(`${response.topPerformingContext.name} é o contexto de melhor performance (${response.topPerformingContext.valueFormatted} de média).`);
+  if (response.topPerformingProposal) insights.push(`${response.topPerformingProposal.name} é a proposta de melhor desempenho (${response.topPerformingProposal.valueFormatted} de média).`);
+  if (response.bestDay) {
+    const dayName = getPortugueseWeekdayNameForSummary(response.bestDay.dayOfWeek);
+    insights.push(`O melhor dia para postar é ${dayName}, com média de ${response.bestDay.average.toFixed(1)} interações por post.`);
+  }
+  if (response.lowPerformingFormat && response.lowPerformingFormat.name !== response.topPerformingFormat?.name) {
+    insights.push(`O formato ${response.lowPerformingFormat.name} tem performance mais baixa (${response.lowPerformingFormat.valueFormatted}).`);
+  }
+  response.insightSummary = insights.join(' ');
+  if (insights.length === 0) {
+    response.insightSummary = 'Não há dados suficientes para gerar insights de performance no período selecionado.';
+  }
+  return NextResponse.json(camelizeKeys(response), { status: 200 });
+}

--- a/src/app/api/admin/dashboard/performance/average-engagement/route.ts
+++ b/src/app/api/admin/dashboard/performance/average-engagement/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import MetricModel, { IMetric } from '@/app/models/Metric';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { getNestedValue } from '@/utils/dataAccessHelpers';
+import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
+import {
+  ALLOWED_TIME_PERIODS,
+  ALLOWED_ENGAGEMENT_METRICS,
+  TimePeriod,
+  EngagementMetricField,
+} from '@/app/lib/constants/timePeriods';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+// Tipo local para agrupamento
+type GroupingType = 'format' | 'context' | 'proposal';
+
+// Constantes para validação e defaults
+const ALLOWED_GROUPINGS: GroupingType[] = ['format', 'context', 'proposal'];
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod') as TimePeriod | null;
+  const engagementMetricParam = searchParams.get('engagementMetricField') as EngagementMetricField | null;
+  const groupByParam = searchParams.get('groupBy') as GroupingType | null;
+  // ✅ PASSO 1: LER O NOVO PARÂMETRO 'limit' DA URL
+  const limitParam = searchParams.get('limit');
+
+  // Validar timePeriod
+  const timePeriod: TimePeriod = timePeriodParam && ALLOWED_TIME_PERIODS.includes(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+  if (timePeriodParam && !ALLOWED_TIME_PERIODS.includes(timePeriodParam)) {
+    return NextResponse.json({ error: `timePeriod inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  // Validar engagementMetricField
+  const engagementMetric: EngagementMetricField = engagementMetricParam && ALLOWED_ENGAGEMENT_METRICS.includes(engagementMetricParam)
+    ? engagementMetricParam
+    : 'stats.total_interactions';
+  if (engagementMetricParam && !ALLOWED_ENGAGEMENT_METRICS.includes(engagementMetricParam)) {
+    return NextResponse.json({ error: `engagementMetricField inválido. Permitidos: ${ALLOWED_ENGAGEMENT_METRICS.join(', ')}` }, { status: 400 });
+  }
+
+  // Validar groupBy
+  const groupBy: GroupingType = groupByParam && ALLOWED_GROUPINGS.includes(groupByParam)
+    ? groupByParam
+    : 'format';
+  if (groupByParam && !ALLOWED_GROUPINGS.includes(groupByParam)) {
+    return NextResponse.json({ error: `groupBy inválido. Permitidos: ${ALLOWED_GROUPINGS.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    await connectToDatabase();
+
+    const activeUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    const activeIds = activeUsers.map(u => u._id);
+
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+    const startDate = getStartDateFromTimePeriod(today, timePeriod);
+
+    const query: any = {};
+    if (activeIds.length > 0) {
+      query.user = { $in: activeIds };
+    }
+    if (timePeriod !== 'all_time') {
+      query.postDate = { $gte: startDate, $lte: endDate };
+    }
+
+    const posts: IMetric[] = await MetricModel.find(query).lean();
+
+    const performanceByGroup: Record<string, { sumPerformance: number; count: number }> = {};
+    for (const post of posts) {
+      const groupKey = groupBy === 'format' ? post.format : groupBy === 'context' ? post.context : post.proposal;
+      const metricValue = getNestedValue(post, engagementMetric);
+      if (groupKey && metricValue !== null) {
+        // Corrigido para lidar com arrays e strings
+        const keys = Array.isArray(groupKey) ? groupKey : [groupKey];
+        for (const key of keys) {
+            if (!performanceByGroup[key]) {
+                performanceByGroup[key] = { sumPerformance: 0, count: 0 };
+            }
+            performanceByGroup[key].sumPerformance += metricValue;
+            performanceByGroup[key].count += 1;
+        }
+      }
+    }
+
+    // ✅ Usamos 'let' para que a variável possa ser modificada
+    let results = Object.entries(performanceByGroup).map(([key, data]) => ({
+      name: key,
+      value: data.sumPerformance / data.count,
+      postsCount: data.count,
+    })).sort((a, b) => b.value - a.value);
+
+    // ✅ PASSO 2: APLICAR O LIMITE SE ELE FOI FORNECIDO
+    if (limitParam) {
+      const limit = parseInt(limitParam, 10);
+      // Garante que o limite é um número válido e positivo
+      if (!isNaN(limit) && limit > 0) {
+        // Usa slice() para pegar apenas os N primeiros itens do array já ordenado
+        results = results.slice(0, limit);
+      }
+    }
+
+    // Retorna dados
+    return NextResponse.json({ chartData: results, metricUsed: engagementMetric, groupBy }, { status: 200 });
+  } catch (error) {
+    logger.error('[API PLATFORM/PERFORMANCE/AVERAGE-ENGAGEMENT] Error:', error);
+    return NextResponse.json({ error: 'Erro ao processar engajamento médio agrupado.', details: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/performance/time-distribution/route.ts
+++ b/src/app/api/admin/dashboard/performance/time-distribution/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { getCategoryById } from '@/app/lib/classification';
+import { aggregatePlatformTimePerformance } from '@/utils/aggregatePlatformTimePerformance';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+function getPortugueseWeekdayName(day: number): string {
+  const days = ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado'];
+  return days[day - 1] || '';
+}
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam!
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const metricField = metricParam || 'stats.total_interactions';
+
+  const result = await aggregatePlatformTimePerformance(
+    periodInDaysValue,
+    metricField,
+    {
+      format: formatParam || undefined,
+      proposal: proposalParam || undefined,
+      context: contextParam || undefined,
+    },
+  );
+
+  const best = result.bestSlots[0];
+  const worst = result.worstSlots[0];
+  let summary = '';
+  if (best) {
+    const dayName = getPortugueseWeekdayName(best.dayOfWeek).toLowerCase();
+    const bestAvg = best.average.toLocaleString('pt-BR', { maximumFractionDigits: 1 });
+    summary += `O pico de performance ocorre ${dayName} às ${best.hour}h, com uma média de ${bestAvg} de engajamento por post.`;
+  }
+  if (worst) {
+    const dayName = getPortugueseWeekdayName(worst.dayOfWeek).toLowerCase();
+    summary += ` O menor desempenho é ${dayName} às ${worst.hour}h.`;
+  }
+
+  const filterLabels: string[] = [];
+  if (formatParam) filterLabels.push(getCategoryById(formatParam, 'format')?.label || formatParam);
+  if (proposalParam) filterLabels.push(getCategoryById(proposalParam, 'proposal')?.label || proposalParam);
+  if (contextParam) filterLabels.push(getCategoryById(contextParam, 'context')?.label || contextParam);
+  if (filterLabels.length > 0 && summary) {
+    summary = `Para posts sobre ${filterLabels.join(' e ')}, ${summary.charAt(0).toLowerCase() + summary.slice(1)}`;
+  }
+
+  return NextResponse.json(camelizeKeys({ ...result, insightSummary: summary }), { status: 200 });
+}

--- a/src/app/api/admin/dashboard/platform-kpis/periodic-comparison/route.ts
+++ b/src/app/api/admin/dashboard/platform-kpis/periodic-comparison/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import AccountInsightModel from '@/app/models/AccountInsight';
+import MetricModel from '@/app/models/Metric'; // Importar MetricModel
+import calculateAverageEngagementPerPost from '@/utils/calculateAverageEngagementPerPost'; // Usado para engajamento
+import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneric } from '@/utils/dateHelpers';
+import { Types } from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+// Tipos de dados para a resposta
+interface MiniChartDataPoint {
+  name: string; // Ex: "Anterior", "Atual"
+  value: number;
+  // periodKey?: string; // Opcional, se o frontend precisar para algo
+  // comparisonPair?: string; // Opcional
+}
+
+interface KPIComparisonData {
+  currentValue: number | null;
+  previousValue: number | null;
+  percentageChange: number | null;
+  chartData?: MiniChartDataPoint[];
+}
+
+interface PlatformPeriodicComparisonResponse {
+  platformFollowerGrowth: KPIComparisonData;
+  platformTotalEngagement: KPIComparisonData;
+  platformPostingFrequency: KPIComparisonData;
+  platformActiveCreators: KPIComparisonData;
+  insightSummary?: {
+    platformFollowerGrowth?: string;
+    platformTotalEngagement?: string;
+    platformPostingFrequency?: string;
+    platformActiveCreators?: string;
+  };
+}
+
+const ALLOWED_COMPARISON_PERIODS: { [key: string]: { currentPeriodDays: number, periodNameCurrent: string, periodNamePrevious: string } } = {
+  "month_vs_previous": { currentPeriodDays: 30, periodNameCurrent: "Este Mês", periodNamePrevious: "Mês Passado"},
+  "last_7d_vs_previous_7d": { currentPeriodDays: 7, periodNameCurrent: "Últimos 7 Dias", periodNamePrevious: "7 Dias Anteriores"},
+  "last_30d_vs_previous_30d": { currentPeriodDays: 30, periodNameCurrent: "Últimos 30 Dias", periodNamePrevious: "30 Dias Anteriores"},
+};
+
+function calculatePercentageChange(current: number | null, previous: number | null): number | null {
+  if (current === null || previous === null) return null;
+  if (previous === 0) {
+    return current > 0 ? 1.0 : (current === 0 ? 0.0 : -1.0);
+  }
+  return (current - previous) / previous;
+}
+
+async function getPlatformTotalFollowersAtDate(date: Date, userIds: Types.ObjectId[]): Promise<number> {
+    const userFollowerPromises = userIds.map(async (userId) => {
+        const snapshot = await AccountInsightModel.findOne({
+            user: userId,
+            recordedAt: { $lte: date }
+        }).sort({ recordedAt: -1 }).select('followersCount').lean();
+        return snapshot?.followersCount || 0;
+    });
+    const userFollowersCounts = await Promise.all(userFollowerPromises);
+    return userFollowersCounts.reduce((sum, count) => sum + count, 0);
+}
+
+async function getPlatformTotalPostsInPeriod(startDate: Date, endDate: Date, userIds: Types.ObjectId[]): Promise<number> {
+    // TODO: Considerar apenas posts de usuários ativos da plataforma
+    const count = await MetricModel.countDocuments({
+        user: { $in: userIds },
+        postDate: { $gte: startDate, $lte: endDate }
+    });
+    return count;
+}
+
+async function getTotalActiveCreatorsAtDate(date: Date, userIds: Types.ObjectId[]): Promise<number> {
+    if (userIds.length === 0) return 0;
+    return UserModel.countDocuments({ _id: { $in: userIds }, createdAt: { $lte: date } });
+}
+
+
+export async function GET(
+  request: NextRequest
+) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const comparisonPeriodParam = searchParams.get('comparisonPeriod');
+
+  const comparisonConfig = comparisonPeriodParam && ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]
+    ? ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]
+    : ALLOWED_COMPARISON_PERIODS["last_30d_vs_previous_30d"];
+
+  if (comparisonPeriodParam && !ALLOWED_COMPARISON_PERIODS[comparisonPeriodParam]) {
+     return NextResponse.json({ error: `Comparison period inválido. Permitidos: ${Object.keys(ALLOWED_COMPARISON_PERIODS).join(', ')}` }, { status: 400 });
+  }
+
+  const { currentPeriodDays, periodNameCurrent, periodNamePrevious } = comparisonConfig!; // Adicionado periodNameCurrent/Previous
+  const today = new Date();
+
+  const currentEndDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+  const currentStartDate = getStartDateFromTimePeriodGeneric(today, `last_${currentPeriodDays}_days`);
+
+  const previousEndDate = addDays(new Date(currentStartDate), -1);
+  previousEndDate.setHours(23,59,59,999);
+  const previousStartDate = addDays(new Date(previousEndDate), -(currentPeriodDays -1));
+  previousStartDate.setHours(0,0,0,0);
+
+  try {
+    await connectToDatabase();
+    const platformUsers = await UserModel.find().select('_id').lean();
+
+    if (!platformUsers || platformUsers.length === 0) {
+      const emptyKpi: KPIComparisonData = { currentValue: 0, previousValue: 0, percentageChange: 0, chartData: [{name: periodNamePrevious, value:0}, {name: periodNameCurrent, value:0}]};
+      return NextResponse.json({
+        platformFollowerGrowth: emptyKpi,
+        platformTotalEngagement: emptyKpi,
+        platformPostingFrequency: emptyKpi,
+        platformActiveCreators: emptyKpi,
+        insightSummary: {
+            platformFollowerGrowth: "Nenhum usuário na plataforma.",
+            platformTotalEngagement: "Nenhum usuário na plataforma.",
+            platformPostingFrequency: "Nenhum usuário na plataforma.",
+            platformActiveCreators: "Nenhum usuário na plataforma."
+        }
+      }, { status: 200 });
+    }
+    const userIds = platformUsers.map(user => user._id as Types.ObjectId);
+
+    // --- Platform Follower Growth ---
+    const followersT0 = await getPlatformTotalFollowersAtDate(currentEndDate, userIds);
+    const followersT1 = await getPlatformTotalFollowersAtDate(previousEndDate, userIds);
+    const dayBeforePreviousStartDate = addDays(new Date(previousStartDate), -1);
+    dayBeforePreviousStartDate.setHours(23,59,59,999);
+    const followersT2 = await getPlatformTotalFollowersAtDate(dayBeforePreviousStartDate, userIds);
+
+    const currentFollowerGainPlatform = followersT0 - followersT1;
+    const previousFollowerGainPlatform = followersT1 - followersT2;
+
+    const followerGrowthData: KPIComparisonData = {
+      currentValue: currentFollowerGainPlatform,
+      previousValue: previousFollowerGainPlatform,
+      percentageChange: calculatePercentageChange(currentFollowerGainPlatform, previousFollowerGainPlatform),
+      chartData: [
+        { name: periodNamePrevious, value: previousFollowerGainPlatform ?? 0 },
+        { name: periodNameCurrent, value: currentFollowerGainPlatform ?? 0 }
+      ]
+    };
+
+    // --- Platform Total Engagement ---
+    let currentPlatformTotalEngagement = 0;
+    let previousPlatformTotalEngagement = 0;
+
+    const engagementPromisesCurrent = userIds.map(uid =>
+        calculateAverageEngagementPerPost(uid, {startDate: currentStartDate, endDate: currentEndDate})
+    );
+    const engagementResultsCurrent = await Promise.allSettled(engagementPromisesCurrent);
+    engagementResultsCurrent.forEach(result => {
+        if (result.status === 'fulfilled') currentPlatformTotalEngagement += result.value.totalEngagement;
+        else console.error("Error fetching current engagement for a user:", result.reason);
+    });
+
+    const engagementPromisesPrevious = userIds.map(uid =>
+        calculateAverageEngagementPerPost(uid, {startDate: previousStartDate, endDate: previousEndDate})
+    );
+    const engagementResultsPrevious = await Promise.allSettled(engagementPromisesPrevious);
+    engagementResultsPrevious.forEach(result => {
+        if (result.status === 'fulfilled') previousPlatformTotalEngagement += result.value.totalEngagement;
+        else console.error("Error fetching previous engagement for a user:", result.reason);
+    });
+
+    const totalEngagementData: KPIComparisonData = {
+      currentValue: currentPlatformTotalEngagement,
+      previousValue: previousPlatformTotalEngagement,
+      percentageChange: calculatePercentageChange(currentPlatformTotalEngagement, previousPlatformTotalEngagement),
+      chartData: [
+        { name: periodNamePrevious, value: previousPlatformTotalEngagement ?? 0 },
+        { name: periodNameCurrent, value: currentPlatformTotalEngagement ?? 0 }
+      ]
+    };
+
+    // --- Platform Posting Frequency ---
+    const currentTotalPostsPlatform = await getPlatformTotalPostsInPeriod(currentStartDate, currentEndDate, userIds);
+    const previousTotalPostsPlatform = await getPlatformTotalPostsInPeriod(previousStartDate, previousEndDate, userIds);
+
+    // Número de dias nos períodos (deve ser currentPeriodDays para ambos, mas calcular para precisão)
+    const daysInCurrentPeriod = (currentEndDate.getTime() - currentStartDate.getTime()) / (1000 * 3600 * 24) + 1;
+    const daysInPreviousPeriod = (previousEndDate.getTime() - previousStartDate.getTime()) / (1000 * 3600 * 24) + 1;
+
+    const currentPlatformWeeklyFreq = daysInCurrentPeriod > 0 ? (currentTotalPostsPlatform / daysInCurrentPeriod) * 7 : 0;
+    const previousPlatformWeeklyFreq = daysInPreviousPeriod > 0 ? (previousTotalPostsPlatform / daysInPreviousPeriod) * 7 : 0;
+
+    const postingFrequencyData: KPIComparisonData = {
+        currentValue: currentPlatformWeeklyFreq,
+        previousValue: previousPlatformWeeklyFreq,
+        percentageChange: calculatePercentageChange(currentPlatformWeeklyFreq, previousPlatformWeeklyFreq),
+        chartData: [
+            { name: periodNamePrevious, value: previousPlatformWeeklyFreq ? parseFloat(previousPlatformWeeklyFreq.toFixed(1)) : 0 },
+            { name: periodNameCurrent, value: currentPlatformWeeklyFreq ? parseFloat(currentPlatformWeeklyFreq.toFixed(1)) : 0 }
+        ]
+    };
+
+    // --- Platform Active Creators ---
+    const currentActiveCreators = await getTotalActiveCreatorsAtDate(currentEndDate, userIds);
+    const previousActiveCreators = await getTotalActiveCreatorsAtDate(previousEndDate, userIds);
+
+    const activeCreatorsData: KPIComparisonData = {
+        currentValue: currentActiveCreators,
+        previousValue: previousActiveCreators,
+        percentageChange: calculatePercentageChange(currentActiveCreators, previousActiveCreators),
+        chartData: [
+            { name: periodNamePrevious, value: previousActiveCreators ?? 0 },
+            { name: periodNameCurrent, value: currentActiveCreators ?? 0 }
+        ]
+    };
+
+    const response: PlatformPeriodicComparisonResponse = {
+      platformFollowerGrowth: followerGrowthData,
+      platformTotalEngagement: totalEngagementData,
+      platformPostingFrequency: postingFrequencyData,
+      platformActiveCreators: activeCreatorsData,
+      insightSummary: {
+          platformFollowerGrowth: `Crescimento de seguidores da plataforma: ${followerGrowthData.currentValue?.toLocaleString() ?? 'N/A'} vs ${followerGrowthData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`,
+          platformTotalEngagement: `Engajamento total da plataforma: ${totalEngagementData.currentValue?.toLocaleString() ?? 'N/A'} vs ${totalEngagementData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`,
+          platformPostingFrequency: `Frequência de posts da plataforma: ${postingFrequencyData.currentValue?.toFixed(1) ?? 'N/A'} posts/sem vs ${postingFrequencyData.previousValue?.toFixed(1) ?? 'N/A'} no período anterior.`,
+          platformActiveCreators: `Criadores ativos na plataforma: ${activeCreatorsData.currentValue?.toLocaleString() ?? 'N/A'} vs ${activeCreatorsData.previousValue?.toLocaleString() ?? 'N/A'} no período anterior.`
+      }
+    };
+
+    return NextResponse.json(response, { status: 200 });
+
+  } catch (error) {
+    console.error("[API PLATFORM/KPIS/PERIODIC] Error fetching platform periodic comparison KPIs:", error);
+    const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
+    const errorKpi: KPIComparisonData = { currentValue: null, previousValue: null, percentageChange: null, chartData: [{name: periodNamePrevious, value:0}, {name: periodNameCurrent, value:0}]};
+    return NextResponse.json({
+        error: "Erro ao processar sua solicitação de KPIs da plataforma.",
+        details: errorMessage,
+        platformFollowerGrowth: errorKpi,
+        platformTotalEngagement: errorKpi,
+        platformPostingFrequency: errorKpi,
+        platformActiveCreators: errorKpi,
+     }, { status: 500 });
+  }
+}
+

--- a/src/app/api/admin/dashboard/platform-kpis/summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-kpis/summary/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User'; // Descomentado para contagem real
+import { connectToDatabase } from '@/app/lib/mongoose'; // Added
+import { logger } from '@/app/lib/logger'; // Added
+import { getAdminSession } from '@/lib/getAdminSession';
+
+// Interface para a resposta do endpoint
+interface PlatformKpisSummaryResponse {
+  totalActiveCreators: number;
+  // Adicionar outras KPIs de resumo da plataforma aqui no futuro, se necessário
+  // totalPostsLast30Days: number;
+  // totalEngagementLast30Days: number;
+  insightSummary?: string;
+}
+
+export async function GET(
+  request: NextRequest
+) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    await connectToDatabase(); // Added
+
+    // Definição de "criador ativo" - pode ser ajustada conforme as regras de negócio
+    // Exemplo: status não é 'inactive' ou 'suspended', e teve atividade recente (não implementado aqui)
+    const activeCreatorCriteria = {
+      // status: { $nin: ['inactive', 'suspended', 'pending_approval'] },
+    };
+
+    const activeCreatorsCount = await UserModel.countDocuments(activeCreatorCriteria);
+
+    const response: PlatformKpisSummaryResponse = {
+      totalActiveCreators: activeCreatorsCount,
+      insightSummary: `Total de ${activeCreatorsCount.toLocaleString()} criadores na plataforma.`
+                       // Poderia adicionar "ativos" se os critérios fossem mais específicos.
+    };
+    return NextResponse.json(response, { status: 200 });
+
+  } catch (error) {
+    logger.error("[API PLATFORM/KPIS/SUMMARY] Error fetching platform summary KPIs:", error); // Replaced console.error
+    const errorMessage = error instanceof Error ? error.message : "Erro desconhecido";
+    // Retornar um valor padrão ou um erro claro se a contagem falhar
+    return NextResponse.json({
+        error: "Erro ao buscar KPIs da plataforma.",
+        details: errorMessage,
+        totalActiveCreators: null, // Indicar que o valor não pôde ser obtido
+        insightSummary: "Não foi possível obter o número total de criadores."
+    }, { status: 500 });
+  }
+}
+

--- a/src/app/api/admin/dashboard/platform-summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.ts
@@ -3,67 +3,45 @@ import { z } from 'zod';
 import { logger } from '@/app/lib/logger';
 import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 import { DatabaseError } from '@/app/lib/errors';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
-
+import { getAdminSession } from '@/lib/getAdminSession';
 
 const TAG = '/api/admin/dashboard/platform-summary';
 
-// Zod schema for optional query parameters
 const querySchema = z.object({
-  startDate: z.string().datetime({ message: "Invalid start date format. Expected ISO 8601 string." }).optional(),
-  endDate: z.string().datetime({ message: "Invalid end date format. Expected ISO 8601 string." }).optional(),
+  startDate: z.string().datetime({ message: 'Invalid start date format. Expected ISO 8601 string.' }).optional(),
+  endDate: z.string().datetime({ message: 'Invalid end date format. Expected ISO 8601 string.' }).optional(),
 }).superRefine((data, ctx) => {
   if (data.startDate && !data.endDate) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "endDate is required if startDate is provided.",
-      path: ["endDate"],
-    });
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'endDate is required if startDate is provided.', path: ['endDate'] });
   }
   if (!data.startDate && data.endDate) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "startDate is required if endDate is provided.",
-      path: ["startDate"],
-    });
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'startDate is required if endDate is provided.', path: ['startDate'] });
   }
   if (data.startDate && data.endDate && new Date(data.startDate) > new Date(data.endDate)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "endDate cannot be earlier than startDate.",
-      path: ["endDate"],
-    });
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'endDate cannot be earlier than startDate.', path: ['endDate'] });
   }
 });
 
 export async function GET(req: NextRequest) {
   logger.info(`${TAG} Request received`);
 
-  // 1. Admin Session Validation
-  const session = await getServerSession(authOptions);
-  
-  if (!session || !session.user || session.user.role !== 'admin') {
+  const session = await getAdminSession(req);
+  if (!session || !session.user) {
     logger.warn(`${TAG} Unauthorized access attempt.`);
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  logger.info(`${TAG} Admin session validated for user: ${session.user.id}`);
 
 
-  // 2. Validate Query Parameters
   const { searchParams } = new URL(req.url);
   const queryParamsFromUrl = {
     startDate: searchParams.get('startDate') || undefined,
     endDate: searchParams.get('endDate') || undefined,
   };
-
-  // Remove undefined fields before validation if they are truly optional and not just empty strings
   const definedQueryParams: any = {};
   if (queryParamsFromUrl.startDate) definedQueryParams.startDate = queryParamsFromUrl.startDate;
   if (queryParamsFromUrl.endDate) definedQueryParams.endDate = queryParamsFromUrl.endDate;
 
   const validationResult = querySchema.safeParse(definedQueryParams);
-
   if (!validationResult.success) {
     logger.warn(`${TAG} Invalid query parameters:`, validationResult.error.flatten());
     return NextResponse.json({ error: 'Invalid query parameters', details: validationResult.error.flatten() }, { status: 400 });
@@ -71,33 +49,19 @@ export async function GET(req: NextRequest) {
 
   let dateRange;
   if (validationResult.data.startDate && validationResult.data.endDate) {
-    dateRange = {
-      startDate: new Date(validationResult.data.startDate),
-      endDate: new Date(validationResult.data.endDate),
-    };
+    dateRange = { startDate: new Date(validationResult.data.startDate), endDate: new Date(validationResult.data.endDate) };
   }
 
   logger.info(`${TAG} Query parameters validated. Date range: ${dateRange ? JSON.stringify(dateRange) : 'Not provided'}`);
 
   try {
-    // 3. Call Service Function
-    logger.info(`${TAG} Calling fetchPlatformSummary service`);
-    const summaryData = await fetchPlatformSummary({ dateRange }); // Pass dateRange (which might be undefined)
-    logger.info(`${TAG} Successfully fetched platform summary data.`);
-
-    // 4. Return Data
+    const summaryData = await fetchPlatformSummary({ dateRange });
     return NextResponse.json(summaryData, { status: 200 });
-
   } catch (error: any) {
-    logger.error(`${TAG} Error in request handler:`, {
-      message: error.message,
-      stack: error.stack,
-    });
-
+    logger.error(`${TAG} Error in request handler:`, { message: error.message, stack: error.stack });
     if (error instanceof DatabaseError) {
       return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });
     }
-
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/src/app/api/admin/dashboard/trends/follower-change/route.ts
+++ b/src/app/api/admin/dashboard/trends/follower-change/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import getFollowerDailyChangeData from '@/charts/getFollowerDailyChangeData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+interface ApiChangePoint { date: string; change: number | null; }
+interface FollowerChangeResponse { chartData: ApiChangePoint[]; insightSummary?: string; }
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_30_days';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers || agencyUsers.length === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum usuário encontrado para agregar dados.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const BATCH_SIZE = 50;
+    const results: PromiseSettledResult<FollowerChangeResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batchIds.map(id => getFollowerDailyChangeData(id.toString(), timePeriod));
+      const batchRes = await Promise.allSettled(batchPromises);
+      results.push(...batchRes);
+    }
+    const aggregatedByDate = new Map<string, number>();
+    results.forEach(r => {
+      if (r.status === 'fulfilled' && r.value) {
+        r.value.chartData.forEach(p => {
+          if (p.change !== null) {
+            const curr = aggregatedByDate.get(p.date) || 0;
+            aggregatedByDate.set(p.date, curr + p.change);
+          }
+        });
+      } else if (r.status === 'rejected') {
+        logger.error('Erro ao buscar mudança de seguidores para um usuário:', r.reason);
+      }
+    });
+    if (aggregatedByDate.size === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum dado de seguidores encontrado para os usuários no período.' }, { status: 200 });
+    }
+    const chartData: ApiChangePoint[] = Array.from(aggregatedByDate.entries())
+      .map(([date, change]) => ({ date, change }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+    let insight = 'Dados de variação diária de seguidores da plataforma.';
+    if (chartData.length > 0) {
+      const totalChange = chartData.reduce((acc, p) => acc + (p.change ?? 0), 0);
+      const periodText = timePeriod === 'all_time' ? 'todo o período' : timePeriod.replace('last_', 'últimos ').replace('_days', ' dias').replace('_months', ' meses');
+      if (totalChange > 0) {
+        insight = `A plataforma ganhou ${totalChange.toLocaleString()} seguidores nos ${periodText}.`;
+      } else if (totalChange < 0) {
+        insight = `A plataforma perdeu ${Math.abs(totalChange).toLocaleString()} seguidores nos ${periodText}.`;
+      } else {
+        insight = `Sem mudança no total de seguidores da plataforma nos ${periodText}.`;
+      }
+    }
+    return NextResponse.json({ chartData, insightSummary: insight }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/FOLLOWER-CHANGE] Error aggregating agency follower change:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/trends/followers/route.ts
+++ b/src/app/api/admin/dashboard/trends/followers/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse, NextRequest } from 'next/server';
+import UserModel from '@/app/models/User';
+import getFollowerTrendChartData from '@/charts/getFollowerTrendChartData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+interface ApiChartDataPoint {
+  date: string;
+  value: number | null;
+}
+
+interface FollowerTrendChartResponse {
+  chartData: ApiChartDataPoint[];
+  insightSummary?: string;
+}
+
+const ALLOWED_GRANULARITIES = ['daily', 'monthly'];
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const granularityParam = searchParams.get('granularity');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam
+    : 'last_30_days';
+  const granularity =
+    granularityParam && ALLOWED_GRANULARITIES.includes(granularityParam)
+      ? (granularityParam as 'daily' | 'monthly')
+      : 'daily';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json(
+      { error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  if (granularityParam && !ALLOWED_GRANULARITIES.includes(granularityParam)) {
+    return NextResponse.json(
+      { error: `Granularity inválida. Permitidas: ${ALLOWED_GRANULARITIES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await connectToDatabase();
+    const session = await getAdminSession(request);
+
+    if (!session || !session.user) {
+      logger.warn('[API ADMIN/TRENDS/FOLLOWERS] Unauthorized access attempt.');
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const users = await UserModel.find({ planStatus: 'active' })
+      .select('_id')
+      .lean();
+
+    if (!users || users.length === 0) {
+      return NextResponse.json(
+        {
+          chartData: [],
+          insightSummary: 'Nenhum usuário encontrado para agregar dados.',
+        },
+        { status: 200 }
+      );
+    }
+
+    const userIds = users.map((u) => u._id);
+
+    const BATCH_SIZE = 50;
+    const userTrendResults: PromiseSettledResult<FollowerTrendChartResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batchIds.map((id) =>
+        getFollowerTrendChartData(id.toString(), timePeriod, granularity)
+      );
+      const batchResults = await Promise.allSettled(batchPromises);
+      userTrendResults.push(...batchResults);
+    }
+
+    const aggregatedFollowersByDate = new Map<string, number>();
+    userTrendResults.forEach((result) => {
+      if (result.status === 'fulfilled' && result.value && result.value.chartData) {
+        result.value.chartData.forEach((d) => {
+          if (d.value !== null && d.date) {
+            const current = aggregatedFollowersByDate.get(d.date) || 0;
+            aggregatedFollowersByDate.set(d.date, current + d.value);
+          }
+        });
+      } else if (result.status === 'rejected') {
+        logger.error('Erro ao buscar dados de tendência para um usuário:', result.reason);
+      }
+    });
+
+    if (aggregatedFollowersByDate.size === 0) {
+      return NextResponse.json(
+        {
+          chartData: [],
+          insightSummary: 'Nenhum dado de seguidores encontrado para os usuários no período.',
+        },
+        { status: 200 }
+      );
+    }
+
+    const chartData: ApiChartDataPoint[] = Array.from(aggregatedFollowersByDate.entries())
+      .map(([date, total]) => ({ date, value: total }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let insight = 'Dados de tendência de seguidores dos usuários da plataforma.';
+    if (chartData.length > 0) {
+      const first = chartData[0];
+      const last = chartData[chartData.length - 1];
+      if (first && last && first.value !== null && last.value !== null) {
+        const diff = last.value - first.value;
+        const periodText = timePeriod
+          .replace('last_', 'últimos ')
+          .replace('_days', ' dias')
+          .replace('_months', ' meses');
+        const displayPeriod = timePeriod === 'all_time' ? 'todo o período' : `nos ${periodText}`;
+        if (diff > 0) {
+          insight = `Os usuários ganharam ${diff.toLocaleString()} seguidores ${displayPeriod}.`;
+        } else if (diff < 0) {
+          insight = `Os usuários perderam ${Math.abs(diff).toLocaleString()} seguidores ${displayPeriod}.`;
+        } else {
+          insight = `Sem mudança no total de seguidores ${displayPeriod}.`;
+        }
+      } else if (last && last.value !== null) {
+        insight = `Total de ${last.value.toLocaleString()} seguidores ao final do período.`;
+      }
+    }
+
+    const response: FollowerTrendChartResponse = {
+      chartData,
+      insightSummary: insight,
+    };
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    logger.error('[API ADMIN/TRENDS/FOLLOWERS] Error aggregating follower trend:', error);
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/trends/moving-average-engagement/route.ts
+++ b/src/app/api/admin/dashboard/trends/moving-average-engagement/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import MetricModel from '@/app/models/Metric';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { addDays, formatDateYYYYMMDD } from '@/utils/dateHelpers';
+import { Types } from 'mongoose';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+interface MovingAverageDataPoint { date: string; movingAverageEngagement: number | null; }
+interface ResponseData { series: MovingAverageDataPoint[]; insightSummary?: string; }
+const DEFAULT_DATA_WINDOW_DAYS = 30;
+const DEFAULT_MOVING_AVERAGE_WINDOW_DAYS = 7;
+const MAX_DATA_WINDOW_DAYS = 365;
+const MAX_MOVING_AVERAGE_WINDOW_DAYS = 90;
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  let dataWindowInDays = DEFAULT_DATA_WINDOW_DAYS;
+  const dwParam = searchParams.get('dataWindowInDays');
+  if (dwParam) {
+    const parsed = parseInt(dwParam,10);
+    if (isNaN(parsed) || parsed <= 0 || parsed > MAX_DATA_WINDOW_DAYS) {
+      return NextResponse.json({ error: `Parâmetro dataWindowInDays inválido. Deve ser um número positivo até ${MAX_DATA_WINDOW_DAYS}.` }, { status: 400 });
+    }
+    dataWindowInDays = parsed;
+  }
+  let movingWindow = DEFAULT_MOVING_AVERAGE_WINDOW_DAYS;
+  const mwParam = searchParams.get('movingAverageWindowInDays');
+  if (mwParam) {
+    const parsed = parseInt(mwParam,10);
+    if (isNaN(parsed) || parsed <= 0 || parsed > MAX_MOVING_AVERAGE_WINDOW_DAYS) {
+      return NextResponse.json({ error: `Parâmetro movingAverageWindowInDays inválido. Deve ser um número positivo até ${MAX_MOVING_AVERAGE_WINDOW_DAYS}.` }, { status: 400 });
+    }
+    movingWindow = parsed;
+  }
+  if (movingWindow > dataWindowInDays) {
+    return NextResponse.json({ error: 'movingAverageWindowInDays não pode ser maior que dataWindowInDays.' }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers.length) {
+      return NextResponse.json({ series: [], insightSummary: 'Nenhum usuário encontrado.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const today = new Date();
+    const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23,59,59,999);
+    const startDateForQuery = new Date(today);
+    startDateForQuery.setDate(startDateForQuery.getDate() - (dataWindowInDays + movingWindow));
+    startDateForQuery.setHours(0,0,0,0);
+
+    const agg = await MetricModel.aggregate([
+      { $match: { user: { $in: userIds }, postDate: { $gte: startDateForQuery, $lte: endDate } } },
+      { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$postDate' } }, dailyEngagement: { $sum: { $add: [ { $ifNull: ['$stats.likes',0] }, { $ifNull: ['$stats.comments',0] }, { $ifNull: ['$stats.shares',0] }, { $ifNull: ['$stats.saved',0] } ] } } } },
+      { $sort: { _id: 1 } }
+    ]);
+    const map = new Map<string, number>(agg.map(it => [it._id, it.dailyEngagement]));
+    const complete: { date: string; total: number }[] = [];
+    let cursor = new Date(startDateForQuery);
+    while (cursor <= endDate) {
+      const key = formatDateYYYYMMDD(cursor);
+      complete.push({ date: key, total: map.get(key) || 0 });
+      cursor = addDays(cursor,1);
+    }
+    const series: MovingAverageDataPoint[] = [];
+    for (let i=movingWindow-1; i<complete.length; i++) {
+      const window = complete.slice(i-movingWindow+1, i+1);
+      const sum = window.reduce((a,b)=>a+b.total,0);
+      
+      // CORREÇÃO: Adicionada uma verificação para garantir que o item existe
+      // antes de tentar acessar suas propriedades.
+      const currentEntry = complete[i];
+      if (currentEntry) {
+        series.push({ date: currentEntry.date, movingAverageEngagement: sum / movingWindow });
+      }
+    }
+    const displayStart = new Date(today); displayStart.setDate(displayStart.getDate()-dataWindowInDays+1); displayStart.setHours(0,0,0,0);
+    const finalSeries = series.filter(p => new Date(p.date) >= displayStart);
+    const insight = `Média móvel de ${movingWindow} dias do engajamento diário das contas nos últimos ${dataWindowInDays} dias.`;
+    return NextResponse.json({ series: finalSeries, insightSummary: finalSeries.length ? insight : 'Dados insuficientes para calcular a média móvel.' }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/MOVING-AVERAGE-ENGAGEMENT] Error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao calcular a média móvel.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/trends/reach-engagement/route.ts
+++ b/src/app/api/admin/dashboard/trends/reach-engagement/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import UserModel from '@/app/models/User';
+import { getUserReachInteractionTrendChartData } from '@/charts/getReachInteractionTrendChartData';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import { Types } from 'mongoose';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+interface ApiChartDataPoint { date: string; reach: number | null; totalInteractions: number | null; }
+interface ChartResponse { chartData: ApiChartDataPoint[]; insightSummary?: string; averageReach?: number; averageInteractions?: number; }
+const ALLOWED_GRANULARITIES: string[] = ['daily','weekly'];
+function isAllowedTimePeriod(period: any): period is TimePeriod { return ALLOWED_TIME_PERIODS.includes(period); }
+
+export async function GET(request: NextRequest) {
+  const session = await getAdminSession(request);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const granularityParam = searchParams.get('granularity');
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam) ? timePeriodParam! : 'last_30_days';
+  const granularity = granularityParam && ALLOWED_GRANULARITIES.includes(granularityParam) ? (granularityParam as 'daily' | 'weekly') : 'daily';
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+  if (granularityParam && !ALLOWED_GRANULARITIES.includes(granularityParam)) {
+    return NextResponse.json({ error: `Granularity inválida. Permitidas: ${ALLOWED_GRANULARITIES.join(', ')}` }, { status: 400 });
+  }
+  try {
+    await connectToDatabase();
+    const agencyUsers = await UserModel.find({ planStatus: 'active' }).select('_id').lean();
+    if (!agencyUsers || agencyUsers.length === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum usuário encontrado para agregar dados.' }, { status: 200 });
+    }
+    const userIds = agencyUsers.map(u => u._id);
+    const BATCH_SIZE = 30;
+    const results: PromiseSettledResult<ChartResponse>[] = [];
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+      const batch = userIds.slice(i, i + BATCH_SIZE);
+      const batchPromises = batch.map(id => getUserReachInteractionTrendChartData(id.toString(), timePeriod, granularity));
+      const batchResults = await Promise.allSettled(batchPromises);
+      results.push(...batchResults);
+    }
+    const aggregated = new Map<string,{ reachValues:number[]; interactionValues:number[] }>();
+    results.forEach(r => {
+      if (r.status === 'fulfilled' && r.value && r.value.chartData) {
+        r.value.chartData.forEach(p => {
+          const entry = aggregated.get(p.date) || { reachValues: [], interactionValues: [] };
+          if (p.reach !== null) entry.reachValues.push(p.reach);
+          if (p.totalInteractions !== null) entry.interactionValues.push(p.totalInteractions);
+          aggregated.set(p.date, entry);
+        });
+      } else if (r.status === 'rejected') {
+        logger.error('Erro ao buscar trend para usuário :', r.reason);
+      }
+    });
+    if (aggregated.size === 0) {
+      return NextResponse.json({ chartData: [], insightSummary: 'Nenhum dado encontrado para os usuários .' }, { status: 200 });
+    }
+    const chartData: ApiChartDataPoint[] = Array.from(aggregated.entries()).map(([date, data]) => {
+      const avgReach = data.reachValues.length ? data.reachValues.reduce((a,b)=>a+b,0)/data.reachValues.length : null;
+      const avgInt = data.interactionValues.length ? data.interactionValues.reduce((a,b)=>a+b,0)/data.interactionValues.length : null;
+      return { date, reach: avgReach, totalInteractions: avgInt };
+    }).sort((a,b)=>a.date.localeCompare(b.date));
+    const valid = chartData.filter(p => p.reach !== null || p.totalInteractions !== null);
+    let insight = 'Dados de tendência de alcance e interações .';
+    if (valid.length) {
+      const avgReach = valid.reduce((s,p)=>s+(p.reach??0),0)/valid.length;
+      const avgInt = valid.reduce((s,p)=>s+(p.totalInteractions??0),0)/valid.length;
+      const periodText = timePeriod === 'all_time' ? 'todo o período' : timePeriod.replace('last_','últimos ').replace('_days',' dias').replace('_months',' meses');
+      insight = `Média de alcance: ${avgReach.toFixed(0)}, interações: ${avgInt.toFixed(0)} por ${granularity==='daily'?'dia':'semana'} nos ${periodText}.`;
+    }
+    return NextResponse.json({ chartData, insightSummary: insight }, { status: 200 });
+  } catch (error) {
+    logger.error('[API AGENCY/TRENDS/REACH-ENGAGEMENT] Error aggregating agency data:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido';
+    return NextResponse.json({ error: 'Erro ao processar sua solicitação.', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/dashboard/users/[userId]/performance/time-distribution/route.ts
+++ b/src/app/api/admin/dashboard/users/[userId]/performance/time-distribution/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { camelizeKeys } from '@/utils/camelizeKeys';
+import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+import { timePeriodToDays } from '@/utils/timePeriodHelpers';
+import { Types } from 'mongoose';
+import { getCategoryById } from '@/app/lib/classification';
+import { aggregateUserTimePerformance } from '@/utils/aggregateUserTimePerformance';
+import { getAdminSession } from '@/lib/getAdminSession';
+
+function getPortugueseWeekdayName(day: number): string {
+  const days = ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado'];
+  return days[day - 1] || '';
+}
+
+function isAllowedTimePeriod(period: any): period is TimePeriod {
+  return ALLOWED_TIME_PERIODS.includes(period);
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return NextResponse.json(
+      { error: 'User ID inválido ou ausente.' },
+      { status: 400 }
+    );
+  }
+
+  const session = await getAdminSession(req);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Acesso não autorizado' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const timePeriodParam = searchParams.get('timePeriod');
+  const formatParam = searchParams.get('format');
+  const proposalParam = searchParams.get('proposal');
+  const contextParam = searchParams.get('context');
+  const metricParam = searchParams.get('metric');
+
+  const timePeriod: TimePeriod = isAllowedTimePeriod(timePeriodParam)
+    ? timePeriodParam!
+    : 'last_90_days';
+
+  if (timePeriodParam && !isAllowedTimePeriod(timePeriodParam)) {
+    return NextResponse.json({ error: `Time period inválido. Permitidos: ${ALLOWED_TIME_PERIODS.join(', ')}` }, { status: 400 });
+  }
+
+  const periodInDaysValue = timePeriodToDays(timePeriod);
+  const metricField = metricParam || 'stats.total_interactions';
+
+  const result = await aggregateUserTimePerformance(userId, periodInDaysValue, metricField, {
+    format: formatParam || undefined,
+    proposal: proposalParam || undefined,
+    context: contextParam || undefined,
+  });
+
+  const best = result.bestSlots[0];
+  const worst = result.worstSlots[0];
+  let summary = '';
+  if (best) {
+    const dayName = getPortugueseWeekdayName(best.dayOfWeek).toLowerCase();
+    const bestAvg = best.average.toLocaleString('pt-BR', { maximumFractionDigits: 1 });
+    summary += `O pico de performance ocorre ${dayName} às ${best.hour}h, com uma média de ${bestAvg} de engajamento por post.`;
+  }
+  if (worst) {
+    const dayName = getPortugueseWeekdayName(worst.dayOfWeek).toLowerCase();
+    summary += ` O menor desempenho é ${dayName} às ${worst.hour}h.`;
+  }
+
+  const filterLabels: string[] = [];
+  if (formatParam) filterLabels.push(getCategoryById(formatParam, 'format')?.label || formatParam);
+  if (proposalParam) filterLabels.push(getCategoryById(proposalParam, 'proposal')?.label || proposalParam);
+  if (contextParam) filterLabels.push(getCategoryById(contextParam, 'context')?.label || contextParam);
+  if (filterLabels.length > 0 && summary) {
+    summary = `Para posts sobre ${filterLabels.join(' e ')}, ${summary.charAt(0).toLowerCase() + summary.slice(1)}`;
+  }
+
+  return NextResponse.json(camelizeKeys({ ...result, insightSummary: summary }), { status: 200 });
+}

--- a/src/app/api/admin/users/search/route.ts
+++ b/src/app/api/admin/users/search/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import UserModel from '@/app/models/User';
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+export async function GET(req: NextRequest) {
+  try {
+    // 1. Valida a sessão de Admin
+    const session = await getAdminSession(req);
+    if (!session) {
+      return NextResponse.json({ error: 'Acesso não autorizado' }, { status: 401 });
+    }
+
+    // 2. Obtém o termo de busca da URL
+    const { searchParams } = new URL(req.url);
+    const nameQuery = searchParams.get('name');
+
+    if (!nameQuery) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    await connectToDatabase();
+
+    // 3. Executa a consulta filtrando APENAS por NOME
+    const creators = await UserModel.find({
+      name: { $regex: nameQuery, $options: 'i' },
+    })
+      .limit(10)
+      .select('name email profile_picture_url')
+      .lean();
+
+    // 4. Retorna os resultados formatados
+    const formattedCreators = creators.map(c => ({
+      id: c._id.toString(),
+      name: c.name,
+      email: c.email,
+      profilePictureUrl: c.profile_picture_url,
+    }));
+
+    return NextResponse.json(formattedCreators, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Erro interno do servidor' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add admin dashboard routes mirroring agency endpoints
- use `getAdminSession` and drop agency filtering
- implement admin creator search endpoint
- add admin user time distribution route

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a312f294832e960c36e98aeec22b