### PR TITLE
refactor: use agency pricing constant

### DIFF
--- a/src/app/api/admin/monitoring/summary/route.test.ts
+++ b/src/app/api/admin/monitoring/summary/route.test.ts
@@ -1,7 +1,7 @@
 import { GET } from './route';
 import AgencyModel from '@/app/models/Agency';
 import UserModel from '@/app/models/User';
-import { MONTHLY_PRICE } from '@/config/pricing.config';
+import { MONTHLY_PRICE, AGENCY_MONTHLY_PRICE } from '@/config/pricing.config';
 
 jest.mock('@/app/models/Agency', () => ({
   countDocuments: jest.fn(),
@@ -16,8 +16,6 @@ const mockUserCount = (UserModel as any).countDocuments as jest.Mock;
 
 describe('GET /api/admin/monitoring/summary', () => {
   it('returns aggregated metrics', async () => {
-    const agencyPrice = Number(process.env.AGENCY_MONTHLY_PRICE || '99');
-
     mockAgencyCount.mockResolvedValueOnce(2);
     mockUserCount
       .mockResolvedValueOnce(100) // users
@@ -31,9 +29,9 @@ describe('GET /api/admin/monitoring/summary', () => {
       activeAgencies: 2,
       creators: { users: 100, guests: 20 },
       mrr: {
-        agencies: 2 * agencyPrice,
+        agencies: 2 * AGENCY_MONTHLY_PRICE,
         creators: 50 * MONTHLY_PRICE,
-        total: 2 * agencyPrice + 50 * MONTHLY_PRICE,
+        total: 2 * AGENCY_MONTHLY_PRICE + 50 * MONTHLY_PRICE,
       },
     });
   });

--- a/src/app/api/admin/monitoring/summary/route.ts
+++ b/src/app/api/admin/monitoring/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import AgencyModel from '@/app/models/Agency';
 import UserModel from '@/app/models/User';
-import { MONTHLY_PRICE } from '@/config/pricing.config';
+import { MONTHLY_PRICE, AGENCY_MONTHLY_PRICE } from '@/config/pricing.config';
 
 export async function GET() {
   const activeAgencies = await AgencyModel.countDocuments({ planStatus: 'active' });
@@ -9,7 +9,7 @@ export async function GET() {
   const guestsCount = await UserModel.countDocuments({ role: 'guest' });
   const activeCreators = await UserModel.countDocuments({ planStatus: 'active', role: { $in: ['user', 'guest'] } });
 
-  const agencyMrr = activeAgencies * Number(process.env.AGENCY_MONTHLY_PRICE || '99');
+  const agencyMrr = activeAgencies * AGENCY_MONTHLY_PRICE;
   const creatorMrr = activeCreators * MONTHLY_PRICE;
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary
- use `AGENCY_MONTHLY_PRICE` constant in monitoring summary route
- update monitoring summary tests to use agency pricing constant

## Testing
- `npm test` *(fails: jest: not found; dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688c1bb5a230832e971109f8e7264e21