### PR TITLE
feat: use monospaced pricing value

### DIFF
--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -436,7 +436,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
                   transition={{ duration: 0.2 }}
                   className="text-6xl font-extrabold tracking-tight leading-none text-brand-pink"
                 >
-                  {formattedTotalPriceWithoutSymbol}
+                  <span className="font-mono tabular-nums">{formattedTotalPriceWithoutSymbol}</span>
                 </motion.span>
               </AnimatePresence>
               <span className="text-xl font-medium text-brand-dark/80">{planType === 'annual' ? '/ano' : '/mês'}</span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,7 @@ const config: Config = { // Define o tipo da configuração
       fontFamily: {
         // Define Poppins como a fonte principal 'sans'
         sans: ['Poppins', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'],
       },
       colors: {
         // Cores definidas no Manual da Marca


### PR DESCRIPTION
## Summary
- wrap payment value with monospaced font for consistent spacing
- declare mono font family in Tailwind config

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; ReferenceError: TextEncoder is not defined)*
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e359f10c8832e8341a4ed7fc8bf4f