### PR TITLE
Relax save rate filter for community inspirations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ just the most recent posts. Database-level sorting ensures that only the
 highest-engagement items are kept. The cron job selects each user's
 top-performing content so the community feed highlights what resonated the most
 with their followers.
+Posts are considered eligible only if they have at least three shares and a save
+rate of 0.2% (saved divided by reach) or higher.
 
 #### Running the community cron manually
 

--- a/src/app/api/cron/populate-community-inspirations/route.ts
+++ b/src/app/api/cron/populate-community-inspirations/route.ts
@@ -37,8 +37,10 @@ const RECENT_POST_WINDOW_DAYS = 90; // Considerar posts dos últimos 90 dias
 const MAX_POSTS_TO_PROCESS_PER_USER = 10; // Limite para não sobrecarregar em uma única execução por usuário
 const MAX_USERS_TO_PROCESS_PER_RUN = 50; // Limite de usuários a processar por execução do CRON
 const DEFAULT_PERFORMANCE_CRITERIA: CommunityPerformanceCriteria = {
+    // A post must have at least three shares and a minimum save rate of
+    // 0.2% (saved / reach) to be considered for the community feed.
     minShares: 3,
-    minSaveRate: 0.01,
+    minSaveRate: 0.002,
 };
 
 /**


### PR DESCRIPTION
## Summary
- lower minSaveRate threshold used by the community cron to 0.2%
- document the performance criteria for community inspirations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be5277e90832e9df5d3a480ab7db5