### PR TITLE
Add top FPC trends placeholder

### DIFF
--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -11,5 +11,6 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{FOLLOWER_GROWTH_LAST30}}');
     expect(prompt).toContain('{{EMERGING_FPC_COMBOS}}');
     expect(prompt).toContain('{{HOT_TIMES_LAST_ANALYSIS}}');
+    expect(prompt).toContain('{{TOP_FPC_TRENDS}}');
   });
 });

--- a/src/app/lib/promptSystemFC.ts
+++ b/src/app/lib/promptSystemFC.ts
@@ -1,5 +1,6 @@
-// @/app/lib/promptSystemFC.ts – v2.33.9 (Adiciona consciência das tendências do usuário)
+// @/app/lib/promptSystemFC.ts – v2.34.0 (Inclui placeholder de tendências F/P/C)
 // - ATUALIZADO: Adicionada a função getUserTrend e o ranking de categorias à lógica e persona do Tuca.
+// - NOVO: {{TOP_FPC_TRENDS}} mostra as combinações de formato/proposta/contexto com maior crescimento de interações.
 // - Mantém todas as melhorias anteriores.
 
 export function getSystemPrompt(userName: string = 'usuário'): string { // userName aqui já será o firstName
@@ -52,6 +53,7 @@ Resumo Atual (últimos 30 dias)
 - Crescimento de seguidores: {{FOLLOWER_GROWTH_LAST30}}
 - Principais F/P/C emergentes: {{EMERGING_FPC_COMBOS}}
 - Horários quentes da última análise: {{HOT_TIMES_LAST_ANALYSIS}}
+- Tendências F/P/C em alta: {{TOP_FPC_TRENDS}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de ${userName}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de ${userName}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é ${userName}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**


### PR DESCRIPTION
## Summary
- compute top F/P/C trends in `askLLMWithEnrichedContext`
- inject `{{TOP_FPC_TRENDS}}` into the system prompt
- document new placeholder in `promptSystemFC.ts`
- cover placeholder with unit test

## Testing
- `npx jest` *(fails: jest not installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d602edba0832e8b1baf40b66a4c00