### PR TITLE
chore: lazy load hero video

### DIFF
--- a/src/app/landing/components/HeroVideo.tsx
+++ b/src/app/landing/components/HeroVideo.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export default function HeroVideo() {
+  return (
+    <video
+      autoPlay
+      muted
+      loop
+      playsInline
+      controls
+      poster="/images/tuca-analise-whatsapp.png"
+      className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
+      preload="none"
+      loading="lazy"
+      decoding="async"
+    >
+      <source src="/videos/hero-demo.webm" type="video/webm" />
+      <source src="/videos/hero-demo.mp4" type="video/mp4" />
+      Seu navegador não suporta o elemento de vídeo.
+    </video>
+  );
+}
+

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -1,6 +1,18 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import ButtonPrimary from './ButtonPrimary';
+
+const HeroVideo = dynamic(() => import('./HeroVideo'), {
+  ssr: false,
+  loading: () => (
+    <img
+      src="/images/tuca-analise-whatsapp.png"
+      alt="Demonstração do produto"
+      className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
+    />
+  ),
+});
 
 export default function LegacyHero() {
   return (
@@ -16,17 +28,7 @@ export default function LegacyHero() {
           Fazer Login
         </ButtonPrimary>
         <div className="mt-12">
-          <video
-            autoPlay
-            muted
-            loop
-            playsInline
-            poster="/images/tuca-analise-whatsapp.png"
-            src="/videos/hero-demo.mp4"
-            className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
-            loading="lazy"
-            decoding="async"
-          />
+          <HeroVideo />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Lazy load landing hero video via dynamic import to reduce LCP impact
- Add HeroVideo component with poster, controls and fallback sources

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689221dd2c08832e800f71f4fec7cec7