### PR TITLE
chore: support only mercado pago in payment webhook

### DIFF
--- a/src/app/api/webhooks/payment/route.test.ts
+++ b/src/app/api/webhooks/payment/route.test.ts
@@ -1,0 +1,87 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import mercadopago from '@/app/lib/mercadopago';
+import AgencyModel from '@/app/models/Agency';
+
+jest.mock('@/app/lib/mercadopago', () => ({
+  __esModule: true,
+  default: {
+    preapproval: { get: jest.fn() },
+  },
+}));
+
+jest.mock('@/app/models/Agency', () => ({
+  __esModule: true,
+  default: { findById: jest.fn() },
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('POST /api/webhooks/payment (Mercado Pago)', () => {
+  const mercadopagoMock = mercadopago as any;
+  const agencyModelMock = AgencyModel as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('processes a valid preapproval event', async () => {
+    mercadopagoMock.preapproval.get.mockResolvedValue({
+      body: { external_reference: 'agency1', status: 'authorized' },
+    });
+
+    const agency = { _id: 'agency1', planStatus: 'inactive', save: jest.fn() };
+    agencyModelMock.findById.mockResolvedValue(agency);
+
+    const req = new NextRequest('http://localhost/api/webhooks/payment', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'preapproval', data: { id: 'pre1' } }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ received: true });
+    expect(agency.planStatus).toBe('active');
+    expect(agency.paymentGatewaySubscriptionId).toBe('pre1');
+    expect(agency.save).toHaveBeenCalled();
+  });
+
+  it('ignores preapproval events without id', async () => {
+    const req = new NextRequest('http://localhost/api/webhooks/payment', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'preapproval', data: {} }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mercadopagoMock.preapproval.get).not.toHaveBeenCalled();
+    expect(agencyModelMock.findById).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated event types', async () => {
+    const req = new NextRequest('http://localhost/api/webhooks/payment', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'unknown' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mercadopagoMock.preapproval.get).not.toHaveBeenCalled();
+    expect(agencyModelMock.findById).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/app/api/webhooks/payment/route.ts
+++ b/src/app/api/webhooks/payment/route.ts
@@ -6,79 +6,54 @@ import mercadopago from '@/app/lib/mercadopago';
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/webhooks/payment]';
 
-interface PaymentEvent {
-  type: string;
+interface MercadoPagoEvent {
+  type?: string;
   action?: string;
   data?: {
     id?: string;
-    subscriptionId?: string;
   };
 }
 
 export async function POST(req: NextRequest) {
   const TAG = `${SERVICE_TAG}[POST]`;
   try {
-    const body = (await req.json()) as PaymentEvent;
+    const body = (await req.json()) as MercadoPagoEvent;
     logger.info(`${TAG} event received: ${body.type}`);
 
-    if (body.type === 'preapproval') {
-      const preapprovalId = body.data?.id;
-      if (!preapprovalId) {
-        logger.warn(`${TAG} missing preapproval id`);
-        return NextResponse.json({ received: true });
-      }
-
-      const { body: preapproval } = await mercadopago.preapproval.get(preapprovalId);
-      const agencyId = preapproval.external_reference;
-      if (!agencyId) {
-        logger.warn(`${TAG} preapproval ${preapprovalId} without external reference`);
-        return NextResponse.json({ received: true });
-      }
-
-      const agency = await AgencyModel.findById(agencyId);
-      if (!agency) {
-        logger.warn(`${TAG} agency not found for preapproval ${preapprovalId}`);
-        return NextResponse.json({ received: true });
-      }
-
-      agency.paymentGatewaySubscriptionId = preapprovalId;
-      if (preapproval.status === 'authorized') {
-        agency.planStatus = 'active';
-      } else if (preapproval.status === 'cancelled') {
-        agency.planStatus = 'canceled';
-      } else if (preapproval.status === 'paused' || preapproval.status === 'suspended') {
-        agency.planStatus = 'inactive';
-      }
-      await agency.save();
-      logger.info(`${TAG} agency ${agency._id} updated to ${agency.planStatus}`);
-    } else {
-      const subscriptionId = body.data?.subscriptionId;
-      if (!subscriptionId) {
-        logger.warn(`${TAG} missing subscriptionId`);
-        return NextResponse.json({ received: true });
-      }
-
-      const agency = await AgencyModel.findOne({ paymentGatewaySubscriptionId: subscriptionId });
-      if (!agency) {
-        logger.warn(`${TAG} agency not found for subscription ${subscriptionId}`);
-        return NextResponse.json({ received: true });
-      }
-
-      if (body.type === 'checkout.session.completed' || body.type === 'subscription.active') {
-        agency.planStatus = 'active';
-        agency.paymentGatewaySubscriptionId = subscriptionId;
-        await agency.save();
-        logger.info(`${TAG} agency ${agency._id} activated`);
-      } else if (body.type === 'invoice.payment_failed') {
-        agency.planStatus = 'inactive';
-        await agency.save();
-        logger.info(`${TAG} agency ${agency._id} marked inactive`);
-      } else if (body.type === 'customer.subscription.deleted') {
-        agency.planStatus = 'canceled';
-        await agency.save();
-        logger.info(`${TAG} agency ${agency._id} canceled`);
-      }
+    if (body.type !== 'preapproval') {
+      return NextResponse.json({ received: true });
     }
+
+    const preapprovalId = body.data?.id;
+    if (!preapprovalId) {
+      logger.warn(`${TAG} missing preapproval id`);
+      return NextResponse.json({ received: true });
+    }
+
+    const { body: preapproval } = await mercadopago.preapproval.get(preapprovalId);
+    const agencyId = preapproval.external_reference;
+    if (!agencyId) {
+      logger.warn(`${TAG} preapproval ${preapprovalId} without external reference`);
+      return NextResponse.json({ received: true });
+    }
+
+    const agency = await AgencyModel.findById(agencyId);
+    if (!agency) {
+      logger.warn(`${TAG} agency not found for preapproval ${preapprovalId}`);
+      return NextResponse.json({ received: true });
+    }
+
+    agency.paymentGatewaySubscriptionId = preapprovalId;
+    if (preapproval.status === 'authorized') {
+      agency.planStatus = 'active';
+    } else if (preapproval.status === 'cancelled') {
+      agency.planStatus = 'canceled';
+    } else if (preapproval.status === 'paused' || preapproval.status === 'suspended') {
+      agency.planStatus = 'inactive';
+    }
+
+    await agency.save();
+    logger.info(`${TAG} agency ${agency._id} updated to ${agency.planStatus}`);
 
     return NextResponse.json({ received: true });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- handle only Mercado Pago events in payment webhook
- ignore unrelated webhook types
- add unit tests for valid and invalid Mercado Pago webhook events

## Testing
- `npm test -- src/app/api/webhooks/payment/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f5c817744832ea11723c16929f3c7