### PR TITLE
refactor landing page into server component

### DIFF
--- a/src/app/landing/components/AnimatedSection.tsx
+++ b/src/app/landing/components/AnimatedSection.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { motion, useAnimation } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+
+interface AnimatedSectionProps {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}
+
+export default function AnimatedSection({ children, delay = 0, className = '' }: AnimatedSectionProps) {
+  const controls = useAnimation();
+  const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.1 });
+
+  useEffect(() => {
+    if (inView) controls.start('visible');
+  }, [controls, inView]);
+
+  return (
+    <motion.div
+      ref={ref}
+      initial="hidden"
+      animate={controls}
+      variants={{
+        hidden: { opacity: 0, y: 20 },
+        visible: {
+          opacity: 1,
+          y: 0,
+          transition: { duration: 0.7, ease: [0.22, 1, 0.36, 1], delay },
+        },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+

--- a/src/app/landing/components/ButtonPrimary.tsx
+++ b/src/app/landing/components/ButtonPrimary.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+import React from 'react';
+
+interface ButtonPrimaryProps {
+  href?: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ButtonPrimary({ href, onClick, children, className = '' }: ButtonPrimaryProps) {
+  const commonClasses = `group inline-flex items-center justify-center gap-3 rounded-full bg-gradient-to-r from-brand-pink to-brand-red px-8 py-4 text-lg font-bold text-white shadow-lg shadow-pink-500/30 transition-all duration-300 hover:shadow-xl hover:shadow-pink-500/40 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 ${className}`;
+  if (href) {
+    return (
+      <Link href={href} onClick={onClick} className={commonClasses}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <button onClick={onClick} className={commonClasses}>
+      {children}
+    </button>
+  );
+}
+

--- a/src/app/landing/components/CallToAction.tsx
+++ b/src/app/landing/components/CallToAction.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import { FaGoogle } from 'react-icons/fa';
+import ButtonPrimary from './ButtonPrimary';
+
+export default function CallToAction() {
+  const handleSignIn = () => {
+    if (typeof window !== 'undefined' && (window as any).gtag) {
+      (window as any).gtag('event', 'sign_in_click');
+    }
+    signIn('google', { callbackUrl: '/auth/complete-signup' });
+  };
+
+  return (
+    <section className="snap-start py-12 sm:py-20 bg-brand-dark text-white">
+      <div className="max-w-screen-xl mx-auto px-6 text-left">
+        <div className="max-w-3xl">
+          <h2 className="text-4xl md:text-5xl font-bold tracking-tight text-white">Pronto para transformar sua criação de conteúdo?</h2>
+          <p className="mt-4 text-lg md:text-xl text-gray-300 max-w-3xl leading-relaxed">Pare de adivinhar e comece a crescer com estratégia. O Mobi está esperando por você.</p>
+          <div className="mt-10">
+            <ButtonPrimary onClick={handleSignIn}>
+              <FaGoogle /> Ativar meu estrategista agora ▸
+            </ButtonPrimary>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/landing/components/FounderVideo.tsx
+++ b/src/app/landing/components/FounderVideo.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { FaPlay } from 'react-icons/fa';
+
+interface FounderVideoProps {
+  videoId: string;
+}
+
+export default function FounderVideo({ videoId }: FounderVideoProps) {
+  const videoRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = videoRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver((entries, obs) => {
+      const entry = entries[0];
+      if (entry.isIntersecting) {
+        const iframe = document.createElement('iframe');
+        iframe.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1`;
+        iframe.title = 'YouTube video player';
+        iframe.frameBorder = '0';
+        iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.allowFullscreen = true;
+        iframe.className = 'absolute top-0 left-0 h-full w-full';
+        container.innerHTML = '';
+        container.appendChild(iframe);
+        obs.disconnect();
+      }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [videoId]);
+
+  return (
+    <div
+      ref={videoRef}
+      className="relative mt-10 overflow-hidden rounded-2xl shadow-lg w-full aspect-video"
+    >
+      <img
+        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+        alt="Thumbnail do vídeo"
+        className="absolute top-0 left-0 h-full w-full object-cover"
+        loading="lazy"
+        decoding="async"
+      />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="bg-black/60 rounded-full p-4">
+          <FaPlay className="text-white text-3xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import Link from 'next/link';
+import { signIn } from 'next-auth/react';
+import ButtonPrimary from './ButtonPrimary';
+import { FaGoogle } from 'react-icons/fa';
+
+export default function HeroSection() {
+  const { scrollY } = useScroll();
+  const topBlobY = useTransform(scrollY, [0, 500], [0, -100]);
+  const bottomBlobY = useTransform(scrollY, [0, 500], [0, -150]);
+
+  const trackEvent = (eventName: string) => {
+    if (typeof window !== 'undefined' && (window as any).gtag) {
+      (window as any).gtag('event', eventName);
+    }
+  };
+
+  const handleSignIn = () => {
+    trackEvent('sign_in_click');
+    signIn('google', { callbackUrl: '/auth/complete-signup' });
+  };
+
+  const heroVariants = {
+    hidden: { opacity: 0, scale: 0.95 },
+    visible: {
+      opacity: [0, 1],
+      scale: [0.95, 1],
+      transition: {
+        ease: [0.33, 1, 0.68, 1],
+        staggerChildren: 0.2,
+        delayChildren: 0.1,
+      },
+    },
+  };
+
+  const heroItemVariants = {
+    hidden: { opacity: 0, y: 20, scale: 0.95 },
+    visible: {
+      opacity: [0, 1],
+      y: 0,
+      scale: [0.95, 1],
+      transition: { duration: 0.7, ease: [0.33, 1, 0.68, 1] },
+    },
+  };
+
+  return (
+    <section className="snap-start relative flex flex-col h-screen pt-20 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        <motion.div
+          style={{ y: topBlobY }}
+          className="absolute top-0 left-1/2 -translate-x-1/2 w-[40rem] h-[40rem] bg-[radial-gradient(circle_at_top,rgba(236,72,153,0.35),transparent)]"
+        />
+        <motion.div
+          style={{ y: bottomBlobY }}
+          className="absolute bottom-20 right-0 w-72 h-72 bg-brand-pink/20 blur-3xl rounded-full"
+        />
+      </div>
+      <div className="flex-grow flex flex-col justify-start pt-32">
+        <div className="w-full">
+          <motion.div
+            variants={heroVariants}
+            initial="hidden"
+            animate="visible"
+            className="w-full"
+          >
+            <div className="max-w-3xl mx-auto px-6 lg:px-8">
+              <motion.h1
+                variants={heroItemVariants}
+                className="text-5xl md:text-7xl font-semibold tracking-tighter bg-gradient-to-r from-brand-pink to-brand-red bg-clip-text text-transparent"
+              >
+                A IA que diz o que postar no Instagram
+              </motion.h1>
+
+              <motion.p
+                variants={heroItemVariants}
+                className="mt-4 text-lg md:text-xl text-gray-600 max-w-2xl mx-auto"
+              >
+                Receba análises e ideias prontas direto no WhatsApp.
+              </motion.p>
+
+              <motion.div variants={heroItemVariants}>
+                <ButtonPrimary onClick={handleSignIn} className="mt-8">
+                  <FaGoogle /> Ative sua IA do Instagram no WhatsApp ▸
+                </ButtonPrimary>
+              </motion.div>
+              <motion.div variants={heroItemVariants}>
+                <Link href="#features" onClick={() => trackEvent('saiba_mais_click')} className="mt-4 inline-block text-sm font-semibold text-brand-pink hover:underline">
+                  Saiba Mais
+                </Link>
+              </motion.div>
+            </div>
+
+            <motion.div
+              variants={heroItemVariants}
+              className="relative mt-12 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50"
+            >
+              <video
+                autoPlay
+                muted
+                loop
+                playsInline
+                poster="/images/tuca-analise-whatsapp.png"
+                src="/videos/hero-demo.mp4"
+                className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
+                loading="lazy"
+                decoding="async"
+              />
+            </motion.div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import ButtonPrimary from './ButtonPrimary';
+
+export default function LandingHeader() {
+  const { data: session } = useSession();
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const trackEvent = (eventName: string) => {
+    if (typeof window !== 'undefined' && (window as any).gtag) {
+      (window as any).gtag('event', eventName);
+    }
+  };
+
+  useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', handleScroll);
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header className={`fixed top-0 w-full z-50 backdrop-blur-md transition-all ${isScrolled ? 'bg-white shadow' : 'bg-white/60'}`}>
+      <div className="max-w-screen-xl mx-auto flex justify-between items-center h-20 px-6">
+        <Link href="/" className="font-bold text-2xl text-brand-dark flex items-center gap-2">
+          <span className="text-brand-pink">[2]</span>
+          <span>data2content</span>
+        </Link>
+        <nav className="flex items-center gap-5">
+          {session ? (
+            <Link href="/dashboard" className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors">Meu Painel</Link>
+          ) : (
+            <Link href="/login" onClick={() => trackEvent('login_link_click')} className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors">Fazer Login</Link>
+          )}
+          <ButtonPrimary href="/register" onClick={() => trackEvent('cta_start_now_click')}>Começar Agora</ButtonPrimary>
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import Image from 'next/image';
+import React, { useEffect, useRef, useState } from 'react';
+import { motion, PanInfo } from 'framer-motion';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+
+interface Screenshot {
+  title: string;
+  imageUrl: string;
+}
+
+interface ScreenshotCarouselProps {
+  items: Screenshot[];
+}
+
+export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  const scrollCarousel = (direction: 'left' | 'right') => {
+    if (carouselRef.current) {
+      const card = carouselRef.current.children[0] as HTMLElement;
+      const cardWidth = card?.offsetWidth || 0;
+      const gap = 32;
+      const scrollAmount = cardWidth + gap;
+      carouselRef.current.scrollBy({ left: direction === 'right' ? scrollAmount : -scrollAmount, behavior: 'smooth' });
+    }
+  };
+
+  const ScreenshotCard = ({ imageUrl, title }: { imageUrl: string; title: string }) => {
+    const [isTouch, setIsTouch] = useState(false);
+
+    useEffect(() => {
+      const handlePointerDown = (e: PointerEvent) => {
+        setIsTouch(e.pointerType === 'touch');
+      };
+      window.addEventListener('pointerdown', handlePointerDown, { once: true });
+      return () => window.removeEventListener('pointerdown', handlePointerDown);
+    }, []);
+
+    return (
+      <div
+        className="flex-shrink-0 w-[60vw] sm:w-[40vw] md:w-[28vw] lg:w-[22vw] aspect-[9/16] rounded-3xl bg-gradient-to-br from-gray-100 to-gray-200 p-1 shadow-2xl cursor-grab active:cursor-grabbing"
+        style={{ perspective: '1000px', transformStyle: 'preserve-3d' }}
+      >
+        <motion.div
+          className="relative w-full h-full bg-white rounded-[22px] shadow-inner overflow-hidden"
+          whileTap={{ scale: 0.98, transition: { duration: 0.2 } }}
+          whileHover={isTouch ? undefined : { rotateX: 5, rotateY: -5 }}
+        >
+          <Image
+            src={imageUrl}
+            alt={title}
+            fill
+            className="object-cover"
+            loading="lazy"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = 'https://placehold.co/360x640/f0f0f0/333?text=Imagem+Indispon\u00edvel';
+            }}
+          />
+        </motion.div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="relative mt-6">
+      <motion.div
+        ref={carouselRef}
+        className="overflow-hidden snap-x snap-mandatory hide-scrollbar"
+        drag="x"
+        dragConstraints={{ left: 0, right: 0 }}
+        dragElastic={0.05}
+        style={{ touchAction: 'pan-y' }}
+        onDragEnd={(event, info: PanInfo) => {
+          const pointerEvent = event as PointerEvent;
+          if (pointerEvent.pointerType !== 'touch') return;
+          if (info.offset.x < -50) {
+            scrollCarousel('right');
+          } else if (info.offset.x > 50) {
+            scrollCarousel('left');
+          }
+        }}
+      >
+        <div
+          className="flex gap-8"
+          style={{
+            paddingTop: '1.5rem',
+            paddingBottom: '1.5rem',
+            paddingLeft: 'calc(max(0px, (100vw - 1280px) / 2) + 1.5rem)',
+            paddingRight: 'calc(max(0px, (100vw - 1280px) / 2) + 1.5rem)',
+          }}
+        >
+          {items.map((item, index) => (
+            <div key={index} className="flex flex-col items-start gap-2 flex-shrink-0 snap-center">
+              <h3 className="font-bold text-lg text-gray-600 pl-1">{item.title}</h3>
+              <ScreenshotCard imageUrl={item.imageUrl} title={item.title} />
+            </div>
+          ))}
+        </div>
+      </motion.div>
+      <div className="absolute top-1/2 -translate-y-1/2 w-full flex justify-between px-4 pointer-events-none">
+        <button
+          onClick={() => scrollCarousel('left')}
+          className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
+          aria-label="Anterior"
+        >
+          <FaChevronLeft />
+        </button>
+        <button
+          onClick={() => scrollCarousel('right')}
+          className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
+          aria-label="Pr\u00f3ximo"
+        >
+          <FaChevronRight />
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,19 @@
-"use client";
-
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import Head from "next/head";
-import Link from "next/link";
 import Image from "next/image";
-import { useSession, signIn } from "next-auth/react";
-import { motion, useAnimation, useScroll, useTransform, PanInfo } from "framer-motion";
-import { useInView } from "react-intersection-observer";
-import { FaGoogle, FaGem, FaChartPie, FaHeart, FaBriefcase, FaStar, FaPaintBrush, FaBullhorn, FaChalkboardTeacher, FaQuestionCircle, FaCheckCircle, FaTimesCircle, FaChevronLeft, FaChevronRight, FaPlay } from 'react-icons/fa';
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import { FaChalkboardTeacher, FaBullhorn, FaStar, FaQuestionCircle } from "react-icons/fa";
 import testimonials from "@/data/testimonials";
 import faqItems from "@/data/faq";
 
-// --- DADOS E CONSTANTES DA PÁGINA ---
+const AnimatedSection = dynamic(() => import("./landing/components/AnimatedSection"), { ssr: false });
+const LandingHeader = dynamic(() => import("./landing/components/LandingHeader"), { ssr: false });
+const HeroSection = dynamic(() => import("./landing/components/HeroSection"), { ssr: false });
+const ScreenshotCarousel = dynamic(() => import("./landing/components/ScreenshotCarousel"), { ssr: false });
+const FounderVideo = dynamic(() => import("./landing/components/FounderVideo"), { ssr: false });
+const CallToAction = dynamic(() => import("./landing/components/CallToAction"), { ssr: false });
+
 const exampleScreenshots = [
   { title: "(1) Alerta Diário Recebido", imageUrl: "/images/WhatsApp Image 2025-07-07 at 14.00.20.png" },
   { title: "(2) Análise de Conteúdo", imageUrl: "/images/WhatsApp Image 2025-07-07 at 14.00.20 (1).png" },
@@ -21,212 +23,63 @@ const exampleScreenshots = [
 ];
 
 const creatorTypes = [
-    {
-        icon: FaChalkboardTeacher,
-        title: "Especialistas e Coaches",
-        description: "Transforme seu conhecimento em conteúdo de alto valor que educa e converte."
-    },
-    {
-        icon: FaBullhorn,
-        title: "Influenciadores e Atores",
-        description: "Entenda sua audiência para aumentar o engajamento e fechar mais publicidades."
-    },
-    {
-        icon: FaStar,
-        title: "Marcas e Empreendedores",
-        description: "Use seu Instagram como uma ferramenta de negócios poderosa, com estratégia baseada em dados."
-    }
+  {
+    icon: FaChalkboardTeacher,
+    title: "Especialistas e Coaches",
+    description: "Transforme seu conhecimento em conteúdo de alto valor que educa e converte."
+  },
+  {
+    icon: FaBullhorn,
+    title: "Influenciadores e Atores",
+    description: "Entenda sua audiência para aumentar o engajamento e fechar mais publicidades."
+  },
+  {
+    icon: FaStar,
+    title: "Marcas e Empreendedores",
+    description: "Use seu Instagram como uma ferramenta de negócios poderosa, com estratégia baseada em dados."
+  }
 ];
 
-
-// --- COMPONENTES DE UI REUTILIZÁVEIS ---
-const AnimatedSection = React.memo(({ children, delay = 0, className = "" }: { children: React.ReactNode; delay?: number; className?: string; }) => {
-  const controls = useAnimation();
-  const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.1 });
-  useEffect(() => { if (inView) controls.start("visible"); }, [controls, inView]);
-  return (
-    <motion.div ref={ref} initial="hidden" animate={controls} variants={{ hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0, transition: { duration: 0.7, ease: [0.22, 1, 0.36, 1], delay: delay }}}} className={className}>
-      {children}
-    </motion.div>
-  );
-});
-AnimatedSection.displayName = "AnimatedSection";
-
 const SectionTitle = ({ children, className = "" }: { children: React.ReactNode; className?: string }) => (
-    <h2 className={`text-4xl md:text-5xl font-bold tracking-tight text-brand-dark ${className}`}>{children}</h2>
+  <h2 className={`text-4xl md:text-5xl font-bold tracking-tight text-brand-dark ${className}`}>{children}</h2>
 );
 
-const SectionSubtitle = ({ children, className = "" }: { children: React.ReactNode, className?:string }) => (
-    <p className={`mt-4 text-lg md:text-xl text-gray-600 max-w-3xl leading-relaxed ${className}`}>{children}</p>
+const SectionSubtitle = ({ children, className = "" }: { children: React.ReactNode; className?: string }) => (
+  <p className={`mt-4 text-lg md:text-xl text-gray-600 max-w-3xl leading-relaxed ${className}`}>{children}</p>
 );
 
-const ButtonPrimary = ({ href, onClick, children, className }: { href?: string; onClick?: () => void; children: React.ReactNode; className?: string }) => {
-    const commonClasses = `group inline-flex items-center justify-center gap-3 rounded-full bg-gradient-to-r from-brand-pink to-brand-red px-8 py-4 text-lg font-bold text-white shadow-lg shadow-pink-500/30 transition-all duration-300 hover:shadow-xl hover:shadow-pink-500/40 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 ${className}`;
-
-    if (href) {
-        return <Link href={href} onClick={onClick} className={commonClasses}>{children}</Link>;
-    }
-    return <button onClick={onClick} className={commonClasses}>{children}</button>;
-};
-
-const PillarCard = ({ icon: Icon, title, children }: { icon: React.ElementType; title: string; children: React.ReactNode; }) => (
-    <div className="group relative h-full rounded-2xl bg-gradient-to-br from-white to-gray-50 p-6 text-left transition-all duration-300 hover:shadow-2xl hover:-translate-y-2">
-        <div className="absolute -inset-px rounded-2xl bg-gradient-to-r from-pink-200/50 to-purple-200/50 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-        <div className="relative">
-            <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand-pink/10 text-2xl text-brand-pink shadow-inner shadow-pink-100 transition-all duration-300 group-hover:scale-110 group-hover:bg-brand-pink group-hover:text-white">
-                <Icon />
-            </div>
-            <h3 className="text-lg font-semibold text-brand-dark">{title}</h3>
-            <p className="mt-2 text-sm text-gray-600">{children}</p>
-        </div>
+const PillarCard = ({ icon: Icon, title, children }: { icon: React.ElementType; title: string; children: React.ReactNode }) => (
+  <div className="group relative h-full rounded-2xl bg-gradient-to-br from-white to-gray-50 p-6 text-left transition-all duration-300 hover:shadow-2xl hover:-translate-y-2">
+    <div className="absolute -inset-px rounded-2xl bg-gradient-to-r from-pink-200/50 to-purple-200/50 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+    <div className="relative">
+      <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand-pink/10 text-2xl text-brand-pink shadow-inner shadow-pink-100 transition-all duration-300 group-hover:scale-110 group-hover:bg-brand-pink group-hover:text-white">
+        <Icon />
+      </div>
+      <h3 className="text-lg font-semibold text-brand-dark">{title}</h3>
+      <p className="mt-2 text-sm text-gray-600">{children}</p>
     </div>
+  </div>
 );
 
-const ScreenshotCard = ({ imageUrl, title }: { imageUrl: string; title: string; }) => {
-    const [isTouch, setIsTouch] = useState(false);
-
-    useEffect(() => {
-        const handlePointerDown = (e: PointerEvent) => {
-            setIsTouch(e.pointerType === "touch");
-        };
-        window.addEventListener("pointerdown", handlePointerDown, { once: true });
-        return () => window.removeEventListener("pointerdown", handlePointerDown);
-    }, []);
-
-    return (
-        <div
-            className="flex-shrink-0 w-[60vw] sm:w-[40vw] md:w-[28vw] lg:w-[22vw] aspect-[9/16] rounded-3xl bg-gradient-to-br from-gray-100 to-gray-200 p-1 shadow-2xl cursor-grab active:cursor-grabbing"
-            style={{ perspective: "1000px", transformStyle: "preserve-3d" }}
-        >
-            <motion.div
-                className="relative w-full h-full bg-white rounded-[22px] shadow-inner overflow-hidden"
-                whileTap={{ scale: 0.98, transition: { duration: 0.2 } }}
-                whileHover={isTouch ? undefined : { rotateX: 5, rotateY: -5 }}
-            >
-                <Image
-                    src={imageUrl}
-                    alt={title}
-                    layout="fill"
-                    className="object-cover"
-                    loading="lazy"
-                    onError={(e) => { e.currentTarget.src = 'https://placehold.co/360x640/f0f0f0/333?text=Imagem+Indisponível'; }}
-                />
-            </motion.div>
-        </div>
-    );
-};
-
-const TestimonialCard = ({ name, handle, quote, avatarUrl }: { name: string; handle: string; quote: string; avatarUrl: string; }) => (
-    <div className="bg-white p-6 rounded-xl h-full shadow-lg flex flex-col">
-        <div className="flex text-yellow-400 gap-1 mb-4">{[...Array(5)].map((_, i) => <FaStar key={i} />)}</div>
-        <p className="text-gray-700 italic text-sm flex-grow">"{quote}"</p>
-        <div className="flex items-center mt-4">
-            <div className="relative w-10 h-10 rounded-full overflow-hidden">
-                <Image
-                    src={avatarUrl}
-                    alt={`Avatar de ${name}`}
-                    layout="fill"
-                    className="object-cover"
-                />
-            </div>
-            <div className="ml-4">
-                <p className="font-semibold text-brand-dark text-sm">{name}</p>
-                <p className="text-xs text-gray-500">{handle}</p>
-            </div>
-        </div>
+const TestimonialCard = ({ name, handle, quote, avatarUrl }: { name: string; handle: string; quote: string; avatarUrl: string }) => (
+  <div className="bg-white p-6 rounded-xl h-full shadow-lg flex flex-col">
+    <div className="flex text-yellow-400 gap-1 mb-4">{[...Array(5)].map((_, i) => <FaStar key={i} />)}</div>
+    <p className="text-gray-700 italic text-sm flex-grow">"{quote}"</p>
+    <div className="flex items-center mt-4">
+      <div className="relative w-10 h-10 rounded-full overflow-hidden">
+        <Image src={avatarUrl} alt={`Avatar de ${name}`} fill className="object-cover" />
+      </div>
+      <div className="ml-4">
+        <p className="font-semibold text-brand-dark text-sm">{name}</p>
+        <p className="text-xs text-gray-500">{handle}</p>
+      </div>
     </div>
+  </div>
 );
 
-
-
-// --- COMPONENTE PRINCIPAL DA PÁGINA ---
 export default function FinalCompleteLandingPage() {
-  const { data: session } = useSession();
-  const carouselRef = useRef<HTMLDivElement>(null);
-  const [isScrolled, setIsScrolled] = useState(false);
-
-  const trackEvent = (eventName: string) => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('event', eventName);
-    }
-  };
-
-  const handleSignIn = () => {
-    trackEvent('sign_in_click');
-    signIn("google", { callbackUrl: "/auth/complete-signup" });
-  };
-
-  const scrollCarousel = (direction: 'left' | 'right') => {
-    if (carouselRef.current) {
-        const card = carouselRef.current.children[0] as HTMLElement;
-        const cardWidth = card?.offsetWidth || 0;
-        const gap = 32; // Corresponde a 'gap-8' no Tailwind
-        const scrollAmount = cardWidth + gap;
-        carouselRef.current.scrollBy({ left: direction === 'right' ? scrollAmount : -scrollAmount, behavior: 'smooth' });
-    }
-  };
-
   const videoId = "dQw4w9WgXcQ";
-  const videoRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const container = videoRef.current;
-    if (!container) return;
 
-    const observer = new IntersectionObserver((entries, obs) => {
-      const entry = entries[0];
-      if (entry.isIntersecting) {
-        const iframe = document.createElement("iframe");
-        iframe.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1`;
-        iframe.title = "YouTube video player";
-        iframe.frameBorder = "0";
-        iframe.allow =
-          "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
-        iframe.allowFullscreen = true;
-        iframe.className = "absolute top-0 left-0 h-full w-full";
-        container.innerHTML = "";
-        container.appendChild(iframe);
-        obs.disconnect();
-      }
-    });
-
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [videoId]);
-
-  const heroVariants = {
-    hidden: { opacity: 0, scale: 0.95 },
-    visible: {
-      opacity: [0, 1],
-      scale: [0.95, 1],
-      transition: {
-        ease: [0.33, 1, 0.68, 1],
-        staggerChildren: 0.2,
-        delayChildren: 0.1,
-      },
-    },
-  };
-
-  const heroItemVariants = {
-    hidden: { opacity: 0, y: 20, scale: 0.95 },
-    visible: {
-      opacity: [0, 1],
-      y: 0,
-      scale: [0.95, 1],
-      transition: { duration: 0.7, ease: [0.33, 1, 0.68, 1] },
-    },
-  };
-
-  const { scrollY } = useScroll();
-  const topBlobY = useTransform(scrollY, [0, 500], [0, -100]);
-  const bottomBlobY = useTransform(scrollY, [0, 500], [0, -150]);
-
-  useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 50);
-    window.addEventListener("scroll", handleScroll);
-    handleScroll();
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-  
   return (
     <>
       <Head>
@@ -235,290 +88,128 @@ export default function FinalCompleteLandingPage() {
       </Head>
 
       <div className="bg-white text-gray-800 font-sans">
-        
-        <header className={`fixed top-0 w-full z-50 backdrop-blur-md transition-all ${isScrolled ? 'bg-white shadow' : 'bg-white/60'}`}>
-            <div className="max-w-screen-xl mx-auto flex justify-between items-center h-20 px-6">
-                <Link href="/" className="font-bold text-2xl text-brand-dark flex items-center gap-2">
-                    <span className="text-brand-pink">[2]</span>
-                    <span>data2content</span>
-                </Link>
-                <nav className="flex items-center gap-5">
-                  {session ? (
-                     <Link href="/dashboard" className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors">Meu Painel</Link>
-                  ) : (
-                     <Link href="/login" onClick={() => trackEvent('login_link_click')} className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors">Fazer Login</Link>
-                  )}
-                    <ButtonPrimary href="/register" onClick={() => trackEvent('cta_start_now_click')}>Começar Agora</ButtonPrimary>
-                </nav>
-            </div>
-        </header>
-
+        <LandingHeader />
         <main className="snap-y snap-mandatory overflow-y-scroll h-screen scroll-pt-20">
-          {/* [CORREÇÃO] A altura mínima foi ajustada para 90vh para diminuir o espaço vertical. */}
-          <section className="snap-start relative flex flex-col h-screen pt-20 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
-            <div className="absolute inset-0 -z-10 overflow-hidden">
-              <motion.div
-                style={{ y: topBlobY }}
-                className="absolute top-0 left-1/2 -translate-x-1/2 w-[40rem] h-[40rem] bg-[radial-gradient(circle_at_top,rgba(236,72,153,0.35),transparent)]"
-              />
-              <motion.div
-                style={{ y: bottomBlobY }}
-                className="absolute bottom-20 right-0 w-72 h-72 bg-brand-pink/20 blur-3xl rounded-full"
-              />
+          <HeroSection />
+
+          <section className="snap-start py-10 sm:py-14 bg-gray-50/70">
+            <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
+              <AnimatedSection>
+                <SectionTitle>Veja Nossa IA em Ação.</SectionTitle>
+                <SectionSubtitle>Receba alertas, análises e ideias diretamente no seu WhatsApp, de forma clara e objetiva.</SectionSubtitle>
+              </AnimatedSection>
             </div>
-            {/* O container interno usa flex-grow e justify-start para alinhar o conteúdo ao topo. */}
-            <div className="flex-grow flex flex-col justify-start pt-32">
-                <div className="w-full">
-                    <motion.div
-                      variants={heroVariants}
-                      initial="hidden"
-                      animate="visible"
-                      className="w-full"
-                    >
-                      <div className="max-w-3xl mx-auto px-6 lg:px-8">
-                        <motion.h1
-                          variants={heroItemVariants}
-                          className="text-5xl md:text-7xl font-semibold tracking-tighter bg-gradient-to-r from-brand-pink to-brand-red bg-clip-text text-transparent"
-                        >
-                          A IA que diz o que postar no Instagram
-                        </motion.h1>
+            <ScreenshotCarousel items={exampleScreenshots} />
+          </section>
 
-                        <motion.p
-                          variants={heroItemVariants}
-                          className="mt-4 text-lg md:text-xl text-gray-600 max-w-2xl mx-auto"
-                        >
-                          Receba análises e ideias prontas direto no WhatsApp.
-                        </motion.p>
-
-                        <motion.div variants={heroItemVariants}>
-                          <ButtonPrimary onClick={handleSignIn} className="mt-8">
-                            <FaGoogle /> Ative sua IA do Instagram no WhatsApp ▸
-                          </ButtonPrimary>
-                        </motion.div>
-                        <motion.div variants={heroItemVariants}>
-                          <Link href="#features" onClick={() => trackEvent('saiba_mais_click')} className="mt-4 inline-block text-sm font-semibold text-brand-pink hover:underline">
-                            Saiba Mais
-                          </Link>
-                        </motion.div>
-                      </div>
-
-                      <motion.div
-                        variants={heroItemVariants}
-                        className="relative mt-12 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50"
-                      >
-                        <video
-                          autoPlay
-                          muted
-                          loop
-                          playsInline
-                          poster="/images/tuca-analise-whatsapp.png"
-                          src="/videos/hero-demo.mp4"
-                          className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </motion.div>
-
-                    </motion.div>
-                </div>
+          <section id="features" className="snap-start py-10 sm:py-14 bg-white">
+            <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
+              <AnimatedSection>
+                <SectionTitle>Feito para todos os tipos de criadores.</SectionTitle>
+                <SectionSubtitle>Se você cria conteúdo, a data2content trabalha para você. Nossa IA se adapta ao seu histórico de conteúdo, nicho e objetivos.</SectionSubtitle>
+              </AnimatedSection>
+              <div className="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                {creatorTypes.map((creator, index) => (
+                  <AnimatedSection delay={0.1 * (index + 1)} key={creator.title}>
+                    <PillarCard icon={creator.icon} title={creator.title}>
+                      {creator.description}
+                    </PillarCard>
+                  </AnimatedSection>
+                ))}
+              </div>
             </div>
           </section>
 
           <section className="snap-start py-10 sm:py-14 bg-gray-50/70">
-              <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
-                <AnimatedSection>
-                  <SectionTitle>Veja Nossa IA em Ação.</SectionTitle>
-                  <SectionSubtitle>Receba alertas, análises e ideias diretamente no seu WhatsApp, de forma clara e objetiva.</SectionSubtitle>
-                </AnimatedSection>
+            <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
+              <AnimatedSection>
+                <SectionTitle>Resultados que falam por si.</SectionTitle>
+                <SectionSubtitle>Criadores como você já estão economizando tempo e crescendo com mais estratégia.</SectionSubtitle>
+              </AnimatedSection>
+              <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-8">
+                {testimonials.map((testimonial, index) => (
+                  <AnimatedSection delay={0.1 * (index + 1)} key={testimonial.name}>
+                    <TestimonialCard {...testimonial} />
+                  </AnimatedSection>
+                ))}
               </div>
-              <div className="relative mt-6">
-                <motion.div
-                  ref={carouselRef}
-                  className="overflow-hidden snap-x snap-mandatory hide-scrollbar"
-                  drag="x"
-                  dragConstraints={{ left: 0, right: 0 }}
-                  dragElastic={0.05}
-                  style={{ touchAction: "pan-y" }}
-                  onDragEnd={(event, info: PanInfo) => {
-                    const pointerEvent = event as PointerEvent;
-                    if (pointerEvent.pointerType !== 'touch') return;
-                    if (info.offset.x < -50) {
-                      scrollCarousel('right');
-                    } else if (info.offset.x > 50) {
-                      scrollCarousel('left');
-                    }
-                  }}
-                >
-                    <div
-                      className="flex gap-8"
-                      style={{
-                        paddingTop: '1.5rem',
-                        paddingBottom: '1.5rem',
-                        paddingLeft: 'calc(max(0px, (100vw - 1280px) / 2) + 1.5rem)',
-                        paddingRight: 'calc(max(0px, (100vw - 1280px) / 2) + 1.5rem)'
-                      }}
-                    >
-                        {exampleScreenshots.map((item, index) => (
-                          <div key={index} className="flex flex-col items-start gap-2 flex-shrink-0 snap-center">
-                            <h3 className="font-bold text-lg text-gray-600 pl-1">{item.title}</h3>
-                            <ScreenshotCard imageUrl={item.imageUrl} title={item.title} />
-                          </div>
-                        ))}
-                    </div>
-                </motion.div>
-                <div className="absolute top-1/2 -translate-y-1/2 w-full flex justify-between px-4 pointer-events-none">
-                    <button
-                        onClick={() => scrollCarousel('left')}
-                        className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
-                        aria-label="Anterior"
-                    >
-                        <FaChevronLeft />
-                    </button>
-                    <button 
-                        onClick={() => scrollCarousel('right')} 
-                        className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
-                        aria-label="Próximo"
-                    >
-                        <FaChevronRight />
-                    </button>
-                </div>
+            </div>
+          </section>
+
+          <section id="arthur-marba" className="snap-start py-10 sm:py-14 bg-white">
+            <div className="max-w-screen-md mx-auto px-6 text-left">
+              <AnimatedSection>
+                <SectionTitle className="text-3xl">Conheça o Fundador da data2content</SectionTitle>
+                <p className="mt-5 text-lg text-gray-600 leading-relaxed">Arthur Marbá, Fundador da data2content, une 10 anos de marketing digital para criadores a uma herança familiar de 40 anos no agenciamento de talentos. Ele percebeu que criadores precisam de um especialista para traduzir dados em direcionamento estratégico. O Mobi é a personificação dessa filosofia.</p>
+                <blockquote className="mt-5 pl-5 border-l-4 border-brand-pink italic text-gray-700 text-lg">
+                  "Democratizamos a consultoria estratégica, tornando-a acessível, proativa e capaz de evoluir com cada criador, tudo via WhatsApp."
+                  <cite className="mt-4 block text-base font-semibold text-brand-dark not-italic">- Arthur Marbá, Fundador</cite>
+                </blockquote>
+              </AnimatedSection>
+
+              <AnimatedSection delay={0.1}>
+                <FounderVideo videoId={videoId} />
+              </AnimatedSection>
+            </div>
+          </section>
+
+          <section id="faq" className="snap-start py-10 sm:py-14 bg-white">
+            <div className="max-w-3xl mx-auto px-6">
+              <AnimatedSection className="text-left mb-10">
+                <SectionTitle>Dúvidas Frequentes</SectionTitle>
+              </AnimatedSection>
+              <div className="space-y-4">
+                {faqItems.map((item, index) => (
+                  <AnimatedSection delay={0.05 * (index + 1)} key={index}>
+                    <details className="group bg-gray-50/80 p-6 rounded-lg transition-shadow duration-200 hover:shadow-lg">
+                      <summary className="flex justify-between items-center text-lg font-semibold text-brand-dark cursor-pointer list-none">
+                        {item.q}
+                        <span className="text-brand-pink transition-transform duration-300 group-open:rotate-180">
+                          <FaQuestionCircle />
+                        </span>
+                      </summary>
+                      <div
+                        className="text-gray-700 mt-4 text-base font-light leading-relaxed whitespace-pre-line"
+                        dangerouslySetInnerHTML={{ __html: item.a.replace(/\n\n\*/g, '<br /><br />&#8226; ').replace(/\n\*/g, '<br />&#8226; ').replace(/\n/g, '<br />') }}
+                      />
+                    </details>
+                  </AnimatedSection>
+                ))}
               </div>
-            </section>
+            </div>
+          </section>
 
-            <section id="features" className="snap-start py-10 sm:py-14 bg-white">
-                <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
-                    <AnimatedSection>
-                        <SectionTitle>Feito para todos os tipos de criadores.</SectionTitle>
-                        <SectionSubtitle>Se você cria conteúdo, a data2content trabalha para você. Nossa IA se adapta ao seu histórico de conteúdo, nicho e objetivos.</SectionSubtitle>
-                    </AnimatedSection>
-                    <div className="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                        {creatorTypes.map((creator, index) => (
-                            <AnimatedSection delay={0.1 * (index + 1)} key={creator.title}>
-                                <PillarCard icon={creator.icon} title={creator.title}>
-                                    {creator.description}
-                                </PillarCard>
-                            </AnimatedSection>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            <section className="snap-start py-10 sm:py-14 bg-gray-50/70">
-                <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">
-                    <AnimatedSection>
-                        <SectionTitle>Resultados que falam por si.</SectionTitle>
-                        <SectionSubtitle>Criadores como você já estão economizando tempo e crescendo com mais estratégia.</SectionSubtitle>
-                    </AnimatedSection>
-                    <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-8">
-                        {testimonials.map((testimonial, index) => (
-                            <AnimatedSection delay={0.1 * (index + 1)} key={testimonial.name}>
-                                <TestimonialCard {...testimonial} />
-                            </AnimatedSection>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            <section id="arthur-marba" className="snap-start py-10 sm:py-14 bg-white">
-                <div className="max-w-screen-md mx-auto px-6 text-left">
-                    <AnimatedSection>
-                        <SectionTitle className="text-3xl">Conheça o Fundador da data2content</SectionTitle>
-                        <p className="mt-5 text-lg text-gray-600 leading-relaxed">Arthur Marbá, Fundador da data2content, une 10 anos de marketing digital para criadores a uma herança familiar de 40 anos no agenciamento de talentos. Ele percebeu que criadores precisam de um especialista para traduzir dados em direcionamento estratégico. O Mobi é a personificação dessa filosofia.</p>
-                        <blockquote className="mt-5 pl-5 border-l-4 border-brand-pink italic text-gray-700 text-lg">
-                            "Democratizamos a consultoria estratégica, tornando-a acessível, proativa e capaz de evoluir com cada criador, tudo via WhatsApp."
-                            <cite className="mt-4 block text-base font-semibold text-brand-dark not-italic">- Arthur Marbá, Fundador</cite>
-                        </blockquote>
-                    </AnimatedSection>
-                    
-                    <AnimatedSection delay={0.1}>
-                        <div
-                            ref={videoRef}
-                            className="relative mt-10 overflow-hidden rounded-2xl shadow-lg w-full aspect-video"
-                        >
-                            <img
-                                src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
-                                alt="Thumbnail do vídeo"
-                                className="absolute top-0 left-0 h-full w-full object-cover"
-                                loading="lazy"
-                                decoding="async"
-                            />
-                            <div className="absolute inset-0 flex items-center justify-center">
-                                <div className="bg-black/60 rounded-full p-4">
-                                    <FaPlay className="text-white text-3xl" />
-                                </div>
-                            </div>
-                        </div>
-                    </AnimatedSection>
-                </div>
-            </section>
-
-            <section id="faq" className="snap-start py-10 sm:py-14 bg-white">
-                <div className="max-w-3xl mx-auto px-6">
-                    <AnimatedSection className="text-left mb-10">
-                        <SectionTitle>Dúvidas Frequentes</SectionTitle>
-                    </AnimatedSection>
-                    <div className="space-y-4">
-                        {faqItems.map((item, index) => (
-                            <AnimatedSection delay={0.05 * (index + 1)} key={index}>
-                                <details className="group bg-gray-50/80 p-6 rounded-lg transition-shadow duration-200 hover:shadow-lg">
-                                    <summary className="flex justify-between items-center text-lg font-semibold text-brand-dark cursor-pointer list-none">
-                                        {item.q}
-                                        <span className="text-brand-pink transition-transform duration-300 group-open:rotate-180">
-                                            <FaQuestionCircle />
-                                        </span>
-                                    </summary>
-                                    <div className="text-gray-700 mt-4 text-base font-light leading-relaxed whitespace-pre-line"
-                                       dangerouslySetInnerHTML={{ __html: item.a.replace(/\n\n\*/g, '<br /><br />&#8226; ').replace(/\n\*/g, '<br />&#8226; ').replace(/\n/g, '<br />') }}
-                                    ></div>
-                                </details>
-                            </AnimatedSection>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            <section className="snap-start py-12 sm:py-20 bg-brand-dark text-white">
-                <div className="max-w-screen-xl mx-auto px-6 text-left">
-                    <AnimatedSection className="max-w-3xl">
-                        <SectionTitle className="text-white">Pronto para transformar sua criação de conteúdo?</SectionTitle>
-                        <SectionSubtitle className="text-gray-300">Pare de adivinhar e comece a crescer com estratégia. O Mobi está esperando por você.</SectionSubtitle>
-                        <div className="mt-10">
-                           <ButtonPrimary onClick={handleSignIn}>
-                               <FaGoogle /> Ativar meu estrategista agora ▸
-                           </ButtonPrimary>
-                        </div>
-                    </AnimatedSection>
-                </div>
-            </section>
+          <CallToAction />
         </main>
 
         <footer className="text-center py-8 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 border-t">
-            <div className="mb-4 text-brand-dark font-bold text-2xl flex justify-center items-center gap-2"><span className="text-brand-pink">[2]</span>data2content</div>
-            <p className="text-sm text-gray-500 mb-4">© {new Date().getFullYear()} Mobi Media Produtores de Conteúdo LTDA.</p>
-            <div className="flex justify-center gap-6 text-sm">
-                 <Link href="/politica-de-privacidade" className="text-gray-600 hover:text-brand-pink transition-colors">Política de Privacidade</Link>
-                 <Link href="/termos-e-condicoes" className="text-gray-600 hover:text-brand-pink transition-colors">Termos e Condições</Link>
-            </div>
+          <div className="mb-4 text-brand-dark font-bold text-2xl flex justify-center items-center gap-2"><span className="text-brand-pink">[2]</span>data2content</div>
+          <p className="text-sm text-gray-500 mb-4">© {new Date().getFullYear()} Mobi Media Produtores de Conteúdo LTDA.</p>
+          <div className="flex justify-center gap-6 text-sm">
+            <Link href="/politica-de-privacidade" className="text-gray-600 hover:text-brand-pink transition-colors">Política de Privacidade</Link>
+            <Link href="/termos-e-condicoes" className="text-gray-600 hover:text-brand-pink transition-colors">Termos e Condições</Link>
+          </div>
         </footer>
       </div>
 
       <style jsx global>{`
         :root {
-            --brand-pink: #FF85C0;
-            --brand-red: #FF6B6B;
-            --brand-dark: #111827;
+          --brand-pink: #FF85C0;
+          --brand-red: #FF6B6B;
+          --brand-dark: #111827;
         }
         html {
-            font-family: 'Inter', sans-serif;
+          font-family: 'Inter', sans-serif;
         }
         .hide-scrollbar::-webkit-scrollbar {
-            display: none;
+          display: none;
         }
         .hide-scrollbar {
-            -ms-overflow-style: none;
-            scrollbar-width: none;
+          -ms-overflow-style: none;
+          scrollbar-width: none;
         }
       `}</style>
     </>
-    )
+  );
 }
+


### PR DESCRIPTION
## Summary
- refactor landing page into a server component
- move interactive hero, header, carousel, video, CTA and animated sections into client components

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: multiple modules missing and TextEncoder undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6891386f6384832e9abfbf64039e3c59