### PR TITLE
Enhance inspiration fallback with user prefs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/react-simple-maps": "^3.0.6",
+        "@types/next": "13.4.19",
         "autoprefixer": "^10.4.20",
         "encoding": "^0.1.13",
         "eslint": "^8.44.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-simple-maps": "^3.0.6",
+    "@types/next": "13.4.19",
     "autoprefixer": "^10.4.20",
     "encoding": "^0.1.13",
     "eslint": "^8.44.0",

--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -270,6 +270,22 @@ async function buildInspirationFilters(
         } catch (e) {
             logger.warn(`[DailyTipHandler] Falha ao inferir formato para inspiração: ${e}`);
         }
+
+        // Complementa com preferências do usuário, se disponíveis
+        try {
+            const user = await dataService.lookupUserById(userId);
+            const prefs = user.userPreferences;
+            if (prefs) {
+                if (!filters.format && Array.isArray(prefs.preferredFormats) && prefs.preferredFormats.length > 0) {
+                    filters.format = prefs.preferredFormats[0] as any;
+                }
+                if (!filters.tone && typeof prefs.preferredAiTone === 'string') {
+                    filters.tone = prefs.preferredAiTone as any;
+                }
+            }
+        } catch (e) {
+            logger.warn(`[DailyTipHandler] Falha ao consultar preferências do usuário para inspiração: ${e}`);
+        }
     }
 
     return filters;


### PR DESCRIPTION
## Summary
- use stored user preferences as a fallback for community inspiration filters
- add `@types/next` to dev dependencies for tsc

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'next')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d507932ec832e9be91f32eb4411fc