### PR TITLE
Add invite verification docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Usuários com papel **agency** podem acessar `/agency/dashboard` para acompanhar
 2. **Assinatura** – após o cadastro, o gestor deve acessar `/agency/subscription` e contratar o plano para ativar sua conta.
 3. **Compartilhar link** – com a assinatura ativa, copie o link de convite exibido na página de assinatura ou no painel admin e envie aos criadores.
 4. **Criadores** – ao acessar `/assinar?codigo_agencia=<código>`, o criador faz login normalmente e é levado ao dashboard inativo. O código de convite é salvo e o desconto é aplicado automaticamente ao concluir a assinatura pelo painel de pagamento.
+5. **Verificação do convite** – o criador pode confirmar se o código ainda é válido chamando `GET /api/agency/info/<inviteCode>`. Se a resposta incluir o nome da agência, o convite está ativo. Essa verificação também ocorre automaticamente na tela de pagamento quando o código está salvo no `localStorage` sob a chave `agencyInviteCode`.
 
 Cada criador pode se vincular a apenas uma agência por vez. O cancelamento da assinatura da agência não remove a assinatura individual do WhatsApp dos criadores.
 

--- a/src/app/api/agency/info/[inviteCode]/route.test.ts
+++ b/src/app/api/agency/info/[inviteCode]/route.test.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import AgencyModel from '@/app/models/Agency';
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/Agency', () => ({
+  findOne: jest.fn(),
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindOne = (AgencyModel as any).findOne as jest.Mock;
+
+const createRequest = (code: string) => new NextRequest(`http://localhost/api/agency/info/${code}`);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe('GET /api/agency/info/[inviteCode]', () => {
+  it('returns 404 when agency is missing or inactive', async () => {
+    const lean = jest.fn().mockResolvedValue(null);
+    const select = jest.fn().mockReturnValue({ lean });
+    mockFindOne.mockReturnValue({ select });
+
+    const res = await GET(createRequest('abc'), { params: { inviteCode: 'abc' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns name when invite code is valid and active', async () => {
+    const lean = jest.fn().mockResolvedValue({ name: 'Agency', planStatus: 'active' });
+    const select = jest.fn().mockReturnValue({ lean });
+    mockFindOne.mockReturnValue({ select });
+
+    const res = await GET(createRequest('xyz'), { params: { inviteCode: 'xyz' } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ name: 'Agency' });
+  });
+});


### PR DESCRIPTION
## Summary
- document the invite-check endpoint in README
- add unit tests for `/api/agency/info/[inviteCode]`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883b67f710832eb48b80d3bc122c0f