### PR TITLE
test: add migrateRolesAndPlans script tests

### DIFF
--- a/scripts/__tests__/migrateRolesAndPlans.test.ts
+++ b/scripts/__tests__/migrateRolesAndPlans.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment node */
+
+import { USER_ROLES, PLAN_STATUSES } from '@/types/enums';
+
+const userUpdateMany = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+const agencyUpdateMany = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+
+jest.mock('@/app/lib/mongoose', () => ({
+  connectToDatabase: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('mongoose', () => ({
+  disconnect: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/app/models/User', () => ({
+  __esModule: true,
+  default: { updateMany: userUpdateMany },
+}));
+
+jest.mock('@/app/models/Agency', () => ({
+  __esModule: true,
+  default: { updateMany: agencyUpdateMany },
+}));
+
+describe('migrateRolesAndPlans script', () => {
+  beforeAll(async () => {
+    await import('../migrateRolesAndPlans');
+  });
+
+  it('updates users with invalid role and planStatus to default enums', () => {
+    expect(userUpdateMany).toHaveBeenNthCalledWith(
+      1,
+      { role: { $nin: USER_ROLES as any } },
+      { $set: { role: 'user' } }
+    );
+    expect(userUpdateMany).toHaveBeenNthCalledWith(
+      2,
+      { planStatus: { $nin: PLAN_STATUSES as any } },
+      { $set: { planStatus: 'inactive' } }
+    );
+  });
+
+  it('updates agencies with invalid planStatus to default enum', () => {
+    expect(agencyUpdateMany).toHaveBeenCalledWith(
+      { planStatus: { $nin: PLAN_STATUSES as any } },
+      { $set: { planStatus: 'inactive' } }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests to validate role and planStatus migrations

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_688bad63e40c832e9bc040ffc1fc1cb7