### PR TITLE
Remove unused sharing preference field

### DIFF
--- a/src/app/api/cron/populate-community-inspirations/route.ts
+++ b/src/app/api/cron/populate-community-inspirations/route.ts
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
         communityInspirationOptIn: true,
         isInstagramConnected: true // Apenas usuários com Instagram conectado
     })
-    .select('_id name communityInspirationSharingPreference followers_count') // Campos necessários para o processamento
+    .select('_id name followers_count') // Campos necessários para o processamento
     .limit(MAX_USERS_TO_PROCESS_PER_RUN) // Limitar o número de usuários por execução
     .lean();
 


### PR DESCRIPTION
## Summary
- drop `communityInspirationSharingPreference` from the populate cron

## Testing
- `npm install` *(fails: no internet)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad61698b4832eafdcc6e0af09272f