### PR TITLE
Add performance summary to system prompt

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -1,6 +1,9 @@
 import { populateSystemPrompt } from '../aiOrchestrator';
 import { functionExecutors } from '../aiFunctions';
 import { Types } from 'mongoose';
+import aggregateUserPerformanceHighlights from '@/utils/aggregateUserPerformanceHighlights';
+import aggregateUserDayPerformance from '@/utils/aggregateUserDayPerformance';
+import { aggregateUserTimePerformance } from '@/utils/aggregateUserTimePerformance';
 
 jest.mock('../aiFunctions', () => ({
   functionExecutors: {
@@ -12,8 +15,14 @@ jest.mock('../aiFunctions', () => ({
     getLatestAudienceDemographics: jest.fn(),
   }
 }));
+jest.mock('@/utils/aggregateUserPerformanceHighlights');
+jest.mock('@/utils/aggregateUserDayPerformance');
+jest.mock('@/utils/aggregateUserTimePerformance');
 
 const execs = functionExecutors as jest.Mocked<typeof functionExecutors>;
+const mockPerf = aggregateUserPerformanceHighlights as jest.Mock;
+const mockDayPerf = aggregateUserDayPerformance as jest.Mock;
+const mockTimePerf = aggregateUserTimePerformance as jest.Mock;
 
 describe('populateSystemPrompt', () => {
   const user = { _id: new Types.ObjectId(), name: 'Tester' } as any;
@@ -34,6 +43,16 @@ describe('populateSystemPrompt', () => {
     execs.getDayPCOStats.mockResolvedValue({ dayPCOStats: { '1': { dica: { tech: { avgTotalInteractions: 10 } } } } });
     execs.getCategoryRanking.mockResolvedValue({ ranking: [{ category: 'reel' }, { category: 'carrossel' }] });
     execs.getLatestAudienceDemographics.mockResolvedValue({ demographics: { follower_demographics: { country: { Brasil: 80 }, age: { '18-24': 50 } } } });
+    mockPerf.mockResolvedValue({
+      topFormat: { name: 'VIDEO', average: 10, count: 2 },
+      lowFormat: { name: 'IMAGE', average: 2, count: 1 },
+      topContext: null,
+      topProposal: null,
+      topTone: null,
+      topReference: null,
+    });
+    mockDayPerf.mockResolvedValue({ buckets: [], bestDays: [{ dayOfWeek: 5, average: 12, count: 4 }], worstDays: [] });
+    mockTimePerf.mockResolvedValue({ buckets: [], bestSlots: [{ dayOfWeek: 5, hour: 14, average: 20, count: 2 }], worstSlots: [] });
   });
 
   it('fills placeholders with values', async () => {
@@ -41,8 +60,11 @@ describe('populateSystemPrompt', () => {
     expect(prompt).toContain('100');
     expect(prompt).toContain('reel');
     expect(prompt).toContain('Brasil');
+    expect(prompt).toContain('VIDEO');
+    expect(prompt).toContain('14h');
     expect(prompt).not.toContain('{{AVG_REACH_LAST30}}');
     expect(prompt).not.toContain('{{TOP_CATEGORY_RANKINGS}}');
     expect(prompt).not.toContain('{{TOP_DAY_PCO_COMBOS}}');
+    expect(prompt).not.toContain('{{PERFORMANCE_INSIGHT_SUMMARY}}');
   });
 });

--- a/src/app/lib/dataService/index.ts
+++ b/src/app/lib/dataService/index.ts
@@ -49,7 +49,12 @@ export * from './demographicService';
 // --- (NOVO) Funções relacionadas com Rankings de Categorias ---
 // Adicionando a exportação da nossa nova função para torná-la visível.
 export {
-    fetchTopCategories
+    fetchTopCategories,
+    fetchAvgEngagementPerPostCreators,
+    fetchAvgReachPerPostCreators,
+    fetchEngagementVariationCreators,
+    fetchPerformanceConsistencyCreators,
+    fetchReachPerFollowerCreators
 } from './marketAnalysis/rankingsService';
 // -------------------------------------------------------------
 

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -11,6 +11,10 @@ Resumo Atual (últimos 30 dias)
 - Segmento de público em destaque: {{AUDIENCE_TOP_SEGMENT}}
 - Horários quentes da última análise: {{HOT_TIMES_LAST_ANALYSIS}}
 - Melhores combinações dia/F/P/C: {{TOP_DAY_PCO_COMBOS}}
+- Formato de melhor desempenho: {{TOP_PERFORMING_FORMAT}}
+- Formato de pior desempenho: {{LOW_PERFORMING_FORMAT}}
+- Melhor dia para postar: {{BEST_DAY}}
+- Insight de desempenho: {{PERFORMANCE_INSIGHT_SUMMARY}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de {{USER_NAME}}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de {{USER_NAME}}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é {{USER_NAME}}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**


### PR DESCRIPTION
## Summary
- export advanced ranking services
- enrich system prompt with performance summary and heatmap data
- include new placeholders in system prompt template
- test populateSystemPrompt replaces new fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d6db58ec4832e90542a925b0c4770