### PR TITLE
Add annual billing note to payment panel

### DIFF
--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -477,6 +477,9 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
               Equivale a {currencyFormatter.format(discountedMonthlyPrice)} / mês
             </span>
           )}
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Cobrança anual única. Cancelamento a qualquer momento.
+          </p>
           <p className="text-sm text-brand-dark/70 mt-2 font-light">
             {planType === 'annual'
               ? `Economize R$ ${savingsAmount.toFixed(2).replace('.', ',')} (${discountPercentage}%) com 12 meses de acesso completo.`


### PR DESCRIPTION
## Summary
- show note about single annual charge and cancellation flexibility below total price

## Testing
- `npx eslint src/app/dashboard/PaymentPanel.tsx` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e52ae0900832e95b6e9cf0a911dbd