### PR TITLE
Use Mercado Pago preapproval for plan subscriptions

### DIFF
--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -3,7 +3,14 @@
 // - CORRIGIDO: As chamadas para `models.User` e `model("User", ...)` foram atualizadas para `mongoose.models.User` e `mongoose.model(...)` para alinhar com a nova importação.
 import mongoose, { Schema, Document, Model, Types } from "mongoose";
 import { logger } from "@/app/lib/logger";
-import { USER_ROLES, PLAN_STATUSES, type UserRole, type PlanStatus } from '@/types/enums';
+import {
+  USER_ROLES,
+  PLAN_STATUSES,
+  PLAN_TYPES,
+  type UserRole,
+  type PlanStatus,
+  type PlanType,
+} from '@/types/enums';
 
 // --- INTERFACES ---
 export interface IPeakSharesDetails {
@@ -229,6 +236,8 @@ export interface IUser extends Document {
   agency?: Types.ObjectId | null;
   pendingAgency?: Types.ObjectId | null;
   planStatus?: PlanStatus;
+  planType?: PlanType;
+  paymentGatewaySubscriptionId?: string | null;
   planExpiresAt?: Date | null;
   whatsappVerificationCode?: string | null;
   whatsappPhone?: string | null;
@@ -330,6 +339,8 @@ const userSchema = new Schema<IUser>(
         select: false
     },
     planStatus: { type: String, enum: PLAN_STATUSES, default: "inactive", index: true }, // OTIMIZAÇÃO: Mantido índice.
+    planType: { type: String, enum: PLAN_TYPES, default: 'monthly' },
+    paymentGatewaySubscriptionId: { type: String, default: null },
     inferredExpertiseLevel: {
         type: String,
         enum: ['iniciante', 'intermediario', 'avancado'],

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -3,3 +3,6 @@ export type UserRole = typeof USER_ROLES[number];
 
 export const PLAN_STATUSES = ['active', 'pending', 'canceled', 'inactive', 'trial'] as const;
 export type PlanStatus = typeof PLAN_STATUSES[number];
+
+export const PLAN_TYPES = ['monthly', 'annual'] as const;
+export type PlanType = typeof PLAN_TYPES[number];


### PR DESCRIPTION
## Summary
- switch plan subscription API to create Mercado Pago preapprovals and return subscription id
- store subscription id and plan type on users
- add plan type enums

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @sentry/node)*

------
https://chatgpt.com/codex/tasks/task_e_688be69f9e78832eaff84c53b9832459