### PR TITLE
Add agency summary route

### DIFF
--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -52,16 +52,12 @@ const AgencyDashboardContent: React.FC = () => {
   const photoCache = useRef<Record<string, string | null>>({});
 
   useEffect(() => {
-    fetch('/api/agency/invite-code')
+    fetch('/api/agency/summary')
       .then(res => res.json())
-      .then(data => { if (data.inviteCode) setInviteCode(data.inviteCode); })
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    fetch('/api/agency/profile')
-      .then(res => res.json())
-      .then(data => { if (data.name) setAgencyName(data.name); })
+      .then(data => {
+        if (data.inviteCode) setInviteCode(data.inviteCode);
+        if (data.name) setAgencyName(data.name);
+      })
       .catch(() => {});
   }, []);
 

--- a/src/app/api/agency/summary/route.test.ts
+++ b/src/app/api/agency/summary/route.test.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { getAgencySession } from '@/lib/getAgencySession';
+import AgencyModel from '@/app/models/Agency';
+
+jest.mock('@/lib/getAgencySession', () => ({
+  getAgencySession: jest.fn(),
+}));
+
+jest.mock('@/app/models/Agency', () => ({
+  findById: jest.fn(),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockGetAgencySession = getAgencySession as jest.Mock;
+const mockFindById = (AgencyModel as any).findById as jest.Mock;
+
+const createRequest = () => new NextRequest('http://localhost/api/agency/summary');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/agency/summary', () => {
+  it('returns 401 when session is missing', async () => {
+    mockGetAgencySession.mockResolvedValue(null);
+    const res = await GET(createRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when plan is inactive', async () => {
+    mockGetAgencySession.mockResolvedValue({ user: { agencyId: '1' } });
+    const lean = jest.fn().mockResolvedValue({ name: 'Test', inviteCode: 'abc', planStatus: 'inactive' });
+    const select = jest.fn().mockReturnValue({ lean });
+    mockFindById.mockReturnValue({ select });
+
+    const res = await GET(createRequest());
+    const body = await res.json();
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Plano da agência inativo. Assine para acessar o link de convite.');
+  });
+
+  it('returns name and inviteCode when authorized and active', async () => {
+    mockGetAgencySession.mockResolvedValue({ user: { agencyId: '1' } });
+    const lean = jest.fn().mockResolvedValue({ name: 'Test', inviteCode: 'abc', planStatus: 'active' });
+    const select = jest.fn().mockReturnValue({ lean });
+    mockFindById.mockReturnValue({ select });
+
+    const res = await GET(createRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ name: 'Test', inviteCode: 'abc' });
+  });
+});

--- a/src/app/api/agency/summary/route.ts
+++ b/src/app/api/agency/summary/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAgencySession } from '@/lib/getAgencySession';
+import AgencyModel from '@/app/models/Agency';
+import { logger } from '@/app/lib/logger';
+
+export const runtime = 'nodejs';
+const SERVICE_TAG = '[api/agency/summary]';
+
+export async function GET(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[GET]`;
+  try {
+    const session = await getAgencySession(req);
+    if (!session?.user?.agencyId) {
+      logger.warn(`${TAG} unauthorized attempt`);
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const agency = await AgencyModel.findById(session.user.agencyId)
+      .select('name inviteCode planStatus')
+      .lean();
+    if (!agency) {
+      return NextResponse.json({ error: 'Agency not found' }, { status: 404 });
+    }
+
+    if (agency.planStatus !== 'active') {
+      logger.warn(
+        `${TAG} agency ${session.user.agencyId} attempted access with plan status ${agency.planStatus}`,
+      );
+      return NextResponse.json(
+        { error: 'Plano da agência inativo. Assine para acessar o link de convite.' },
+        { status: 403 },
+      );
+    }
+
+    return NextResponse.json({ name: agency.name, inviteCode: agency.inviteCode });
+  } catch (err: any) {
+    logger.error(`${TAG} unexpected error`, err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- combine invite code and name data in `/api/agency/summary`
- adjust dashboard to fetch from the new endpoint
- test the new route

## Testing
- `npx jest` *(fails: npm install attempts require network)*

------
https://chatgpt.com/codex/tasks/task_e_6885638dbbf4832e9a781abc4c08df61