### PR TITLE
Improve inspiration selection

### DIFF
--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -232,9 +232,16 @@ async function buildInspirationFilters(
         if (typeof details.context === 'string') filters.context = details.context;
         if (typeof details.tone === 'string') filters.tone = details.tone;
         if (typeof details.reference === 'string') filters.reference = details.reference;
+        if (typeof details.isPositiveAlert === 'boolean') {
+            if (details.isPositiveAlert) {
+                filters.performanceHighlights_Qualitative_INCLUDES_ANY = ['excelente_retencao_em_reels', 'viralizou_nos_compartilhamentos'];
+            } else {
+                filters.performanceHighlights_Qualitative_INCLUDES_ANY = ['desempenho_padrao', 'baixo_volume_de_dados'];
+            }
+        }
     }
 
-    if (!filters.format && forFallback) {
+    if (forFallback && (!filters.format || !filters.proposal || !filters.context)) {
         try {
             const posts = await dataService.getRecentPostObjectsWithAggregatedMetrics(userId, 30);
             if (posts && posts.length > 0) {
@@ -243,9 +250,15 @@ async function buildInspirationFilters(
                     const dB = new Date(b.postDate as any).getTime();
                     return dB - dA;
                 });
-                const lastFormat = posts[0]?.format;
-                if (typeof lastFormat === 'string') {
-                    filters.format = lastFormat as any;
+                const lastPost = posts[0];
+                if (!filters.format && typeof lastPost?.format === 'string') {
+                    filters.format = lastPost.format as any;
+                }
+                if (!filters.proposal && typeof lastPost?.proposal === 'string') {
+                    filters.proposal = lastPost.proposal as any;
+                }
+                if (!filters.context && typeof lastPost?.context === 'string') {
+                    filters.context = lastPost.context as any;
                 }
             }
         } catch (e) {

--- a/src/app/lib/ruleEngine/rules/dropWatchTimeRule.ts
+++ b/src/app/lib/ruleEngine/rules/dropWatchTimeRule.ts
@@ -165,7 +165,7 @@ export const dropWatchTimeRule: IRule = {
     },
 
     action: async (context: RuleContext, conditionData?: any): Promise<DetectedEvent | null> => {
-        const { user } = context;
+        const { user, allUserPosts } = context;
         const actionTAG = `${RULE_TAG_BASE}[action] User ${user._id}:`;
         if (!conditionData || typeof conditionData.currentAverageReelsWatchTime !== 'number' || typeof conditionData.historicalAverageReelsWatchTime !== 'number' || !Array.isArray(conditionData.reelsAnalyzedIds)) {
             logger.error(`${actionTAG} conditionData inválido ou incompleto.`);
@@ -178,10 +178,17 @@ export const dropWatchTimeRule: IRule = {
 
         logger.info(`${actionTAG} Gerando evento.`);
 
+        let lastReel = allUserPosts
+            .filter(p => p.type === 'REEL')
+            .sort((a,b) => new Date(b.postDate as any).getTime() - new Date(a.postDate as any).getTime())[0];
+
         const details: IDropWatchTimeDetails = {
-            currentAvg: currentAverageReelsWatchTime, 
-            historicalAvg: historicalAverageReelsWatchTime, 
-            reelsAnalyzedIds
+            currentAvg: currentAverageReelsWatchTime,
+            historicalAvg: historicalAverageReelsWatchTime,
+            reelsAnalyzedIds,
+            format: 'Reel',
+            proposal: lastReel?.proposal,
+            context: lastReel?.context
         };
 
         const messageForAI = `Radar Tuca detectou: O tempo médio de visualização dos seus Reels mais recentes está em torno de ${currentAverageReelsWatchTime.toFixed(0)}s. Isso é um pouco abaixo da sua média histórica de ${historicalAverageReelsWatchTime.toFixed(0)}s. Pode ser um sinal para revisitar as introduções ou o ritmo desses Reels.`;

--- a/src/app/lib/ruleEngine/rules/evergreenRepurposeRule.ts
+++ b/src/app/lib/ruleEngine/rules/evergreenRepurposeRule.ts
@@ -190,11 +190,14 @@ export const evergreenRepurposeRule: IRule = {
         const details: IEvergreenRepurposeDetails = {
             originalPostId: originalPost._id,
             originalPlatformPostId: originalPost.instagramMediaId,
-            originalPostDate: originalPostDateObj, 
+            originalPostDate: originalPostDateObj,
             originalPostDescriptionExcerpt: postDescriptionExcerpt,
             originalPostMetricValue,
             originalPostMetricName,
-            suggestionType: randomSuggestionType
+            suggestionType: randomSuggestionType,
+            format: originalPost.format,
+            proposal: originalPost.proposal,
+            context: originalPost.context
         };
         
         let suggestionText = "";

--- a/src/app/lib/ruleEngine/rules/followerGrowthStagnationRule.ts
+++ b/src/app/lib/ruleEngine/rules/followerGrowthStagnationRule.ts
@@ -193,7 +193,7 @@ export const followerGrowthStagnationRule: IRule = {
     },
 
     action: async (context: RuleContext, conditionData?: any): Promise<DetectedEvent | null> => {
-        const { user } = context;
+        const { user, allUserPosts } = context;
         const actionTAG = `${RULE_TAG_BASE}[action] User ${user._id}:`;
         if (!conditionData || typeof conditionData.currentGrowthRate !== 'number' || typeof conditionData.previousGrowthRate !== 'number') {
             logger.error(`${actionTAG} conditionData inválido ou incompleto.`);
@@ -204,12 +204,18 @@ export const followerGrowthStagnationRule: IRule = {
         
         logger.info(`${actionTAG} Gerando evento.`);
 
-        const details: IFollowerStagnationDetails = { 
+        const lastPost = allUserPosts
+            .sort((a,b) => new Date(b.postDate as any).getTime() - new Date(a.postDate as any).getTime())[0];
+
+        const details: IFollowerStagnationDetails = {
             currentGrowthRate: parseFloat(currentGrowthRate.toFixed(2)),
             previousGrowthRate: parseFloat(previousGrowthRate.toFixed(2)),
             currentGrowthAbs: currentGrowth,
             previousGrowthAbs: previousGrowth,
-            periodAnalyzed
+            periodAnalyzed,
+            mostRecentFormat: lastPost?.format,
+            mostRecentProposal: lastPost?.proposal,
+            mostRecentContext: lastPost?.context
         };
 
         const messageForAI = `Radar Tuca observou: Notei que seu crescimento de seguidores deu uma desacelerada nas ${periodAnalyzed.replace('vs. as ', 'em comparação com as ')} (crescimento de ${currentGrowthRate.toFixed(1)}% vs ${previousGrowthRate.toFixed(1)}% anteriormente). Gostaria de analisar algumas estratégias para reaquecer o crescimento ou entender melhor essa tendência?`;

--- a/src/app/lib/ruleEngine/rules/newFormatPerformanceRule.ts
+++ b/src/app/lib/ruleEngine/rules/newFormatPerformanceRule.ts
@@ -189,7 +189,7 @@ export const newFormatPerformanceRule: IRule = {
     },
 
     action: async (context: RuleContext, conditionData?: any): Promise<DetectedEvent | null> => {
-        const { user } = context;
+        const { user, allUserPosts } = context;
         const actionTAG = `${RULE_TAG_BASE}[action] User ${user._id}:`;
         if (!conditionData) { 
             logger.error(`${actionTAG} conditionData inválido.`);
@@ -210,13 +210,19 @@ export const newFormatPerformanceRule: IRule = {
         
         logger.info(`${actionTAG} Gerando evento para novo formato '${formatName}'.`);
 
+        const samplePost = allUserPosts
+            .filter(p => p.format === formatName)
+            .sort((a,b) => new Date(b.postDate as any).getTime() - new Date(a.postDate as any).getTime())[0];
+
         const details: INewFormatPerformanceDetails = {
             formatName,
             avgPerformanceNewFormat: parseFloat(avgPerformanceNewFormat.toFixed(2)),
             referenceAvgPerformance: parseFloat(referenceAvgPerformance.toFixed(2)),
             metricUsed, // Agora será 'views'
             numberOfPostsInNewFormat,
-            isPositiveAlert
+            isPositiveAlert,
+            dominantProposal: samplePost?.proposal,
+            dominantContext: samplePost?.context
         };
         
         let messageForAI: string;

--- a/src/app/lib/ruleEngine/rules/postingConsistencyRule.ts
+++ b/src/app/lib/ruleEngine/rules/postingConsistencyRule.ts
@@ -130,7 +130,7 @@ export const postingConsistencyRule: IRule = {
     },
 
     action: async (context: RuleContext, conditionData?: any): Promise<DetectedEvent | null> => {
-        const { user } = context;
+        const { user, allUserPosts } = context;
         const actionTAG = `${RULE_TAG_BASE}[action] User ${user._id}:`;
         if (!conditionData || typeof conditionData.daysSinceLastPost !== 'number') {
             logger.error(`${actionTAG} conditionData inválido ou incompleto. Data: ${JSON.stringify(conditionData)}`);
@@ -141,10 +141,16 @@ export const postingConsistencyRule: IRule = {
         
         logger.info(`${actionTAG} Gerando evento.`);
 
+        const lastPost = allUserPosts
+            .sort((a,b) => new Date(b.postDate as any).getTime() - new Date(a.postDate as any).getTime())[0];
+
         const details: IPostingConsistencyDetails = {
             previousAverageFrequencyDays: parseFloat(previousAverageFrequencyDays?.toFixed(1) ?? '0'),
             daysSinceLastPost,
-            breakInPattern: true
+            breakInPattern: true,
+            lastPostFormat: lastPost?.format,
+            lastPostProposal: lastPost?.proposal,
+            lastPostContext: lastPost?.context
         };
         
         let messageForAI = `Radar Tuca Alerta: Percebi que já faz ${daysSinceLastPost} dias desde o seu último post. `;

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -20,6 +20,9 @@ export interface IDropWatchTimeDetails {
     currentAvg: number;
     historicalAvg: number;
     reelsAnalyzedIds: string[];
+    format?: string;
+    proposal?: string;
+    context?: string;
 }
 export interface IForgottenFormatDetails {
     format: string;
@@ -62,6 +65,9 @@ export interface IFollowerStagnationDetails {
     currentGrowthAbs: number;
     previousGrowthAbs: number;
     periodAnalyzed: string;
+    mostRecentFormat?: string;
+    mostRecentProposal?: string;
+    mostRecentContext?: string;
 }
 export interface IBestDayFormatDetails {
     format: string;
@@ -76,6 +82,9 @@ export interface IPostingConsistencyDetails {
     currentAverageFrequencyDays?: number;
     daysSinceLastPost?: number;
     breakInPattern?: boolean;
+    lastPostFormat?: string;
+    lastPostProposal?: string;
+    lastPostContext?: string;
 }
 export interface IEvergreenRepurposeDetails {
     originalPostId: string;
@@ -85,6 +94,9 @@ export interface IEvergreenRepurposeDetails {
     originalPostMetricValue: number;
     originalPostMetricName: string;
     suggestionType: 'tbt' | 'new_angle' | 'story_series' | 'other';
+    format?: string;
+    proposal?: string;
+    context?: string;
 }
 export interface INewFormatPerformanceDetails {
     formatName: string;
@@ -93,6 +105,8 @@ export interface INewFormatPerformanceDetails {
     metricUsed: string;
     numberOfPostsInNewFormat: number;
     isPositiveAlert: boolean;
+    dominantProposal?: string;
+    dominantContext?: string;
 }
 export interface IMediaTypePerformance {
     type: string;


### PR DESCRIPTION
## Summary
- include context, proposal and format in several alert details
- infer format, proposal and context for fallback inspiration
- add performance highlight filters for new format alerts

## Testing
- `npx --no-install tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3c8af9b8832eaedf9b3a9156fdd3