### PR TITLE
feat: show plan pricing and agency discounts

### DIFF
--- a/src/app/assinar/page.test.tsx
+++ b/src/app/assinar/page.test.tsx
@@ -28,7 +28,8 @@ describe('PublicSubscribePage', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ name: 'Agência X' }) }) as any;
     render(<PublicSubscribePage />);
     await waitFor(() => {
-      expect(screen.getByText('Bem-vindo como convidado da Agência X.')).toBeInTheDocument();
+      expect(screen.getByText('Bem-vindo como convidado da Agência X!')).toBeInTheDocument();
+      expect(screen.getByText(/39,90/)).toBeInTheDocument();
     });
   });
 

--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -2,6 +2,12 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useSession, signIn } from 'next-auth/react';
+import {
+  MONTHLY_PRICE,
+  ANNUAL_MONTHLY_PRICE,
+  AGENCY_GUEST_MONTHLY_PRICE,
+  AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
+} from '@/config/pricing.config';
 
 export default function PublicSubscribePage() {
   const searchParams = useSearchParams();
@@ -34,9 +40,33 @@ export default function PublicSubscribePage() {
 
   return (
     <div className="p-6 max-w-md mx-auto space-y-4">
-      {agencyName && (
-        <div className="bg-green-100 text-green-800 p-2 rounded">
-          Bem-vindo como convidado da {agencyName}.
+      {agencyName ? (
+        <div className="bg-green-100 text-green-800 p-2 rounded space-y-1">
+          <p>Bem-vindo como convidado da {agencyName}!</p>
+          <p>
+            Como convidado, o plano mensal sai por{' '}
+            <strong>
+              R${AGENCY_GUEST_MONTHLY_PRICE.toFixed(2).replace('.', ',')}
+            </strong>{' '}
+            e o plano anual por{' '}
+            <strong>
+              R${AGENCY_GUEST_ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}
+              /mês
+            </strong>{' '}
+            (cobrado anualmente).
+          </p>
+        </div>
+      ) : (
+        <div className="bg-gray-100 text-gray-800 p-2 rounded">
+          <p className="mb-1">Conheça nossos planos:</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              Plano Mensal - R${MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês
+            </li>
+            <li>
+              Plano Anual - R${ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês (cobrança anual)
+            </li>
+          </ul>
         </div>
       )}
       {alert === 'convite_invalido' && (


### PR DESCRIPTION
## Summary
- display standard plan pricing above sign-in on subscription page
- show discounted rates when accessing via agency invite
- align tests with new pricing messages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be2508cf8832e9de7f41bc00c634e