### PR TITLE
feat: add decorative hero background

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -278,6 +278,10 @@ export default function FinalCompleteLandingPage() {
         <>
           {/* [CORREÇÃO] A altura mínima foi ajustada para 90vh para diminuir o espaço vertical. */}
           <section className="relative flex flex-col h-screen bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
+            <div className="absolute inset-0 -z-10 overflow-hidden">
+              <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[40rem] h-[40rem] bg-[radial-gradient(circle_at_top,rgba(236,72,153,0.35),transparent)]" />
+              <div className="absolute bottom-20 right-0 w-72 h-72 bg-brand-pink/20 blur-3xl rounded-full" />
+            </div>
             {/* O container interno usa flex-grow e justify-start para alinhar o conteúdo ao topo. */}
             <div className="flex-grow flex flex-col justify-start pt-32">
                 <div className="w-full">


### PR DESCRIPTION
## Summary
- enhance hero section with absolutely positioned radial gradient and blurred brand-pink shapes

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, Response is not defined, etc.)*
- `npm run lint` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6890221b67d8832ebace9423296cc2dc