### PR TITLE
feat(admin): add endpoint to convert agency guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Usuários com papel **agency** podem acessar `/agency/dashboard` para acompanhar
 
 Cada criador pode se vincular a apenas uma agência por vez. O cancelamento da assinatura da agência não remove a assinatura individual do WhatsApp dos criadores.
 
+### Desvinculação de Criadores
+
+Administradores podem utilizar o endpoint interno `POST /api/admin/users/convert-guest` para remover manualmente um criador de uma agência. O corpo da requisição deve incluir `userId` e o `planStatus` desejado. A chamada redefine o papel para `user`, limpa o `agency` e ajusta o status do plano informado.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/src/app/api/admin/users/convert-guest/route.test.ts
+++ b/src/app/api/admin/users/convert-guest/route.test.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  findById: jest.fn(),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { info: jest.fn() },
+}));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindById = (UserModel as any).findById as jest.Mock;
+
+const createRequest = (body: any) =>
+  new NextRequest('http://localhost/api/admin/users/convert-guest', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe('POST /api/admin/users/convert-guest', () => {
+  it('returns 401 when session is missing', async () => {
+    mockGetAdminSession.mockResolvedValue(null);
+    const res = await POST(createRequest({ userId: '1', planStatus: 'active' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 on invalid body', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    const res = await POST(createRequest({ userId: '1', planStatus: 'foo' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockFindById.mockResolvedValue(null);
+    const res = await POST(createRequest({ userId: '1', planStatus: 'active' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('updates user and returns success', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    const save = jest.fn();
+    const user = { role: 'guest', agency: 'a1', planStatus: 'pending', save };
+    mockFindById.mockResolvedValue(user);
+    const res = await POST(createRequest({ userId: '1', planStatus: 'active' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+    expect(user.role).toBe('user');
+    expect(user.agency).toBeNull();
+    expect(user.planStatus).toBe('active');
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/users/convert-guest/route.ts
+++ b/src/app/api/admin/users/convert-guest/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { PLAN_STATUSES } from '@/types/enums';
+import { logger } from '@/app/lib/logger';
+
+const bodySchema = z.object({
+  userId: z.string(),
+  planStatus: z.enum(PLAN_STATUSES),
+});
+
+export async function POST(req: NextRequest) {
+  const session = await getAdminSession(req);
+  if (!session) {
+    return NextResponse.json(
+      { error: 'Acesso não autorizado.' },
+      { status: 401 }
+    );
+  }
+
+  const json = await req.json().catch(() => null);
+  const validation = bodySchema.safeParse(json);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos.' },
+      { status: 400 }
+    );
+  }
+
+  const { userId, planStatus } = validation.data;
+
+  await connectToDatabase();
+  const user = await UserModel.findById(userId);
+  if (!user) {
+    return NextResponse.json(
+      { error: 'Usuário não encontrado.' },
+      { status: 404 }
+    );
+  }
+
+  user.role = 'user';
+  user.agency = null;
+  user.planStatus = planStatus;
+  await user.save();
+
+  logger.info(
+    `[admin/convert-guest] User ${userId} convertido para role 'user' com plano ${planStatus}`
+  );
+
+  return NextResponse.json({ success: true });
+}
+
+export const runtime = 'nodejs';


### PR DESCRIPTION
## Summary
- allow admins to convert agency guests back to standalone users via `/api/admin/users/convert-guest`
- document new guest detachment endpoint in README
- cover guest conversion scenarios with unit tests

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npx jest --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af997b070832e9c9b31b490676802