### PR TITLE
feat(plan): cobranca anual unica

### DIFF
--- a/src/app/agency/subscription/page.tsx
+++ b/src/app/agency/subscription/page.tsx
@@ -81,7 +81,7 @@ export default function AgencySubscriptionPage() {
               onChange={() => setSelectedPlan('annual')}
             />
             <span>
-              Plano Anual - R$ {AGENCY_ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês
+              Plano Anual - R$ {(AGENCY_ANNUAL_MONTHLY_PRICE * 12).toFixed(2).replace('.', ',')}/ano
             </span>
           </label>
         </div>

--- a/src/app/api/plan/subscribe/route.ts
+++ b/src/app/api/plan/subscribe/route.ts
@@ -139,9 +139,9 @@ export async function POST(req: NextRequest) {
       external_reference: user._id.toString(), // Utilizado para o webhook
       payer_email: user.email,
       auto_recurring: {
-        frequency: 1,
+        frequency: planType === "annual" ? 12 : 1,
         frequency_type: "months",
-        transaction_amount: monthlyPrice,
+        transaction_amount: planType === "annual" ? price : monthlyPrice,
         currency_id: "BRL",
       },
     } as any;

--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -50,10 +50,9 @@ export default function PublicSubscribePage() {
             </strong>{' '}
             e o plano anual por{' '}
             <strong>
-              R${AGENCY_GUEST_ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}
-              /mês
+              R${(AGENCY_GUEST_ANNUAL_MONTHLY_PRICE * 12).toFixed(2).replace('.', ',')}
             </strong>{' '}
-            (cobrado anualmente).
+            pagos uma vez ao ano.
           </p>
         </div>
       ) : (
@@ -64,7 +63,7 @@ export default function PublicSubscribePage() {
               Plano Mensal - R${MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês
             </li>
             <li>
-              Plano Anual - R${ANNUAL_MONTHLY_PRICE.toFixed(2).replace('.', ',')}/mês (cobrança anual)
+              Plano Anual - R${(ANNUAL_MONTHLY_PRICE * 12).toFixed(2).replace('.', ',')}/ano
             </li>
           </ul>
         </div>

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -376,12 +376,14 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           </div>
           <div className="flex items-baseline justify-center space-x-1 text-brand-dark mt-2">
               <span className="text-2xl font-medium">R$</span>
-              <span className="text-6xl font-extrabold tracking-tight leading-none text-brand-pink">{selectedMonthlyPrice.toFixed(2).replace('.', ',')}</span>
-              <span className="text-xl font-medium text-brand-dark/80">/mês</span>
+              <span className="text-6xl font-extrabold tracking-tight leading-none text-brand-pink">
+                {(planType === 'annual' ? totalPrice : selectedMonthlyPrice).toFixed(2).replace('.', ',')}
+              </span>
+              <span className="text-xl font-medium text-brand-dark/80">{planType === 'annual' ? '/ano' : '/mês'}</span>
           </div>
           {planType === 'annual' && (
             <p className="text-xs text-brand-dark/70 mt-1">
-              Cobrança anual de R$ {totalPrice.toFixed(2).replace('.', ',')}
+              Equivalente a R$ {selectedMonthlyPrice.toFixed(2).replace('.', ',')}/mês
             </p>
           )}
           <p className="text-sm text-brand-dark/70 mt-2 font-light">


### PR DESCRIPTION
## Summary
- adjust Mercado Pago data to bill annual plans once per year
- reflect one-time annual payment across payment panel and subscription pages

## Testing
- `npm install` *(fails: No matching version found for @sentry/node@^7.122.0)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1d986fbc832e8bd22611988256a3