### PR TITLE
feat: add legacy hero section

### DIFF
--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -6,7 +6,11 @@ import { useEffect, useState } from 'react';
 import ButtonPrimary from './ButtonPrimary';
 import Container from '../../components/Container';
 
-export default function LandingHeader() {
+interface LandingHeaderProps {
+  showLoginButton?: boolean;
+}
+
+export default function LandingHeader({ showLoginButton = false }: LandingHeaderProps) {
   const { data: session } = useSession();
   const [isScrolled, setIsScrolled] = useState(false);
 
@@ -38,6 +42,10 @@ export default function LandingHeader() {
             >
               Meu Painel
             </Link>
+          ) : showLoginButton ? (
+            <ButtonPrimary href="/login" onClick={() => trackEvent('login_button_click')}>
+              Fazer Login
+            </ButtonPrimary>
           ) : (
             <Link
               href="/login"

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import ButtonPrimary from './ButtonPrimary';
+
+export default function LegacyHero() {
+  return (
+    <section className="snap-start relative flex flex-col h-screen pt-20 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
+      <div className="flex-grow flex flex-col justify-center px-6">
+        <h1 className="text-5xl md:text-7xl font-semibold tracking-tight text-brand-dark">
+          O fim da dúvida: o que postar hoje
+        </h1>
+        <p className="mt-4 text-lg md:text-xl text-gray-600">
+          Uma inteligência artificial conectada ao Instagram e conversa no WhatsApp
+        </p>
+        <ButtonPrimary href="/login" className="mt-8">
+          Fazer Login
+        </ButtonPrimary>
+        <div className="mt-12">
+          <video
+            autoPlay
+            muted
+            loop
+            playsInline
+            poster="/images/tuca-analise-whatsapp.png"
+            src="/videos/hero-demo.mp4"
+            className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
+            loading="lazy"
+            decoding="async"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,11 +14,15 @@ import { IntroSlide } from "./landing/components/IntroSlide";
 import { FeaturesSlide } from "./landing/components/FeaturesSlide";
 import { ExamplesSlide } from "./landing/components/ExamplesSlide";
 import Container from "./components/Container";
+import LegacyHero from "./landing/components/LegacyHero";
 
 const AnimatedSection = withViewport(
   dynamic(() => import("./landing/components/AnimatedSection"), { ssr: false })
 );
-const LandingHeader = dynamic(() => import("./landing/components/LandingHeader"), { ssr: false });
+const LandingHeader = dynamic(
+  () => import("./landing/components/LandingHeader"),
+  { ssr: false }
+) as React.ComponentType<{ showLoginButton?: boolean }>;
 const FounderVideo = withViewport(
   dynamic(() => import("./landing/components/FounderVideo"), { ssr: false })
 );
@@ -79,8 +83,9 @@ export default function FinalCompleteLandingPage() {
       />
 
       <div className="bg-white text-gray-800 font-sans">
-        <LandingHeader />
+        <LandingHeader showLoginButton />
         <main className="snap-y snap-mandatory overflow-y-scroll h-screen scroll-pt-20">
+          <LegacyHero />
           <IntroSlide />
           <FeaturesSlide />
           <ExamplesSlide screenshots={exampleScreenshots} />


### PR DESCRIPTION
## Summary
- add LegacyHero component with login button and video
- load LegacyHero before IntroSlide and enable header login button
- support login button display in LandingHeader

## Testing
- `npm test` *(fails: Request/TextEncoder not defined, missing modules)*
- `npm run lint` *(interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68920d89818c832e8e1ca24ce625c866