### PR TITLE
feat: link agency invite to user

### DIFF
--- a/src/app/api/agency/accept-invite/route.test.ts
+++ b/src/app/api/agency/accept-invite/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { getServerSession } from 'next-auth/next';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import AgencyModel from '@/app/models/Agency';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findById: jest.fn() }));
+jest.mock('@/app/models/Agency', () => ({ findOne: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { info: jest.fn() } }));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindUser = (UserModel as any).findById as jest.Mock;
+const mockFindAgency = (AgencyModel as any).findOne as jest.Mock;
+
+const createRequest = (body: any) =>
+  new NextRequest('http://localhost/api/agency/accept-invite', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe('POST /api/agency/accept-invite', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await POST(createRequest({ inviteCode: 'abc' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when agency not found', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindAgency.mockResolvedValue(null);
+    const res = await POST(createRequest({ inviteCode: 'abc' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when agency inactive', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindAgency.mockResolvedValue({ _id: 'a1', planStatus: 'inactive' });
+    const res = await POST(createRequest({ inviteCode: 'abc' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 409 when user already linked to another agency', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindAgency.mockResolvedValue({ _id: 'a1', planStatus: 'active' });
+    const save = jest.fn();
+    mockFindUser.mockResolvedValue({ agency: 'other', role: 'user', planStatus: 'inactive', save });
+    const res = await POST(createRequest({ inviteCode: 'abc' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('links user to agency and returns success', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindAgency.mockResolvedValue({ _id: 'a1', planStatus: 'active' });
+    const save = jest.fn();
+    const user = { agency: null, role: 'user', planStatus: 'inactive', save };
+    mockFindUser.mockResolvedValue(user);
+    const res = await POST(createRequest({ inviteCode: 'abc' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+    expect(user.agency).toBe('a1');
+    expect(user.role).toBe('guest');
+    expect(user.planStatus).toBe('pending');
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/agency/accept-invite/route.ts
+++ b/src/app/api/agency/accept-invite/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import AgencyModel from '@/app/models/Agency';
+import { logger } from '@/app/lib/logger';
+import { z } from 'zod';
+
+const bodySchema = z.object({
+  inviteCode: z.string(),
+});
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession({ req, ...authOptions });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Dados inválidos' }, { status: 400 });
+  }
+
+  await connectToDatabase();
+
+  const agency = await AgencyModel.findOne({ inviteCode: parsed.data.inviteCode })
+    .select('_id planStatus')
+    .lean();
+  if (!agency) {
+    return NextResponse.json({ error: 'Convite inválido' }, { status: 404 });
+  }
+  if (agency.planStatus !== 'active') {
+    return NextResponse.json({ error: 'Agência sem assinatura ativa' }, { status: 403 });
+  }
+
+  const user = await UserModel.findById(session.user.id);
+  if (!user) {
+    return NextResponse.json({ error: 'Usuário não encontrado' }, { status: 404 });
+  }
+
+  if (user.agency && user.agency.toString() !== agency._id.toString()) {
+    return NextResponse.json(
+      { error: 'Usuário já vinculado a outra agência. Saia da atual antes de prosseguir.' },
+      { status: 409 }
+    );
+  }
+
+  user.agency = agency._id as any;
+  user.role = 'guest';
+  if (user.planStatus === 'inactive') {
+    user.planStatus = 'pending';
+  }
+  await user.save();
+
+  logger.info(
+    `[agency/accept-invite] User ${session.user.id} linked to agency ${agency._id}`
+  );
+
+  return NextResponse.json({ success: true });
+}
+
+export const runtime = 'nodejs';


### PR DESCRIPTION
## Summary
- link creators to an agency as guests via new accept-invite endpoint
- auto-apply invite code after login using AuthRedirectHandler
- cover agency invite flow with unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b87a6d144832ebe0b9381084dd725