### PR TITLE
feat: add revenue guard middleware helper

### DIFF
--- a/src/app/lib/planGuard.test.ts
+++ b/src/app/lib/planGuard.test.ts
@@ -1,0 +1,23 @@
+import { guardPremiumRequest } from './planGuard';
+import { getToken } from 'next-auth/jwt';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+
+const mockGetToken = getToken as jest.Mock;
+
+describe('guardPremiumRequest', () => {
+  it('allows request when plan status is active', async () => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'active' });
+    const res = await guardPremiumRequest({} as any);
+    expect(res).toBeNull();
+  });
+
+  it('blocks request when plan status is not active', async () => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+    const res = await guardPremiumRequest({} as any);
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+    const data = await res?.json();
+    expect(data?.error).toBeDefined();
+  });
+});

--- a/src/app/lib/planGuard.ts
+++ b/src/app/lib/planGuard.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { logger } from '@/app/lib/logger';
+import type { PlanStatus } from '@/types/enums';
+
+/**
+ * Centralized helper to ensure a user has an active plan before accessing
+ * premium APIs. Returns a NextResponse with status 403 when the plan is not
+ * active. When the plan is active, returns null so the caller can proceed.
+ */
+export async function guardPremiumRequest(
+  req: NextRequest
+): Promise<NextResponse | null> {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const status = token?.planStatus as PlanStatus | undefined;
+
+  if (status === 'active') {
+    return null;
+  }
+
+  const userId = token?.id ?? 'anonymous';
+  logger.warn(
+    `[planGuard] Blocked request for user ${userId} with status ${status}`
+  );
+
+  return NextResponse.json(
+    { error: 'Seu acesso está inativo. Verifique sua assinatura para continuar.' },
+    { status: 403 }
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,13 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getToken } from 'next-auth/jwt';
-import { logger } from '@/app/lib/logger';
-import type { PlanStatus } from '@/types/enums';
+import { guardPremiumRequest } from '@/app/lib/planGuard';
 
 export async function middleware(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
-  const status = token?.planStatus as PlanStatus | undefined;
-
-  if (status === 'active') {
-    return NextResponse.next();
+  const guardResponse = await guardPremiumRequest(req);
+  if (guardResponse) {
+    return guardResponse;
   }
-
-  const userId = token?.id ?? 'anonymous';
-  logger.warn(`[middleware/plan] Blocked request for user ${userId} with status ${status}`);
-  return NextResponse.json(
-    { error: 'Seu acesso está inativo. Verifique sua assinatura para continuar.' },
-    { status: 403 }
-  );
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- centralize plan status validation in `guardPremiumRequest`
- use revenue guard in middleware to block inactive users
- test revenue guard for active and inactive plans

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aeabbdef8832eb19e55bbe5fc36ea