### PR TITLE
Check agency plan before returning invite code

### DIFF
--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -9,9 +9,17 @@ export default function AgencySubscriptionPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    fetch('/api/agency/invite-code').then(res => res.json()).then(data => {
-      if (data.inviteCode) setInviteCode(data.inviteCode);
-    }).catch(() => {});
+    fetch('/api/agency/invite-code')
+      .then(async res => {
+        if (res.ok) {
+          const data = await res.json();
+          if (data.inviteCode) setInviteCode(data.inviteCode);
+        } else if (res.status === 403) {
+          const data = await res.json().catch(() => null);
+          toast.error(data?.error || 'Você precisa de um plano ativo para acessar o link de convite.');
+        }
+      })
+      .catch(() => {});
   }, []);
 
   const planStatus = session?.user?.agencyPlanStatus || 'inactive';

--- a/src/app/api/agency/invite-code/route.ts
+++ b/src/app/api/agency/invite-code/route.ts
@@ -15,9 +15,21 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const agency = await AgencyModel.findById(session.user.agencyId).select('inviteCode').lean();
+    const agency = await AgencyModel.findById(session.user.agencyId)
+      .select('inviteCode planStatus')
+      .lean();
     if (!agency) {
       return NextResponse.json({ error: 'Agency not found' }, { status: 404 });
+    }
+
+    if (agency.planStatus !== 'active') {
+      logger.warn(
+        `${TAG} agency ${session.user.agencyId} attempted access with plan status ${agency.planStatus}`,
+      );
+      return NextResponse.json(
+        { error: 'Plano da agência inativo. Assine para acessar o link de convite.' },
+        { status: 403 },
+      );
     }
 
     return NextResponse.json({ inviteCode: agency.inviteCode });


### PR DESCRIPTION
## Summary
- restrict invite code API to agencies with an active plan
- show a toast on the subscription page when invite code access is forbidden

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855321d770832e9ad59a545cc87873