### PR TITLE
Add tone and reference inference from best post

### DIFF
--- a/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
+++ b/src/app/api/whatsapp/__tests__/buildInspirationFilters.test.ts
@@ -24,9 +24,9 @@ describe('buildInspirationFilters', () => {
 
   test('prioritizes top post categories over provided details', async () => {
     const posts: any[] = [
-      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
-      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
       { proposal: ['Mensagem/Motivacional'], context: ['Estilo de Vida e Bem-Estar'], references: ['pop_culture_books'], tone: ['inspirational'] },
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
+      { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
       { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] },
       { proposal: ['Humor/Cena'], context: ['Moda/Estilo'], references: ['pop_culture_music'], tone: ['humorous'] }
     ];
@@ -42,10 +42,10 @@ describe('buildInspirationFilters', () => {
     }, true);
 
     expect(filters.format).toBe('Foto');
-    expect(filters.proposal).toBe('Humor/Cena');
-    expect(filters.context).toBe('Moda/Estilo');
-    expect(filters.reference).toBe('pop_culture_music');
-    expect(filters.tone).toBe('humorous');
+    expect(filters.proposal).toBe('Mensagem/Motivacional');
+    expect(filters.context).toBe('Estilo de Vida e Bem-Estar');
+    expect(filters.reference).toBe('pop_culture_books');
+    expect(filters.tone).toBe('inspirational');
   });
 
   test('uses provided details when user has few posts', async () => {


### PR DESCRIPTION
## Summary
- derive tone/reference from the first top post when building inspiration filters
- log extracted tone and reference
- update tests for new behaviour

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e71262a18832ead970d90ca5a2805