### PR TITLE
feat: add landing slides with scroll transitions

### DIFF
--- a/src/app/landing/components/ExamplesSlide.tsx
+++ b/src/app/landing/components/ExamplesSlide.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { ScrollCue } from './ScrollCue';
+
+export function ExamplesSlide() {
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] });
+  const opacity = useTransform(scrollYProgress, [0, 0.3, 1], [0, 1, 1]);
+  const y = useTransform(scrollYProgress, [0, 0.3], [100, 0]);
+
+  return (
+    <motion.section
+      ref={ref}
+      style={{ opacity, y }}
+      className="relative h-screen flex flex-col items-center justify-center bg-purple-600 text-white"
+      id="examples"
+    >
+      <h2 className="text-3xl font-bold mb-4">Exemplos</h2>
+      <p>Veja como nosso produto pode ajudar você.</p>
+      <ScrollCue targetId="features" direction="up" />
+    </motion.section>
+  );
+}
+

--- a/src/app/landing/components/FeaturesSlide.tsx
+++ b/src/app/landing/components/FeaturesSlide.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { ScrollCue } from './ScrollCue';
+
+export function FeaturesSlide() {
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] });
+  const opacity = useTransform(scrollYProgress, [0, 0.3, 1], [0, 1, 1]);
+  const y = useTransform(scrollYProgress, [0, 0.3], [100, 0]);
+
+  return (
+    <motion.section
+      ref={ref}
+      style={{ opacity, y }}
+      className="relative h-screen flex flex-col items-center justify-center bg-green-600 text-white"
+      id="features"
+    >
+      <h2 className="text-3xl font-bold mb-4">Recursos</h2>
+      <ul className="list-disc">
+        <li>Recurso 1</li>
+        <li>Recurso 2</li>
+        <li>Recurso 3</li>
+      </ul>
+      <ScrollCue targetId="examples" />
+      <ScrollCue targetId="intro" direction="up" />
+    </motion.section>
+  );
+}
+

--- a/src/app/landing/components/IntroSlide.tsx
+++ b/src/app/landing/components/IntroSlide.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { ScrollCue } from './ScrollCue';
+
+export function IntroSlide() {
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] });
+  const opacity = useTransform(scrollYProgress, [0, 0.3, 1], [0, 1, 1]);
+  const y = useTransform(scrollYProgress, [0, 0.3], [100, 0]);
+
+  return (
+    <motion.section
+      ref={ref}
+      style={{ opacity, y }}
+      className="relative h-screen flex items-center justify-center bg-blue-600 text-white"
+      id="intro"
+    >
+      <h1 className="text-4xl font-bold">Bem-vindo ao Data2Content</h1>
+      <ScrollCue targetId="features" />
+    </motion.section>
+  );
+}
+

--- a/src/app/landing/components/ScrollCue.tsx
+++ b/src/app/landing/components/ScrollCue.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+interface ScrollCueProps {
+  targetId: string;
+  direction?: 'down' | 'up';
+}
+
+export function ScrollCue({ targetId, direction = 'down' }: ScrollCueProps) {
+  const handleClick = () => {
+    const el = document.getElementById(targetId);
+    el?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={`Scroll ${direction}`}
+      className="absolute left-1/2 -translate-x-1/2 text-white animate-bounce p-2"
+      style={direction === 'down' ? { bottom: '1rem' } : { top: '1rem' }}
+    >
+      {direction === 'down' ? <ChevronDown size={32} /> : <ChevronUp size={32} />}
+    </button>
+  );
+}
+

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,14 @@
+import { IntroSlide } from './components/IntroSlide';
+import { FeaturesSlide } from './components/FeaturesSlide';
+import { ExamplesSlide } from './components/ExamplesSlide';
+
+export default function LandingPage() {
+  return (
+    <main className="snap-y snap-mandatory h-screen overflow-y-scroll">
+      <IntroSlide />
+      <FeaturesSlide />
+      <ExamplesSlide />
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build full-screen landing slides (Intro, Features, Examples)
- add scroll-triggered animations via framer-motion
- include arrow-based scroll navigation cues

## Testing
- `npm test` (fails: Cannot find module '@/utils/calculateFollowerGrowthRate' etc.)
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6890fb48f844832eb7c9747166b9d056