### PR TITLE
Use app URL env var for Mercado Pago back_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables for the project
+
+# Public base URL of the application
+NEXT_PUBLIC_APP_URL=https://example.com
+
+# Base URL for NextAuth (fallback for NEXT_PUBLIC_APP_URL)
+NEXTAUTH_URL=https://example.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/app/api/plan/subscribe/route.ts
+++ b/src/app/api/plan/subscribe/route.ts
@@ -125,9 +125,17 @@ export async function POST(req: NextRequest) {
     await user.save();
 
     // 8) Cria a assinatura no Mercado Pago
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL;
+    if (!appUrl) {
+      throw new Error(
+        "NEXT_PUBLIC_APP_URL ou NEXTAUTH_URL não está definida"
+      );
+    }
+
     const preapprovalData = {
       reason: planType === "annual" ? "Plano Anual" : "Plano Mensal",
-      back_url: "https://seusite.com/dashboard",
+      back_url: `${appUrl}/dashboard`,
       external_reference: user._id.toString(), // Utilizado para o webhook
       payer_email: user.email,
       auto_recurring: {


### PR DESCRIPTION
## Summary
- build Mercado Pago `back_url` from `NEXT_PUBLIC_APP_URL` with `NEXTAUTH_URL` fallback and runtime validation
- document `NEXT_PUBLIC_APP_URL` in a committed `.env.example`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: No matching version found for @sentry/node@^7.122.0)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_688c29a9e3d0832e95f9ff3873a3ee5a