### PR TITLE
Add community post performance criteria

### DIFF
--- a/src/app/api/cron/populate-community-inspirations/route.ts
+++ b/src/app/api/cron/populate-community-inspirations/route.ts
@@ -8,6 +8,7 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import User, { IUser } from '@/app/models/User'; // IUser v1.9.0+
 import { IMetric } from '@/app/models/Metric'; // IMetric v1.3+
 import * as dataService from '@/app/lib/dataService'; // dataService v2.12.0+
+import type { CommunityPerformanceCriteria } from '@/app/lib/dataService';
 import * as communityProcessorService from '@/app/lib/communityProcessorService'; // communityProcessorService v1.0.0+
 import { subDays } from 'date-fns';
 
@@ -35,6 +36,10 @@ if (!currentSigningKey || !nextSigningKey) {
 const RECENT_POST_WINDOW_DAYS = 90; // Considerar posts dos últimos 90 dias
 const MAX_POSTS_TO_PROCESS_PER_USER = 10; // Limite para não sobrecarregar em uma única execução por usuário
 const MAX_USERS_TO_PROCESS_PER_RUN = 50; // Limite de usuários a processar por execução do CRON
+const DEFAULT_PERFORMANCE_CRITERIA: CommunityPerformanceCriteria = {
+    minShares: 3,
+    minSaveRate: 0.01,
+};
 
 /**
  * POST /api/cron/populate-community-inspirations
@@ -98,7 +103,7 @@ export async function POST(request: NextRequest) {
             // ainda é um TODO, por enquanto busca posts recentes e classificados.
             const eligibleMetrics: IMetric[] = await dataService.findUserPostsEligibleForCommunity(
                 user._id.toString(),
-                { sinceDate } // Poderia adicionar mais critérios aqui se findUserPostsEligibleForCommunity suportar
+                { sinceDate, minPerformanceCriteria: DEFAULT_PERFORMANCE_CRITERIA }
             );
             
             totalEligibleMetricsFound += eligibleMetrics.length;

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -144,8 +144,26 @@ export interface CommunityInspirationFilters {
   format?: FormatType;
   primaryObjectiveAchieved_Qualitative?: QualitativeObjectiveType;
   performanceHighlights_Qualitative_INCLUDES_ANY?: PerformanceHighlightType[];
-  performanceHighlights_Qualitative_CONTAINS?: string; 
+  performanceHighlights_Qualitative_CONTAINS?: string;
   tags_IA?: string[];
+}
+
+/**
+ * Critérios mínimos de performance para seleção de posts elegíveis
+ * à comunidade de inspiração.
+ * Todos os valores são opcionais e representam limites mínimos
+ * (inclusive) que o post deve atingir nas métricas correspondentes.
+ * As taxas como saveRate ou shareRate devem ser fornecidas como
+ * números decimais (ex: 0.05 para 5%).
+ */
+export interface CommunityPerformanceCriteria {
+  minLikes?: number;
+  minComments?: number;
+  minShares?: number;
+  minSaved?: number;
+  minReach?: number;
+  minSaveRate?: number; // saved / reach
+  minShareRate?: number; // shares / reach
 }
 
 /**


### PR DESCRIPTION
## Summary
- enable passing of minimum performance criteria when finding user posts for the inspiration community
- support share/save rate thresholds in the community service query
- update cron job to use default performance criteria
- document `CommunityPerformanceCriteria` interface

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abcfb9748832eab9f82fc07759b85