### PR TITLE
feat: centralize agency pricing constants

### DIFF
--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -3,6 +3,10 @@ import React, { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-hot-toast';
 import Link from 'next/link';
+import {
+  AGENCY_ANNUAL_MONTHLY_PRICE,
+  AGENCY_MONTHLY_PRICE,
+} from '@/config/pricing.config';
 
 export default function AgencySubscriptionPage() {
   const { data: session } = useSession();
@@ -63,7 +67,9 @@ export default function AgencySubscriptionPage() {
               checked={selectedPlan === 'basic'}
               onChange={() => setSelectedPlan('basic')}
             />
-            <span>Plano Mensal - R$ 99/mês</span>
+            <span>
+              Plano Mensal - R$ {AGENCY_MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês
+            </span>
           </label>
           <label className="flex items-center gap-2">
             <input
@@ -73,7 +79,9 @@ export default function AgencySubscriptionPage() {
               checked={selectedPlan === 'annual'}
               onChange={() => setSelectedPlan('annual')}
             />
-            <span>Plano Anual - R$ 90/mês</span>
+            <span>
+              Plano Anual - R$ {AGENCY_ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês
+            </span>
           </label>
         </div>
         <ul className="list-disc list-inside text-sm text-gray-700">

--- a/src/app/api/agency/subscription/create-checkout/route.ts
+++ b/src/app/api/agency/subscription/create-checkout/route.ts
@@ -4,6 +4,10 @@ import { logger } from '@/app/lib/logger';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
 import mercadopago from '@/app/lib/mercadopago';
+import {
+  AGENCY_ANNUAL_MONTHLY_PRICE,
+  AGENCY_MONTHLY_PRICE,
+} from '@/config/pricing.config';
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/create-checkout]';
@@ -35,8 +39,8 @@ export async function POST(req: NextRequest) {
 
     const price =
       validation.data.planId === 'annual'
-        ? Number(process.env.AGENCY_ANNUAL_MONTHLY_PRICE || 90)
-        : Number(process.env.AGENCY_MONTHLY_PRICE || 99);
+        ? AGENCY_ANNUAL_MONTHLY_PRICE
+        : AGENCY_MONTHLY_PRICE;
 
     const preapprovalData = {
       reason: 'Plano Agência Data2Content',

--- a/src/config/pricing.config.ts
+++ b/src/config/pricing.config.ts
@@ -2,3 +2,5 @@ export const MONTHLY_PRICE = parseFloat(process.env.MONTHLY_PLAN_PRICE || '49.9'
 export const ANNUAL_MONTHLY_PRICE = parseFloat(process.env.ANNUAL_PLAN_MONTHLY_PRICE || '29.9');
 export const AGENCY_GUEST_MONTHLY_PRICE = parseFloat(process.env.AGENCY_GUEST_MONTHLY_PRICE || '39.9');
 export const AGENCY_GUEST_ANNUAL_MONTHLY_PRICE = parseFloat(process.env.AGENCY_GUEST_ANNUAL_MONTHLY_PRICE || '19.9');
+export const AGENCY_MONTHLY_PRICE = parseFloat(process.env.AGENCY_MONTHLY_PRICE || '99');
+export const AGENCY_ANNUAL_MONTHLY_PRICE = parseFloat(process.env.AGENCY_ANNUAL_MONTHLY_PRICE || '90');


### PR DESCRIPTION
## Summary
- add agency monthly and annual constants to pricing config
- use shared pricing constants in agency checkout endpoint
- display pricing constants on agency subscription page

## Testing
- `npm install` (failed: 403 Forbidden)
- `npm test` (failed: jest: not found)
- `npm run lint` (failed: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_688bdc96e9d8832eb3e42b443debfe5c