### PR TITLE
feat(admin): show plan guard blocks

### DIFF
--- a/docs/monitoring-observability.md
+++ b/docs/monitoring-observability.md
@@ -6,8 +6,9 @@ This module provides near real-time visibility into key KPIs and centralised err
 - **Active Agencies** – count of agencies with `planStatus: active`.
 - **Creators** – total creators segmented by role (`user` vs `guest`).
 - **Segmented MRR** – monthly recurring revenue derived from active creators and agencies.
+- **Plan Guard Blocks** – total premium requests denied due to inactive plans.
 
-Metrics are served by `/api/admin/monitoring/summary` and refreshed every 30s on the admin dashboard.
+Metrics are served by `/api/admin/monitoring/summary` and `/api/admin/plan-guard/metrics` and refreshed every 30s on the admin dashboard.
 To add new metrics:
 1. Extend the API route with the desired aggregation.
 2. Update `src/app/admin/monitoring/page.tsx` to render the new data (cards, tables or charts).

--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -13,9 +13,16 @@ import {
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
 export default function MonitoringPage() {
-  const { data } = useSWR('/api/admin/monitoring/summary', fetcher, { refreshInterval: 30000 });
+  const { data } = useSWR('/api/admin/monitoring/summary', fetcher, {
+    refreshInterval: 30000,
+  });
+  const { data: planGuard } = useSWR(
+    '/api/admin/plan-guard/metrics',
+    fetcher,
+    { refreshInterval: 30000 }
+  );
 
-  if (!data) {
+  if (!data || !planGuard) {
     return <p>Carregando...</p>;
   }
 
@@ -35,7 +42,13 @@ export default function MonitoringPage() {
         </div>
         <div className="bg-white shadow p-4 rounded">
           <p className="text-sm text-gray-500">MRR Total</p>
-          <p className="text-2xl font-semibold">R$ {data.mrr.total.toFixed(2)}</p>
+          <p className="text-2xl font-semibold">
+            R$ {data.mrr.total.toFixed(2)}
+          </p>
+        </div>
+        <div className="bg-white shadow p-4 rounded">
+          <p className="text-sm text-gray-500">Bloqueios de Plano</p>
+          <p className="text-2xl font-semibold">{planGuard.blocked}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- fetch plan guard metrics and show blocked request count on admin monitoring dashboard
- document plan guard block metrics and endpoint usage

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_688bb6d39edc832eaad7fcffb91f155f