### PR TITLE
chore: rely on tailwind brand colors

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,18 @@
+# Design Tokens
+
+## Cores da marca
+
+As cores abaixo estão configuradas no `tailwind.config.ts` e podem ser utilizadas através das classes utilitárias do Tailwind.
+
+| Nome        | Classe Tailwind         | Valor HEX |
+|-------------|-------------------------|-----------|
+| `brand-dark` | `text-brand-dark`, `bg-brand-dark`, `border-brand-dark` | `#191E1E` |
+| `brand-red`  | `text-brand-red`, `bg-brand-red`, `border-brand-red`    | `#FF6B6B` |
+| `brand-pink` | `text-brand-pink`, `bg-brand-pink`, `border-brand-pink` | `#FF85C0` |
+| `brand-light`| `text-brand-light`, `bg-brand-light`, `border-brand-light` | `#F0F7F7` |
+
+Exemplo de uso:
+
+```tsx
+<p className="text-brand-pink bg-brand-light">Texto com as cores da marca</p>
+```

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -157,11 +157,6 @@ export default function FinalCompleteLandingPage() {
       </div>
 
       <style jsx global>{`
-        :root {
-          --brand-pink: #FF85C0;
-          --brand-red: #FF6B6B;
-          --brand-dark: #111827;
-        }
         html {
           font-family: 'Inter', sans-serif;
         }


### PR DESCRIPTION
## Summary
- remove brand CSS variables from landing page and rely on Tailwind classes
- document available brand colors

## Testing
- `npm test` (fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, etc.)
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68917e8fa758832e9c21d0e373b29b02