### PR TITLE
test: ensure plan guard blocks ai and whatsapp routes

### DIFF
--- a/src/app/api/ai/planGuard.test.ts
+++ b/src/app/api/ai/planGuard.test.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server';
+import { middleware } from '../../../middleware';
+import { getToken } from 'next-auth/jwt';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+
+const mockGetToken = getToken as jest.Mock;
+
+function makeRequest(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe('plan guard for ai routes', () => {
+  beforeEach(() => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+  });
+
+  it.each([
+    '/api/ai/chat',
+    '/api/ai/dynamicCards',
+    '/api/ai/insights',
+  ])('blocks inactive plan for %s', async (path) => {
+    const res = await middleware(makeRequest(path));
+    expect(res.status).toBe(403);
+  });
+});
+

--- a/src/app/api/whatsapp/planGuard.test.ts
+++ b/src/app/api/whatsapp/planGuard.test.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import { middleware } from '../../../middleware';
+import { getToken } from 'next-auth/jwt';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+
+const mockGetToken = getToken as jest.Mock;
+
+function makeRequest(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe('plan guard for whatsapp routes', () => {
+  beforeEach(() => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+  });
+
+  it.each([
+    '/api/whatsapp/generateCode',
+    '/api/whatsapp/sendTips',
+    '/api/whatsapp/verify',
+    '/api/whatsapp/weeklyReport',
+  ])('blocks inactive plan for %s', async (path) => {
+    const res = await middleware(makeRequest(path));
+    expect(res.status).toBe(403);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add plan guard tests for ai routes
- add plan guard tests for whatsapp routes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: 403 Forbidden when fetching @sentry/node)*
- `npm install` *(fails: 403 Forbidden when fetching @sentry/node)*

------
https://chatgpt.com/codex/tasks/task_e_688baabe9710832eab446eb55495f328