### PR TITLE
refactor hero typing effect

### DIFF
--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import ButtonPrimary from './ButtonPrimary';
-import { TypeAnimation } from 'react-type-animation';
+import dynamic from 'next/dynamic';
 import Marquee from './Marquee';
+
+const TypingEffect = dynamic(() => import('./TypingEffect'), { ssr: false });
 
 export default function LegacyHero() {
   return (
@@ -11,7 +13,7 @@ export default function LegacyHero() {
         <h1 className="text-5xl md:text-7xl font-semibold tracking-tight text-brand-dark">
           O fim da dúvida: o que postar hoje
         </h1>
-        <TypeAnimation
+        <TypingEffect
           sequence={[
             'Uma inteligência artificial',
             1000,
@@ -20,9 +22,6 @@ export default function LegacyHero() {
             'que conversa no WhatsApp',
             1000,
           ]}
-          wrapper="p"
-          speed={50}
-          repeat={Infinity}
           className="mt-4 text-lg md:text-xl text-gray-600"
         />
         <ButtonPrimary href="/login" className="mt-8">

--- a/src/app/landing/components/TypingEffect.tsx
+++ b/src/app/landing/components/TypingEffect.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { TypeAnimation } from 'react-type-animation';
+
+interface TypingEffectProps {
+  sequence: (string | number)[];
+  className?: string;
+}
+
+export default function TypingEffect({ sequence, className }: TypingEffectProps) {
+  return (
+    <TypeAnimation
+      sequence={sequence}
+      wrapper="p"
+      speed={50}
+      repeat={Infinity}
+      className={className}
+    />
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,17 @@ import { FaQuestionCircle } from "react-icons/fa";
 import testimonials from "@/data/testimonials";
 import faqItems from "@/data/faq";
 import { landingJsonLd } from "@/seo/landing";
-import { IntroSlide } from "./landing/components/IntroSlide";
-import { FeaturesSlide } from "./landing/components/FeaturesSlide";
-import { ExamplesSlide } from "./landing/components/ExamplesSlide";
 import Container from "./components/Container";
-import LegacyHero from "./landing/components/LegacyHero";
+const LegacyHero = dynamic(() => import("./landing/components/LegacyHero"), { ssr: false });
+const IntroSlide = withViewport(
+  dynamic(() => import("./landing/components/IntroSlide"), { ssr: false })
+);
+const FeaturesSlide = withViewport(
+  dynamic(() => import("./landing/components/FeaturesSlide"), { ssr: false })
+);
+const ExamplesSlide = withViewport(
+  dynamic(() => import("./landing/components/ExamplesSlide"), { ssr: false })
+);
 
 const AnimatedSection = withViewport(
   dynamic(() => import("./landing/components/AnimatedSection"), { ssr: false })


### PR DESCRIPTION
## Summary
- extract typing effect into dedicated component for landing hero
- dynamically load hero and slide components with viewport-based hydration

## Testing
- `npm test` (fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and related TextEncoder errors)
- `npm run lint` (interactive prompt aborted)

------
https://chatgpt.com/codex/tasks/task_e_689231dcef38832e869a2e76aeaadf9e