### PR TITLE
Update inspiration filters logic

### DIFF
--- a/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
+++ b/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
@@ -6,31 +6,61 @@ describe('buildInspirationFilters', () => {
 
   test('uses most common categories from top posts when missing', async () => {
     const posts: any[] = [
-      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
-      { format: ['Foto'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
-      { format: ['Reel'], proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'] }
+      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { format: ['Foto'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { format: ['Reel'], proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] }
     ];
     jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue(posts);
     jest.spyOn(dataService, 'lookupUserById').mockResolvedValue({ userPreferences: {} } as any);
 
     const filters = await buildInspirationFilters('user1', undefined, true);
-    expect(filters.format).toBe('Reel');
     expect(filters.proposal).toBe('Humor/Cena');
     expect(filters.context).toBe('Moda/Estilo');
+    expect(filters.reference).toBe('pop_culture_music');
+    expect(filters.tone).toBe('humorous');
   });
 
-  test('does not override provided filters', async () => {
+  test('prioritizes top post categories over provided details', async () => {
     const posts: any[] = [
-      { format: ['Reel'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
-      { format: ['Foto'], proposal: ['Humor/Cena'], context: ['Moda/Estilo'] },
-      { format: ['Reel'], proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'] }
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'], references: ['pop_culture_books'], tone: ['inspirational'] },
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] }
     ];
     jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue(posts);
     jest.spyOn(dataService, 'lookupUserById').mockResolvedValue({ userPreferences: {} } as any);
 
-    const filters = await buildInspirationFilters('user1', { format: 'Foto' }, true);
+    const filters = await buildInspirationFilters('user1', {
+      proposal: 'Mensagem/Motivacional',
+      context: 'Estilo de Vida e Bem-Estar',
+      reference: 'pop_culture_books',
+      tone: 'inspirational',
+      format: 'Foto'
+    }, true);
+
     expect(filters.format).toBe('Foto');
     expect(filters.proposal).toBe('Humor/Cena');
     expect(filters.context).toBe('Moda/Estilo');
+    expect(filters.reference).toBe('pop_culture_music');
+    expect(filters.tone).toBe('humorous');
+  });
+
+  test('uses provided details when user has few posts', async () => {
+    const posts: any[] = [
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'] }
+    ];
+    jest.spyOn(dataService, 'getTopPostsByMetric').mockResolvedValue(posts);
+    jest.spyOn(dataService, 'lookupUserById').mockResolvedValue({ userPreferences: {} } as any);
+
+    const filters = await buildInspirationFilters('user1', {
+      proposal: 'Mensagem/Motivacional',
+      context: 'Estilo de Vida e Bem-Estar'
+    }, true);
+
+    expect(filters.proposal).toBe('Mensagem/Motivacional');
+    expect(filters.context).toBe('Estilo de Vida e Bem-Estar');
   });
 });


### PR DESCRIPTION
## Summary
- analyze user's top posts to get best-performing proposal, context, reference and tone
- use these values over provided details when building inspiration filters
- keep previous behaviour when there are few posts
- update tests for new filter logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6fc33b7c832e8bff73085f48c849