### PR TITLE
Add last post context to best day rule

### DIFF
--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -229,7 +229,13 @@ async function buildInspirationFilters(
             filters.format = details.formatName;
         }
         if (typeof details.proposal === 'string') filters.proposal = details.proposal;
+        if (!filters.proposal && typeof details.lastPostProposal === 'string') {
+            filters.proposal = details.lastPostProposal as any;
+        }
         if (typeof details.context === 'string') filters.context = details.context;
+        if (!filters.context && typeof details.lastPostContext === 'string') {
+            filters.context = details.lastPostContext as any;
+        }
         if (typeof details.tone === 'string') filters.tone = details.tone;
         if (typeof details.reference === 'string') filters.reference = details.reference;
         if (typeof details.isPositiveAlert === 'boolean') {

--- a/src/app/lib/ruleEngine/rules/bestDayFormatEngagementRule.ts
+++ b/src/app/lib/ruleEngine/rules/bestDayFormatEngagementRule.ts
@@ -192,7 +192,10 @@ export const bestDayFormatEngagementRule: IRule = {
         });
 
         const bestSlot = promisingSlots[0]!;
-        const bestSlotFormatAvg = bestSlot.formatAvg as number; 
+        const bestSlotFormatAvg = bestSlot.formatAvg as number;
+        const lastPostInSlot = bestSlot.postsInSlot[0];
+        const lastPostProposal = lastPostInSlot?.proposal;
+        const lastPostContext = lastPostInSlot?.context;
 
         logger.debug(`${detectionTAG} Condição ATENDIDA. Melhor slot: Formato ${bestSlot.format} às ${bestSlot.dayName}. Média slot (${METRIC_TO_USE_FOR_PERFORMANCE}): ${bestSlot.avgMetricValue.toFixed(1)}, Média formato (${METRIC_TO_USE_FOR_PERFORMANCE}): ${bestSlotFormatAvg.toFixed(1)}, Dias desde último uso: ${bestSlot.daysSinceLastUsedInSlot}`);
         
@@ -204,9 +207,11 @@ export const bestDayFormatEngagementRule: IRule = {
                     dayOfWeek: bestSlot.dayName,
                     avgEngValue: bestSlot.avgMetricValue,
                     metricUsed: METRIC_TO_USE_FOR_PERFORMANCE,
-                    referenceAvgEngValue: bestSlotFormatAvg, 
+                    referenceAvgEngValue: bestSlotFormatAvg,
                 },
-                daysSinceLastUsedInSlot: bestSlot.daysSinceLastUsedInSlot
+                daysSinceLastUsedInSlot: bestSlot.daysSinceLastUsedInSlot,
+                lastPostProposal,
+                lastPostContext
             }
         };
     },
@@ -219,7 +224,7 @@ export const bestDayFormatEngagementRule: IRule = {
             return null;
         }
 
-        const { bestCombination, daysSinceLastUsedInSlot } = conditionData;
+        const { bestCombination, daysSinceLastUsedInSlot, lastPostProposal, lastPostContext } = conditionData;
         const { format, dayOfWeek, avgEngValue, metricUsed, referenceAvgEngValue } = bestCombination;
 
         if (typeof format !== 'string' ||
@@ -239,7 +244,9 @@ export const bestDayFormatEngagementRule: IRule = {
             avgEngRate: parseFloat(avgEngValue.toFixed(2)),
             metricUsed,
             referenceAvgEngRate: parseFloat(referenceAvgEngValue.toFixed(2)),
-            daysSinceLastUsedInSlot
+            daysSinceLastUsedInSlot,
+            lastPostProposal,
+            lastPostContext
         };
         
         const percentageSuperior = referenceAvgEngValue > 0 ? ((avgEngValue / referenceAvgEngValue - 1) * 100) : (avgEngValue > 0 ? 100 : 0);

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -76,6 +76,8 @@ export interface IBestDayFormatDetails {
     metricUsed: string;
     referenceAvgEngRate?: number;
     daysSinceLastUsedInSlot: number;
+    lastPostProposal?: string;
+    lastPostContext?: string;
 }
 export interface IPostingConsistencyDetails {
     previousAverageFrequencyDays?: number;


### PR DESCRIPTION
## Summary
- support capturing proposal/context for most recent post in best-day rule
- expose these fields in user model
- use last post info in inspiration filter fallback

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4eab196c832ea949eaf4c45ff704