### PR TITLE
Implement state transition flows for agency and creator

### DIFF
--- a/docs/state-transitions.md
+++ b/docs/state-transitions.md
@@ -1,0 +1,14 @@
+# Cenários de Transição de Estado
+
+Este documento descreve os processos automáticos e manuais quando uma agência ou criador muda de status.
+
+## Agência cancela assinatura
+- Os convidados permanecem com acesso até a data em `planExpiresAt`.
+- Um job diário (`cron/guestTransition.ts`) verifica convidados:
+  - 7 dias antes do vencimento, envia e-mail avisando sobre a migração.
+  - Após o vencimento, o convidado é migrado para `role: user`, `planStatus: inactive` e a agência é removida.
+
+## Criador sai da agência
+- Endpoint protegido: `PATCH /api/admin/users/[userId]/role`.
+- Permite a um administrador alterar `role` e `planStatus` de qualquer usuário.
+- Todas as alterações são registradas com `logger.info` para auditoria.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "fix-formats": "tsx --env-file=.env.local ./scripts/fixFormatLabels.ts",
     "test:demographics": "tsx --env-file=.env.local ./scripts/testDemographics.ts",
     "backfill:demographics": "tsx --env-file=.env.local ./scripts/backfillDemographicSnapshots.ts",
-    "migrate:roles": "tsx --env-file=.env.local ./scripts/migrateRolesAndPlans.ts"
+    "migrate:roles": "tsx --env-file=.env.local ./scripts/migrateRolesAndPlans.ts",
+    "cron:guest-transition": "tsx --env-file=.env.local ./src/cron/guestTransition.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",

--- a/src/app/api/admin/users/[userId]/role/route.test.ts
+++ b/src/app/api/admin/users/[userId]/role/route.test.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from 'next/server';
+import { PATCH } from './route';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+
+jest.mock('@/lib/getAdminSession', () => ({ getAdminSession: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findById: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { info: jest.fn() } }));
+
+const mockGetAdminSession = getAdminSession as jest.Mock;
+const mockFindById = (UserModel as any).findById as jest.Mock;
+
+const createRequest = (userId: string, body: any) =>
+  new NextRequest(`http://localhost/api/admin/users/${userId}/role`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (connectToDatabase as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('PATCH /api/admin/users/[userId]/role', () => {
+  it('returns 401 when session missing', async () => {
+    mockGetAdminSession.mockResolvedValue(null);
+    const res = await PATCH(createRequest('1', { role: 'user', planStatus: 'active' }), { params: { userId: '1' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 on invalid body', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    const res = await PATCH(createRequest('1', { role: 'foo', planStatus: 'active' }), { params: { userId: '1' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
+    mockFindById.mockResolvedValue(null);
+    const res = await PATCH(createRequest('1', { role: 'user', planStatus: 'inactive' }), { params: { userId: '1' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('updates user and returns success', async () => {
+    mockGetAdminSession.mockResolvedValue({ user: { role: 'admin', email: 'admin@test.com' } });
+    const save = jest.fn();
+    const user = { role: 'guest', planStatus: 'active', agency: 'a1', save };
+    mockFindById.mockResolvedValue(user);
+    const res = await PATCH(createRequest('1', { role: 'user', planStatus: 'inactive' }), { params: { userId: '1' } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+    expect(user.role).toBe('user');
+    expect(user.planStatus).toBe('inactive');
+    expect(user.agency).toBeNull();
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/users/[userId]/role/route.ts
+++ b/src/app/api/admin/users/[userId]/role/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getAdminSession } from '@/lib/getAdminSession';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { USER_ROLES, PLAN_STATUSES } from '@/types/enums';
+import { logger } from '@/app/lib/logger';
+
+const bodySchema = z.object({
+  role: z.enum(USER_ROLES),
+  planStatus: z.enum(PLAN_STATUSES),
+});
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const session = await getAdminSession(req);
+  if (!session) {
+    return NextResponse.json({ error: 'Acesso não autorizado.' }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const validation = bodySchema.safeParse(json);
+  if (!validation.success) {
+    return NextResponse.json({ error: 'Dados inválidos.' }, { status: 400 });
+  }
+
+  const { role, planStatus } = validation.data;
+  const { userId } = params;
+
+  await connectToDatabase();
+  const user = await UserModel.findById(userId);
+  if (!user) {
+    return NextResponse.json({ error: 'Usuário não encontrado.' }, { status: 404 });
+  }
+
+  user.role = role;
+  user.planStatus = planStatus;
+  if (role !== 'guest') {
+    user.agency = null;
+  }
+  await user.save();
+
+  logger.info(
+    `[admin/user-role] Admin ${session.user?.email || session.user?.id} mudou role para '${role}' e planStatus para '${planStatus}' do usuário ${userId}`
+  );
+
+  return NextResponse.json({ success: true });
+}
+
+export const runtime = 'nodejs';

--- a/src/app/lib/emailService.ts
+++ b/src/app/lib/emailService.ts
@@ -1,0 +1,29 @@
+import nodemailer from 'nodemailer';
+import { logger } from '@/app/lib/logger';
+import { guestMigrationNotice } from '@/emails/guestMigrationNotice';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.EMAIL_HOST,
+  port: Number(process.env.EMAIL_PORT) || 587,
+  secure: false,
+  auth: process.env.EMAIL_USER && process.env.EMAIL_PASS ? {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  } : undefined,
+});
+
+export async function sendGuestMigrationEmail(to: string, expiresAt: Date) {
+  const template = guestMigrationNotice(expiresAt);
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM || 'no-reply@data2content.ai',
+      to,
+      subject: template.subject,
+      text: template.text,
+      html: template.html,
+    });
+    logger.info(`[emailService] Aviso de migração enviado para ${to}`);
+  } catch (err) {
+    logger.error('[emailService] Falha ao enviar email de migração', err);
+  }
+}

--- a/src/cron/guestTransition.test.ts
+++ b/src/cron/guestTransition.test.ts
@@ -1,0 +1,51 @@
+import { handleGuestTransitions } from './guestTransition';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import UserModel from '@/app/models/User';
+import { sendGuestMigrationEmail } from '@/app/lib/emailService';
+
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ find: jest.fn() }));
+jest.mock('@/app/lib/emailService', () => ({ sendGuestMigrationEmail: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { info: jest.fn(), error: jest.fn() } }));
+
+const mockFind = (UserModel as any).find as jest.Mock;
+const mockSend = sendGuestMigrationEmail as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (connectToDatabase as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('handleGuestTransitions', () => {
+  it('converts expired guests and sends warning emails', async () => {
+    const now = new Date();
+    const expiring = {
+      _id: '1',
+      email: 'a@test.com',
+      planExpiresAt: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000),
+      role: 'guest',
+      planStatus: 'active',
+      agency: 'ag1',
+      save: jest.fn(),
+    };
+    const expired = {
+      _id: '2',
+      email: 'b@test.com',
+      planExpiresAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+      role: 'guest',
+      planStatus: 'active',
+      agency: 'ag1',
+      save: jest.fn(),
+    };
+    mockFind.mockResolvedValue([expiring, expired]);
+
+    await handleGuestTransitions();
+
+    expect(mockSend).toHaveBeenCalledWith(expiring.email, expiring.planExpiresAt);
+    expect(expired.role).toBe('user');
+    expect(expired.planStatus).toBe('inactive');
+    expect(expired.agency).toBeNull();
+    expect(expired.save).toHaveBeenCalled();
+    expect(expiring.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/cron/guestTransition.ts
+++ b/src/cron/guestTransition.ts
@@ -1,0 +1,35 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import { logger } from '@/app/lib/logger';
+import UserModel from '@/app/models/User';
+import { sendGuestMigrationEmail } from '@/app/lib/emailService';
+
+export async function handleGuestTransitions() {
+  const TAG = '[cron guestTransition]';
+  await connectToDatabase();
+  const now = new Date();
+  const upcoming = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const guests = await UserModel.find({ role: 'guest', planExpiresAt: { $ne: null } });
+
+  for (const guest of guests) {
+    if (!guest.planExpiresAt) continue;
+    if (guest.planExpiresAt <= now) {
+      guest.role = 'user';
+      guest.agency = null;
+      guest.planStatus = 'inactive';
+      await guest.save();
+      logger.info(`${TAG} guest ${guest._id} migrado para user`);
+    } else if (guest.planExpiresAt <= upcoming && guest.email) {
+      await sendGuestMigrationEmail(guest.email, guest.planExpiresAt);
+      logger.info(`${TAG} aviso de migração enviado para guest ${guest._id}`);
+    }
+  }
+}
+
+export default handleGuestTransitions;
+
+if (process.argv[1]?.endsWith('guestTransition.ts')) {
+  handleGuestTransitions()
+    .catch(err => {
+      logger.error('[cron guestTransition] unhandled error', err);
+    });
+}

--- a/src/emails/guestMigrationNotice.ts
+++ b/src/emails/guestMigrationNotice.ts
@@ -1,0 +1,8 @@
+export function guestMigrationNotice(expiresAt: Date) {
+  const date = expiresAt.toLocaleDateString('pt-BR');
+  return {
+    subject: 'Aviso de migração de conta',
+    text: `Seu acesso como convidado terminará em ${date}. Após essa data sua conta será migrada para usuário e o valor do plano será ajustado.`,
+    html: `<p>Seu acesso como convidado terminará em <strong>${date}</strong>. Após essa data sua conta será migrada para usuário e o valor do plano será ajustado.</p>`,
+  };
+}


### PR DESCRIPTION
## Summary
- add cron job to migrate guests after agency cancellations and email warnings
- expose admin endpoint to change user role and plan status with logging
- provide email templates and docs for state transitions

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9c2a7170832e8098484e7745e389