### PR TITLE
perf: enable lazy loading for hero media

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -322,6 +322,8 @@ export default function FinalCompleteLandingPage() {
                           poster="/images/tuca-analise-whatsapp.png"
                           src="/videos/hero-demo.mp4"
                           className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
+                          loading="lazy"
+                          decoding="async"
                         />
                       </div>
                     </motion.div>
@@ -433,6 +435,8 @@ export default function FinalCompleteLandingPage() {
                                 src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
                                 alt="Thumbnail do vídeo"
                                 className="absolute top-0 left-0 h-full w-full object-cover"
+                                loading="lazy"
+                                decoding="async"
                             />
                             <div className="absolute inset-0 flex items-center justify-center">
                                 <div className="bg-black/60 rounded-full p-4">


### PR DESCRIPTION
## Summary
- add lazy loading and async decoding to hero demo video
- lazy load founder video thumbnail

## Testing
- `npm test` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688fcfd23ed0832eb49bd1904894c6ae