### PR TITLE
feat: add monitoring dashboard and alerting

### DIFF
--- a/docs/monitoring-observability.md
+++ b/docs/monitoring-observability.md
@@ -1,0 +1,28 @@
+# Monitoring & Observability
+
+This module provides near real-time visibility into key KPIs and centralised error reporting.
+
+## Dashboard Metrics
+- **Active Agencies** – count of agencies with `planStatus: active`.
+- **Creators** – total creators segmented by role (`user` vs `guest`).
+- **Segmented MRR** – monthly recurring revenue derived from active creators and agencies.
+
+Metrics are served by `/api/admin/monitoring/summary` and refreshed every 30s on the admin dashboard.
+To add new metrics:
+1. Extend the API route with the desired aggregation.
+2. Update `src/app/admin/monitoring/page.tsx` to render the new data (cards, tables or charts).
+
+## Alerts
+`sendAlert` (in `src/app/lib/alerts.ts`) sends messages to configured Slack and email channels. 
+It is used for:
+- Access denied attempts (`getAdminSession`).
+- Automatic notification for any `logger.error` call.
+
+Configure environment variables:
+- `ALERTS_SLACK_WEBHOOK_URL`
+- `ALERTS_EMAIL_FROM`
+- `ALERTS_EMAIL_TO`
+- `SMTP_HOST` (`SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` when needed)
+- `SENTRY_DSN` for error aggregation.
+
+To add custom alerts, import and call `sendAlert` wherever needed. The logger can also be extended with additional transports.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "swiper": "^11.2.6",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "@sentry/node": "^7.122.0",
+    "nodemailer": "^6.9.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import useSWR from 'swr';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer
+} from 'recharts';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function MonitoringPage() {
+  const { data } = useSWR('/api/admin/monitoring/summary', fetcher, { refreshInterval: 30000 });
+
+  if (!data) {
+    return <p>Carregando...</p>;
+  }
+
+  const creatorsData = [
+    { type: 'Usuários', value: data.creators.users },
+    { type: 'Convidados', value: data.creators.guests }
+  ];
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Monitoramento & Observabilidade</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-white shadow p-4 rounded">
+          <p className="text-sm text-gray-500">Agências Ativas</p>
+          <p className="text-2xl font-semibold">{data.activeAgencies}</p>
+        </div>
+        <div className="bg-white shadow p-4 rounded">
+          <p className="text-sm text-gray-500">MRR Total</p>
+          <p className="text-2xl font-semibold">R$ {data.mrr.total.toFixed(2)}</p>
+        </div>
+      </div>
+
+      <div className="bg-white shadow p-4 rounded">
+        <h2 className="text-lg font-semibold mb-2">Criadores</h2>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={creatorsData}>
+              <XAxis dataKey="type" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="value" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className="bg-white shadow p-4 rounded">
+        <h2 className="text-lg font-semibold mb-2">MRR Segmentado</h2>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="py-2">Segmento</th>
+              <th className="py-2">Valor</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="py-2">Criadores</td>
+              <td className="py-2">R$ {data.mrr.creators.toFixed(2)}</td>
+            </tr>
+            <tr>
+              <td className="py-2">Agências</td>
+              <td className="py-2">R$ {data.mrr.agencies.toFixed(2)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/monitoring/summary/route.ts
+++ b/src/app/api/admin/monitoring/summary/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import AgencyModel from '@/app/models/Agency';
+import UserModel from '@/app/models/User';
+import { MONTHLY_PRICE } from '@/config/pricing.config';
+
+export async function GET() {
+  const activeAgencies = await AgencyModel.countDocuments({ planStatus: 'active' });
+  const usersCount = await UserModel.countDocuments({ role: 'user' });
+  const guestsCount = await UserModel.countDocuments({ role: 'guest' });
+  const activeCreators = await UserModel.countDocuments({ planStatus: 'active', role: { $in: ['user', 'guest'] } });
+
+  const agencyMrr = activeAgencies * Number(process.env.AGENCY_MONTHLY_PRICE || '99');
+  const creatorMrr = activeCreators * MONTHLY_PRICE;
+
+  return NextResponse.json({
+    activeAgencies,
+    creators: { users: usersCount, guests: guestsCount },
+    mrr: {
+      agencies: agencyMrr,
+      creators: creatorMrr,
+      total: agencyMrr + creatorMrr,
+    },
+  });
+}

--- a/src/app/lib/alerts.ts
+++ b/src/app/lib/alerts.ts
@@ -1,0 +1,45 @@
+import nodemailer from 'nodemailer';
+
+const slackWebhook = process.env.ALERTS_SLACK_WEBHOOK_URL;
+const emailFrom = process.env.ALERTS_EMAIL_FROM;
+const emailTo = process.env.ALERTS_EMAIL_TO;
+const smtpHost = process.env.SMTP_HOST;
+
+/**
+ * sendAlert - envia alertas para os canais configurados.
+ * Atualmente suporta Slack (via webhook) e email (via SMTP).
+ */
+export async function sendAlert(message: string): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+  if (slackWebhook) {
+    tasks.push(
+      fetch(slackWebhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message })
+      })
+    );
+  }
+  if (smtpHost && emailFrom && emailTo) {
+    const transporter = nodemailer.createTransport({
+      host: smtpHost,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: false,
+      auth: process.env.SMTP_USER && process.env.SMTP_PASS ? {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS
+      } : undefined,
+    });
+    tasks.push(
+      transporter.sendMail({
+        from: emailFrom,
+        to: emailTo,
+        subject: 'Data2Content Alert',
+        text: message,
+      })
+    );
+  }
+  if (tasks.length > 0) {
+    await Promise.allSettled(tasks);
+  }
+}

--- a/src/app/lib/logger.ts
+++ b/src/app/lib/logger.ts
@@ -1,5 +1,11 @@
 // Em src/app/lib/logger.ts
 import winston from "winston";
+import * as Sentry from "@sentry/node";
+import { sendAlert } from "@/app/lib/alerts";
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({ dsn: process.env.SENTRY_DSN });
+}
 
 export const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || "debug",
@@ -13,3 +19,13 @@ export const logger = winston.createLogger({
     })
   ]
 });
+
+const originalError = logger.error.bind(logger);
+logger.error = (message: unknown, ...meta: unknown[]) => {
+  originalError(message, ...meta);
+  const err = meta[0] instanceof Error ? meta[0] : new Error(typeof message === "string" ? message : JSON.stringify(message));
+  if (process.env.SENTRY_DSN) {
+    Sentry.captureException(err);
+  }
+  void sendAlert(`Erro crítico: ${err.message}`);
+};

--- a/src/lib/getAdminSession.ts
+++ b/src/lib/getAdminSession.ts
@@ -2,12 +2,14 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { logger } from '@/app/lib/logger';
+import { sendAlert } from '@/app/lib/alerts';
 
 export async function getAdminSession(req: NextRequest) {
   try {
     const session = await getServerSession({ req, ...authOptions });
     if (!session || session.user?.role !== 'admin') {
       logger.warn('[getAdminSession] session invalid or user not admin');
+      void sendAlert(`Tentativa de acesso negada: ${req.url}`);
       return null;
     }
     return session;


### PR DESCRIPTION
## Summary
- add Slack/email alert service and Sentry integration for critical errors
- expose monitoring metrics API and admin dashboard with realtime refresh
- document how to extend monitoring metrics and alerts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e0c5538832e8b33fb70cf789e9a