### PR TITLE
feat: apply Poppins font globally

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 
 import type { Metadata } from "next";
-import { Poppins, Inter } from "next/font/google";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 
 // Imports do NextAuth para buscar a sessão no servidor
@@ -22,10 +22,6 @@ const poppins = Poppins({
   variable: "--font-poppins",
 });
 
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Data2Content: Gestão de Carreira IA para Criadores",
@@ -50,7 +46,7 @@ export default async function RootLayout({
       </head>
       <body
         className={`
-          ${inter.className}
+          ${poppins.className}
           antialiased
           flex
           flex-col


### PR DESCRIPTION
## Summary
- drop Inter font
- use Poppins on the body element

## Testing
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689264e129a0832eaf8dce453f30339e