### PR TITLE
Improve inspiration filter inference

### DIFF
--- a/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
+++ b/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
@@ -1,0 +1,36 @@
+import { buildInspirationFilters } from '../process-response/dailyTipHandler';
+import * as dataService from '@/app/lib/dataService';
+
+describe('buildInspirationFilters', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  test('uses most common categories from top posts when missing', async () => {
+    const posts: any[] = [
+      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
+      { format: ['Foto'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
+      { format: ['Reel'], proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'] }
+    ];
+    jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue(posts);
+    jest.spyOn(dataService, 'lookupUserById').mockResolvedValue({ userPreferences: {} } as any);
+
+    const filters = await buildInspirationFilters('user1', undefined, true);
+    expect(filters.format).toBe('Reel');
+    expect(filters.proposal).toBe('Humor/Cena');
+    expect(filters.context).toBe('Moda/Estilo');
+  });
+
+  test('does not override provided filters', async () => {
+    const posts: any[] = [
+      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
+      { format: ['Foto'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
+      { format: ['Reel'], proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'] }
+    ];
+    jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue(posts);
+    jest.spyOn(dataService, 'lookupUserById').mockResolvedValue({ userPreferences: {} } as any);
+
+    const filters = await buildInspirationFilters('user1', { format: 'Foto' }, true);
+    expect(filters.format).toBe('Foto');
+    expect(filters.proposal).toBe('Humor/Cena');
+    expect(filters.context).toBe('Moda/Estilo');
+  });
+});


### PR DESCRIPTION
## Summary
- improve fallback logic for inspiration filters to analyse top 3 posts and choose the most common format/proposal/context
- export `buildInspirationFilters` so it can be tested
- add unit tests covering new behaviour

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_687e68db0bc8832eb404086f52f2700c