### PR TITLE
Add avg metrics in system prompt

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -14,6 +14,7 @@ jest.mock('../aiFunctions', () => ({
     getDayPCOStats: jest.fn(),
     getCategoryRanking: jest.fn(),
     getLatestAudienceDemographics: jest.fn(),
+    getMetricsHistory: jest.fn(),
   }
 }));
 jest.mock('@/utils/aggregateUserPerformanceHighlights');
@@ -56,6 +57,13 @@ describe('populateSystemPrompt', () => {
     execs.getDayPCOStats.mockResolvedValue({ dayPCOStats: { '1': { dica: { tech: { avgTotalInteractions: 10 } } } } });
     execs.getCategoryRanking.mockResolvedValue({ ranking: [{ category: 'reel' }, { category: 'carrossel' }] });
     execs.getLatestAudienceDemographics.mockResolvedValue({ demographics: { follower_demographics: { country: { Brasil: 80 }, age: { '18-24': 50 } } } });
+    execs.getMetricsHistory.mockResolvedValue({
+      history: {
+        propagationIndex: { labels: [], datasets: [{ data: [10, 20] }] },
+        followerConversionRate: { labels: [], datasets: [{ data: [3, 5] }] },
+        retentionRate: { labels: [], datasets: [{ data: [60, 80] }] },
+      }
+    });
     mockPerf.mockResolvedValue({
       topFormat: { name: 'VIDEO', average: 10, count: 2 },
       lowFormat: { name: 'IMAGE', average: 2, count: 1 },
@@ -77,6 +85,9 @@ describe('populateSystemPrompt', () => {
     expect(prompt).toContain('14h');
     expect(prompt).toContain('1.5');
     expect(prompt).toContain('5000');
+    expect(prompt).toContain('15.0');
+    expect(prompt).toContain('4.0');
+    expect(prompt).toContain('70.0');
     expect(prompt).toContain('tech');
     expect(prompt).not.toContain('{{AVG_REACH_LAST30}}');
     expect(prompt).not.toContain('{{TOP_CATEGORY_RANKINGS}}');
@@ -84,6 +95,9 @@ describe('populateSystemPrompt', () => {
     expect(prompt).not.toContain('{{PERFORMANCE_INSIGHT_SUMMARY}}');
     expect(prompt).not.toContain('{{DEALS_COUNT_LAST30}}');
     expect(prompt).not.toContain('{{FOLLOWER_GROWTH_RATE_LAST30}}');
+    expect(prompt).not.toContain('{{AVG_PROPAGATION_LAST30}}');
+    expect(prompt).not.toContain('{{AVG_FOLLOWER_CONV_RATE_LAST30}}');
+    expect(prompt).not.toContain('{{AVG_RETENTION_RATE_LAST30}}');
   });
 
   it('uses fallback phrase when metrics retrieval fails', async () => {
@@ -93,6 +107,7 @@ describe('populateSystemPrompt', () => {
     execs.getDayPCOStats.mockRejectedValue(new Error('fail'));
     execs.getCategoryRanking.mockRejectedValue(new Error('fail'));
     execs.getLatestAudienceDemographics.mockRejectedValue(new Error('fail'));
+    execs.getMetricsHistory.mockRejectedValue(new Error('fail'));
     mockPerf.mockRejectedValue(new Error('fail'));
     mockDayPerf.mockRejectedValue(new Error('fail'));
     mockTimePerf.mockRejectedValue(new Error('fail'));
@@ -114,6 +129,9 @@ describe('populateSystemPrompt', () => {
       '{{BEST_DAY}}',
       '{{PERFORMANCE_INSIGHT_SUMMARY}}',
       '{{FOLLOWER_GROWTH_RATE_LAST30}}',
+      '{{AVG_PROPAGATION_LAST30}}',
+      '{{AVG_FOLLOWER_CONV_RATE_LAST30}}',
+      '{{AVG_RETENTION_RATE_LAST30}}',
       '{{AVG_ENG_POST_LAST30}}',
       '{{AVG_REACH_POST_LAST30}}',
       '{{DEALS_COUNT_LAST30}}',

--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -14,6 +14,7 @@ jest.mock('../aiFunctions', () => ({
     getDayPCOStats: jest.fn(),
     getCategoryRanking: jest.fn(),
     getLatestAudienceDemographics: jest.fn(),
+    getMetricsHistory: jest.fn(),
   }
 }));
 jest.mock('@/utils/aggregateUserPerformanceHighlights');
@@ -37,6 +38,9 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{FOLLOWER_GROWTH_RATE_LAST30}}');
     expect(prompt).toContain('{{AVG_ENG_POST_LAST30}}');
     expect(prompt).toContain('{{AVG_REACH_POST_LAST30}}');
+    expect(prompt).toContain('{{AVG_PROPAGATION_LAST30}}');
+    expect(prompt).toContain('{{AVG_FOLLOWER_CONV_RATE_LAST30}}');
+    expect(prompt).toContain('{{AVG_RETENTION_RATE_LAST30}}');
     expect(prompt).toContain('{{EMERGING_FPC_COMBOS}}');
     expect(prompt).toContain('{{HOT_TIMES_LAST_ANALYSIS}}');
     expect(prompt).toContain('{{TOP_DAY_PCO_COMBOS}}');
@@ -73,6 +77,7 @@ describe('populateSystemPrompt user preference placeholders', () => {
     execs.getDayPCOStats.mockResolvedValue({});
     execs.getCategoryRanking.mockResolvedValue({});
     execs.getLatestAudienceDemographics.mockResolvedValue({});
+    execs.getMetricsHistory.mockResolvedValue({ history: {} });
     mockPerf.mockResolvedValue({});
     mockDayPerf.mockResolvedValue({});
     mockTimePerf.mockResolvedValue({});

--- a/src/app/lib/aiOrchestrator.ts
+++ b/src/app/lib/aiOrchestrator.ts
@@ -229,6 +229,31 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             logger.error(`${fnTag} Erro ao obter demographics:`, e);
         }
 
+        let avgPropagationText = 'Dados insuficientes';
+        let avgFollowerConvText = 'Dados insuficientes';
+        let avgRetentionText = 'Dados insuficientes';
+        try {
+            let metricsRes: any = {};
+            if (functionExecutors && typeof functionExecutors.getMetricsHistory === 'function') {
+                metricsRes = await functionExecutors.getMetricsHistory({ days: 30 }, user);
+            } else {
+                logger.warn(`${fnTag} Executor function 'getMetricsHistory' not found.`);
+            }
+            const history = metricsRes?.history || {};
+            const avgOf = (arr: any): number | null => {
+                const vals = Array.isArray(arr) ? arr.filter((v: any) => typeof v === 'number') : [];
+                return vals.length ? vals.reduce((a: number, b: number) => a + b, 0) / vals.length : null;
+            };
+            const propAvg = avgOf(history.propagationIndex?.datasets?.[0]?.data);
+            const convAvg = avgOf(history.followerConversionRate?.datasets?.[0]?.data);
+            const retAvg = avgOf(history.retentionRate?.datasets?.[0]?.data);
+            if (propAvg !== null) avgPropagationText = propAvg.toFixed(1);
+            if (convAvg !== null) avgFollowerConvText = convAvg.toFixed(1);
+            if (retAvg !== null) avgRetentionText = retAvg.toFixed(1);
+        } catch (e) {
+            logger.error(`${fnTag} Erro ao processar MetricsHistory:`, e);
+        }
+
         let topFormatText = 'N/A';
         let lowFormatText = 'N/A';
         let bestDayText = 'N/A';
@@ -302,6 +327,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{FOLLOWER_GROWTH_RATE_LAST30}}', followerGrowthRateText)
             .replace('{{AVG_ENG_POST_LAST30}}', avgEngPostText)
             .replace('{{AVG_REACH_POST_LAST30}}', avgReachPostText)
+            .replace('{{AVG_PROPAGATION_LAST30}}', avgPropagationText)
+            .replace('{{AVG_FOLLOWER_CONV_RATE_LAST30}}', avgFollowerConvText)
+            .replace('{{AVG_RETENTION_RATE_LAST30}}', avgRetentionText)
             .replace('{{DEALS_COUNT_LAST30}}', dealsCountText)
             .replace('{{DEALS_REVENUE_LAST30}}', dealsRevenueText)
             .replace('{{DEAL_AVG_VALUE_LAST30}}', dealsAvgValueText)
@@ -341,6 +369,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{FOLLOWER_GROWTH_RATE_LAST30}}', 'Dados insuficientes')
             .replace('{{AVG_ENG_POST_LAST30}}', 'Dados insuficientes')
             .replace('{{AVG_REACH_POST_LAST30}}', 'Dados insuficientes')
+            .replace('{{AVG_PROPAGATION_LAST30}}', 'Dados insuficientes')
+            .replace('{{AVG_FOLLOWER_CONV_RATE_LAST30}}', 'Dados insuficientes')
+            .replace('{{AVG_RETENTION_RATE_LAST30}}', 'Dados insuficientes')
             .replace('{{DEALS_COUNT_LAST30}}', 'Dados insuficientes')
             .replace('{{DEALS_REVENUE_LAST30}}', 'Dados insuficientes')
             .replace('{{DEAL_AVG_VALUE_LAST30}}', 'Dados insuficientes')

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -18,6 +18,9 @@ Resumo Atual (últimos 30 dias)
 - Taxa de crescimento de seguidores: {{FOLLOWER_GROWTH_RATE_LAST30}}
 - Engajamento médio por post: {{AVG_ENG_POST_LAST30}}
 - Alcance médio por post (histórico): {{AVG_REACH_POST_LAST30}}
+- Índice de propagação médio: {{AVG_PROPAGATION_LAST30}}
+- Taxa de conversão de seguidores: {{AVG_FOLLOWER_CONV_RATE_LAST30}}
+- Taxa de retenção média: {{AVG_RETENTION_RATE_LAST30}}
 - Total de parcerias fechadas: {{DEALS_COUNT_LAST30}}
 - Receita de parcerias (BRL): {{DEALS_REVENUE_LAST30}}
 - Valor médio por parceria (BRL): {{DEAL_AVG_VALUE_LAST30}}


### PR DESCRIPTION
## Summary
- include avg propagation, conversion and retention placeholders in the system prompt template
- compute 30‑day averages using `getMetricsHistory`
- show averages or fallback message when data missing
- update tests for new metrics

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d84172374832eb7024425fe0589b4