### PR TITLE
feat: secure guest invite flow

### DIFF
--- a/src/app/agency/dashboard/page.tsx
+++ b/src/app/agency/dashboard/page.tsx
@@ -40,6 +40,7 @@ const AgencyDashboardContent: React.FC = () => {
 
   const [inviteCode, setInviteCode] = useState<string>('');
   const [agencyName, setAgencyName] = useState<string>('');
+  const [guests, setGuests] = useState<Array<{ id: string; name: string; email: string; planStatus: string }>>([]);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
   const [selectedUserPhotoUrl, setSelectedUserPhotoUrl] = useState<string | null>(null);
@@ -58,6 +59,13 @@ const AgencyDashboardContent: React.FC = () => {
         if (data.inviteCode) setInviteCode(data.inviteCode);
         if (data.name) setAgencyName(data.name);
       })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/agency/guests')
+      .then(res => res.json())
+      .then(data => setGuests(data.guests || []))
       .catch(() => {});
   }, []);
 
@@ -142,9 +150,39 @@ const AgencyDashboardContent: React.FC = () => {
                 />
               </div>
             </div>
-            {inviteCode && (
-              <div className="mt-2 bg-gray-100 p-4 rounded-lg shadow">
-                <p className="text-sm mb-2">Link de convite para cadastrar criadores:</p>
+          </div>
+        </header>
+
+        <main className="max-w-full mx-auto py-8 px-4 sm:px-6 lg:px-8">
+          <section id="my-guests" className="mb-8">
+            <h2 className="text-lg font-semibold mb-2">Meus Convidados ({guests.length})</h2>
+            {guests.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="min-w-full bg-white">
+                  <thead>
+                    <tr>
+                      <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Nome</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">E-mail</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {guests.map((g) => (
+                      <tr key={g.id} className="border-t">
+                        <td className="px-4 py-2 text-sm">{g.name || '-'}</td>
+                        <td className="px-4 py-2 text-sm">{g.email}</td>
+                        <td className="px-4 py-2 text-sm">{g.planStatus}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">Nenhum convidado registrado ainda.</p>
+            )}
+            {inviteLink && (
+              <div className="mt-4">
+                <p className="text-sm mb-2">Convide novos criadores com o link:</p>
                 <div className="flex">
                   <input
                     type="text"
@@ -161,10 +199,7 @@ const AgencyDashboardContent: React.FC = () => {
                 </div>
               </div>
             )}
-          </div>
-        </header>
-
-        <main className="max-w-full mx-auto py-8 px-4 sm:px-6 lg:px-8">
+          </section>
           <section id="platform-summary" className="mb-8">
             <PlatformSummaryKpis apiPrefix={apiPrefix} startDate={startDate} endDate={endDate} />
           </section>

--- a/src/app/api/agency/guests/route.test.ts
+++ b/src/app/api/agency/guests/route.test.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { getAgencySession } from '@/lib/getAgencySession';
+import UserModel from '@/app/models/User';
+
+jest.mock('@/lib/getAgencySession', () => ({
+  getAgencySession: jest.fn(),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  find: jest.fn(),
+}));
+
+const mockGetAgencySession = getAgencySession as jest.Mock;
+const mockFind = (UserModel as any).find as jest.Mock;
+
+const createRequest = () => new NextRequest('http://localhost/api/agency/guests');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/agency/guests', () => {
+  it('returns 401 when unauthorized', async () => {
+    mockGetAgencySession.mockResolvedValue(null);
+    const res = await GET(createRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns guests when authorized', async () => {
+    mockGetAgencySession.mockResolvedValue({ user: { agencyId: 'a1' } });
+    const lean = jest.fn().mockResolvedValue([
+      { _id: '1', name: 'Guest1', email: 'g1@test.com', planStatus: 'pending' },
+      { _id: '2', name: null, email: 'g2@test.com', planStatus: 'active' },
+    ]);
+    const select = jest.fn().mockReturnValue({ lean });
+    mockFind.mockReturnValue({ select });
+
+    const res = await GET(createRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.guests).toHaveLength(2);
+    expect(body.guests[0]).toEqual({ id: '1', name: 'Guest1', email: 'g1@test.com', planStatus: 'pending' });
+    expect(body.guests[1]).toEqual({ id: '2', name: '', email: 'g2@test.com', planStatus: 'active' });
+  });
+});

--- a/src/app/api/agency/guests/route.ts
+++ b/src/app/api/agency/guests/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAgencySession } from '@/lib/getAgencySession';
+import UserModel from '@/app/models/User';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: NextRequest) {
+  const session = await getAgencySession(req);
+  if (!session?.user?.agencyId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const guests = await UserModel.find({ agency: session.user.agencyId, role: 'guest' })
+    .select('name email planStatus')
+    .lean();
+
+  const formatted = guests.map((g: any) => ({
+    id: g._id.toString(),
+    name: g.name || '',
+    email: g.email,
+    planStatus: g.planStatus,
+  }));
+
+  return NextResponse.json({ guests: formatted });
+}

--- a/src/app/assinar/page.test.tsx
+++ b/src/app/assinar/page.test.tsx
@@ -28,15 +28,15 @@ describe('PublicSubscribePage', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ name: 'Agência X' }) }) as any;
     render(<PublicSubscribePage />);
     await waitFor(() => {
-      expect(screen.getByText(/Agência X/)).toBeInTheDocument();
+      expect(screen.getByText('Bem-vindo como convidado da Agência X.')).toBeInTheDocument();
     });
   });
 
-  it('shows warning when invite is invalid', async () => {
+  it('redirects when invite is invalid', async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) }) as any;
     render(<PublicSubscribePage />);
     await waitFor(() => {
-      expect(screen.getByText(/Convite inválido/)).toBeInTheDocument();
+      expect(mockReplace).toHaveBeenCalledWith('/assinar?alert=convite_invalido');
     });
   });
 });

--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -6,10 +6,10 @@ import { useSession, signIn } from 'next-auth/react';
 export default function PublicSubscribePage() {
   const searchParams = useSearchParams();
   const agencyCode = searchParams.get('codigo_agencia');
+  const alert = searchParams.get('alert');
   const { status } = useSession();
   const router = useRouter();
   const [agencyName, setAgencyName] = useState<string | null>(null);
-  const [invalidInvite, setInvalidInvite] = useState(false);
 
   useEffect(() => {
     if (agencyCode) {
@@ -19,12 +19,12 @@ export default function PublicSubscribePage() {
             const data = await res.json();
             setAgencyName(data.name);
           } else {
-            setInvalidInvite(true);
+            router.replace('/assinar?alert=convite_invalido');
           }
         })
-        .catch(() => setInvalidInvite(true));
+        .catch(() => router.replace('/assinar?alert=convite_invalido'));
     }
-  }, [agencyCode]);
+  }, [agencyCode, router]);
 
   useEffect(() => {
     if (status === 'authenticated') {
@@ -32,15 +32,14 @@ export default function PublicSubscribePage() {
     }
   }, [status, router]);
 
-
   return (
     <div className="p-6 max-w-md mx-auto space-y-4">
       {agencyName && (
         <div className="bg-green-100 text-green-800 p-2 rounded">
-          Boas-vindas! Como convidado da {agencyName}, você tem acesso a planos exclusivos.
+          Bem-vindo como convidado da {agencyName}.
         </div>
       )}
-      {invalidInvite && (
+      {alert === 'convite_invalido' && (
         <div className="bg-yellow-100 text-yellow-800 p-2 rounded">
           Convite inválido ou agência inativa. Confira nossos planos.
         </div>


### PR DESCRIPTION
## Summary
- customize public subscription page to greet agency guests and redirect inactive invites
- provide API to list an agency's guests
- show "Meus Convidados" section on agency dashboard with guest list and invite link

## Testing
- `npm test` *(fails: jest: not found / registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_688b9998bf48832e87b5d49741cc99e9