### PR TITLE
chore: block WhatsApp tasks for inactive plans

### DIFF
--- a/src/app/api/whatsapp/incoming/route.ts
+++ b/src/app/api/whatsapp/incoming/route.ts
@@ -205,6 +205,15 @@ Você pode começar me pedindo um planejamento de conteudo que otimize seu alcan
       return NextResponse.json({ error: 'Failed to lookup user' }, { status: 500 });
   }
 
+  if (user.planStatus !== 'active') {
+      try {
+          await sendWhatsAppMessage(fromPhone, `Olá ${userFirstName}! Seu plano está ${user.planStatus}. Para continuar usando a Tuca, reative seu plano em nosso site.`);
+      } catch (sendError) {
+          logger.error(`${postTag} Falha ao enviar mensagem de plano inativo:`, sendError);
+      }
+      return NextResponse.json({ plan_inactive: true }, { status: 200 });
+  }
+
   // CORREÇÃO APLICADA AQUI:
   let currentDialogueState: stateService.IDialogueState = stateService.getDefaultDialogueState();
   try {

--- a/src/app/api/whatsapp/process-response/userMessageHandler.ts
+++ b/src/app/api/whatsapp/process-response/userMessageHandler.ts
@@ -269,6 +269,16 @@ export async function handleUserMessage(payload: ProcessRequestBody): Promise<Ne
 
         logger.debug(`${handlerTAG} Dados carregados. Nome: ${firstName}, Histórico: ${historyMessages.length} msgs. Sumário Conv: ${dialogueState.conversationSummary ? '"' + extractExcerpt(dialogueState.conversationSummary, 30) + '"': 'N/A'}`);
 
+        if (user.planStatus !== 'active') {
+            try {
+                const wamid = await sendWhatsAppMessage(fromPhone, `Olá ${firstName}! Seu plano está ${user.planStatus}. Para continuar usando a Tuca, reative seu plano em nosso site.`);
+                logger.info(`${handlerTAG} Mensagem de plano inativo enviada. WhatsAppMsgID: ${wamid}`);
+            } catch (sendError) {
+                logger.error(`${handlerTAG} Falha ao enviar mensagem de plano inativo:`, sendError);
+            }
+            return NextResponse.json({ plan_inactive: true }, { status: 200 });
+        }
+
         const stateUpdateForProcessingStart: Partial<stateService.IDialogueState> = {
             currentProcessingMessageId: messageId_MsgAtual,
             currentProcessingQueryExcerpt: queryExcerpt_MsgAtual


### PR DESCRIPTION
## Summary
- stop processing incoming WhatsApp messages when user's plan is inactive
- prevent background response handling for inactive users

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - @sentry/node)*

------
https://chatgpt.com/codex/tasks/task_e_688bde619998832e8c189ae207369df2