### PR TITLE
Implement cached system prompt

### DIFF
--- a/src/app/lib/stateService.ts
+++ b/src/app/lib/stateService.ts
@@ -143,6 +143,18 @@ export async function setInCache(key: string, value: string, ttlSeconds: number)
   }
 }
 
+export async function deleteFromCache(key: string): Promise<void> {
+   const TAG = '[stateService][deleteFromCache v1.9.17]';
+   try {
+    const redis = getClient();
+    logger.debug(`${TAG} Deletando chave: ${key}`);
+    await redis.del(key);
+    logger.debug(`${TAG} Chave ${key} deletada com sucesso.`);
+  } catch (error) {
+     logger.error(`${TAG} Erro ao deletar key ${key}:`, error);
+  }
+}
+
 // --- Estado do Diálogo ---
 
 export type { CurrentTask, ILastResponseContext, IFallbackInsightHistoryEntry, IDialogueState };


### PR DESCRIPTION
## Summary
- add deleteFromCache utility in state service
- cache populated system prompt for 5 minutes
- allow cache invalidation
- test cache behavior with mocked Redis

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d98c70460832e97303bd2e2b71437