### PR TITLE
Support user goals and key facts in system prompt

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -142,6 +142,8 @@ describe('populateSystemPrompt', () => {
       '{{USER_TONE_PREF}}',
       '{{USER_PREFERRED_FORMATS}}',
       '{{USER_DISLIKED_TOPICS}}',
+      '{{USER_LONG_TERM_GOALS}}',
+      '{{USER_KEY_FACTS}}',
     ];
 
     const expected = placeholders.reduce(

--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -55,6 +55,8 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{USER_TONE_PREF}}');
     expect(prompt).toContain('{{USER_PREFERRED_FORMATS}}');
     expect(prompt).toContain('{{USER_DISLIKED_TOPICS}}');
+    expect(prompt).toContain('{{USER_LONG_TERM_GOALS}}');
+    expect(prompt).toContain('{{USER_KEY_FACTS}}');
   });
 });
 
@@ -67,6 +69,13 @@ describe('populateSystemPrompt user preference placeholders', () => {
       preferredFormats: ['reel', 'story'],
       dislikedTopics: ['politica', 'religiao'],
     },
+    userLongTermGoals: [
+      { goal: 'ser influenciador digital' },
+      { goal: 'vender curso' },
+    ],
+    userKeyFacts: [
+      { fact: 'ama gatos' },
+    ],
   } as any;
 
   beforeEach(() => {
@@ -88,8 +97,12 @@ describe('populateSystemPrompt user preference placeholders', () => {
     expect(prompt).toContain('direto');
     expect(prompt).toContain('reel, story');
     expect(prompt).toContain('politica, religiao');
+    expect(prompt).toContain('ser influenciador digital, vender curso');
+    expect(prompt).toContain('ama gatos');
     expect(prompt).not.toContain('{{USER_TONE_PREF}}');
     expect(prompt).not.toContain('{{USER_PREFERRED_FORMATS}}');
     expect(prompt).not.toContain('{{USER_DISLIKED_TOPICS}}');
+    expect(prompt).not.toContain('{{USER_LONG_TERM_GOALS}}');
+    expect(prompt).not.toContain('{{USER_KEY_FACTS}}');
   });
 });

--- a/src/app/lib/aiOrchestrator.ts
+++ b/src/app/lib/aiOrchestrator.ts
@@ -317,6 +317,12 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
         const dislikedTopics = Array.isArray(user.userPreferences?.dislikedTopics) && user.userPreferences?.dislikedTopics.length
             ? user.userPreferences!.dislikedTopics.join(', ')
             : 'N/A';
+        const longTermGoals = Array.isArray(user.userLongTermGoals) && user.userLongTermGoals.length
+            ? user.userLongTermGoals.map(g => g.goal).join(', ')
+            : 'Dados insuficientes';
+        const keyFacts = Array.isArray(user.userKeyFacts) && user.userKeyFacts.length
+            ? user.userKeyFacts.map(f => f.fact).join(', ')
+            : 'Dados insuficientes';
 
         systemPrompt = systemPrompt
             .replace('{{AVG_REACH_LAST30}}', String(avgReach))
@@ -347,7 +353,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{PERFORMANCE_INSIGHT_SUMMARY}}', perfSummaryText)
             .replace('{{USER_TONE_PREF}}', tonePref)
             .replace('{{USER_PREFERRED_FORMATS}}', prefFormats)
-            .replace('{{USER_DISLIKED_TOPICS}}', dislikedTopics);
+            .replace('{{USER_DISLIKED_TOPICS}}', dislikedTopics)
+            .replace('{{USER_LONG_TERM_GOALS}}', longTermGoals)
+            .replace('{{USER_KEY_FACTS}}', keyFacts);
     } catch (metricErr) {
         logger.error(`${fnTag} Erro ao obter métricas para systemPrompt:`, metricErr);
         systemPrompt = systemPrompt
@@ -379,7 +387,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{DEALS_FREQUENCY}}', 'Dados insuficientes')
             .replace('{{USER_TONE_PREF}}', 'Dados insuficientes')
             .replace('{{USER_PREFERRED_FORMATS}}', 'Dados insuficientes')
-            .replace('{{USER_DISLIKED_TOPICS}}', 'Dados insuficientes');
+            .replace('{{USER_DISLIKED_TOPICS}}', 'Dados insuficientes')
+            .replace('{{USER_LONG_TERM_GOALS}}', 'Dados insuficientes')
+            .replace('{{USER_KEY_FACTS}}', 'Dados insuficientes');
     }
 
     return systemPrompt;

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -30,6 +30,8 @@ Resumo Atual (últimos 30 dias)
 - Preferência de tom do usuário: {{USER_TONE_PREF}}
 - Formatos preferidos pelo usuário: {{USER_PREFERRED_FORMATS}}
 - Tópicos evitados pelo usuário: {{USER_DISLIKED_TOPICS}}
+- Metas de longo prazo do usuário: {{USER_LONG_TERM_GOALS}}
+- Fatos-chave sobre o usuário: {{USER_KEY_FACTS}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de {{USER_NAME}}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de {{USER_NAME}}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é {{USER_NAME}}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**


### PR DESCRIPTION
## Summary
- add `{{USER_LONG_TERM_GOALS}}` and `{{USER_KEY_FACTS}}` placeholders to the system prompt template
- populate these new placeholders in `populateSystemPrompt`
- adjust unit tests for the new placeholders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8a90245c832e969aa1870c9b22b8