### PR TITLE
feat: enforce plan and role enums

### DIFF
--- a/src/app/api/plan/webhook/route.ts
+++ b/src/app/api/plan/webhook/route.ts
@@ -166,6 +166,7 @@ export async function POST(request: NextRequest) {
       if (user.pendingAgency) {
         user.agency = user.pendingAgency;
         user.pendingAgency = null;
+        user.role = 'guest';
       }
 
       // Processa comissão

--- a/src/app/api/webhooks/payment/route.ts
+++ b/src/app/api/webhooks/payment/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest) {
       } else if (preapproval.status === 'cancelled') {
         agency.planStatus = 'canceled';
       } else if (preapproval.status === 'paused' || preapproval.status === 'suspended') {
-        agency.planStatus = 'past_due';
+        agency.planStatus = 'inactive';
       }
       await agency.save();
       logger.info(`${TAG} agency ${agency._id} updated to ${agency.planStatus}`);
@@ -70,9 +70,9 @@ export async function POST(req: NextRequest) {
         await agency.save();
         logger.info(`${TAG} agency ${agency._id} activated`);
       } else if (body.type === 'invoice.payment_failed') {
-        agency.planStatus = 'past_due';
+        agency.planStatus = 'inactive';
         await agency.save();
-        logger.info(`${TAG} agency ${agency._id} marked past_due`);
+        logger.info(`${TAG} agency ${agency._id} marked inactive`);
       } else if (body.type === 'customer.subscription.deleted') {
         agency.planStatus = 'canceled';
         await agency.save();

--- a/src/app/api/whatsapp/generateCode/route.ts
+++ b/src/app/api/whatsapp/generateCode/route.ts
@@ -154,21 +154,6 @@ export async function POST(request: NextRequest) {
     console.log(`[whatsapp/generateCode] Usuário encontrado no DB: ${user._id}`);
 
 
-    // Log para verificar o status antes do check
-    console.log(`[whatsapp/generateCode] Verificando status do plano para usuário ${user._id}. Status atual no DB: '${user.planStatus}'`);
-
-    // Verifica se o plano do usuário está ativo (Autorização nº 2)
-    if (user.planStatus !== "active") {
-      // Log para quando a verificação falha
-      console.warn(`[whatsapp/generateCode] Falha na Autorização nº 2 (Plano): Status do plano é '${user.planStatus}', esperado 'active'. Retornando 403.`);
-      return NextResponse.json(
-        { error: "Você não possui um plano ativo ou acesso permitido." },
-        { status: 403 }
-      );
-    }
-    console.log("[whatsapp/generateCode] Autorização nº 2 (Plano Ativo): OK.");
-
-
     // Se o usuário já tiver um número vinculado, retorna uma flag para indicar isso
     if (user.whatsappPhone) {
       console.log(`[whatsapp/generateCode] Usuário ${user._id} já possui telefone vinculado: ${user.whatsappPhone}. Retornando status 'linked'.`);

--- a/src/app/models/Agency.ts
+++ b/src/app/models/Agency.ts
@@ -1,11 +1,12 @@
 import { Schema, model, models, Document, Model } from 'mongoose';
 import { nanoid } from 'nanoid';
+import { PLAN_STATUSES, type PlanStatus } from '@/types/enums';
 
 export interface IAgency extends Document {
   name: string;
   contactEmail?: string;
   inviteCode: string;
-  planStatus?: string;
+  planStatus?: PlanStatus;
   paymentGatewaySubscriptionId?: string | null;
 }
 
@@ -13,7 +14,7 @@ const agencySchema = new Schema<IAgency>({
   name: { type: String, required: true },
   contactEmail: { type: String },
   inviteCode: { type: String, required: true, default: () => nanoid(10), unique: true },
-  planStatus: { type: String, default: 'inactive' },
+  planStatus: { type: String, enum: PLAN_STATUSES, default: 'inactive' },
   paymentGatewaySubscriptionId: { type: String, default: null },
 }, { timestamps: true });
 

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -3,6 +3,7 @@
 // - CORRIGIDO: As chamadas para `models.User` e `model("User", ...)` foram atualizadas para `mongoose.models.User` e `mongoose.model(...)` para alinhar com a nova importação.
 import mongoose, { Schema, Document, Model, Types } from "mongoose";
 import { logger } from "@/app/lib/logger";
+import { USER_ROLES, PLAN_STATUSES, type UserRole, type PlanStatus } from '@/types/enums';
 
 // --- INTERFACES ---
 export interface IPeakSharesDetails {
@@ -224,10 +225,10 @@ export interface IUser extends Document {
   linkTokenExpiresAt?: Date;
   mediaKitToken?: string;
   mediaKitSlug?: string;
-  role: string;
+  role: UserRole;
   agency?: Types.ObjectId | null;
   pendingAgency?: Types.ObjectId | null;
-  planStatus?: string;
+  planStatus?: PlanStatus;
   planExpiresAt?: Date | null;
   whatsappVerificationCode?: string | null;
   whatsappPhone?: string | null;
@@ -328,7 +329,7 @@ const userSchema = new Schema<IUser>(
         type: String,
         select: false
     },
-    planStatus: { type: String, default: "inactive", index: true }, // OTIMIZAÇÃO: Mantido índice.
+    planStatus: { type: String, enum: PLAN_STATUSES, default: "inactive", index: true }, // OTIMIZAÇÃO: Mantido índice.
     inferredExpertiseLevel: {
         type: String,
         enum: ['iniciante', 'intermediario', 'avancado'],
@@ -360,7 +361,7 @@ const userSchema = new Schema<IUser>(
     linkTokenExpiresAt: { type: Date },
     mediaKitToken: { type: String, unique: true, sparse: true },
     mediaKitSlug: { type: String, unique: true, sparse: true },
-    role: { type: String, default: "user" },
+    role: { type: String, enum: USER_ROLES, default: "user" },
     agency: { type: Schema.Types.ObjectId, ref: 'Agency', default: null },
     pendingAgency: { type: Schema.Types.ObjectId, ref: 'Agency', default: null },
     planExpiresAt: { type: Date, default: null },

--- a/src/lib/getAgencySession.ts
+++ b/src/lib/getAgencySession.ts
@@ -2,11 +2,12 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { logger } from '@/app/lib/logger';
+import type { UserRole } from '@/types/enums';
 
 export async function getAgencySession(req: NextRequest) {
   try {
     const session = await getServerSession({ req, ...authOptions });
-    if (!session || session.user?.role !== 'agency') {
+    if (!session || (session.user?.role as UserRole) !== 'agency') {
       logger.warn('[getAgencySession] session invalid or user not agency');
       return null;
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { logger } from '@/app/lib/logger';
+import type { PlanStatus } from '@/types/enums';
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const status = token?.planStatus as PlanStatus | undefined;
+
+  if (status === 'active') {
+    return NextResponse.next();
+  }
+
+  const userId = token?.id ?? 'anonymous';
+  logger.warn(`[middleware/plan] Blocked request for user ${userId} with status ${status}`);
+  return NextResponse.json(
+    { error: 'Seu acesso está inativo. Verifique sua assinatura para continuar.' },
+    { status: 403 }
+  );
+}
+
+export const config = {
+  matcher: ['/api/whatsapp/generateCode/:path*', '/api/ai/:path*'],
+};

--- a/src/types/admin/creators.ts
+++ b/src/types/admin/creators.ts
@@ -1,5 +1,7 @@
 // src/types/admin/creators.ts
 
+import type { PlanStatus } from '@/types/enums';
+
 // Define os possíveis status de um criador no contexto de admin
 export type AdminCreatorStatus = 'pending' | 'approved' | 'rejected' | 'active'; // 'active' pode ser um sinônimo de 'approved' ou um estado pós-aprovação.
 
@@ -8,7 +10,7 @@ export interface AdminCreatorListItem {
   _id: string; // Geralmente o ID do MongoDB como string
   name: string;
   email: string;
-  planStatus?: string; // Status do plano (ex: 'Free', 'Pro', 'Trial') - vindo do UserModel
+  planStatus?: PlanStatus; // Status do plano - vindo do UserModel
   inferredExpertiseLevel?: string; // Nível de expertise inferido - vindo do UserModel
   profilePictureUrl?: string; // URL da foto de perfil
   mediaKitSlug?: string; // Slug do mídia kit, se já gerado
@@ -30,7 +32,7 @@ export interface AdminCreatorListParams {
   limit?: number;
   search?: string; // Para buscar por nome, email, etc.
   status?: AdminCreatorStatus; // Para filtrar por status de admin
-  planStatus?: string; // Para filtrar por status do plano
+  planStatus?: PlanStatus; // Para filtrar por status do plano
   sortBy?: keyof AdminCreatorListItem | string; // Campo para ordenação
   sortOrder?: 'asc' | 'desc';
   // Adicionar startDate e endDate se a lista principal de gerenciamento de criadores for filtrável por data

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,5 @@
+export const USER_ROLES = ['user', 'guest', 'agency', 'admin'] as const;
+export type UserRole = typeof USER_ROLES[number];
+
+export const PLAN_STATUSES = ['active', 'pending', 'canceled', 'inactive', 'trial'] as const;
+export type PlanStatus = typeof PLAN_STATUSES[number];

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -3,6 +3,7 @@
 import { DefaultSession, DefaultUser } from "next-auth";
 import { JWT as DefaultJWT } from "next-auth/jwt"; // Import JWT type for merging
 import type { AvailableInstagramAccount } from '@/app/lib/instagramService'; // Importando o tipo que faltava
+import type { UserRole, PlanStatus } from '@/types/enums';
 
 /**
  * Aqui estendemos a interface `Session` para incluir campos extras.
@@ -16,10 +17,10 @@ declare module "next-auth" {
       email?: string | null;
       image?: string | null;
       provider?: string | null; // Provider usado no login ATUAL ('google', 'facebook')
-      role?: string;
+      role?: UserRole;
       agencyId?: string | null;
-      agencyPlanStatus?: string | null;
-      planStatus?: string;
+      agencyPlanStatus?: PlanStatus | null;
+      planStatus?: PlanStatus;
       planExpiresAt?: string | null; // Mantido como string (ISO) para o cliente
       affiliateCode?: string;
       affiliateBalance?: number;
@@ -49,7 +50,7 @@ declare module "next-auth" {
    */
   interface User extends DefaultUser { // DefaultUser já tem id, name, email, image
     id: string; // Garante que nosso ID (do DB) sobrescreva/seja o principal
-    role?: string | null;
+    role?: UserRole | null;
     agency?: string | null;
     provider?: string | null; // Provider do primeiro login ou principal
     providerAccountId?: string | null; // ID do provider principal
@@ -58,7 +59,7 @@ declare module "next-auth" {
     isNewUserForOnboarding?: boolean;
     onboardingCompletedAt?: Date | null; // Pode ser Date aqui, pois vem do DB
     
-    planStatus?: string | null;
+    planStatus?: PlanStatus | null;
     planExpiresAt?: Date | null; // Pode ser Date aqui
     affiliateCode?: string | null;
     affiliateBalance?: number;
@@ -86,10 +87,11 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT { // DefaultJWT já tem name, email, picture, sub
     id: string; // ID do usuário do seu DB (obrigatório)
-    role?: string | null;
+    role?: UserRole | null;
     agencyId?: string | null;
-    agencyPlanStatus?: string | null;
+    agencyPlanStatus?: PlanStatus | null;
     provider?: string | null;
+    planStatus?: PlanStatus | null;
     
     isNewUserForOnboarding?: boolean;
     onboardingCompletedAt?: Date | string | null; // Pode ser Date ou string (após encode)


### PR DESCRIPTION
## Summary
- add middleware to guard AI and WhatsApp APIs based on planStatus
- normalize user and agency schemas with role and planStatus enums
- update webhooks and session types to use new enums

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae0a3e314832ea50c0ad62952d579