### PR TITLE
update plan pricing and UI

### DIFF
--- a/src/app/afiliados/page.tsx
+++ b/src/app/afiliados/page.tsx
@@ -6,6 +6,7 @@ import Head from 'next/head';
 // Usaremos ícones para ilustrar as seções
 import { FaInfoCircle, FaLink, FaDollarSign, FaTrophy, FaQuestionCircle, FaHandshake, FaBullhorn, FaMoneyBillWave } from 'react-icons/fa'; // <<< FaMoneyBillWave ADICIONADO AQUI >>>
 import { motion } from 'framer-motion';
+import { MONTHLY_PRICE } from '@/config/pricing.config';
 
 // Componente para um Card de Informação
 const InfoCard = ({
@@ -111,7 +112,7 @@ export default function AffiliateProgramPage() {
             Você recebe uma comissão de <strong>10% sobre o valor da primeira assinatura</strong> de cada novo cliente que utilizar o seu código ou link de afiliado.
           </p>
           <p className="mt-2">
-            Por exemplo, se o plano mensal é R$ 29,90, a sua comissão por uma nova assinatura mensal indicada por você será de R$ 1,99.
+            Por exemplo, se o plano mensal é R$ {MONTHLY_PRICE.toFixed(2).replace('.', ',')}, a sua comissão por uma nova assinatura mensal indicada por você será de R$ {(MONTHLY_PRICE * 0.1).toFixed(2).replace('.', ',')}.
           </p>
           <p className="mt-2">
             <strong>Importante:</strong> A comissão é válida apenas para a primeira assinatura do novo cliente. Não há comissões recorrentes sobre renovações neste momento.

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-icons/fa";
 // Importando Framer Motion
 import { motion, AnimatePresence } from "framer-motion";
+import { MONTHLY_PRICE } from "@/config/pricing.config";
 
 interface PaymentPanelProps {
   user: {
@@ -337,7 +338,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           </h3>
           <div className="flex items-baseline justify-center space-x-1 text-brand-dark mt-2">
               <span className="text-2xl font-medium">R$</span>
-              <span className="text-6xl font-extrabold tracking-tight leading-none text-brand-pink">29,90</span>
+              <span className="text-6xl font-extrabold tracking-tight leading-none text-brand-pink">{MONTHLY_PRICE.toFixed(2).replace('.', ',')}</span>
               <span className="text-xl font-medium text-brand-dark/80">/mês</span>
           </div>
           <p className="text-sm text-brand-dark/70 mt-2 font-light">
@@ -387,7 +388,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           whileTap={!(loading || ctaClicked) ? { scale: 0.97 } : {}}
           transition={{ type: "spring", stiffness: 350, damping: 17 }}
           className={` shimmer-button w-full px-6 py-4 bg-gradient-to-br from-brand-pink to-pink-500 text-white text-lg font-bold rounded-full hover:shadow-2xl transition-all duration-200 ease-out disabled:opacity-60 disabled:cursor-not-allowed shadow-xl flex items-center justify-center gap-2.5 relative overflow-hidden focus:outline-none focus:ring-4 focus:ring-offset-2 focus:ring-pink-500/70 ${(loading || ctaClicked) ? 'cursor-wait' : ''} `}
-          aria-label="Assinar o plano Data2Content Completo por R$29,90 por mês"
+          aria-label={`Assinar o plano Data2Content Completo por R$${MONTHLY_PRICE.toFixed(2).replace('.', ',')} por mês`}
         >
           {loading ? (
             <> <FaSpinner className="animate-spin w-5 h-5" /> <span>PROCESSANDO...</span> </>

--- a/src/config/pricing.config.ts
+++ b/src/config/pricing.config.ts
@@ -1,0 +1,4 @@
+export const MONTHLY_PRICE = parseFloat(process.env.MONTHLY_PLAN_PRICE || '49.9');
+export const ANNUAL_MONTHLY_PRICE = parseFloat(process.env.ANNUAL_PLAN_MONTHLY_PRICE || '29.9');
+export const AGENCY_GUEST_MONTHLY_PRICE = parseFloat(process.env.AGENCY_GUEST_MONTHLY_PRICE || '39.9');
+export const AGENCY_GUEST_ANNUAL_MONTHLY_PRICE = parseFloat(process.env.AGENCY_GUEST_ANNUAL_MONTHLY_PRICE || '19.9');


### PR DESCRIPTION
## Summary
- introduce pricing constants with env var fallbacks
- update subscription API to use new prices
- display new pricing in the dashboard payment panel
- reflect price change in affiliates page

## Testing
- `npx jest --watchAll=false` *(fails: jest not found / registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a539a84dc832e9ddf3416187400fa