### PR TITLE
feat: handle agency subscription webhooks

### DIFF
--- a/src/app/api/agency/subscription/manage-portal/route.ts
+++ b/src/app/api/agency/subscription/manage-portal/route.ts
@@ -20,8 +20,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Agency not found' }, { status: 404 });
     }
 
-    // TODO: Integrate with payment gateway customer portal using agency.paymentGatewaySubscriptionId
-    const portalUrl = `https://pagamento.exemplo.com/manage/${agency.paymentGatewaySubscriptionId || ''}`;
+    const portalUrl = `https://www.mercadopago.com.br/subscriptions/redirect?preapproval_id=${agency.paymentGatewaySubscriptionId || ''}`;
 
     logger.info(`${TAG} portal session for agency ${agency._id}`);
     return NextResponse.json({ portalUrl });

--- a/src/app/api/agency/subscription/webhook/route.ts
+++ b/src/app/api/agency/subscription/webhook/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/app/lib/logger';
+import AgencyModel from '@/app/models/Agency';
+import mercadopago from '@/app/lib/mercadopago';
+
+export const runtime = 'nodejs';
+const SERVICE_TAG = '[api/agency/subscription/webhook]';
+
+interface PreapprovalEvent {
+  type?: string;
+  data?: {
+    id?: string;
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const TAG = `${SERVICE_TAG}[POST]`;
+  try {
+    const body = (await req.json()) as PreapprovalEvent;
+    logger.info(`${TAG} event received: ${body.type}`);
+
+    if (body.type !== 'preapproval') {
+      return NextResponse.json({ received: true });
+    }
+
+    const preapprovalId = body.data?.id;
+    if (!preapprovalId) {
+      logger.warn(`${TAG} missing preapproval id`);
+      return NextResponse.json({ received: true });
+    }
+
+    const { body: preapproval } = await mercadopago.preapproval.get(preapprovalId);
+    const agencyId = preapproval.external_reference;
+    if (!agencyId) {
+      logger.warn(`${TAG} preapproval ${preapprovalId} without external reference`);
+      return NextResponse.json({ received: true });
+    }
+
+    const agency = await AgencyModel.findById(agencyId);
+    if (!agency) {
+      logger.warn(`${TAG} agency not found for preapproval ${preapprovalId}`);
+      return NextResponse.json({ received: true });
+    }
+
+    agency.paymentGatewaySubscriptionId = preapprovalId;
+    if (preapproval.status === 'authorized') {
+      agency.planStatus = 'active';
+    } else if (preapproval.status === 'cancelled') {
+      agency.planStatus = 'canceled';
+    } else if (preapproval.status === 'paused' || preapproval.status === 'suspended') {
+      agency.planStatus = 'inactive';
+    }
+    await agency.save();
+    logger.info(`${TAG} agency ${agency._id} updated to ${agency.planStatus}`);
+
+    return NextResponse.json({ received: true });
+  } catch (err: any) {
+    logger.error(`${TAG} unexpected error`, err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add Mercado Pago preapproval webhook for agencies
- link manage portal route to Mercado Pago subscription portal

## Testing
- `npm install` *(fails: 403 Forbidden for @sentry/node)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c103466f4832e80882138cfe8383f