### PR TITLE
perf: preconnect to YouTube domains

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,11 @@ export default async function RootLayout({
 
   return (
     <html lang="pt-BR" className={`${poppins.variable} h-full`}>
-      <head />
+      <head>
+        <link rel="preconnect" href="https://www.youtube.com" />
+        <link rel="preconnect" href="https://www.google.com" />
+        <link rel="preconnect" href="https://img.youtube.com" />
+      </head>
       <body
         className={`
           font-sans


### PR DESCRIPTION
## Summary
- add preconnect links to YouTube, Google, and img.youtube.com in layout head

## Testing
- `npm test` (fails: 114 failed, 18 passed)
- `npm run lint` (could not run: ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_688fca236618832ebb222bb834685bce