### PR TITLE
feat: add animated marquee to legacy hero

### DIFF
--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -2,6 +2,7 @@
 
 import ButtonPrimary from './ButtonPrimary';
 import { TypeAnimation } from 'react-type-animation';
+import Marquee from './Marquee';
 
 export default function LegacyHero() {
   return (
@@ -40,6 +41,10 @@ export default function LegacyHero() {
             decoding="async"
           />
         </div>
+      </div>
+      <div className="mt-8 space-y-2 overflow-hidden">
+        <Marquee direction="left" />
+        <Marquee direction="right" />
       </div>
     </section>
   );

--- a/src/app/landing/components/Marquee.tsx
+++ b/src/app/landing/components/Marquee.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { motion } from "framer-motion";
+import heroQuestions from "@/data/heroQuestions";
+
+interface MarqueeProps {
+  direction?: "left" | "right";
+}
+
+export default function Marquee({ direction = "left" }: MarqueeProps) {
+  const questions = [...heroQuestions, ...heroQuestions];
+  const animateFrom = direction === "left" ? "0%" : "-100%";
+  const animateTo = direction === "left" ? "-100%" : "0%";
+
+  return (
+    <div className="overflow-hidden whitespace-nowrap">
+      <motion.div
+        className="flex gap-8"
+        animate={{ x: [animateFrom, animateTo] }}
+        transition={{ repeat: Infinity, ease: "linear", duration: 30 }}
+      >
+        {questions.map((q, idx) => (
+          <span key={idx} className="text-sm md:text-base text-gray-600">
+            {q}
+          </span>
+        ))}
+      </motion.div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Marquee component with continuous scroll of landing questions
- show two marquees at bottom of LegacyHero with opposing directions

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68922ebcf390832e9663c40d4a80393a