### PR TITLE
Add annual plan option for agency subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npm test
 
 Esta aplicação utiliza MongoDB. Configure as variáveis de ambiente `MONGODB_URI` e `MONGODB_DB_NAME` (ou `DB_NAME`) no arquivo `.env.local` apontando para sua instância. Certifique‑se de que o banco especificado exista antes de iniciar o servidor.
 
+Para os valores da assinatura de agências, você pode definir `AGENCY_MONTHLY_PRICE` e `AGENCY_ANNUAL_MONTHLY_PRICE` (padrões `99` e `90`).
+
 ### Creators Scatter Plot
 
 Na dashboard administrativa, utilize o componente **CreatorsScatterPlot** para comparar métricas de diferentes criadores em um gráfico de dispersão.

--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -8,6 +8,7 @@ export default function AgencySubscriptionPage() {
   const { data: session } = useSession();
   const [inviteCode, setInviteCode] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedPlan, setSelectedPlan] = useState<'basic' | 'annual'>('basic');
 
   useEffect(() => {
     fetch('/api/agency/invite-code')
@@ -29,7 +30,7 @@ export default function AgencySubscriptionPage() {
     setIsLoading(true);
     const res = await fetch('/api/agency/subscription/create-checkout', {
       method: 'POST',
-      body: JSON.stringify({ planId: 'basic' })
+      body: JSON.stringify({ planId: selectedPlan })
     });
     const json = await res.json();
     if (res.ok && json.initPoint) {
@@ -52,7 +53,29 @@ export default function AgencySubscriptionPage() {
     <div className="p-6 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold">Assinatura da Agência</h1>
       <div className="border rounded-lg p-4 space-y-2 bg-white shadow">
-        <p className="text-lg font-semibold">Plano Básico - R$ 99/mês</p>
+        <p className="text-lg font-semibold">Escolha o plano</p>
+        <div className="space-y-1">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="plan"
+              value="basic"
+              checked={selectedPlan === 'basic'}
+              onChange={() => setSelectedPlan('basic')}
+            />
+            <span>Plano Mensal - R$ 99/mês</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="plan"
+              value="annual"
+              checked={selectedPlan === 'annual'}
+              onChange={() => setSelectedPlan('annual')}
+            />
+            <span>Plano Anual - R$ 90/mês</span>
+          </label>
+        </div>
         <ul className="list-disc list-inside text-sm text-gray-700">
           <li>Acesso ao dashboard dos criadores vinculados</li>
           <li>Suporte prioritário via WhatsApp</li>

--- a/src/app/api/agency/subscription/create-checkout/route.ts
+++ b/src/app/api/agency/subscription/create-checkout/route.ts
@@ -9,7 +9,7 @@ export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/create-checkout]';
 
 const bodySchema = z.object({
-  planId: z.string(),
+  planId: z.enum(['basic', 'annual']).default('basic'),
 });
 
 export async function POST(req: NextRequest) {
@@ -33,6 +33,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Agency not found' }, { status: 404 });
     }
 
+    const price =
+      validation.data.planId === 'annual'
+        ? Number(process.env.AGENCY_ANNUAL_MONTHLY_PRICE || 90)
+        : Number(process.env.AGENCY_MONTHLY_PRICE || 99);
+
     const preapprovalData = {
       reason: 'Plano Agência Data2Content',
       back_url: `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || ''}/agency/subscription`,
@@ -41,7 +46,7 @@ export async function POST(req: NextRequest) {
       auto_recurring: {
         frequency: 1,
         frequency_type: 'months',
-        transaction_amount: Number(process.env.AGENCY_MONTHLY_PRICE || 99),
+        transaction_amount: price,
         currency_id: 'BRL',
       },
     } as any;


### PR DESCRIPTION
## Summary
- allow selecting `planId` when creating agency checkout sessions
- set price to `AGENCY_ANNUAL_MONTHLY_PRICE` when `planId` is `annual`
- let the agency subscription page choose between monthly and annual plans
- document `AGENCY_MONTHLY_PRICE` and `AGENCY_ANNUAL_MONTHLY_PRICE`

## Testing
- `npm install` *(fails: network blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a56c168c4832e99e54579c5c44e81