### PR TITLE
Use min-h-screen for landing slide sections

### DIFF
--- a/src/app/landing/components/ExamplesSlide.tsx
+++ b/src/app/landing/components/ExamplesSlide.tsx
@@ -26,7 +26,7 @@ export function ExamplesSlide({ screenshots }: ExamplesSlideProps) {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex flex-col items-center justify-center bg-brand-light text-brand-dark"
+      className="relative min-h-screen flex flex-col items-center justify-center bg-brand-light text-brand-dark py-20"
       id="examples"
     >
       <Container className="text-center">

--- a/src/app/landing/components/FeaturesSlide.tsx
+++ b/src/app/landing/components/FeaturesSlide.tsx
@@ -15,7 +15,7 @@ export function FeaturesSlide() {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex flex-col items-center justify-center bg-gradient-to-r from-brand-pink to-brand-red text-brand-dark"
+      className="relative min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-brand-pink to-brand-red text-brand-dark py-20"
       id="features"
     >
       <Container className="text-center">

--- a/src/app/landing/components/IntroSlide.tsx
+++ b/src/app/landing/components/IntroSlide.tsx
@@ -15,7 +15,7 @@ export function IntroSlide() {
     <motion.section
       ref={ref}
       style={{ opacity, y }}
-      className="relative h-screen flex items-center justify-center bg-brand-light text-brand-dark"
+      className="relative min-h-screen flex items-center justify-center bg-brand-light text-brand-dark py-20"
       id="intro"
     >
       <Container className="text-center">


### PR DESCRIPTION
## Summary
- use `min-h-screen` on landing slide sections to avoid forcing full height
- add `py-20` for consistent vertical spacing

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; ReferenceError: TextEncoder is not defined)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68924c73dca8832eba2201bf5d80f488