### PR TITLE
feat: add scroll cue to legacy hero

### DIFF
--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -4,6 +4,7 @@ import ButtonPrimary from './ButtonPrimary';
 import dynamic from 'next/dynamic';
 import Marquee from './Marquee';
 import Container from '../../components/Container';
+import { ScrollCue } from './ScrollCue';
 
 const TypingEffect = dynamic(() => import('./TypingEffect'), { ssr: false });
 
@@ -45,6 +46,9 @@ export default function LegacyHero() {
       <div className="mt-8 space-y-2 overflow-hidden">
         <Marquee direction="left" />
         <Marquee direction="right" />
+      </div>
+      <div className="relative mt-6 h-12">
+        <ScrollCue targetId="intro" />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add ScrollCue import and component to LegacyHero

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' from 'src/charts/getRadarChartData.test.ts', ReferenceError: TextEncoder is not defined, Response is not defined, Element type is invalid)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689249ce4de8832ea33123bcceabbcc0