### PR TITLE
feat: track agency plan type

### DIFF
--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -29,6 +29,7 @@ export default function AgencySubscriptionPage() {
   }, []);
 
   const planStatus = session?.user?.agencyPlanStatus || 'inactive';
+  const planType = session?.user?.agencyPlanType || 'basic';
 
   const handleSubscribe = async () => {
     setIsLoading(true);
@@ -89,6 +90,7 @@ export default function AgencySubscriptionPage() {
           <li>Suporte prioritário via WhatsApp</li>
           <li>Desconto de 10% para seus criadores</li>
         </ul>
+        <p className="text-sm">Plano atual: <strong>{planType}</strong></p>
         <p className="text-sm">Status atual: <strong>{planStatus}</strong></p>
         {planStatus !== 'active' && (
           <button

--- a/src/app/api/agency/subscription/create-checkout/route.ts
+++ b/src/app/api/agency/subscription/create-checkout/route.ts
@@ -59,6 +59,7 @@ export async function POST(req: NextRequest) {
 
     if (response.body.init_point) {
       agency.planStatus = 'pending';
+      agency.planType = validation.data.planId;
       agency.paymentGatewaySubscriptionId = response.body.id;
       await agency.save();
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -57,6 +57,7 @@ declare module "next-auth" {
         role?: string | null;
         agencyId?: string | null;
         agencyPlanStatus?: string | null;
+        agencyPlanType?: string | null;
         planStatus?: string | null;
         planExpiresAt?: string | null;
         affiliateCode?: string | null;
@@ -86,6 +87,7 @@ declare module "next-auth/jwt" {
         role?: string | null;
         agencyId?: string | null;
         agencyPlanStatus?: string | null;
+        agencyPlanType?: string | null;
         provider?: string | null; // Reflects the primary provider after initial link
 
          isNewUserForOnboarding?: boolean;
@@ -553,14 +555,17 @@ export const authOptions: NextAuthOptions = {
                 if (token.agencyId) {
                     try {
                         await connectToDatabase();
-                        const agency = await AgencyModel.findById(token.agencyId).select('planStatus').lean();
+                        const agency = await AgencyModel.findById(token.agencyId).select('planStatus planType').lean();
                         token.agencyPlanStatus = agency?.planStatus ?? null;
+                        token.agencyPlanType = agency?.planType ?? null;
                     } catch (e) {
                         logger.error(`${TAG_JWT} Erro ao buscar planStatus da agência ${token.agencyId}:`, e);
                         token.agencyPlanStatus = null;
+                        token.agencyPlanType = null;
                     }
                 } else {
                     token.agencyPlanStatus = null;
+                    token.agencyPlanType = null;
                 }
 
                 logger.info(`${TAG_JWT} Token populado de userFromSignIn. ID: ${token.id}, Provider: ${token.provider}, planStatus: ${token.planStatus}, igAccounts: ${token.availableIgAccounts?.length}, igLlatSet: ${!!token.instagramAccessToken}`);
@@ -622,14 +627,17 @@ export const authOptions: NextAuthOptions = {
                             token.agencyId = dbUser.agency ? dbUser.agency.toString() : token.agencyId ?? null;
                             if (token.agencyId) {
                                 try {
-                                    const agency = await AgencyModel.findById(token.agencyId).select('planStatus').lean();
+                                    const agency = await AgencyModel.findById(token.agencyId).select('planStatus planType').lean();
                                     token.agencyPlanStatus = agency?.planStatus ?? null;
+                                    token.agencyPlanType = agency?.planType ?? null;
                                 } catch (e) {
                                     logger.error(`${TAG_JWT} Erro ao buscar planStatus da agência ${token.agencyId}:`, e);
                                     token.agencyPlanStatus = null;
+                                    token.agencyPlanType = null;
                                 }
                             } else {
                                 token.agencyPlanStatus = null;
+                                token.agencyPlanType = null;
                             }
 
                             logger.info(`${TAG_JWT} Token enriquecido/atualizado do DB. ID: ${token.id}, Provider: ${token.provider}, planStatus: ${token.planStatus}, igAccounts: ${token.availableIgAccounts?.length}, igLlatSet: ${!!token.instagramAccessToken}, igErr: ${token.igConnectionError ? 'Sim ('+String(token.igConnectionError).substring(0,30)+'...)': 'Não'}`);
@@ -694,6 +702,7 @@ export const authOptions: NextAuthOptions = {
             session.user.affiliateCode = token.affiliateCode;
             session.user.agencyId = token.agencyId ?? null;
             session.user.agencyPlanStatus = token.agencyPlanStatus ?? null;
+            session.user.agencyPlanType = token.agencyPlanType ?? null;
             
             // These fields might be populated from other sources or kept if already in session
             session.user.affiliateBalance = session.user.affiliateBalance ?? undefined; 
@@ -719,8 +728,9 @@ export const authOptions: NextAuthOptions = {
                     }
                     if (session.user.agencyId) {
                         try {
-                            const agency = await AgencyModel.findById(session.user.agencyId).select('planStatus').lean();
+                            const agency = await AgencyModel.findById(session.user.agencyId).select('planStatus planType').lean();
                             session.user.agencyPlanStatus = agency?.planStatus ?? session.user.agencyPlanStatus ?? null;
+                            session.user.agencyPlanType = agency?.planType ?? session.user.agencyPlanType ?? null;
                         } catch (e) {
                             logger.error(`${TAG_SESSION} Erro ao buscar planStatus da agência ${session.user.agencyId}:`, e);
                         }

--- a/src/app/models/Agency.ts
+++ b/src/app/models/Agency.ts
@@ -1,12 +1,13 @@
 import { Schema, model, models, Document, Model } from 'mongoose';
 import { nanoid } from 'nanoid';
-import { PLAN_STATUSES, type PlanStatus } from '@/types/enums';
+import { PLAN_STATUSES, type PlanStatus, AGENCY_PLAN_TYPES, type AgencyPlanType } from '@/types/enums';
 
 export interface IAgency extends Document {
   name: string;
   contactEmail?: string;
   inviteCode: string;
   planStatus?: PlanStatus;
+  planType?: AgencyPlanType;
   paymentGatewaySubscriptionId?: string | null;
 }
 
@@ -15,6 +16,7 @@ const agencySchema = new Schema<IAgency>({
   contactEmail: { type: String },
   inviteCode: { type: String, required: true, default: () => nanoid(10), unique: true },
   planStatus: { type: String, enum: PLAN_STATUSES, default: 'inactive' },
+  planType: { type: String, enum: AGENCY_PLAN_TYPES, default: 'basic' },
   paymentGatewaySubscriptionId: { type: String, default: null },
 }, { timestamps: true });
 

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -6,3 +6,6 @@ export type PlanStatus = typeof PLAN_STATUSES[number];
 
 export const PLAN_TYPES = ['monthly', 'annual'] as const;
 export type PlanType = typeof PLAN_TYPES[number];
+
+export const AGENCY_PLAN_TYPES = ['basic', 'annual'] as const;
+export type AgencyPlanType = typeof AGENCY_PLAN_TYPES[number];

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -3,7 +3,7 @@
 import { DefaultSession, DefaultUser } from "next-auth";
 import { JWT as DefaultJWT } from "next-auth/jwt"; // Import JWT type for merging
 import type { AvailableInstagramAccount } from '@/app/lib/instagramService'; // Importando o tipo que faltava
-import type { UserRole, PlanStatus } from '@/types/enums';
+import type { UserRole, PlanStatus, AgencyPlanType } from '@/types/enums';
 
 /**
  * Aqui estendemos a interface `Session` para incluir campos extras.
@@ -20,6 +20,7 @@ declare module "next-auth" {
       role?: UserRole;
       agencyId?: string | null;
       agencyPlanStatus?: PlanStatus | null;
+      agencyPlanType?: AgencyPlanType | null;
       planStatus?: PlanStatus;
       planExpiresAt?: string | null; // Mantido como string (ISO) para o cliente
       affiliateCode?: string;
@@ -90,6 +91,7 @@ declare module "next-auth/jwt" {
     role?: UserRole | null;
     agencyId?: string | null;
     agencyPlanStatus?: PlanStatus | null;
+    agencyPlanType?: AgencyPlanType | null;
     provider?: string | null;
     planStatus?: PlanStatus | null;
     


### PR DESCRIPTION
## Summary
- add agency plan type enum and schema field
- persist plan type when creating checkout sessions
- surface agency plan type in auth session and subscription UI

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_688cfa529b38832e816c43a138e7379a