### PR TITLE
Add user expertise placeholder

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -144,6 +144,7 @@ describe('populateSystemPrompt', () => {
       '{{USER_DISLIKED_TOPICS}}',
       '{{USER_LONG_TERM_GOALS}}',
       '{{USER_KEY_FACTS}}',
+      '{{USER_EXPERTISE_LEVEL}}',
     ];
 
     const expected = placeholders.reduce(

--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -57,6 +57,7 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{USER_DISLIKED_TOPICS}}');
     expect(prompt).toContain('{{USER_LONG_TERM_GOALS}}');
     expect(prompt).toContain('{{USER_KEY_FACTS}}');
+    expect(prompt).toContain('{{USER_EXPERTISE_LEVEL}}');
   });
 });
 
@@ -64,6 +65,7 @@ describe('populateSystemPrompt user preference placeholders', () => {
   const user = {
     _id: new Types.ObjectId(),
     name: 'Tester',
+    inferredExpertiseLevel: 'Iniciante',
     userPreferences: {
       preferredAiTone: 'direto',
       preferredFormats: ['reel', 'story'],
@@ -99,11 +101,13 @@ describe('populateSystemPrompt user preference placeholders', () => {
     expect(prompt).toContain('politica, religiao');
     expect(prompt).toContain('ser influenciador digital, vender curso');
     expect(prompt).toContain('ama gatos');
+    expect(prompt).toContain('Iniciante');
     expect(prompt).toContain('Dados insuficientes');
     expect(prompt).not.toContain('{{USER_TONE_PREF}}');
     expect(prompt).not.toContain('{{USER_PREFERRED_FORMATS}}');
     expect(prompt).not.toContain('{{USER_DISLIKED_TOPICS}}');
     expect(prompt).not.toContain('{{USER_LONG_TERM_GOALS}}');
     expect(prompt).not.toContain('{{USER_KEY_FACTS}}');
+    expect(prompt).not.toContain('{{USER_EXPERTISE_LEVEL}}');
   });
 });

--- a/src/app/lib/aiOrchestrator.ts
+++ b/src/app/lib/aiOrchestrator.ts
@@ -323,6 +323,7 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
         const keyFacts = Array.isArray(user.userKeyFacts) && user.userKeyFacts.length
             ? user.userKeyFacts.map(f => f.fact).join(', ')
             : 'Dados insuficientes';
+        const expertiseLevel = user.inferredExpertiseLevel || 'Dados insuficientes';
 
         systemPrompt = systemPrompt
             .replace('{{AVG_REACH_LAST30}}', String(avgReach))
@@ -355,7 +356,8 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{USER_PREFERRED_FORMATS}}', prefFormats)
             .replace('{{USER_DISLIKED_TOPICS}}', dislikedTopics)
             .replace('{{USER_LONG_TERM_GOALS}}', longTermGoals)
-            .replace('{{USER_KEY_FACTS}}', keyFacts);
+            .replace('{{USER_KEY_FACTS}}', keyFacts)
+            .replace('{{USER_EXPERTISE_LEVEL}}', expertiseLevel);
     } catch (metricErr) {
         logger.error(`${fnTag} Erro ao obter métricas para systemPrompt:`, metricErr);
         systemPrompt = systemPrompt
@@ -389,7 +391,8 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{USER_PREFERRED_FORMATS}}', 'Dados insuficientes')
             .replace('{{USER_DISLIKED_TOPICS}}', 'Dados insuficientes')
             .replace('{{USER_LONG_TERM_GOALS}}', 'Dados insuficientes')
-            .replace('{{USER_KEY_FACTS}}', 'Dados insuficientes');
+            .replace('{{USER_KEY_FACTS}}', 'Dados insuficientes')
+            .replace('{{USER_EXPERTISE_LEVEL}}', 'Dados insuficientes');
     }
 
     return systemPrompt;

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -32,6 +32,7 @@ Resumo Atual (últimos 30 dias)
 - Tópicos evitados pelo usuário: {{USER_DISLIKED_TOPICS}}
 - Metas de longo prazo do usuário: {{USER_LONG_TERM_GOALS}}
 - Fatos-chave sobre o usuário: {{USER_KEY_FACTS}}
+- Nível de expertise do usuário: {{USER_EXPERTISE_LEVEL}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de {{USER_NAME}}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de {{USER_NAME}}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é {{USER_NAME}}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**


### PR DESCRIPTION
## Summary
- include `USER_EXPERTISE_LEVEL` placeholder in system prompt template
- populate the new placeholder from `user.inferredExpertiseLevel`
- cover new field in prompt-related unit tests

## Testing
- `bun test src/app/lib/__tests__/promptSystemFC.test.ts` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_687d8f0483d4832e8d55ac2ddd060fbb