### PR TITLE
chore: use next/font for Inter and remove Google Fonts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 
 import type { Metadata } from "next";
-import { Poppins } from "next/font/google";
+import { Poppins, Inter } from "next/font/google";
 import "./globals.css";
 
 // Imports do NextAuth para buscar a sessão no servidor
@@ -20,6 +20,11 @@ const poppins = Poppins({
   subsets: ["latin"],
   display: 'swap',
   variable: "--font-poppins",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -45,7 +50,7 @@ export default async function RootLayout({
       </head>
       <body
         className={`
-          font-sans
+          ${inter.className}
           antialiased
           flex
           flex-col

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -288,9 +288,6 @@ export default function FinalCompleteLandingPage() {
       <Head>
         <title>data2content - Menos análise, mais criação.</title>
         <meta name="description" content="Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer." />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
       </Head>
 
       <div className="bg-white text-gray-800 font-sans">


### PR DESCRIPTION
## Summary
- remove external Google Fonts references
- load Inter from next/font and apply to body

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, etc.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6bf2b1c832ea25def3911ad4936