### PR TITLE
feat: apply dark gradient to payment panel

### DIFF
--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -384,7 +384,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
 
       <motion.div
         variants={sectionVariants} initial="hidden" animate="visible" custom={paymentBlockIndex}
-        className="p-6 bg-gradient-to-br from-brand-pink/10 to-pink-50/5 via-white border border-brand-pink/20 rounded-xl shadow-lg space-y-6"
+        className="p-6 bg-gradient-to-br from-brand-pink/20 via-brand-dark/90 to-brand-dark text-brand-light border border-brand-pink/20 rounded-xl shadow-lg space-y-6"
         role="region"
         aria-labelledby="plano-title"
       >
@@ -393,15 +393,15 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
             Plano {planType === 'annual' ? 'Anual' : 'Mensal'} Data2Content Completo
           </h3>
           <fieldset className="mt-3">
-            <legend className="text-sm font-medium text-brand-dark mb-2">Tipo de plano</legend>
+            <legend className="text-sm font-medium text-brand-light mb-2">Tipo de plano</legend>
             <div className="flex justify-center gap-4">
               <motion.button
                 type="button"
                 onClick={() => setPlanType('monthly')}
                 className={`flex items-center gap-2 px-4 py-2 rounded-full border transition-colors ${
                   planType === 'monthly'
-                    ? 'bg-brand-pink text-white border-brand-pink'
-                    : 'bg-white text-brand-pink border-brand-pink'
+                    ? 'bg-brand-pink text-brand-light border-brand-pink'
+                    : 'bg-brand-light text-brand-pink border-brand-pink'
                 }`}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
@@ -414,8 +414,8 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                 onClick={() => setPlanType('annual')}
                 className={`flex items-center gap-2 px-4 py-2 rounded-full border transition-colors ${
                   planType === 'annual'
-                    ? 'bg-brand-pink text-white border-brand-pink'
-                    : 'bg-white text-brand-pink border-brand-pink'
+                    ? 'bg-brand-pink text-brand-light border-brand-pink'
+                    : 'bg-brand-light text-brand-pink border-brand-pink'
                 }`}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
@@ -425,7 +425,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
               </motion.button>
             </div>
           </fieldset>
-          <div className="flex items-baseline justify-center space-x-1 text-brand-dark mt-2">
+          <div className="flex items-baseline justify-center space-x-1 text-brand-light mt-2">
               <span className="text-2xl font-medium">R$</span>
               <AnimatePresence mode="wait">
                 <motion.span
@@ -439,7 +439,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                   {formattedTotalPriceWithoutSymbol}
                 </motion.span>
               </AnimatePresence>
-              <span className="text-xl font-medium text-brand-dark/80">{planType === 'annual' ? '/ano' : '/mês'}</span>
+              <span className="text-xl font-medium text-brand-light/80">{planType === 'annual' ? '/ano' : '/mês'}</span>
               <AnimatePresence mode="wait">
                 {planType === 'annual' && (
                   <motion.span
@@ -450,7 +450,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                     transition={{ duration: 0.2 }}
                     className="ml-2 flex items-center gap-2"
                   >
-                    <span className="text-sm line-through text-brand-dark/50">
+                    <span className="text-sm line-through text-brand-light/50">
                       R$ {originalAnnualPrice.toFixed(2).replace('.', ',')}
                     </span>
                     <AnimatePresence mode="wait">
@@ -460,7 +460,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -8 }}
                         transition={{ duration: 0.2 }}
-                        className="bg-brand-pink text-white text-xs font-semibold px-2 py-0.5 rounded"
+                        className="bg-brand-pink text-brand-light text-xs font-semibold px-2 py-0.5 rounded"
                       >
                         -{discountPercentage}%
                       </motion.span>
@@ -470,11 +470,11 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
               </AnimatePresence>
           </div>
           {planType === 'annual' && (
-            <p className="text-xs text-brand-dark/70 mt-1">
+            <p className="text-xs text-brand-light/70 mt-1">
               Equivalente a R$ {discountedMonthlyPrice.toFixed(2).replace('.', ',')}/mês
             </p>
           )}
-          <p className="text-sm text-brand-dark/70 mt-2 font-light">
+          <p className="text-sm text-brand-light/70 mt-2 font-light">
             {planType === 'annual'
               ? `Economize R$ ${savingsAmount.toFixed(2).replace('.', ',')} (${discountPercentage}%) com 12 meses de acesso completo.`
               : 'Investimento mínimo, resultados máximos. Cancele quando quiser.'}
@@ -482,8 +482,8 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
         </div>
 
         <div className={`${loading || ctaClicked ? 'opacity-50 pointer-events-none' : ''}`}>
-              <label htmlFor="affiliateCodeInputPayment" className="block text-sm font-medium text-gray-700 mb-1.5">
-                  Código de Afiliado <span className="text-xs text-gray-500 font-light">(Opcional)</span>
+              <label htmlFor="affiliateCodeInputPayment" className="block text-sm font-medium text-brand-light mb-1.5">
+                  Código de Afiliado <span className="text-xs text-brand-light/70 font-light">(Opcional)</span>
               </label>
               <input
                 id="affiliateCodeInputPayment"
@@ -531,7 +531,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           whileHover={!(loading || ctaClicked) ? { scale: 1.02, y: -1, boxShadow: '0 12px 25px -8px rgba(233, 30, 99, 0.5)' } : {}}
           whileTap={!(loading || ctaClicked) ? { scale: 0.97 } : {}}
           transition={{ type: "spring", stiffness: 350, damping: 17 }}
-          className={` shimmer-button w-full px-6 py-4 bg-gradient-to-br from-brand-pink to-pink-500 text-white text-lg font-bold rounded-full hover:shadow-2xl transition-all duration-200 ease-out disabled:opacity-60 disabled:cursor-not-allowed shadow-xl flex items-center justify-center gap-2.5 relative overflow-hidden focus:outline-none focus:ring-4 focus:ring-offset-2 focus:ring-pink-500/70 ${(loading || ctaClicked) ? 'cursor-wait' : ''} `}
+          className={` shimmer-button w-full px-6 py-4 bg-gradient-to-br from-brand-pink to-pink-500 text-brand-light text-lg font-bold rounded-full hover:shadow-2xl transition-all duration-200 ease-out disabled:opacity-60 disabled:cursor-not-allowed shadow-xl flex items-center justify-center gap-2.5 relative overflow-hidden focus:outline-none focus:ring-4 focus:ring-offset-2 focus:ring-pink-500/70 ${(loading || ctaClicked) ? 'cursor-wait' : ''} `}
           aria-label={`Assinar o plano ${planType === 'annual' ? 'Anual' : 'Mensal'} Data2Content Completo por ${formattedTotalPrice} ${planType === 'annual' ? 'por ano' : 'por mês'}`}
         >
           {loading ? (
@@ -553,13 +553,13 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                 href={initPoint}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2.5 px-8 py-3 bg-green-600 text-white text-base font-semibold rounded-full hover:bg-green-700 transition-default shadow-md hover:shadow-lg"
+                className="inline-flex items-center gap-2.5 px-8 py-3 bg-green-600 text-brand-light text-base font-semibold rounded-full hover:bg-green-700 transition-default shadow-md hover:shadow-lg"
                 aria-label="Finalizar pagamento seguro no Mercado Pago"
             >
                 <FaExternalLinkAlt className="w-4 h-4"/>
                 Finalizar Pagamento Seguro
             </a>
-            <p className="text-xs text-brand-dark/70 mt-2.5 font-light">
+            <p className="text-xs text-brand-light/70 mt-2.5 font-light">
               (Você será redirecionado para um ambiente seguro do Mercado Pago)
             </p>
             </div>


### PR DESCRIPTION
## Summary
- restyle payment card with dark gradient and brand-light text
- update plan selection, pricing, and affiliate input for brand-light/pink contrast
- align CTA and external payment link with brand-light typography

## Testing
- `npx eslint src/app/dashboard/PaymentPanel.tsx` *(fails: ESLint couldn't find the config "next/typescript")*
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' from 'src/charts/getRadarChartData.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688e29c7af08832eb800596c42a2cd67