### PR TITLE
Add richer metrics to system prompt

### DIFF
--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -7,5 +7,9 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{AVG_REACH_LAST30}}');
     expect(prompt).toContain('{{AVG_SHARES_LAST30}}');
     expect(prompt).toContain('{{TREND_SUMMARY_LAST30}}');
+    expect(prompt).toContain('{{AVG_ENG_RATE_LAST30}}');
+    expect(prompt).toContain('{{FOLLOWER_GROWTH_LAST30}}');
+    expect(prompt).toContain('{{EMERGING_FPC_COMBOS}}');
+    expect(prompt).toContain('{{HOT_TIMES_LAST_ANALYSIS}}');
   });
 });

--- a/src/app/lib/promptSystemFC.ts
+++ b/src/app/lib/promptSystemFC.ts
@@ -48,6 +48,10 @@ Resumo Atual (últimos 30 dias)
 - Alcance médio por post: {{AVG_REACH_LAST30}}
 - Compartilhamentos médios por post: {{AVG_SHARES_LAST30}}
 - Tendência principal: {{TREND_SUMMARY_LAST30}}
+- Engajamento médio (%): {{AVG_ENG_RATE_LAST30}}
+- Crescimento de seguidores: {{FOLLOWER_GROWTH_LAST30}}
+- Principais F/P/C emergentes: {{EMERGING_FPC_COMBOS}}
+- Horários quentes da última análise: {{HOT_TIMES_LAST_ANALYSIS}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de ${userName}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de ${userName}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é ${userName}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**
@@ -80,6 +84,7 @@ Regras Gerais de Operação
     * **(NOVO) RANKING DE CATEGORIAS (\`${GET_CATEGORY_RANKING_FUNC_NAME}\`):** Use esta ferramenta para fornecer ao usuário uma visão clara de quais dos *seus* próprios formatos, propostas ou contextos de conteúdo estão performando melhor com base em uma métrica (curtidas, compartilhamentos, etc.) ou quais são os mais publicados. É uma excelente ferramenta para identificar padrões de sucesso e pontos de melhoria no conteúdo do usuário e para ser usada de forma proativa.
     * **(NOVO) TENDÊNCIAS DO USUÁRIO (\`${GET_USER_TREND_FUNC_NAME}\`):** Use para gerar gráficos de evolução de seguidores ou de alcance/engajamento ao longo do tempo.
     * **(NOVO) HISTÓRICO F/P/C (\`${GET_FPC_TREND_HISTORY_FUNC_NAME}\`):** Analise a média de interações por semana ou mês para uma combinação específica de formato, proposta e contexto.
+    * **(NOVO) HORÁRIOS POR F/P/C (\`${GET_DAY_PCO_STATS_FUNC_NAME}\`):** Utilize para descobrir os melhores dias (e blocos de horário, se disponíveis) de cada combinação e destacar oportunidades pouco exploradas.
 
     * **REGRA DE OURO: IDENTIFICAÇÃO CORRETA DE IDs DE POSTS (ATUALIZADO - v2.33.4)**
         * ... (seção existente) ...


### PR DESCRIPTION
## Summary
- inject engagement rate, follower growth, FPC trends and hot times into promptSystemFC
- expose new placeholders to the system prompt and update documentation
- update aiOrchestrator to fetch these new values from existing functions
- extend tests to confirm new placeholders exist

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d58e880d0832e979dd7a60e66d848