### PR TITLE
feat: update landing slides to new brand theme

### DIFF
--- a/src/app/landing/components/ExamplesSlide.tsx
+++ b/src/app/landing/components/ExamplesSlide.tsx
@@ -25,13 +25,15 @@ export function ExamplesSlide({ screenshots }: ExamplesSlideProps) {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex flex-col items-center justify-center bg-purple-600 text-white"
+      className="relative h-screen flex flex-col items-center justify-center bg-brand-light text-brand-dark"
       id="examples"
     >
-      <h2 className="text-3xl font-bold mb-4">Exemplos</h2>
-      <p>Veja como nosso produto pode ajudar você.</p>
-      <div className="mt-8 w-full">
-        <ScreenshotCarousel items={screenshots} />
+      <div className="max-w-screen-xl mx-auto px-6 text-center">
+        <h2 className="text-3xl md:text-4xl font-bold mb-4">Exemplos</h2>
+        <p className="text-lg">Veja como nosso produto pode ajudar você.</p>
+        <div className="mt-8 w-full">
+          <ScreenshotCarousel items={screenshots} />
+        </div>
       </div>
       <ScrollCue targetId="features" direction="up" />
     </motion.section>

--- a/src/app/landing/components/FeaturesSlide.tsx
+++ b/src/app/landing/components/FeaturesSlide.tsx
@@ -14,15 +14,17 @@ export function FeaturesSlide() {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex flex-col items-center justify-center bg-green-600 text-white"
+      className="relative h-screen flex flex-col items-center justify-center bg-gradient-to-r from-brand-pink to-brand-red text-brand-dark"
       id="features"
     >
-      <h2 className="text-3xl font-bold mb-4">Recursos</h2>
-      <ul className="list-disc">
-        <li>Recurso 1</li>
-        <li>Recurso 2</li>
-        <li>Recurso 3</li>
-      </ul>
+      <div className="max-w-screen-xl mx-auto px-6 text-center">
+        <h2 className="text-3xl md:text-4xl font-bold mb-6">Recursos</h2>
+        <ul className="space-y-2">
+          <li>Recurso 1</li>
+          <li>Recurso 2</li>
+          <li>Recurso 3</li>
+        </ul>
+      </div>
       <ScrollCue targetId="examples" />
       <ScrollCue targetId="intro" direction="up" />
     </motion.section>

--- a/src/app/landing/components/IntroSlide.tsx
+++ b/src/app/landing/components/IntroSlide.tsx
@@ -14,10 +14,12 @@ export function IntroSlide() {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex items-center justify-center bg-blue-600 text-white"
+      className="relative h-screen flex items-center justify-center bg-brand-light text-brand-dark"
       id="intro"
     >
-      <h1 className="text-4xl font-bold">Bem-vindo ao Data2Content</h1>
+      <div className="max-w-screen-xl mx-auto px-6 text-center">
+        <h1 className="text-4xl md:text-5xl font-bold">Bem-vindo ao Data2Content</h1>
+      </div>
       <ScrollCue targetId="features" />
     </motion.section>
   );

--- a/src/app/landing/components/ScrollCue.tsx
+++ b/src/app/landing/components/ScrollCue.tsx
@@ -17,7 +17,7 @@ export function ScrollCue({ targetId, direction = 'down' }: ScrollCueProps) {
     <button
       onClick={handleClick}
       aria-label={`Scroll ${direction}`}
-      className="absolute left-1/2 -translate-x-1/2 text-white animate-bounce p-2"
+      className="absolute left-1/2 -translate-x-1/2 text-brand-dark animate-bounce p-2"
       style={direction === 'down' ? { bottom: '1rem' } : { top: '1rem' }}
     >
       {direction === 'down' ? <ChevronDown size={32} /> : <ChevronUp size={32} />}


### PR DESCRIPTION
## Summary
- refactor landing slides to use brand light and gradient backgrounds
- unify slide typography and spacing with standard container classes
- update scroll cue arrow to match brand-dark coloring

## Testing
- `npm test` *(fails: module resolution, TextEncoder and Response references)*

------
https://chatgpt.com/codex/tasks/task_e_6891f7669bc8832e9c385e4cb2a9f640