### PR TITLE
Add excludeCreatorId to getInspirations

### DIFF
--- a/src/app/api/whatsapp/__tests__/inspirationRanking.test.ts
+++ b/src/app/api/whatsapp/__tests__/inspirationRanking.test.ts
@@ -59,7 +59,7 @@ describe('inspiration ranking', () => {
 
     jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue([bestPost]);
     jest.spyOn(dataService, 'recordDailyInspirationShown').mockResolvedValue();
-    jest.spyOn(dataService, 'getInspirations').mockImplementation((f, l, e, simFn) => {
+    jest.spyOn(dataService, 'getInspirations').mockImplementation((f, l, e, simFn, excludeCreatorId) => {
       const arr = [inspLow, inspHigh];
       if (simFn) {
         arr.sort((a, b) => simFn(b) - simFn(a));

--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -453,7 +453,8 @@ export async function fetchInspirationSnippet(
             filters,
             3,
             excludeIds,
-            (i) => computeInspirationSimilarity(bestPost, i)
+            (i) => computeInspirationSimilarity(bestPost, i),
+            userId
         );
 
         const insp = inspirations && inspirations.length > 0 ? inspirations[0] : undefined;

--- a/src/app/lib/dataService/communityService.ts
+++ b/src/app/lib/dataService/communityService.ts
@@ -177,6 +177,7 @@ export async function addInspiration(
  * @param filters - Os filtros a serem aplicados na busca.
  * @param limit - O número máximo de inspirações a serem retornadas (padrão: 3).
  * @param excludeIds - Um array opcional de IDs de inspiração a serem excluídos dos resultados.
+ * @param excludeCreatorId - ID de criador a ser excluído dos resultados.
  * @returns Uma promessa que resolve para um array de inspirações encontradas.
  * @throws {DatabaseError} Se ocorrer um erro de banco de dados.
  */
@@ -184,10 +185,11 @@ export async function getInspirations(
     filters: CommunityInspirationFilters,
     limit: number = 3,
     excludeIds?: string[],
-    similarityFn?: (insp: ICommunityInspiration) => number
+    similarityFn?: (insp: ICommunityInspiration) => number,
+    excludeCreatorId?: string
 ): Promise<ICommunityInspiration[]> {
     const TAG = `${SERVICE_TAG}[getInspirations]`;
-    logger.info(`${TAG} Buscando inspirações com filtros: ${JSON.stringify(filters)}, limite: ${limit}, excluir IDs: ${excludeIds?.join(',')}, similarityFn: ${similarityFn ? 'yes' : 'no'}`);
+    logger.info(`${TAG} Buscando inspirações com filtros: ${JSON.stringify(filters)}, limite: ${limit}, excluir IDs: ${excludeIds?.join(',')}, similarityFn: ${similarityFn ? 'yes' : 'no'}, excludeCreatorId: ${excludeCreatorId}`);
 
     const query: any = { status: 'active' };
 
@@ -221,6 +223,10 @@ export async function getInspirations(
         if (validObjectIds.length > 0) {
             query._id = { $nin: validObjectIds };
         }
+    }
+
+    if (excludeCreatorId && mongoose.isValidObjectId(excludeCreatorId)) {
+        query.originalCreatorId = { $ne: new Types.ObjectId(excludeCreatorId) };
     }
 
     try {


### PR DESCRIPTION
## Summary
- allow filtering inspirations by creator id
- pass current user when fetching inspiration snippets
- update test mocks for new parameter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e67248e30832eb6d8d7db8e8c442e