### PR TITLE
Include tone and reference in Community Inspirations

### DIFF
--- a/src/app/lib/aiFunctionSchemas.zod.ts
+++ b/src/app/lib/aiFunctionSchemas.zod.ts
@@ -9,9 +9,13 @@ import {
     VALID_PROPOSALS,
     VALID_CONTEXTS,
     VALID_QUALITATIVE_OBJECTIVES,
+    VALID_TONES,
+    VALID_REFERENCES,
     FormatType,
     ProposalType,
     ContextType,
+    ToneType,
+    ReferenceType,
     QualitativeObjectiveType
 } from '@/app/lib/constants/communityInspirations.constants';
 
@@ -175,6 +179,16 @@ export const FetchCommunityInspirationsArgsSchema = z.object({
     })
     .optional()
     .describe(`Opcional. Formato do post (ex: Reels, Foto, Carrossel) para refinar a busca. Valores válidos: ${VALID_FORMATS.join(', ')}`),
+  tone: z.enum(VALID_TONES, {
+      invalid_type_error: "Tom inválido. Use um dos valores de tom conhecidos."
+    })
+    .optional()
+    .describe(`Opcional. Tom predominante do post. Valores válidos: ${VALID_TONES.join(', ')}`),
+  reference: z.enum(VALID_REFERENCES, {
+      invalid_type_error: "Referência inválida. Use um dos valores de referência conhecidos."
+    })
+    .optional()
+    .describe(`Opcional. Referência ou elemento utilizado. Valores válidos: ${VALID_REFERENCES.join(', ')}`),
   primaryObjectiveAchieved_Qualitative: z.enum(VALID_QUALITATIVE_OBJECTIVES, {
       invalid_type_error: "Objetivo qualitativo inválido. Por favor, use um dos valores de objetivo conhecidos."
     })

--- a/src/app/lib/aiFunctions.ts
+++ b/src/app/lib/aiFunctions.ts
@@ -15,7 +15,9 @@ import {
     VALID_FORMATS,
     VALID_PROPOSALS,
     VALID_CONTEXTS,
-    VALID_QUALITATIVE_OBJECTIVES
+    VALID_QUALITATIVE_OBJECTIVES,
+    VALID_TONES,
+    VALID_REFERENCES
 } from '@/app/lib/constants/communityInspirations.constants';
 
 import { IUser } from '@/app/models/User';
@@ -109,6 +111,14 @@ export const functionSchemas = [
         format: {
           type: 'string',
           description: `Opcional. Formato do post para refinar a busca. Valores válidos: ${VALID_FORMATS.join(', ')}.`
+        },
+        tone: {
+          type: 'string',
+          description: `Opcional. Tom predominante do post. Valores válidos: ${VALID_TONES.join(', ')}.`
+        },
+        reference: {
+          type: 'string',
+          description: `Opcional. Referência ou elemento utilizado. Valores válidos: ${VALID_REFERENCES.join(', ')}.`
         },
         primaryObjectiveAchieved_Qualitative: {
           type: 'string',
@@ -486,6 +496,8 @@ const fetchCommunityInspirations: ExecutorFn = async (args: z.infer<typeof ZodSc
       proposal: args.proposal,
       context: args.context,
       format: args.format,
+      tone: args.tone,
+      reference: args.reference,
       primaryObjectiveAchieved_Qualitative: args.primaryObjectiveAchieved_Qualitative,
     };
 
@@ -515,6 +527,8 @@ const fetchCommunityInspirations: ExecutorFn = async (args: z.infer<typeof ZodSc
       proposal: insp.proposal,
       context: insp.context,
       format: insp.format,
+      tone: insp.tone,
+      reference: insp.reference,
       contentSummary: insp.contentSummary,
       performanceHighlights_Qualitative: insp.performanceHighlights_Qualitative,
       primaryObjectiveAchieved_Qualitative: insp.primaryObjectiveAchieved_Qualitative,

--- a/src/app/lib/communityProcessorService.ts
+++ b/src/app/lib/communityProcessorService.ts
@@ -237,6 +237,8 @@ export async function processMetricForCommunity(
     const mappedFormat = mapToEnum(metric.format?.[0], VALID_FORMATS, DEFAULT_FORMAT_ENUM);
     const mappedProposal = mapToEnum(metric.proposal?.[0], VALID_PROPOSALS, DEFAULT_PROPOSAL_ENUM);
     const mappedContext = mapToEnum(metric.context?.[0], VALID_CONTEXTS, DEFAULT_CONTEXT_ENUM);
+    const mappedTone = mapToEnum(metric.tone?.[0], VALID_TONES, DEFAULT_TONE_ENUM);
+    const mappedReference = mapToEnum(metric.references?.[0], VALID_REFERENCES, DEFAULT_REFERENCE_ENUM);
 
 
     if (!metric.stats) {
@@ -255,6 +257,8 @@ export async function processMetricForCommunity(
             proposal: mappedProposal,
             context: mappedContext,
             format: mappedFormat,
+            tone: mappedTone,
+            reference: mappedReference,
             contentSummary: basicSummary,
             performanceHighlights_Qualitative: ['sem_metricas_detalhadas_para_analise'],
             primaryObjectiveAchieved_Qualitative: 'analise_qualitativa_do_conteudo',
@@ -299,6 +303,8 @@ export async function processMetricForCommunity(
         proposal: mappedProposal,
         context: mappedContext,
         format: mappedFormat,
+        tone: mappedTone,
+        reference: mappedReference,
         contentSummary: contentSummary,
         performanceHighlights_Qualitative: highlights,
         primaryObjectiveAchieved_Qualitative: primaryObjective,

--- a/src/app/lib/constants/communityInspirations.constants.ts
+++ b/src/app/lib/constants/communityInspirations.constants.ts
@@ -95,3 +95,33 @@ export const VALID_PERFORMANCE_HIGHLIGHTS = [
 ] as const;
 export type PerformanceHighlightType = typeof VALID_PERFORMANCE_HIGHLIGHTS[number];
 export const DEFAULT_PERFORMANCE_HIGHLIGHT_ENUM: PerformanceHighlightType = "desempenho_padrao"; // NOVO: Exportando default
+
+// --- TONALIDADES DO CONTEÚDO ---
+export const VALID_TONES = [
+  'humorous',
+  'inspirational',
+  'educational',
+  'critical',
+  'promotional',
+  'neutral'
+] as const;
+export type ToneType = typeof VALID_TONES[number];
+export const DEFAULT_TONE_ENUM: ToneType = 'neutral';
+
+// --- REFERÊNCIAS UTILIZADAS ---
+export const VALID_REFERENCES = [
+  'pop_culture',
+  'pop_culture_movies_series',
+  'pop_culture_books',
+  'pop_culture_games',
+  'pop_culture_music',
+  'pop_culture_internet',
+  'people_and_groups',
+  'regional_stereotypes',
+  'professions',
+  'geography',
+  'city',
+  'country'
+] as const;
+export type ReferenceType = typeof VALID_REFERENCES[number];
+export const DEFAULT_REFERENCE_ENUM: ReferenceType = 'pop_culture';

--- a/src/app/lib/dataService/communityService.ts
+++ b/src/app/lib/dataService/communityService.ts
@@ -193,6 +193,8 @@ export async function getInspirations(
     if (filters.proposal) query.proposal = filters.proposal;
     if (filters.context) query.context = filters.context;
     if (filters.format) query.format = filters.format;
+    if (filters.tone) query.tone = filters.tone;
+    if (filters.reference) query.reference = filters.reference;
     if (filters.primaryObjectiveAchieved_Qualitative) {
         query.primaryObjectiveAchieved_Qualitative = filters.primaryObjectiveAchieved_Qualitative;
     }

--- a/src/app/lib/dataService/types.ts
+++ b/src/app/lib/dataService/types.ts
@@ -24,6 +24,8 @@ import type {
     FormatType,
     ProposalType,
     ContextType,
+    ToneType,
+    ReferenceType,
     QualitativeObjectiveType,
     PerformanceHighlightType
 } from '@/app/lib/constants/communityInspirations.constants';
@@ -142,6 +144,8 @@ export interface CommunityInspirationFilters {
   proposal?: ProposalType;
   context?: ContextType;
   format?: FormatType;
+  tone?: ToneType;
+  reference?: ReferenceType;
   primaryObjectiveAchieved_Qualitative?: QualitativeObjectiveType;
   performanceHighlights_Qualitative_INCLUDES_ANY?: PerformanceHighlightType[];
   performanceHighlights_Qualitative_CONTAINS?: string;

--- a/src/app/models/CommunityInspiration.ts
+++ b/src/app/models/CommunityInspiration.ts
@@ -9,12 +9,18 @@ import {
     VALID_CONTEXTS,
     VALID_QUALITATIVE_OBJECTIVES,
     VALID_PERFORMANCE_HIGHLIGHTS,
+    VALID_TONES,
+    VALID_REFERENCES,
     FormatType,
     ProposalType,
     ContextType,
+    ToneType,
+    ReferenceType,
     QualitativeObjectiveType,
-    PerformanceHighlightType
-} from "@/app/lib/constants/communityInspirations.constants"; 
+    PerformanceHighlightType,
+    DEFAULT_TONE_ENUM,
+    DEFAULT_REFERENCE_ENUM
+} from "@/app/lib/constants/communityInspirations.constants";
 
 /**
  * Interface para o subdocumento de métricas internas.
@@ -38,8 +44,10 @@ export interface ICommunityInspiration extends Document {
   originalCreatorId: Types.ObjectId; 
   
   proposal: ProposalType; 
-  context: ContextType;   
-  format: FormatType;     
+  context: ContextType;
+  format: FormatType;
+  tone?: ToneType;
+  reference?: ReferenceType;
   
   contentSummary: string;
   performanceHighlights_Qualitative: PerformanceHighlightType[]; 
@@ -79,6 +87,8 @@ const communityInspirationSchema = new Schema<ICommunityInspiration>(
     proposal: { type: String, required: true, enum: VALID_PROPOSALS, index: true, trim: true },
     context: { type: String, required: true, enum: VALID_CONTEXTS, index: true, trim: true },
     format: { type: String, required: true, enum: VALID_FORMATS, index: true, trim: true },
+    tone: { type: String, enum: VALID_TONES, index: true, trim: true, default: DEFAULT_TONE_ENUM },
+    reference: { type: String, enum: VALID_REFERENCES, index: true, trim: true, default: DEFAULT_REFERENCE_ENUM },
     
     contentSummary: { type: String, required: true },
     performanceHighlights_Qualitative: { type: [String], default: [], enum: VALID_PERFORMANCE_HIGHLIGHTS, index: true },
@@ -107,7 +117,9 @@ communityInspirationSchema.index({ postId_Instagram: 1 }, { unique: true });
 // Índices adicionais para otimizar buscas comuns (mantidos da v1.1.0)
 communityInspirationSchema.index({ proposal: 1, context: 1, primaryObjectiveAchieved_Qualitative: 1, status: 1 });
 communityInspirationSchema.index({ format: 1, primaryObjectiveAchieved_Qualitative: 1, status: 1 });
-communityInspirationSchema.index({ originalCreatorId: 1, status: 1 }); 
+communityInspirationSchema.index({ tone: 1, primaryObjectiveAchieved_Qualitative: 1, status: 1 });
+communityInspirationSchema.index({ reference: 1, status: 1 });
+communityInspirationSchema.index({ originalCreatorId: 1, status: 1 });
 
 // NOVO ÍNDICE para otimizar a query principal em communityService.getInspirations (v1.1.1)
 // Suporta filtro por status: 'active' e ordenação por addedToCommunityAt e internalMetricsSnapshot.saveRate


### PR DESCRIPTION
## Summary
- support tone and reference classifications in constants
- store tone and reference in the CommunityInspiration model
- allow filtering by tone and reference via data service and AI functions
- map these new fields when processing metrics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf226621c832e8b537491da2add58