### PR TITLE
Handle user bio and profile tone placeholders

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -145,6 +145,8 @@ describe('populateSystemPrompt', () => {
       '{{USER_LONG_TERM_GOALS}}',
       '{{USER_KEY_FACTS}}',
       '{{USER_EXPERTISE_LEVEL}}',
+      '{{USER_BIO}}',
+      '{{USER_PROFILE_TONE}}',
     ];
 
     const expected = placeholders.reduce(

--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -58,6 +58,8 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('{{USER_LONG_TERM_GOALS}}');
     expect(prompt).toContain('{{USER_KEY_FACTS}}');
     expect(prompt).toContain('{{USER_EXPERTISE_LEVEL}}');
+    expect(prompt).toContain('{{USER_BIO}}');
+    expect(prompt).toContain('{{USER_PROFILE_TONE}}');
   });
 });
 
@@ -66,6 +68,8 @@ describe('populateSystemPrompt user preference placeholders', () => {
     _id: new Types.ObjectId(),
     name: 'Tester',
     inferredExpertiseLevel: 'Iniciante',
+    biography: 'Bio de teste',
+    profileTone: 'profissional',
     userPreferences: {
       preferredAiTone: 'direto',
       preferredFormats: ['reel', 'story'],
@@ -102,6 +106,8 @@ describe('populateSystemPrompt user preference placeholders', () => {
     expect(prompt).toContain('ser influenciador digital, vender curso');
     expect(prompt).toContain('ama gatos');
     expect(prompt).toContain('Iniciante');
+    expect(prompt).toContain('Bio de teste');
+    expect(prompt).toContain('profissional');
     expect(prompt).toContain('Dados insuficientes');
     expect(prompt).not.toContain('{{USER_TONE_PREF}}');
     expect(prompt).not.toContain('{{USER_PREFERRED_FORMATS}}');
@@ -109,5 +115,7 @@ describe('populateSystemPrompt user preference placeholders', () => {
     expect(prompt).not.toContain('{{USER_LONG_TERM_GOALS}}');
     expect(prompt).not.toContain('{{USER_KEY_FACTS}}');
     expect(prompt).not.toContain('{{USER_EXPERTISE_LEVEL}}');
+    expect(prompt).not.toContain('{{USER_BIO}}');
+    expect(prompt).not.toContain('{{USER_PROFILE_TONE}}');
   });
 });

--- a/src/app/lib/aiOrchestrator.ts
+++ b/src/app/lib/aiOrchestrator.ts
@@ -379,6 +379,8 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             ? user.userKeyFacts.map(f => f.fact).join(', ')
             : 'Dados insuficientes';
         const expertiseLevel = user.inferredExpertiseLevel || 'Dados insuficientes';
+        const userBio = user.biography || 'Dados insuficientes';
+        const profileTone = user.profileTone || 'Dados insuficientes';
 
         systemPrompt = systemPrompt
             .replace('{{AVG_REACH_LAST30}}', String(avgReach))
@@ -412,7 +414,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{USER_DISLIKED_TOPICS}}', dislikedTopics)
             .replace('{{USER_LONG_TERM_GOALS}}', longTermGoals)
             .replace('{{USER_KEY_FACTS}}', keyFacts)
-            .replace('{{USER_EXPERTISE_LEVEL}}', expertiseLevel);
+            .replace('{{USER_EXPERTISE_LEVEL}}', expertiseLevel)
+            .replace('{{USER_BIO}}', userBio)
+            .replace('{{USER_PROFILE_TONE}}', profileTone);
     } catch (metricErr) {
         logger.error(`${fnTag} Erro ao obter métricas para systemPrompt:`, metricErr);
         systemPrompt = systemPrompt
@@ -447,7 +451,9 @@ export async function populateSystemPrompt(user: IUser, userName: string): Promi
             .replace('{{USER_DISLIKED_TOPICS}}', 'Dados insuficientes')
             .replace('{{USER_LONG_TERM_GOALS}}', 'Dados insuficientes')
             .replace('{{USER_KEY_FACTS}}', 'Dados insuficientes')
-            .replace('{{USER_EXPERTISE_LEVEL}}', 'Dados insuficientes');
+            .replace('{{USER_EXPERTISE_LEVEL}}', 'Dados insuficientes')
+            .replace('{{USER_BIO}}', 'Dados insuficientes')
+            .replace('{{USER_PROFILE_TONE}}', 'Dados insuficientes');
     }
 
     return systemPrompt;

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -33,6 +33,8 @@ Resumo Atual (últimos 30 dias)
 - Metas de longo prazo do usuário: {{USER_LONG_TERM_GOALS}}
 - Fatos-chave sobre o usuário: {{USER_KEY_FACTS}}
 - Nível de expertise do usuário: {{USER_EXPERTISE_LEVEL}}
+- Biografia do usuário: {{USER_BIO}}
+- Tom do perfil do usuário: {{USER_PROFILE_TONE}}
 
 Você é o **Tuca**, o consultor estratégico de Instagram super antenado e parceiro especialista de {{USER_NAME}}. Seu tom é de um **mentor paciente, perspicaz, encorajador e PROATIVO**. Sua especialidade é analisar dados do Instagram de {{USER_NAME}}, **identificar seus conteúdos de maior sucesso através de rankings por categoria**, fornecer conhecimento prático, gerar insights acionáveis, **propor estratégias de conteúdo** e, futuramente com mais exemplos, buscar inspirações na Comunidade de Criadores IA Tuca. Sua comunicação é **didática**, experiente e adaptada para uma conversa fluida via chat. Use emojis como 😊, 👍, 💡, ⏳, 📊 de forma sutil e apropriada. **Você é o especialista; você analisa os dados e DIZ ao usuário o que deve ser feito e porquê, em vez de apenas fazer perguntas.**
 **Lembre-se que o primeiro nome do usuário é {{USER_NAME}}; use-o para personalizar a interação de forma natural e moderada, especialmente ao iniciar um novo contexto ou após um intervalo significativo sem interação. Evite repetir o nome em cada mensagem subsequente dentro do mesmo fluxo de conversa, optando por pronomes ou uma abordagem mais direta.**


### PR DESCRIPTION
## Summary
- include `{{USER_BIO}}` and `{{USER_PROFILE_TONE}}` placeholders in the system prompt template
- populate these placeholders from `user.biography` and `user.profileTone`
- update tests to cover the new placeholders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d950fc364832eb18cc562937465c6