### PR TITLE
Add debug logging for community cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ highest-engagement items are kept. The cron job selects each user's
 top-performing content so the community feed highlights what resonated the most
 with their followers.
 
+#### Running the community cron manually
+
+Set `LOG_LEVEL=debug` before invoking the cron route to see additional debug
+information, including the MongoDB query parameters and sinceDate whenever a
+user has no eligible posts:
+
+```bash
+LOG_LEVEL=debug curl -X POST http://localhost:3000/api/cron/populate-community-inspirations
+```
+
 
 
 ## Learn More

--- a/src/app/api/cron/populate-community-inspirations/route.ts
+++ b/src/app/api/cron/populate-community-inspirations/route.ts
@@ -101,7 +101,11 @@ export async function POST(request: NextRequest) {
             // Buscar posts elegíveis deste usuário
             // A lógica de 'minPerformanceCriteria' em findUserPostsEligibleForCommunity
             // ainda é um TODO, por enquanto busca posts recentes e classificados.
-            const eligibleMetrics: IMetric[] = await dataService.findUserPostsEligibleForCommunity(
+            const {
+                posts: eligibleMetrics,
+                query: debugQuery,
+                sinceDate: debugSinceDate
+            } = await dataService.findUserPostsEligibleForCommunity(
                 user._id.toString(),
                 { sinceDate, minPerformanceCriteria: DEFAULT_PERFORMANCE_CRITERIA }
             );
@@ -110,7 +114,7 @@ export async function POST(request: NextRequest) {
             logger.debug(`${TAG} User ${user._id}: Encontradas ${eligibleMetrics.length} métricas elegíveis (recentes/classificadas).`);
 
             if (eligibleMetrics.length === 0) {
-                logger.info(`${TAG} User ${user._id}: Nenhuma métrica nova/elegível encontrada para processar.`);
+                logger.info(`${TAG} User ${user._id}: Nenhuma métrica nova/elegível encontrada para processar. Query=${JSON.stringify(debugQuery)} sinceDate=${debugSinceDate.toISOString()}`);
                 continue;
             }
 
@@ -142,7 +146,7 @@ export async function POST(request: NextRequest) {
                     logger.error(`${TAG} User ${user._id}: Erro ao processar Metric ${metric._id}: ${metricError.message}`, metricError.stack);
                 }
             }
-            logger.info(`${TAG} User ${user._id}: Processamento concluído. ${metricsToProcess.length} métricas tentadas. Duração: ${Date.now() - userProcessStartTime}ms`);
+            logger.info(`${TAG} User ${user._id}: Processamento concluído. ${metricsToProcess.length} métricas tentadas. Duração: ${Date.now() - userProcessStartTime}ms. Query=${JSON.stringify(debugQuery)} sinceDate=${debugSinceDate.toISOString()}`);
 
         } catch (userError: any) {
             logger.error(`${TAG} Erro ao processar posts para o usuário ${user._id}: ${userError.message}`, userError.stack);

--- a/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
+++ b/src/app/lib/dataService/__tests__/communityService.findUserPostsEligibleForCommunity.test.ts
@@ -32,7 +32,7 @@ describe('findUserPostsEligibleForCommunity', () => {
     const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
 
     expect(mockConnect).toHaveBeenCalled();
-    expect(result.map(p => p._id)).toEqual(['1', '3', '2']);
+    expect(result.posts.map(p => p._id)).toEqual(['1', '3', '2']);
 
     const pipeline = mockAggregate.mock.calls[0][0];
     const sortIndex = pipeline.findIndex((s: any) => Boolean(s.$sort));
@@ -51,7 +51,7 @@ describe('findUserPostsEligibleForCommunity', () => {
     const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
 
     // Expect IDs from 1..50 which correspond to total_interactions 55..6
-    expect(result.map(p => p._id)).toEqual(posts.slice(0, 50).map(p => p._id));
+    expect(result.posts.map(p => p._id)).toEqual(posts.slice(0, 50).map(p => p._id));
   });
 
   it('computes total_interactions when missing', async () => {
@@ -62,6 +62,6 @@ describe('findUserPostsEligibleForCommunity', () => {
 
     const result = await findUserPostsEligibleForCommunity(userId, { sinceDate: since });
 
-    expect(result[0].stats.total_interactions).toBe(4);
+    expect(result.posts[0].stats.total_interactions).toBe(4);
   });
 });

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -166,6 +166,12 @@ export interface CommunityPerformanceCriteria {
   minShareRate?: number; // shares / reach
 }
 
+export interface FindUserPostsEligibleForCommunityResult {
+  posts: LocalIMetric[];
+  query: any;
+  sinceDate: Date;
+}
+
 /**
  * Representa um objeto de post simplificado.
  * ATUALIZADO v2.14.14: Adicionado instagramMediaId.


### PR DESCRIPTION
## Summary
- log query and sinceDate when community posts search has no results
- include query details in cron logs
- expose debug result type
- document how to run cron with debug logs

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_687bd24fe498832e883a61aaee95cd02