### PR TITLE
feat: alert on plan guard access denial

### DIFF
--- a/src/app/lib/planGuard.test.ts
+++ b/src/app/lib/planGuard.test.ts
@@ -6,12 +6,15 @@ import {
 } from '@/app/lib/planGuard';
 import { getToken } from 'next-auth/jwt';
 import { logger } from '@/app/lib/logger';
+import { sendAlert } from '@/app/lib/alerts';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
 jest.mock('@/app/lib/logger', () => ({ logger: { warn: jest.fn() } }));
+jest.mock('@/app/lib/alerts', () => ({ sendAlert: jest.fn() }));
 
 const mockGetToken = getToken as jest.Mock;
 const mockWarn = logger.warn as jest.Mock;
+const mockSendAlert = sendAlert as jest.Mock;
 
 function createRequest(path: string) {
   return new NextRequest(`http://localhost${path}`);
@@ -28,14 +31,20 @@ describe('guardPremiumRequest', () => {
     const res = await guardPremiumRequest(createRequest('/api/ai/chat'));
     expect(res).toBeNull();
     expect(mockWarn).not.toHaveBeenCalled();
+    expect(mockSendAlert).not.toHaveBeenCalled();
   });
 
-  it('blocks and logs when plan is not active', async () => {
+  it('blocks, logs and alerts when plan is not active', async () => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
     const req = createRequest('/api/ai/chat');
     const res = await guardPremiumRequest(req);
     expect(res?.status).toBe(403);
-    expect(mockWarn).toHaveBeenCalledWith(
+    expect(mockWarn).toHaveBeenCalledWith({
+      userId: 'u1',
+      status: 'inactive',
+      path: '/api/ai/chat',
+    });
+    expect(mockSendAlert).toHaveBeenCalledWith(
       '[planGuard] Blocked request for user u1 with status inactive on /api/ai/chat'
     );
     const metrics = getPlanGuardMetrics();

--- a/src/app/lib/planGuard.ts
+++ b/src/app/lib/planGuard.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { logger } from '@/app/lib/logger';
+import { sendAlert } from '@/app/lib/alerts';
 import type { PlanStatus } from '@/types/enums';
 
 export interface PlanGuardMetrics {
@@ -46,7 +47,8 @@ export async function guardPremiumRequest(
   // Update metrics for monitoring purposes
   planGuardMetrics.blocked += 1;
   planGuardMetrics.byRoute[path] = (planGuardMetrics.byRoute[path] || 0) + 1;
-  logger.warn(
+  logger.warn({ userId, status, path });
+  void sendAlert(
     `[planGuard] Blocked request for user ${userId} with status ${status} on ${path}`
   );
 


### PR DESCRIPTION
## Summary
- log structured details when plan guard blocks access
- trigger alert notification on blocked access
- test logging structure and alert emission

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba595bd5c832e93f2dd265cb16305