### PR TITLE
refactor: enforce enum roles and plan statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "force-clean-indexes": "tsx --env-file=.env.local ./scripts/forceCleanIndexes.ts",
     "fix-formats": "tsx --env-file=.env.local ./scripts/fixFormatLabels.ts",
     "test:demographics": "tsx --env-file=.env.local ./scripts/testDemographics.ts",
-    "backfill:demographics": "tsx --env-file=.env.local ./scripts/backfillDemographicSnapshots.ts"
+    "backfill:demographics": "tsx --env-file=.env.local ./scripts/backfillDemographicSnapshots.ts",
+    "migrate:roles": "tsx --env-file=.env.local ./scripts/migrateRolesAndPlans.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",

--- a/scripts/migrateRolesAndPlans.ts
+++ b/scripts/migrateRolesAndPlans.ts
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import Agency from '@/app/models/Agency';
+import { USER_ROLES, PLAN_STATUSES } from '@/types/enums';
+import { logger } from '@/app/lib/logger';
+
+const TAG = '[migrateRolesAndPlans]';
+
+async function migrate() {
+  await connectToDatabase();
+  logger.info(`${TAG} connected to database`);
+
+  await User.updateMany({ role: { $nin: USER_ROLES as any } }, { $set: { role: 'user' } });
+  await User.updateMany({ planStatus: { $nin: PLAN_STATUSES as any } }, { $set: { planStatus: 'inactive' } });
+  await Agency.updateMany({ planStatus: { $nin: PLAN_STATUSES as any } }, { $set: { planStatus: 'inactive' } });
+
+  logger.info(`${TAG} migration completed`);
+  await mongoose.disconnect();
+}
+
+migrate().catch(err => {
+  logger.error(`${TAG} failed`, err);
+  mongoose.disconnect();
+});

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -5,12 +5,13 @@ import { toast } from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
 import AdminAuthGuard from '../components/AdminAuthGuard';
 import ModalConfirm from '../components/ModalConfirm';
+import type { PlanStatus } from '@/types/enums';
 
 interface Agency {
   _id: string;
   name: string;
   inviteCode: string;
-  planStatus?: string;
+  planStatus?: PlanStatus;
   contactEmail?: string;
   managerEmail?: string;
 }

--- a/src/app/admin/components/AdminAuthGuard.tsx
+++ b/src/app/admin/components/AdminAuthGuard.tsx
@@ -4,6 +4,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
+import type { UserRole } from '@/types/enums';
 
 // Suposição: Seu objeto de usuário na sessão tem uma propriedade 'role'
 // ou uma propriedade booleana como 'isAdmin'.
@@ -12,7 +13,7 @@ interface AdminUser {
   name?: string | null;
   email?: string | null;
   image?: string | null;
-  role?: string; // Exemplo: 'admin', 'user'
+  role?: UserRole; // Exemplo: 'admin', 'user'
   isAdmin?: boolean; // Alternativa: true/false
 }
 

--- a/src/app/agency/components/AgencyAuthGuard.tsx
+++ b/src/app/agency/components/AgencyAuthGuard.tsx
@@ -2,14 +2,15 @@
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
+import type { UserRole, PlanStatus } from '@/types/enums';
 
 interface AgencyUser {
   name?: string | null;
   email?: string | null;
   image?: string | null;
-  role?: string;
+  role?: UserRole;
   isAgency?: boolean;
-  agencyPlanStatus?: string | null;
+  agencyPlanStatus?: PlanStatus | null;
 }
 
 interface ExtendedSession {

--- a/src/app/api/admin/redemptions/route.ts
+++ b/src/app/api/admin/redemptions/route.ts
@@ -7,6 +7,7 @@ import User from "@/app/models/User";
 // <<< ALTERAÇÃO 1: Importamos o modelo E a interface correta que criamos.
 import Redemption, { IRedemption } from "@/app/models/Redemption";
 import { Types } from "mongoose";
+import type { UserRole } from '@/types/enums';
 
 export const runtime = "nodejs";
 export const dynamic = 'force-dynamic';
@@ -31,7 +32,7 @@ interface SessionUser {
   name?: string | null;
   email?: string | null;
   image?: string | null;
-  role?: string;
+  role?: UserRole;
   id?: string;
 }
 

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -22,10 +22,11 @@ import {
 // Importando Framer Motion
 import { motion, AnimatePresence } from "framer-motion";
 import { MONTHLY_PRICE } from "@/config/pricing.config";
+import type { PlanStatus } from '@/types/enums';
 
 interface PaymentPanelProps {
   user: {
-    planStatus?: string;
+    planStatus?: PlanStatus;
     planExpiresAt?: string | null;
     affiliateBalance?: number;
     affiliateCode?: string;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@
  import Image from 'next/image';
  import Head from 'next/head';
  import Link from 'next/link';
+ import type { PlanStatus } from '@/types/enums';
  // Usando React Icons (Font Awesome)
  import { FaCopy, FaCheckCircle, FaClock, FaTimesCircle, FaLock, FaTrophy, FaGift, FaMoneyBillWave, FaWhatsapp, FaUpload, FaCog, FaQuestionCircle, FaSignOutAlt, FaUserCircle, FaDollarSign, FaEllipsisV, FaBullhorn, FaVideo, FaSpinner, FaExclamationCircle, FaInfoCircle, FaHandshake, FaFileContract, FaShieldAlt, FaTrashAlt, FaEnvelope, FaCreditCard } from 'react-icons/fa';
  // Framer Motion para animações
@@ -31,7 +32,7 @@ interface ExtendedUser {
   name?: string | null;
   email?: string | null;
   image?: string | null;
-  planStatus?: string;
+  planStatus?: PlanStatus;
   planExpiresAt?: string | null;
   affiliateCode?: string | null;
   affiliateBalance?: number;

--- a/src/lib/services/adminCreatorService.ts
+++ b/src/lib/services/adminCreatorService.ts
@@ -8,6 +8,7 @@ import RedemptionModel, { IRedemption } from '@/app/models/Redemption';
 // Funções e tipos de suporte
 import { connectToDatabase } from '@/app/lib/dataService/connection';
 import { logger } from '@/app/lib/logger';
+import type { PlanStatus } from '@/types/enums';
 import {
   AdminCreatorListItem,
   AdminCreatorListParams,
@@ -94,7 +95,7 @@ export async function fetchCreators(
         registrationDate?: Date;
         adminStatus?: AdminCreatorStatus;
         profile_picture_url?: string;
-        planStatus?: string;
+        planStatus?: PlanStatus;
         inferredExpertiseLevel?: string;
         mediaKitSlug?: string;
         name?: string;


### PR DESCRIPTION
## Summary
- refactor session guards and services to use typed `UserRole` and `PlanStatus`
- add migration script to normalize legacy role and plan values
- expose migration helper in package scripts

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b926ffa90832eaaff343f9366dd49