### PR TITLE
Improve agency invite onboarding

### DIFF
--- a/src/app/dashboard/StepIndicator.tsx
+++ b/src/app/dashboard/StepIndicator.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { FaCheckCircle, FaCircle } from "react-icons/fa";
+
+interface StepIndicatorProps {
+  planActive: boolean;
+  instagramConnected: boolean;
+  whatsappConnected: boolean;
+}
+
+export default function StepIndicator({ planActive, instagramConnected, whatsappConnected }: StepIndicatorProps) {
+  const steps = [
+    { title: "Assinar Plano", completed: planActive },
+    { title: "Conectar Instagram", completed: instagramConnected },
+    { title: "Vincular WhatsApp", completed: whatsappConnected },
+  ];
+  const currentIndex = steps.findIndex((s) => !s.completed);
+  return (
+    <ol className="flex items-center space-x-4 text-sm mb-6">
+      {steps.map((step, idx) => (
+        <li key={step.title} className="flex items-center">
+          {step.completed ? (
+            <FaCheckCircle className="text-green-600 w-4 h-4 mr-1" />
+          ) : (
+            <FaCircle className={`w-3 h-3 mr-1 ${idx === currentIndex ? 'text-brand-pink' : 'text-gray-400'}`} />
+          )}
+          <span className={idx === currentIndex ? "font-semibold text-brand-pink" : "text-gray-600"}>{step.title}</span>
+          {idx < steps.length - 1 && <span className="mx-2 text-gray-400">/</span>}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
  // src/app/dashboard/page.tsx
  "use client";
 
- import React, { useState, useEffect, useCallback, Fragment, useRef } from 'react';
+import React, { useState, useEffect, useCallback, Fragment, useRef } from 'react';
  import { useSession, signIn, signOut } from 'next-auth/react';
  import { useRouter } from "next/navigation";
  import Image from 'next/image';
@@ -19,13 +19,14 @@
  import PaymentModal from './PaymentModal';
  import AdDealForm from './AdDealForm';
  import VideoCarousel from './VideoCarousel';
- import InstagramConnectCard from './InstagramConnectCard';
+import InstagramConnectCard from './InstagramConnectCard';
+import StepIndicator from './StepIndicator';
 
  // --- FIM IMPORTS ---
 
 
  // --- INTERFACES ---
- interface ExtendedUser {
+interface ExtendedUser {
   id?: string;
   name?: string | null;
   email?: string | null;
@@ -37,7 +38,9 @@
   affiliateRank?: number;
   affiliateInvites?: number;
   provider?: string;
- }
+  isInstagramConnected?: boolean;
+  whatsappVerified?: boolean;
+}
 
  interface VideoData {
     id: string;
@@ -193,6 +196,8 @@
   const [isLoadingCommissionLog, setIsLoadingCommissionLog] = useState(true);
   const [commissionLogError, setCommissionLogError] = useState<string | null>(null);
 
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+
   const redirectToPaymentPanel = useCallback(() => {
     const paymentSection = document.getElementById('payment-section');
     if (paymentSection) {
@@ -259,6 +264,40 @@
       fetchLog();
     }
   }, [status, userId]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('agencyInviteCode');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          if (data && data.code && data.expiresAt && Date.now() < data.expiresAt) {
+            setInviteCode(String(data.code));
+          } else {
+            localStorage.removeItem('agencyInviteCode');
+          }
+        } catch (e) {
+          localStorage.removeItem('agencyInviteCode');
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'authenticated' && user && user.planStatus === 'inactive') {
+      const stored = localStorage.getItem('agencyInviteCode');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          if (data && data.code) {
+            redirectToPaymentPanel();
+          }
+        } catch (e) {
+          // ignore JSON errors
+        }
+      }
+    }
+  }, [status, user, redirectToPaymentPanel]);
 
   // --- FUNÇÕES DE HANDLER RESTAURADAS ---
   const handleRedeemBalance = useCallback(async (userIdFromFunc: string | undefined) => {
@@ -533,6 +572,21 @@
                      <div className="flex-grow text-center sm:text-left">
                         <h1 className="text-2xl sm:text-3xl font-semibold text-brand-dark mb-2">Bem-vindo(a), {user?.name ?? 'Usuário'}!</h1>
                         <p className="text-base text-gray-600 font-light mb-4">Pronto para otimizar sua carreira de criador?</p>
+                        {!canAccessFeatures && (
+                          <>
+                            <StepIndicator
+                              planActive={planStatus === 'active' || planStatus === 'pending'}
+                              instagramConnected={!!user.isInstagramConnected}
+                              whatsappConnected={!!user.whatsappVerified}
+                            />
+                            {inviteCode && (
+                              <p className="text-xs text-green-700 flex items-center gap-1 mb-2">
+                                <FaCheckCircle className="w-3 h-3" />
+                                Convite {inviteCode} ativo! Desconto aplicado na assinatura.
+                              </p>
+                            )}
+                          </>
+                        )}
                         <div className="flex items-center flex-wrap gap-2 justify-center sm:justify-start">
                             <div className={`inline-flex items-center gap-2 text-sm mb-1 px-4 py-1.5 rounded-full border ${statusInfo.colorClasses}`}> {statusInfo.icon} <span className="font-semibold">{statusInfo.text}</span> {planStatus === 'active' && user?.planExpiresAt && ( <span className="hidden md:inline text-xs opacity-80 ml-2">(Expira em {new Date(user.planExpiresAt).toLocaleDateString("pt-BR")})</span> )} </div>
                             {!canAccessFeatures && (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,7 @@
 
 import { signIn } from "next-auth/react";
 import { useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function LoginPage() {
   const searchParams = useSearchParams();
@@ -14,6 +14,23 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false); // Adicionado para desabilitar o botão durante o login
   const [error, setError] = useState('');
+  const [agencyMessage, setAgencyMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('agencyInviteCode');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          if (data && data.code) {
+            setAgencyMessage(`Convite de agência ${data.code} ativo! Desconto será aplicado após assinatura.`);
+          }
+        } catch (e) {
+          // ignore
+        }
+      }
+    }
+  }, []);
 
   const handleGoogleSignIn = () => {
     setIsLoading(true);
@@ -53,6 +70,11 @@ export default function LoginPage() {
           <p className="text-gray-600 mt-3 text-base sm:text-lg">
             Acesse sua conta Data2Content para continuar.
           </p>
+          {agencyMessage && (
+            <p className="mt-2 text-green-700 text-sm bg-green-100 px-3 py-1 rounded">
+              {agencyMessage}
+            </p>
+          )}
         </div>
 
         <div className="space-y-5">


### PR DESCRIPTION
## Summary
- show visual invite confirmation on login
- add a step indicator component in the dashboard
- automatically redirect to the payment panel when an agency invite is saved
- highlight active agency invite on dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888008deb64832e93e4bc925437f4fc