### PR TITLE
Redirect agency users to dashboard when active

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -20,7 +20,11 @@ export default function AuthCallbackPage() {
       if (userRole === 'admin') {
         router.replace('/admin/creator-dashboard');
       } else if (userRole === 'agency') {
-        router.replace('/agency/subscription');
+        if (session.user.agencyPlanStatus === 'active') {
+          router.replace('/agency/dashboard');
+        } else {
+          router.replace('/agency/subscription');
+        }
       } else {
         router.replace('/dashboard');
       }


### PR DESCRIPTION
## Summary
- check `agencyPlanStatus` on auth callback
- redirect agency users with active plans to `/agency/dashboard`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68855698bc24832ebb39e700d9a16daf