### PR TITLE
Add landing page SEO metadata and structured data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { FaChalkboardTeacher, FaBullhorn, FaStar, FaQuestionCircle } from "react-icons/fa";
 import testimonials from "@/data/testimonials";
 import faqItems from "@/data/faq";
+import { landingMetadata, landingJsonLd } from "@/seo/landing";
 
 const AnimatedSection = dynamic(() => import("./landing/components/AnimatedSection"), { ssr: false });
 const LandingHeader = dynamic(() => import("./landing/components/LandingHeader"), { ssr: false });
@@ -77,15 +77,17 @@ const TestimonialCard = ({ name, handle, quote, avatarUrl }: { name: string; han
   </div>
 );
 
+export const metadata = landingMetadata;
+
 export default function FinalCompleteLandingPage() {
   const videoId = "dQw4w9WgXcQ";
 
   return (
     <>
-      <Head>
-        <title>data2content - Menos análise, mais criação.</title>
-        <meta name="description" content="Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer." />
-      </Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(landingJsonLd) }}
+      />
 
       <div className="bg-white text-gray-800 font-sans">
         <LandingHeader />

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+export const landingMetadata: Metadata = {
+  title: "data2content - Menos análise, mais criação.",
+  description:
+    "Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer.",
+  openGraph: {
+    title: "data2content - Menos análise, mais criação.",
+    description:
+      "Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer.",
+    url: "https://data2content.ai",
+    type: "website",
+    images: [
+      {
+        url: "/images/Colorido-Simbolo.png",
+        width: 1200,
+        height: 630,
+        alt: "data2content logo"
+      }
+    ]
+  },
+  twitter: {
+    card: "summary_large_image",
+    creator: "@data2content"
+  }
+};
+
+export const landingJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "data2content",
+  url: "https://data2content.ai"
+};


### PR DESCRIPTION
## Summary
- centralize landing page metadata with Open Graph and Twitter fields
- inject WebSite JSON-LD schema for structured data

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and TextEncoder is not defined)*
- `npm run lint` *(failed: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68913bbce2f4832e9c320015da3986b6