### PR TITLE
feat: add centralized plan guard with metrics

### DIFF
--- a/docs/plan-guard.md
+++ b/docs/plan-guard.md
@@ -1,0 +1,12 @@
+# Guardião da Receita
+
+Middleware centralizado que protege rotas premium (IA, WhatsApp) verificando se o `planStatus` do usuário está **active**.
+
+## Funcionamento
+- `guardPremiumRequest` é chamado pelo `middleware.ts` para rotas sensíveis.
+- Quando o plano não está ativo, a requisição é bloqueada com status `403` e mensagem padrão.
+- Tentativas negadas são registradas com `logger.warn`.
+- Métricas de bloqueio são acumuladas em memória e podem ser consultadas em `/api/admin/plan-guard/metrics`.
+
+## Métricas
+As métricas expõem o total de acessos bloqueados e o detalhamento por rota, permitindo monitoramento no dashboard de suporte.

--- a/src/app/api/admin/plan-guard/metrics/route.test.ts
+++ b/src/app/api/admin/plan-guard/metrics/route.test.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { planGuardMetrics, resetPlanGuardMetrics } from '@/app/lib/planGuard';
+
+jest.mock('@/lib/getAdminSession', () => ({
+  getAdminSession: jest.fn(),
+}));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+
+const createRequest = () => new NextRequest('http://localhost/api/admin/plan-guard/metrics');
+
+describe('GET /api/admin/plan-guard/metrics', () => {
+  beforeEach(() => {
+    resetPlanGuardMetrics();
+    mockGetAdminSession.mockReset();
+  });
+
+  it('returns 401 when session missing', async () => {
+    mockGetAdminSession.mockResolvedValue(null);
+    const res = await GET(createRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns metrics when authorized', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    planGuardMetrics.blocked = 2;
+    planGuardMetrics.byRoute['/api/ai/chat'] = 2;
+    const res = await GET(createRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ blocked: 2, byRoute: { '/api/ai/chat': 2 } });
+  });
+});

--- a/src/app/api/admin/plan-guard/metrics/route.ts
+++ b/src/app/api/admin/plan-guard/metrics/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { getPlanGuardMetrics } from '@/app/lib/planGuard';
+import { logger } from '@/app/lib/logger';
+
+export async function GET(req: NextRequest) {
+  const session = await getAdminSession(req);
+  if (!session) {
+    logger.warn('[planGuardMetrics] unauthorized access attempt');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json(getPlanGuardMetrics(), { status: 200 });
+}

--- a/src/app/lib/planGuard.test.ts
+++ b/src/app/lib/planGuard.test.ts
@@ -1,5 +1,9 @@
 import { NextRequest } from 'next/server';
-import { guardPremiumRequest } from '@/app/lib/planGuard';
+import {
+  guardPremiumRequest,
+  getPlanGuardMetrics,
+  resetPlanGuardMetrics,
+} from '@/app/lib/planGuard';
 import { getToken } from 'next-auth/jwt';
 import { logger } from '@/app/lib/logger';
 
@@ -16,6 +20,7 @@ function createRequest(path: string) {
 describe('guardPremiumRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetPlanGuardMetrics();
   });
 
   it('allows when plan is active', async () => {
@@ -33,6 +38,9 @@ describe('guardPremiumRequest', () => {
     expect(mockWarn).toHaveBeenCalledWith(
       '[planGuard] Blocked request for user u1 with status inactive on /api/ai/chat'
     );
+    const metrics = getPlanGuardMetrics();
+    expect(metrics.blocked).toBe(1);
+    expect(metrics.byRoute['/api/ai/chat']).toBe(1);
   });
 });
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { middleware } from './middleware';
+import { resetPlanGuardMetrics } from '@/app/lib/planGuard';
 import { getToken } from 'next-auth/jwt';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
@@ -11,6 +12,9 @@ function createRequest(path: string) {
 }
 
 describe('middleware plan guard', () => {
+  beforeEach(() => {
+    resetPlanGuardMetrics();
+  });
   it('allows access when plan is active', async () => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'active' });
     const res = await middleware(createRequest('/api/ai/chat'));


### PR DESCRIPTION
## Summary
- track plan guard block metrics and expose via admin API
- add tests for guard and middleware
- document revenue guard middleware usage

## Testing
- `npm install` *(failed: MaxListenersExceededWarning and incomplete install)*
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8cd748fc832ead00e444d7138451