### PR TITLE
feat: add descriptions to landing screenshots

### DIFF
--- a/src/app/landing/components/ExamplesSlide.tsx
+++ b/src/app/landing/components/ExamplesSlide.tsx
@@ -3,8 +3,19 @@
 import { motion, useScroll, useTransform } from 'framer-motion';
 import { useRef } from 'react';
 import { ScrollCue } from './ScrollCue';
+import ScreenshotCarousel from './ScreenshotCarousel';
 
-export function ExamplesSlide() {
+interface ScreenshotItem {
+  title: string;
+  imageUrl: string;
+  description: string;
+}
+
+interface ExamplesSlideProps {
+  screenshots: ScreenshotItem[];
+}
+
+export function ExamplesSlide({ screenshots }: ExamplesSlideProps) {
   const ref = useRef<HTMLElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] });
   const opacity = useTransform(scrollYProgress, [0, 0.3, 1], [0, 1, 1]);
@@ -19,6 +30,9 @@ export function ExamplesSlide() {
     >
       <h2 className="text-3xl font-bold mb-4">Exemplos</h2>
       <p>Veja como nosso produto pode ajudar você.</p>
+      <div className="mt-8 w-full">
+        <ScreenshotCarousel items={screenshots} />
+      </div>
       <ScrollCue targetId="features" direction="up" />
     </motion.section>
   );

--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -2,12 +2,13 @@
 
 import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
-import { motion, PanInfo } from 'framer-motion';
+import { motion, PanInfo, useMotionValueEvent, useScroll } from 'framer-motion';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 
 interface Screenshot {
   title: string;
   imageUrl: string;
+  description: string;
 }
 
 interface ScreenshotCarouselProps {
@@ -16,6 +17,18 @@ interface ScreenshotCarouselProps {
 
 export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
   const carouselRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const { scrollX } = useScroll({ container: carouselRef });
+  useMotionValueEvent(scrollX, 'change', (latest) => {
+    const card = carouselRef.current?.children[0] as HTMLElement;
+    const cardWidth = card?.offsetWidth || 0;
+    const gap = 32;
+    if (cardWidth === 0) return;
+    const index = Math.round(latest / (cardWidth + gap));
+    if (index >= 0 && index < items.length) {
+      setActiveIndex(index);
+    }
+  });
 
   const scrollCarousel = (direction: 'left' | 'right') => {
     if (carouselRef.current) {
@@ -115,6 +128,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
           <FaChevronRight />
         </button>
       </div>
+      <p className="mt-4 text-center text-gray-600 max-w-md mx-auto">{items[activeIndex]?.description}</p>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,6 +49,24 @@ const TestimonialCard = ({ name, handle, quote, avatarUrl }: { name: string; han
   </div>
 );
 
+const exampleScreenshots = [
+  {
+    title: "Análises no WhatsApp",
+    imageUrl: "/images/tuca-analise-whatsapp.png",
+    description: "Receba insights do Mobi diretamente pelo WhatsApp para agir rapidamente.",
+  },
+  {
+    title: "Nova análise",
+    imageUrl: "/images/tuca-nova-analise.png",
+    description: "Descubra oportunidades de conteúdo com base nos dados mais recentes.",
+  },
+  {
+    title: "Comunidade Tuca",
+    imageUrl: "/images/Tuca-comunidade.png",
+    description: "Aprenda com outros criadores e compartilhe experiências na comunidade.",
+  },
+];
+
 export default function FinalCompleteLandingPage() {
   const videoId = "dQw4w9WgXcQ";
 
@@ -64,7 +82,7 @@ export default function FinalCompleteLandingPage() {
         <main className="snap-y snap-mandatory overflow-y-scroll h-screen scroll-pt-20">
           <IntroSlide />
           <FeaturesSlide />
-          <ExamplesSlide />
+          <ExamplesSlide screenshots={exampleScreenshots} />
 
           <section className="snap-start py-10 sm:py-14 bg-gray-50/70">
             <div className="mx-auto max-w-screen-xl px-6 lg:px-8 text-left">


### PR DESCRIPTION
## Summary
- add descriptions to landing screenshot data
- show active screenshot description in carousel using framer-motion

## Testing
- `npm test` *(fails: TextEncoder is not defined / Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689163670a24832eb870090aa27acb33