### PR TITLE
Add dynamic metrics period placeholder

### DIFF
--- a/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
+++ b/src/app/lib/__tests__/aiOrchestratorPrompt.test.ts
@@ -1,6 +1,7 @@
 import { populateSystemPrompt } from '../aiOrchestrator';
 import { getSystemPrompt } from '../promptSystemFC';
 import { functionExecutors } from '../aiFunctions';
+import { DEFAULT_METRICS_FETCH_DAYS } from '../constants';
 import { Types } from 'mongoose';
 import * as stateService from '../stateService';
 import aggregateUserPerformanceHighlights from '@/utils/aggregateUserPerformanceHighlights';
@@ -85,6 +86,7 @@ describe('populateSystemPrompt', () => {
 
   it('fills placeholders with values', async () => {
     const prompt = await populateSystemPrompt(user, 'Ana');
+    expect(prompt).toContain(`últimos ${DEFAULT_METRICS_FETCH_DAYS} dias`);
     expect(prompt).toContain('100');
     expect(prompt).toContain('reel');
     expect(prompt).toContain('Brasil');
@@ -159,7 +161,7 @@ describe('populateSystemPrompt', () => {
     const expected = placeholders.reduce(
       (p, ph) => p.replace(ph, 'Dados insuficientes'),
       getSystemPrompt('Ana')
-    );
+    ).replace('{{METRICS_PERIOD_DAYS}}', DEFAULT_METRICS_FETCH_DAYS.toString());
 
     const prompt = await populateSystemPrompt(user, 'Ana');
     expect(prompt).toBe(expected);

--- a/src/app/lib/__tests__/promptSystemFC.test.ts
+++ b/src/app/lib/__tests__/promptSystemFC.test.ts
@@ -1,6 +1,7 @@
 import { getSystemPrompt } from '../promptSystemFC';
 import { populateSystemPrompt } from '../aiOrchestrator';
 import { functionExecutors } from '../aiFunctions';
+import { DEFAULT_METRICS_FETCH_DAYS } from '../constants';
 import { Types } from 'mongoose';
 import aggregateUserPerformanceHighlights from '@/utils/aggregateUserPerformanceHighlights';
 import aggregateUserDayPerformance from '@/utils/aggregateUserDayPerformance';
@@ -30,6 +31,7 @@ describe('getSystemPrompt', () => {
   it('includes metrics placeholders in Resumo Atual section', () => {
     const prompt = getSystemPrompt('Ana');
     expect(prompt).toContain('Resumo Atual');
+    expect(prompt).toContain('{{METRICS_PERIOD_DAYS}}');
     expect(prompt).toContain('{{AVG_REACH_LAST30}}');
     expect(prompt).toContain('{{AVG_SHARES_LAST30}}');
     expect(prompt).toContain('{{TREND_SUMMARY_LAST30}}');
@@ -100,6 +102,7 @@ describe('populateSystemPrompt user preference placeholders', () => {
 
   it('replaces placeholders with user preferences', async () => {
     const prompt = await populateSystemPrompt(user, 'Ana');
+    expect(prompt).toContain(`últimos ${DEFAULT_METRICS_FETCH_DAYS} dias`);
     expect(prompt).toContain('direto');
     expect(prompt).toContain('reel, story');
     expect(prompt).toContain('politica, religiao');

--- a/src/app/lib/aiOrchestrator.ts
+++ b/src/app/lib/aiOrchestrator.ts
@@ -79,6 +79,7 @@ export async function populateSystemPrompt(
     }
 
     let systemPrompt = getSystemPrompt(userName || user.name || 'usuário');
+    systemPrompt = systemPrompt.replace('{{METRICS_PERIOD_DAYS}}', String(periodDays));
 
     try {
         // CORREÇÃO: Adicionada verificação para garantir que a função existe antes de chamá-la.

--- a/src/app/lib/systemPromptTemplate.md
+++ b/src/app/lib/systemPromptTemplate.md
@@ -1,4 +1,4 @@
-Resumo Atual (últimos 30 dias)
+Resumo Atual (últimos {{METRICS_PERIOD_DAYS}} dias)
 ------------------------------
 - Alcance médio por post: {{AVG_REACH_LAST30}}
 - Compartilhamentos médios por post: {{AVG_SHARES_LAST30}}


### PR DESCRIPTION
## Summary
- parameterize metrics period in template
- replace the placeholder in `populateSystemPrompt`
- adjust unit tests for new dynamic text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d9c2c6ba0832e9a8c97ce0748ff0f