### PR TITLE
Implement agency onboarding improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ Consulte o diretório `docs` para informações adicionais, incluindo o [plano d
 
 Usuários com papel **agency** podem acessar `/agency/creator-dashboard` para acompanhar apenas os criadores vinculados à sua agência. Crie a conta de agência pelo painel admin e compartilhe o link de convite (`/assinar?codigo_agencia=<inviteCode>`). A assinatura do WhatsApp permanece do usuário mesmo que ele saia da agência.
 
+### Onboarding de Agências
+
+1. **Cadastro** – a agência pode ser criada pelo administrador em `/admin/agencies` ou de forma autônoma em `/agency/signup`.
+2. **Assinatura** – após o cadastro, o gestor deve acessar `/agency/subscription` e contratar o plano para ativar sua conta.
+3. **Compartilhar link** – com a assinatura ativa, copie o link de convite exibido na página de assinatura ou no painel admin e envie aos criadores.
+4. **Criadores** – os criadores devem estar autenticados ao acessar `/assinar?codigo_agencia=<código>` para concluir o pagamento com desconto. Só após o pagamento a afiliação à agência é efetivada.
+
+Cada criador pode se vincular a apenas uma agência por vez. O cancelamento da assinatura da agência não remove a assinatura individual do WhatsApp dos criadores.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/src/app/agency/signup/page.tsx
+++ b/src/app/agency/signup/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import { toast } from 'react-hot-toast';
+
+export default function AgencySignupPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ name: '', contactEmail: '', managerEmail: '', password: '' });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/agency/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          contactEmail: form.contactEmail || undefined,
+          managerEmail: form.managerEmail,
+          managerPassword: form.password,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Erro ao cadastrar agência');
+
+      await signIn('credentials', {
+        redirect: false,
+        email: form.managerEmail,
+        password: form.password,
+      });
+      router.push('/agency/subscription');
+    } catch (err: any) {
+      toast.error(err.message || 'Falha ao registrar');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-md mx-auto space-y-4">
+      <h1 className="text-xl font-bold">Cadastro de Agência</h1>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <input name="name" required placeholder="Nome da agência" value={form.name} onChange={handleChange} className="w-full border p-2" />
+        <input name="contactEmail" type="email" placeholder="Email de contato" value={form.contactEmail} onChange={handleChange} className="w-full border p-2" />
+        <input name="managerEmail" type="email" required placeholder="Email do gestor" value={form.managerEmail} onChange={handleChange} className="w-full border p-2" />
+        <input name="password" type="password" required placeholder="Senha" value={form.password} onChange={handleChange} className="w-full border p-2" />
+        <button type="submit" disabled={loading} className="px-4 py-2 bg-brand-pink text-white rounded disabled:opacity-50">
+          {loading ? 'Enviando...' : 'Registrar'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -42,21 +42,33 @@ export default function AgencySubscriptionPage() {
   return (
     <div className="p-6 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold">Assinatura da Agência</h1>
-      <p>Status atual: <strong>{planStatus}</strong></p>
-      {planStatus !== 'active' && (
-        <button
-          className="px-4 py-2 bg-brand-pink text-white rounded disabled:opacity-50"
-          onClick={handleSubscribe}
-          disabled={isLoading}
-        >
-          {isLoading ? 'Aguarde...' : 'Contratar'}
-        </button>
-      )}
-      {planStatus === 'active' && (
-        <button className="px-4 py-2 bg-gray-800 text-white rounded" onClick={handleManage}>Gerenciar Assinatura</button>
-      )}
+      <div className="border rounded-lg p-4 space-y-2 bg-white shadow">
+        <p className="text-lg font-semibold">Plano Básico - R$ 99/mês</p>
+        <ul className="list-disc list-inside text-sm text-gray-700">
+          <li>Acesso ao dashboard dos criadores vinculados</li>
+          <li>Suporte prioritário via WhatsApp</li>
+          <li>Desconto de 10% para seus criadores</li>
+        </ul>
+        <p className="text-sm">Status atual: <strong>{planStatus}</strong></p>
+        {planStatus !== 'active' && (
+          <button
+            className="px-4 py-2 bg-brand-pink text-white rounded disabled:opacity-50"
+            onClick={handleSubscribe}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Aguarde...' : 'Contratar'}
+          </button>
+        )}
+        {planStatus === 'active' && (
+          <button className="px-4 py-2 bg-gray-800 text-white rounded" onClick={handleManage}>Gerenciar Assinatura</button>
+        )}
+      </div>
       {inviteCode && (
-        <p className="mt-4 text-sm">Link de convite: {`${typeof window !== 'undefined' ? window.location.origin : ''}/assinar?codigo_agencia=${inviteCode}`}</p>
+        <div className="text-sm flex items-center gap-2">
+          <span>Link de convite:</span>
+          <span className="truncate">{`${typeof window !== 'undefined' ? window.location.origin : ''}/assinar?codigo_agencia=${inviteCode}`}</span>
+          <button onClick={() => navigator.clipboard.writeText(`${typeof window !== 'undefined' ? window.location.origin : ''}/assinar?codigo_agencia=${inviteCode}`).then(() => toast.success('Copiado!'))} className="text-gray-500 hover:text-brand-pink text-xs border px-2 py-1 rounded">Copiar link</button>
+        </div>
       )}
     </div>
   );

--- a/src/app/api/agency/register/route.ts
+++ b/src/app/api/agency/register/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+import AgencyModel from '@/app/models/Agency';
+import UserModel from '@/app/models/User';
+
+export const runtime = 'nodejs';
+
+const createSchema = z.object({
+  name: z.string(),
+  contactEmail: z.string().email().optional(),
+  managerEmail: z.string().email(),
+  managerPassword: z.string().min(6),
+});
+
+async function hashPassword(pwd: string) {
+  return bcrypt.hash(pwd, 10);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const val = createSchema.safeParse(body);
+    if (!val.success) {
+      return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+    }
+
+    const existingUser = await UserModel.findOne({ email: val.data.managerEmail });
+    if (existingUser) {
+      return NextResponse.json({ error: 'Este e-mail já está em uso por outro usuário.' }, { status: 409 });
+    }
+
+    const agency = await AgencyModel.create({ name: val.data.name, contactEmail: val.data.contactEmail });
+    const hashedPassword = await hashPassword(val.data.managerPassword);
+    await UserModel.create({ email: val.data.managerEmail, password: hashedPassword, role: 'agency', agency: agency._id });
+    return NextResponse.json({ agency });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Erro interno' }, { status: 500 });
+  }
+}

--- a/src/app/api/plan/subscribe/route.ts
+++ b/src/app/api/plan/subscribe/route.ts
@@ -80,7 +80,15 @@ export async function POST(req: NextRequest) {
         console.error(`plan/subscribe -> Agência ${agency._id} com plano inativo`);
         return NextResponse.json({ error: 'Agência sem assinatura ativa.' }, { status: 403 });
       }
-      user.agency = agency._id;
+
+      if (user.agency && user.agency.toString() !== agency._id.toString()) {
+        return NextResponse.json(
+          { error: 'Usuário já vinculado a outra agência. Saia da atual antes de prosseguir.' },
+          { status: 409 }
+        );
+      }
+
+      user.pendingAgency = agency._id;
       price = parseFloat((price * 0.9).toFixed(2));
     }
 

--- a/src/app/api/plan/webhook/route.ts
+++ b/src/app/api/plan/webhook/route.ts
@@ -163,6 +163,11 @@ export async function POST(request: NextRequest) {
       user.planExpiresAt = new Date(approvalDate.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 dias
       user.lastProcessedPaymentId = paymentId;
 
+      if (user.pendingAgency) {
+        user.agency = user.pendingAgency;
+        user.pendingAgency = null;
+      }
+
       // Processa comissão
       if (user.affiliateUsed) {
         //  console.log(`[plan/webhook] Pagamento usou código de afiliado: ${user.affiliateUsed}`);

--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -1,13 +1,15 @@
 'use client';
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useSession, signIn } from 'next-auth/react';
 
 export default function PublicSubscribePage() {
   const searchParams = useSearchParams();
   const agencyCode = searchParams.get('codigo_agencia');
-  const [email, setEmail] = useState('');
+  const { data: session, status } = useSession();
 
   const handleSubscribe = async () => {
+    if (!session) return;
     const res = await fetch('/api/plan/subscribe', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -22,8 +24,11 @@ export default function PublicSubscribePage() {
   return (
     <div className="p-6 max-w-md mx-auto space-y-4">
       {agencyCode && <div className="bg-green-100 text-green-800 p-2 rounded">Você foi convidado por uma agência! Desconto aplicado.</div>}
-      <input type="email" placeholder="Seu email" value={email} onChange={e => setEmail(e.target.value)} className="w-full border p-2" />
-      <button className="px-4 py-2 bg-brand-pink text-white rounded" onClick={handleSubscribe}>Assinar</button>
+      {status === 'authenticated' ? (
+        <button className="px-4 py-2 bg-brand-pink text-white rounded" onClick={handleSubscribe}>Assinar</button>
+      ) : (
+        <button className="px-4 py-2 bg-brand-pink text-white rounded" onClick={() => signIn(undefined, { callbackUrl: window.location.href })}>Entrar para Assinar</button>
+      )}
     </div>
   );
 }

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -226,6 +226,7 @@ export interface IUser extends Document {
   mediaKitSlug?: string;
   role: string;
   agency?: Types.ObjectId | null;
+  pendingAgency?: Types.ObjectId | null;
   planStatus?: string;
   planExpiresAt?: Date | null;
   whatsappVerificationCode?: string | null;
@@ -361,6 +362,7 @@ const userSchema = new Schema<IUser>(
     mediaKitSlug: { type: String, unique: true, sparse: true },
     role: { type: String, default: "user" },
     agency: { type: Schema.Types.ObjectId, ref: 'Agency', default: null },
+    pendingAgency: { type: Schema.Types.ObjectId, ref: 'Agency', default: null },
     planExpiresAt: { type: Date, default: null },
     whatsappVerificationCode: { type: String, default: null, index: true },
     whatsappPhone: { type: String, default: null, index: true },

--- a/src/lib/getAdminSession.test.ts
+++ b/src/lib/getAdminSession.test.ts
@@ -1,32 +1,32 @@
 import { getServerSession } from 'next-auth/next';
-import { getAgencySession } from './getAgencySession';
+import { getAdminSession } from './getAdminSession';
 
 jest.mock('next-auth/next');
 const mockGetServerSession = getServerSession as jest.Mock;
 
-describe('getAgencySession', () => {
+describe('getAdminSession', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('returns session when user is agency', async () => {
-    const session = { user: { role: 'agency' } } as any;
-    const req = { headers: {} } as any;
+  it('returns session when user is admin', async () => {
+    const session = { user: { role: 'admin' } } as any;
+    const req = {} as any;
     mockGetServerSession.mockResolvedValue(session);
-    const result = await getAgencySession(req);
+    const result = await getAdminSession(req);
     expect(result).toBe(session);
     expect(mockGetServerSession).toHaveBeenCalledWith(expect.objectContaining({ req }));
   });
 
-  it('returns null when role is not agency', async () => {
+  it('returns null when role is not admin', async () => {
     const req = {} as any;
     mockGetServerSession.mockResolvedValue({ user: { role: 'user' } });
-    const result = await getAgencySession(req);
+    const result = await getAdminSession(req);
     expect(result).toBeNull();
   });
 
   it('returns null on error', async () => {
     const req = {} as any;
     mockGetServerSession.mockRejectedValue(new Error('err'));
-    const result = await getAgencySession(req);
+    const result = await getAdminSession(req);
     expect(result).toBeNull();
   });
 });

--- a/src/lib/getAdminSession.ts
+++ b/src/lib/getAdminSession.ts
@@ -3,9 +3,9 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { logger } from '@/app/lib/logger';
 
-export async function getAdminSession(_req: NextRequest) {
+export async function getAdminSession(req: NextRequest) {
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getServerSession({ req, ...authOptions });
     if (!session || session.user?.role !== 'admin') {
       logger.warn('[getAdminSession] session invalid or user not admin');
       return null;

--- a/src/lib/getAgencySession.ts
+++ b/src/lib/getAgencySession.ts
@@ -3,9 +3,9 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { logger } from '@/app/lib/logger';
 
-export async function getAgencySession(_req: NextRequest) {
+export async function getAgencySession(req: NextRequest) {
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getServerSession({ req, ...authOptions });
     if (!session || session.user?.role !== 'agency') {
       logger.warn('[getAgencySession] session invalid or user not agency');
       return null;


### PR DESCRIPTION
## Summary
- redesign agency subscription screen with plan details and copy button
- add self-service agency signup form and register endpoint
- require login for invite signup and support copy link on subscription
- defer agency linking until payment approval with new `pendingAgency`
- pass request object to session helpers and test them
- document agency onboarding flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688511995854832e8c72e2f23a50a863