### PR TITLE
Adjust monitoring summary pricing by plan type and role

### DIFF
--- a/src/app/api/admin/monitoring/summary/route.test.ts
+++ b/src/app/api/admin/monitoring/summary/route.test.ts
@@ -1,7 +1,13 @@
 import { GET } from './route';
 import AgencyModel from '@/app/models/Agency';
 import UserModel from '@/app/models/User';
-import { MONTHLY_PRICE, AGENCY_MONTHLY_PRICE } from '@/config/pricing.config';
+import {
+  MONTHLY_PRICE,
+  ANNUAL_MONTHLY_PRICE,
+  AGENCY_GUEST_MONTHLY_PRICE,
+  AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
+  AGENCY_MONTHLY_PRICE,
+} from '@/config/pricing.config';
 
 jest.mock('@/app/models/Agency', () => ({
   countDocuments: jest.fn(),
@@ -20,7 +26,10 @@ describe('GET /api/admin/monitoring/summary', () => {
     mockUserCount
       .mockResolvedValueOnce(100) // users
       .mockResolvedValueOnce(20) // guests
-      .mockResolvedValueOnce(50); // active creators
+      .mockResolvedValueOnce(30) // active user monthly
+      .mockResolvedValueOnce(5) // active user annual
+      .mockResolvedValueOnce(10) // active guest monthly
+      .mockResolvedValueOnce(3); // active guest annual
 
     const res = await GET();
     expect(res.status).toBe(200);
@@ -30,8 +39,17 @@ describe('GET /api/admin/monitoring/summary', () => {
       creators: { users: 100, guests: 20 },
       mrr: {
         agencies: 2 * AGENCY_MONTHLY_PRICE,
-        creators: 50 * MONTHLY_PRICE,
-        total: 2 * AGENCY_MONTHLY_PRICE + 50 * MONTHLY_PRICE,
+        creators:
+          30 * MONTHLY_PRICE +
+          5 * ANNUAL_MONTHLY_PRICE +
+          10 * AGENCY_GUEST_MONTHLY_PRICE +
+          3 * AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
+        total:
+          2 * AGENCY_MONTHLY_PRICE +
+          30 * MONTHLY_PRICE +
+          5 * ANNUAL_MONTHLY_PRICE +
+          10 * AGENCY_GUEST_MONTHLY_PRICE +
+          3 * AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
       },
     });
   });

--- a/src/app/api/admin/monitoring/summary/route.ts
+++ b/src/app/api/admin/monitoring/summary/route.ts
@@ -1,16 +1,46 @@
 import { NextResponse } from 'next/server';
 import AgencyModel from '@/app/models/Agency';
 import UserModel from '@/app/models/User';
-import { MONTHLY_PRICE, AGENCY_MONTHLY_PRICE } from '@/config/pricing.config';
+import {
+  MONTHLY_PRICE,
+  ANNUAL_MONTHLY_PRICE,
+  AGENCY_GUEST_MONTHLY_PRICE,
+  AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
+  AGENCY_MONTHLY_PRICE,
+} from '@/config/pricing.config';
 
 export async function GET() {
   const activeAgencies = await AgencyModel.countDocuments({ planStatus: 'active' });
   const usersCount = await UserModel.countDocuments({ role: 'user' });
   const guestsCount = await UserModel.countDocuments({ role: 'guest' });
-  const activeCreators = await UserModel.countDocuments({ planStatus: 'active', role: { $in: ['user', 'guest'] } });
+
+  const activeUsersMonthly = await UserModel.countDocuments({
+    planStatus: 'active',
+    planType: 'monthly',
+    role: 'user',
+  });
+  const activeUsersAnnual = await UserModel.countDocuments({
+    planStatus: 'active',
+    planType: 'annual',
+    role: 'user',
+  });
+  const activeGuestsMonthly = await UserModel.countDocuments({
+    planStatus: 'active',
+    planType: 'monthly',
+    role: 'guest',
+  });
+  const activeGuestsAnnual = await UserModel.countDocuments({
+    planStatus: 'active',
+    planType: 'annual',
+    role: 'guest',
+  });
 
   const agencyMrr = activeAgencies * AGENCY_MONTHLY_PRICE;
-  const creatorMrr = activeCreators * MONTHLY_PRICE;
+  const creatorMrr =
+    activeUsersMonthly * MONTHLY_PRICE +
+    activeUsersAnnual * ANNUAL_MONTHLY_PRICE +
+    activeGuestsMonthly * AGENCY_GUEST_MONTHLY_PRICE +
+    activeGuestsAnnual * AGENCY_GUEST_ANNUAL_MONTHLY_PRICE;
 
   return NextResponse.json({
     activeAgencies,


### PR DESCRIPTION
## Summary
- compute creator MRR separately for monthly/annual plans and user/guest roles
- expand monitoring summary test to cover new pricing logic

## Testing
- `npm install` *(fails: No matching version found for @sentry/node@^7.122.0)*
- `npm test src/app/api/admin/monitoring/summary/route.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cfd3a87bc832eba7ce8db2bf1cadd