### PR TITLE
style: add gradient to hero heading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -302,7 +302,7 @@ export default function FinalCompleteLandingPage() {
                       <div className="max-w-3xl mx-auto px-6 lg:px-8">
                         <motion.h1 
                           variants={heroItemVariants}
-                          className="text-5xl md:text-7xl font-extrabold tracking-tighter text-brand-dark"
+                          className="text-5xl md:text-7xl font-semibold tracking-tighter bg-gradient-to-r from-brand-pink to-brand-red bg-clip-text text-transparent"
                         >
                           O fim da dúvida: o que postar hoje?
                         </motion.h1>


### PR DESCRIPTION
## Summary
- use pink-to-red gradient for hero title

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, etc.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890dbc903dc832e9f4132ee20e12fb3