### PR TITLE
Show agency name on invites

### DIFF
--- a/src/app/api/agency/info/[inviteCode]/route.ts
+++ b/src/app/api/agency/info/[inviteCode]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import AgencyModel from '@/app/models/Agency';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { inviteCode: string } }
+) {
+  try {
+    const { inviteCode } = params;
+    await connectToDatabase();
+    const agency = await AgencyModel.findOne({ inviteCode })
+      .select('name planStatus')
+      .lean();
+    if (!agency || agency.planStatus !== 'active') {
+      return NextResponse.json({ error: 'Código inválido' }, { status: 404 });
+    }
+    return NextResponse.json({ name: agency.name });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Erro interno' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -195,6 +195,7 @@ interface ExtendedUser {
   const [commissionLog, setCommissionLog] = useState<CommissionLogItem[]>([]);
   const [isLoadingCommissionLog, setIsLoadingCommissionLog] = useState(true);
   const [commissionLogError, setCommissionLogError] = useState<string | null>(null);
+  const [agencyName, setAgencyName] = useState<string | null>(null);
 
   const redirectToPaymentPanel = useCallback(() => {
     const paymentSection = document.getElementById('payment-section');
@@ -271,6 +272,16 @@ interface ExtendedUser {
           const data = JSON.parse(stored);
           if (data && data.code) {
             redirectToPaymentPanel();
+            fetch(`/api/agency/info/${data.code}`)
+              .then((res) => res.ok ? res.json() : null)
+              .then((info) => {
+                if (info && info.name) {
+                  setAgencyName(info.name);
+                } else {
+                  setAgencyName(data.code);
+                }
+              })
+              .catch(() => setAgencyName(data.code));
           }
         } catch (e) {
           // ignore JSON errors
@@ -558,6 +569,11 @@ interface ExtendedUser {
                             instagramConnected={!!user.isInstagramConnected}
                             whatsappConnected={!!user.whatsappVerified}
                           />
+                        )}
+                        {agencyName && !canAccessFeatures && (
+                          <p className="mt-1 text-green-700 bg-green-50 border border-green-200 inline-block px-3 py-1 rounded text-sm">
+                            Convite da agência {agencyName} ativo! Desconto aplicado.
+                          </p>
                         )}
                         <div className="flex items-center flex-wrap gap-2 justify-center sm:justify-start">
                             <div className={`inline-flex items-center gap-2 text-sm mb-1 px-4 py-1.5 rounded-full border ${statusInfo.colorClasses}`}> {statusInfo.icon} <span className="font-semibold">{statusInfo.text}</span> {planStatus === 'active' && user?.planExpiresAt && ( <span className="hidden md:inline text-xs opacity-80 ml-2">(Expira em {new Date(user.planExpiresAt).toLocaleDateString("pt-BR")})</span> )} </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,19 +17,30 @@ export default function LoginPage() {
   const [agencyMessage, setAgencyMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    async function loadAgencyMessage() {
+      if (typeof window === 'undefined') return;
       const stored = localStorage.getItem('agencyInviteCode');
-      if (stored) {
-        try {
-          const data = JSON.parse(stored);
-          if (data && data.code) {
-            setAgencyMessage(`Convite de agência ${data.code} ativo! Desconto será aplicado após assinatura.`);
+      if (!stored) return;
+      try {
+        const data = JSON.parse(stored);
+        if (data && data.code) {
+          try {
+            const res = await fetch(`/api/agency/info/${data.code}`);
+            if (res.ok) {
+              const info = await res.json();
+              setAgencyMessage(`Convite da agência ${info.name} ativo! Desconto será aplicado após assinatura.`);
+            } else {
+              setAgencyMessage(`Convite de agência ${data.code} ativo!`);
+            }
+          } catch {
+            setAgencyMessage(`Convite de agência ${data.code} ativo!`);
           }
-        } catch (e) {
-          // ignore
         }
+      } catch {
+        /* ignore */
       }
     }
+    loadAgencyMessage();
   }, []);
 
   const handleGoogleSignIn = () => {


### PR DESCRIPTION
## Summary
- create `/api/agency/info/[inviteCode]` to expose agency name
- fetch agency info during login and on the payment panel
- show invite info on the dashboard for pending users
- display follow‑up message after subscription

## Testing
- `npx tsc --noEmit` *(fails: missing type definitions)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68880838ca5c832ebfb8828b2de73c8d