### PR TITLE
Show agency name on invites

### DIFF
--- a/src/app/api/agency/info/[inviteCode]/route.ts
+++ b/src/app/api/agency/info/[inviteCode]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import AgencyModel from '@/app/models/Agency';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { inviteCode: string } }
+) {
+  try {
+    const { inviteCode } = params;
+    await connectToDatabase();
+    const agency = await AgencyModel.findOne({ inviteCode })
+      .select('name planStatus')
+      .lean();
+    if (!agency || agency.planStatus !== 'active') {
+      return NextResponse.json({ error: 'Código inválido' }, { status: 404 });
+    }
+    return NextResponse.json({ name: agency.name });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Erro interno' }, { status: 500 });
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,19 +17,30 @@ export default function LoginPage() {
   const [agencyMessage, setAgencyMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    async function loadAgencyMessage() {
+      if (typeof window === 'undefined') return;
       const stored = localStorage.getItem('agencyInviteCode');
-      if (stored) {
-        try {
-          const data = JSON.parse(stored);
-          if (data && data.code) {
-            setAgencyMessage(`Convite de agência ${data.code} ativo! Desconto será aplicado após assinatura.`);
+      if (!stored) return;
+      try {
+        const data = JSON.parse(stored);
+        if (data && data.code) {
+          try {
+            const res = await fetch(`/api/agency/info/${data.code}`);
+            if (res.ok) {
+              const info = await res.json();
+              setAgencyMessage(`Convite da agência ${info.name} ativo! Desconto será aplicado após assinatura.`);
+            } else {
+              setAgencyMessage(`Convite de agência ${data.code} ativo!`);
+            }
+          } catch {
+            setAgencyMessage(`Convite de agência ${data.code} ativo!`);
           }
-        } catch (e) {
-          // ignore
         }
+      } catch {
+        /* ignore */
       }
     }
+    loadAgencyMessage();
   }, []);
 
   const handleGoogleSignIn = () => {


### PR DESCRIPTION
## Summary
- create `/api/agency/info/[inviteCode]` to expose agency name
- fetch agency info during login and on the payment panel
- display follow‑up message after subscription

## Testing
- `npx jest --watchAll=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68880838ca5c832ebfb8828b2de73c8d