### PR TITLE
Sort community posts in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ the public URL becomes `/mediakit/<slug>`.
 ### Community Inspirations
 
 Community inspirations are registered based on total interactions rather than
-just the most recent posts. The cron job selects each user's top-performing
-content so the community feed highlights what resonated the most with their
-followers.
+just the most recent posts. Database-level sorting ensures that only the
+highest-engagement items are kept. The cron job selects each user's
+top-performing content so the community feed highlights what resonated the most
+with their followers.
 
 
 

--- a/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
+++ b/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
@@ -4,13 +4,13 @@ import MetricModel from '@/app/models/Metric';
 import { connectToDatabase } from '../connection';
 
 jest.mock('@/app/models/Metric', () => ({
-  find: jest.fn(),
+  aggregate: jest.fn(),
 }));
 
 jest.mock('../connection');
 
 const mockConnect = connectToDatabase as jest.Mock;
-const mockFind = MetricModel.find as jest.Mock;
+const mockAggregate = MetricModel.aggregate as jest.Mock;
 
 describe('findUserPostsEligibleForCommunity', () => {
   const userId = new Types.ObjectId().toString();
@@ -27,23 +27,38 @@ describe('findUserPostsEligibleForCommunity', () => {
       { _id: '2', stats: { likes: 3, comments: 1, shares: 1, saved: 0 } },
       { _id: '3', stats: { total_interactions: 7 } },
     ];
-    const lean = jest.fn().mockResolvedValue(posts);
-    const limit = jest.fn().mockReturnValue({ lean });
-    mockFind.mockReturnValue({ limit });
+    mockAggregate.mockResolvedValue(posts);
 
     const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
 
     expect(mockConnect).toHaveBeenCalled();
     expect(result.map(p => p._id)).toEqual(['1', '3', '2']);
+
+    const pipeline = mockAggregate.mock.calls[0][0];
+    const sortIndex = pipeline.findIndex((s: any) => Boolean(s.$sort));
+    const limitIndex = pipeline.findIndex((s: any) => Boolean(s.$limit));
+    expect(sortIndex).toBeGreaterThan(-1);
+    expect(limitIndex).toBeGreaterThan(sortIndex);
+  });
+
+  it('limits to the top 50 posts after sorting', async () => {
+    const posts = Array.from({ length: 55 }).map((_, i) => ({
+      _id: `${i + 1}`,
+      stats: { total_interactions: 55 - i }
+    }));
+    mockAggregate.mockResolvedValue(posts.slice(0, 50));
+
+    const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
+
+    // Expect IDs from 1..50 which correspond to total_interactions 55..6
+    expect(result.map(p => p._id)).toEqual(posts.slice(0, 50).map(p => p._id));
   });
 
   it('computes total_interactions when missing', async () => {
     const posts = [
       { _id: '4', stats: { likes: 1, comments: 1, shares: 1, saved: 1 } },
     ];
-    const lean = jest.fn().mockResolvedValue(posts);
-    const limit = jest.fn().mockReturnValue({ lean });
-    mockFind.mockReturnValue({ limit });
+    mockAggregate.mockResolvedValue(posts);
 
     const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
 


### PR DESCRIPTION
## Summary
- sort posts by total_interactions directly in MongoDB
- verify aggregation pipeline uses sort before limit
- adjust tests for DB sorting
- document database level sort for inspirations

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2a9a721c832e8723ac3e1da257f4