### PR TITLE
Update agency dashboard references

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Consulte o diretório `docs` para informações adicionais, incluindo o [plano d
 
 ## Agency Dashboard
 
-Usuários com papel **agency** podem acessar `/agency/creator-dashboard` para acompanhar apenas os criadores vinculados à sua agência. Crie a conta de agência pelo painel admin e compartilhe o link de convite (`/assinar?codigo_agencia=<inviteCode>`). A assinatura do WhatsApp permanece do usuário mesmo que ele saia da agência.
+Usuários com papel **agency** podem acessar `/agency/dashboard` para acompanhar apenas os criadores vinculados à sua agência. Crie a conta de agência pelo painel admin e compartilhe o link de convite (`/assinar?codigo_agencia=<inviteCode>`). A assinatura do WhatsApp permanece do usuário mesmo que ele saia da agência.
 
 ### Onboarding de Agências
 

--- a/src/app/agency/components/AgencyAuthGuard.test.tsx
+++ b/src/app/agency/components/AgencyAuthGuard.test.tsx
@@ -30,7 +30,7 @@ describe('AgencyAuthGuard', () => {
     mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
     render(<AgencyAuthGuard><div>Protected</div></AgencyAuthGuard>);
     await act(async () => {});
-    expect(mockRouterReplace).toHaveBeenCalledWith('/login?error=SessionRequired&callbackUrl=/agency/creator-dashboard');
+    expect(mockRouterReplace).toHaveBeenCalledWith('/login?error=SessionRequired&callbackUrl=/agency/dashboard');
   });
 
   it('should redirect to /unauthorized if authenticated but not agency', async () => {

--- a/src/app/agency/components/AgencyAuthGuard.tsx
+++ b/src/app/agency/components/AgencyAuthGuard.tsx
@@ -25,7 +25,7 @@ export default function AgencyAuthGuard({ children }: { children: React.ReactNod
     if (status === 'loading') return;
 
     if (status === 'unauthenticated') {
-      router.replace('/login?error=SessionRequired&callbackUrl=/agency/creator-dashboard');
+      router.replace('/login?error=SessionRequired&callbackUrl=/agency/dashboard');
       return;
     }
 


### PR DESCRIPTION
## Summary
- update callback URL in `AgencyAuthGuard`
- reflect new URL in `AgencyAuthGuard` tests
- fix README instructions for agency dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855b86ea24832e8eb9151a97d074d5