### PR TITLE
Unify agency invite signup with dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Usuários com papel **agency** podem acessar `/agency/dashboard` para acompanhar
 1. **Cadastro** – a agência pode ser criada pelo administrador em `/admin/agencies` ou de forma autônoma em `/agency/signup`.
 2. **Assinatura** – após o cadastro, o gestor deve acessar `/agency/subscription` e contratar o plano para ativar sua conta.
 3. **Compartilhar link** – com a assinatura ativa, copie o link de convite exibido na página de assinatura ou no painel admin e envie aos criadores.
-4. **Criadores** – os criadores devem estar autenticados ao acessar `/assinar?codigo_agencia=<código>` para concluir o pagamento com desconto. Só após o pagamento a afiliação à agência é efetivada.
+4. **Criadores** – ao acessar `/assinar?codigo_agencia=<código>`, o criador faz login normalmente e é levado ao dashboard inativo. O código de convite é salvo e o desconto é aplicado automaticamente ao concluir a assinatura pelo painel de pagamento. Após gerar o link de pagamento, o código de agência é removido do navegador para evitar reutilizações.
 
 Cada criador pode se vincular a apenas uma agência por vez. O cancelamento da assinatura da agência não remove a assinatura individual do WhatsApp dos criadores.
 

--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -1,31 +1,26 @@
 'use client';
-import React from 'react';
-import { useSearchParams } from 'next/navigation';
+import React, { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useSession, signIn } from 'next-auth/react';
 
 export default function PublicSubscribePage() {
   const searchParams = useSearchParams();
   const agencyCode = searchParams.get('codigo_agencia');
-  const { data: session, status } = useSession();
+  const { status } = useSession();
+  const router = useRouter();
 
-  const handleSubscribe = async () => {
-    if (!session) return;
-    const res = await fetch('/api/plan/subscribe', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ planType: 'monthly', agencyInviteCode: agencyCode }),
-    });
-    if (res.ok) {
-      const json = await res.json();
-      window.location.href = json.initPoint;
+  useEffect(() => {
+    if (status === 'authenticated') {
+      router.replace('/dashboard');
     }
-  };
+  }, [status, router]);
+
 
   return (
     <div className="p-6 max-w-md mx-auto space-y-4">
       {agencyCode && <div className="bg-green-100 text-green-800 p-2 rounded">Você foi convidado por uma agência! Desconto aplicado.</div>}
       {status === 'authenticated' ? (
-        <button className="px-4 py-2 bg-brand-pink text-white rounded" onClick={handleSubscribe}>Assinar</button>
+        <p>Redirecionando para seu dashboard...</p>
       ) : (
         <button className="px-4 py-2 bg-brand-pink text-white rounded" onClick={() => signIn(undefined, { callbackUrl: window.location.href })}>Entrar para Assinar</button>
       )}

--- a/src/app/components/ClientHooksWrapper.tsx
+++ b/src/app/components/ClientHooksWrapper.tsx
@@ -6,25 +6,36 @@ import { useEffect } from 'react';
 
 const AFFILIATE_REF_KEY = 'affiliateRefCode';
 const AFFILIATE_REF_EXPIRATION_DAYS = 30;
+const AGENCY_INVITE_KEY = 'agencyInviteCode';
+const AGENCY_INVITE_EXPIRATION_DAYS = 7;
 
 export default function ClientHooksWrapper() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    // A lógica do window.undefined é para garantir que o código só rode no cliente
+    // A lógica do typeof window !== 'undefined' garante execução somente no cliente
     if (typeof window !== 'undefined') {
       const refCode = searchParams.get('ref');
       if (refCode && refCode.trim() !== '') {
         const expiresAt = Date.now() + AFFILIATE_REF_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
-        const refDataToStore = {
-          code: refCode.trim(),
-          expiresAt: expiresAt,
-        };
+        const refDataToStore = { code: refCode.trim(), expiresAt };
         try {
           localStorage.setItem(AFFILIATE_REF_KEY, JSON.stringify(refDataToStore));
           console.log('[ClientHooksWrapper] Código de referência salvo:', refDataToStore);
         } catch (error) {
           console.error('[ClientHooksWrapper] Erro ao salvar código de referência no localStorage:', error);
+        }
+      }
+
+      const invite = searchParams.get('codigo_agencia');
+      if (invite && invite.trim() !== '') {
+        const expiresAt = Date.now() + AGENCY_INVITE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
+        const data = { code: invite.trim(), expiresAt };
+        try {
+          localStorage.setItem(AGENCY_INVITE_KEY, JSON.stringify(data));
+          console.log('[ClientHooksWrapper] Código de agência salvo:', data);
+        } catch (error) {
+          console.error('[ClientHooksWrapper] Erro ao salvar código de agência no localStorage:', error);
         }
       }
     }

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -32,6 +32,7 @@ interface PaymentPanelProps {
 }
 
 const AFFILIATE_REF_KEY = 'affiliateRefCode';
+const AGENCY_INVITE_KEY = 'agencyInviteCode';
 
 // Componente FAQItem com visual aprimorado
 const FAQItem = ({ question, answer }: { question: string; answer: string | React.ReactNode }) => {
@@ -102,10 +103,12 @@ const FeedbackMessage = ({ message, type }: { message: string; type: 'success' |
 
 export default function PaymentPanel({ user }: PaymentPanelProps) {
   const [affiliateCodeInput, setAffiliateCodeInput] = useState("");
+  const [agencyInviteCode, setAgencyInviteCode] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [statusMessage, setStatusMessage] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
   const [initPoint, setInitPoint] = useState("");
   const [refCodeAppliedMessage, setRefCodeAppliedMessage] = useState<string | null>(null);
+  const [agencyMessage, setAgencyMessage] = useState<string | null>(null);
   const [ctaClicked, setCtaClicked] = useState(false);
 
   useEffect(() => {
@@ -128,6 +131,22 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
         } catch (error) {
           console.error('[PaymentPanel] Erro ao processar dados de referência do localStorage:', error);
           localStorage.removeItem(AFFILIATE_REF_KEY);
+        }
+      }
+
+      const storedAgency = localStorage.getItem(AGENCY_INVITE_KEY);
+      if (storedAgency) {
+        try {
+          const data = JSON.parse(storedAgency);
+          if (data && data.code && data.expiresAt && Date.now() < data.expiresAt) {
+            setAgencyInviteCode(String(data.code));
+            setAgencyMessage(`Convite de agência ${data.code} aplicado!`);
+          } else {
+            localStorage.removeItem(AGENCY_INVITE_KEY);
+          }
+        } catch (error) {
+          console.error('[PaymentPanel] Erro ao processar invite de agência:', error);
+          localStorage.removeItem(AGENCY_INVITE_KEY);
         }
       }
     }
@@ -173,6 +192,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
         body: JSON.stringify({
           planType: "monthly",
           affiliateCode: affiliateCodeInput.trim() === "" ? undefined : affiliateCodeInput.trim(),
+          agencyInviteCode: agencyInviteCode || undefined,
         }),
       });
       const data = await res.json();
@@ -182,6 +202,11 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
         setStatusMessage({ message: data.message || "Link de pagamento gerado abaixo. Você será redirecionado.", type: 'info' });
         if (data.initPoint) {
           setInitPoint(data.initPoint);
+          try {
+            localStorage.removeItem(AGENCY_INVITE_KEY);
+          } catch (error) {
+            console.error('[PaymentPanel] Erro ao limpar código de agência:', error);
+          }
         }
       }
     } catch (error: unknown) {
@@ -333,6 +358,12 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                   <p className="mt-2 text-xs text-green-700 flex items-center gap-1.5">
                     <FaCheckCircle className="w-3.5 h-3.5"/>
                     {refCodeAppliedMessage}
+                  </p>
+                )}
+                {agencyMessage && !loading && (
+                  <p className="mt-2 text-xs text-green-700 flex items-center gap-1.5">
+                    <FaCheckCircle className="w-3.5 h-3.5"/>
+                    {agencyMessage}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- store agency invite code in `ClientHooksWrapper`
- detect invite code in dashboard payment panel and send to API
- show message when agency code is active
- make `/assinar` redirect to dashboard after login
- update README with new agency signup flow
- remove agency invite from localStorage once payment link is generated

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f8c67190832e813adea09f2be9db