### PR TITLE
chore: log blocked path and test plan guard

### DIFF
--- a/src/app/lib/planGuard.test.ts
+++ b/src/app/lib/planGuard.test.ts
@@ -1,23 +1,38 @@
-import { guardPremiumRequest } from './planGuard';
+import { NextRequest } from 'next/server';
+import { guardPremiumRequest } from '@/app/lib/planGuard';
 import { getToken } from 'next-auth/jwt';
+import { logger } from '@/app/lib/logger';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { warn: jest.fn() } }));
 
 const mockGetToken = getToken as jest.Mock;
+const mockWarn = logger.warn as jest.Mock;
+
+function createRequest(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
 
 describe('guardPremiumRequest', () => {
-  it('allows request when plan status is active', async () => {
-    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'active' });
-    const res = await guardPremiumRequest({} as any);
-    expect(res).toBeNull();
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('blocks request when plan status is not active', async () => {
+  it('allows when plan is active', async () => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'active' });
+    const res = await guardPremiumRequest(createRequest('/api/ai/chat'));
+    expect(res).toBeNull();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('blocks and logs when plan is not active', async () => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
-    const res = await guardPremiumRequest({} as any);
-    expect(res).not.toBeNull();
+    const req = createRequest('/api/ai/chat');
+    const res = await guardPremiumRequest(req);
     expect(res?.status).toBe(403);
-    const data = await res?.json();
-    expect(data?.error).toBeDefined();
+    expect(mockWarn).toHaveBeenCalledWith(
+      '[planGuard] Blocked request for user u1 with status inactive on /api/ai/chat'
+    );
   });
 });
+

--- a/src/app/lib/planGuard.ts
+++ b/src/app/lib/planGuard.ts
@@ -19,8 +19,9 @@ export async function guardPremiumRequest(
   }
 
   const userId = token?.id ?? 'anonymous';
+  const path = req.nextUrl.pathname;
   logger.warn(
-    `[planGuard] Blocked request for user ${userId} with status ${status}`
+    `[planGuard] Blocked request for user ${userId} with status ${status} on ${path}`
   );
 
   return NextResponse.json(


### PR DESCRIPTION
## Summary
- log request path when plan guard blocks a request
- add unit test covering guardPremiumRequest logging behavior

## Testing
- `npx jest` *(fails: 403 Forbidden fetching jest package)*

------
https://chatgpt.com/codex/tasks/task_e_688b85a6bc44832eb7bd45049cf0997f