### PR TITLE
Compute similarity when choosing inspirations

### DIFF
--- a/src/app/api/whatsapp/__tests__/inspirationRanking.test.ts
+++ b/src/app/api/whatsapp/__tests__/inspirationRanking.test.ts
@@ -1,0 +1,73 @@
+import { computeInspirationSimilarity, fetchInspirationSnippet } from '../process-response/dailyTipHandler';
+import * as dataService from '@/app/lib/dataService';
+
+describe('inspiration ranking', () => {
+  test('computeInspirationSimilarity gives higher score to closer match', () => {
+    const bestPost: any = {
+      stats: { reach: 1000, saved: 200, shares: 50 },
+      format: ['Reel'],
+      proposal: ['Humor/Cena'],
+      context: ['Estilo de Vida e Bem-Estar']
+    };
+
+    const insp1: any = {
+      format: 'Reel',
+      proposal: 'Humor/Cena',
+      context: 'Estilo de Vida e Bem-Estar',
+      internalMetricsSnapshot: { saveRate: 0.2, shareRate: 0.05 }
+    };
+
+    const insp2: any = {
+      format: 'Foto',
+      proposal: 'Mensagem/Motivacional',
+      context: 'Moda/Estilo',
+      internalMetricsSnapshot: { saveRate: 0.05, shareRate: 0.01 }
+    };
+
+    const score1 = computeInspirationSimilarity(bestPost, insp1);
+    const score2 = computeInspirationSimilarity(bestPost, insp2);
+    expect(score1).toBeGreaterThan(score2);
+  });
+
+  test('fetchInspirationSnippet returns most similar inspiration', async () => {
+    const bestPost: any = {
+      stats: { reach: 1000, saved: 200, shares: 50 },
+      format: ['Reel'],
+      proposal: ['Humor/Cena'],
+      context: ['Estilo de Vida e Bem-Estar']
+    };
+
+    const inspHigh: any = {
+      _id: '1',
+      contentSummary: 'High',
+      originalInstagramPostUrl: 'url1',
+      format: 'Reel',
+      proposal: 'Humor/Cena',
+      context: 'Estilo de Vida e Bem-Estar',
+      internalMetricsSnapshot: { saveRate: 0.2, shareRate: 0.05 }
+    };
+
+    const inspLow: any = {
+      _id: '2',
+      contentSummary: 'Low',
+      originalInstagramPostUrl: 'url2',
+      format: 'Foto',
+      proposal: 'Mensagem/Motivacional',
+      context: 'Moda/Estilo',
+      internalMetricsSnapshot: { saveRate: 0.05, shareRate: 0.01 }
+    };
+
+    jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue([bestPost]);
+    jest.spyOn(dataService, 'recordDailyInspirationShown').mockResolvedValue();
+    jest.spyOn(dataService, 'getInspirations').mockImplementation((f, l, e, simFn) => {
+      const arr = [inspLow, inspHigh];
+      if (simFn) {
+        arr.sort((a, b) => simFn(b) - simFn(a));
+      }
+      return Promise.resolve(arr.slice(0, l));
+    });
+
+    const res = await fetchInspirationSnippet('user1', {}, []);
+    expect(res.text).toContain('High');
+  });
+});

--- a/src/app/lib/dataService/communityService.ts
+++ b/src/app/lib/dataService/communityService.ts
@@ -228,7 +228,7 @@ export async function getInspirations(
         let inspirations = await CommunityInspirationModel.find(query)
             .sort({ addedToCommunityAt: -1, 'internalMetricsSnapshot.saveRate': -1 })
             .limit(similarityFn ? limit * 3 : limit)
-            .select('-internalMetricsSnapshot -updatedAt -status -__v')
+            .select(similarityFn ? '-updatedAt -status -__v' : '-internalMetricsSnapshot -updatedAt -status -__v')
             .lean();
 
         if (similarityFn) {


### PR DESCRIPTION
## Summary
- score inspirations against the user's best post
- return the most similar community inspiration
- include internal metrics when similarity is calculated
- test ranking helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e65330238832eb1bed49f58b2e943