### PR TITLE
Update community post ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Media kit links are now created using a slug based on the creator's name.
 Admin users can generate or revoke this slug from the creators management page, and
 the public URL becomes `/mediakit/<slug>`.
 
+### Community Inspirations
+
+Community inspirations are registered based on total interactions rather than
+just the most recent posts. The cron job selects each user's top-performing
+content so the community feed highlights what resonated the most with their
+followers.
+
 
 
 ## Learn More

--- a/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
+++ b/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
@@ -1,0 +1,52 @@
+import { Types } from 'mongoose';
+import { findUserPostsEligibleForCommunity } from '../communityService';
+import MetricModel from '@/app/models/Metric';
+import { connectToDatabase } from '../connection';
+
+jest.mock('@/app/models/Metric', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('../connection');
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFind = MetricModel.find as jest.Mock;
+
+describe('findUserPostsEligibleForCommunity', () => {
+  const userId = new Types.ObjectId().toString();
+  const since = new Date('2024-01-01');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('sorts posts by total interactions desc', async () => {
+    const posts = [
+      { _id: '1', stats: { total_interactions: 10 } },
+      { _id: '2', stats: { likes: 3, comments: 1, shares: 1, saved: 0 } },
+      { _id: '3', stats: { total_interactions: 7 } },
+    ];
+    const lean = jest.fn().mockResolvedValue(posts);
+    const limit = jest.fn().mockReturnValue({ lean });
+    mockFind.mockReturnValue({ limit });
+
+    const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(result.map(p => p._id)).toEqual(['1', '3', '2']);
+  });
+
+  it('computes total_interactions when missing', async () => {
+    const posts = [
+      { _id: '4', stats: { likes: 1, comments: 1, shares: 1, saved: 1 } },
+    ];
+    const lean = jest.fn().mockResolvedValue(posts);
+    const limit = jest.fn().mockReturnValue({ lean });
+    mockFind.mockReturnValue({ limit });
+
+    const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
+
+    expect(result[0].stats.total_interactions).toBe(4);
+  });
+});

--- a/src/app/lib/dataService/communityService.ts
+++ b/src/app/lib/dataService/communityService.ts
@@ -343,12 +343,30 @@ export async function findUserPostsEligibleForCommunity(
     try {
         await connectToDatabase();
         const eligiblePosts = await MetricModel.find(query)
-            .sort({ postDate: -1 })
             .limit(50)
             .lean();
 
-        logger.info(`${TAG} Encontrados ${eligiblePosts.length} posts elegíveis para comunidade para User ${userId}.`);
-        return eligiblePosts as IMetric[];
+        const postsWithInteractions = eligiblePosts.map(post => {
+            const stats: any = post.stats || {};
+            if (typeof stats.total_interactions !== 'number') {
+                const likes = stats.likes ?? 0;
+                const comments = stats.comments ?? 0;
+                const shares = stats.shares ?? 0;
+                const saved = stats.saved ?? 0;
+                stats.total_interactions = likes + comments + shares + saved;
+            }
+            post.stats = stats;
+            return post;
+        });
+
+        postsWithInteractions.sort((a, b) => {
+            const aInt = a.stats?.total_interactions ?? 0;
+            const bInt = b.stats?.total_interactions ?? 0;
+            return bInt - aInt;
+        });
+
+        logger.info(`${TAG} Encontrados ${postsWithInteractions.length} posts elegíveis para comunidade para User ${userId}.`);
+        return postsWithInteractions as IMetric[];
     } catch (error: any) {
         logger.error(`${TAG} Erro ao buscar posts elegíveis para comunidade para User ${userId}:`, error);
         throw new DatabaseError(`Erro ao buscar posts elegíveis: ${error.message}`);


### PR DESCRIPTION
## Summary
- compute total interactions when fetching eligible posts
- order community posts by engagement
- document that community inspirations use engagement
- add tests for ordering logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad73523a0832eb0869f6fca90e0a7