### PR TITLE
Remove founder video section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,9 +29,6 @@ const LandingHeader = dynamic(
   () => import("./landing/components/LandingHeader"),
   { ssr: false }
 ) as React.ComponentType<{ showLoginButton?: boolean }>;
-const FounderVideo = withViewport(
-  dynamic(() => import("./landing/components/FounderVideo"), { ssr: false })
-);
 const CallToAction = withViewport(
   dynamic(() => import("./landing/components/CallToAction"), { ssr: false })
 );
@@ -79,8 +76,6 @@ const exampleScreenshots = [
 ];
 
 export default function FinalCompleteLandingPage() {
-  const videoId = "dQw4w9WgXcQ";
-
   return (
     <>
       <script
@@ -112,23 +107,6 @@ export default function FinalCompleteLandingPage() {
                 ))}
               </div>
             </Container>
-          </section>
-
-          <section id="arthur-marba" className="snap-start py-10 sm:py-14 bg-white">
-            <div className="max-w-screen-md mx-auto px-6 text-left">
-              <AnimatedSection>
-                <SectionTitle className="text-3xl">Conheça o Fundador da data2content</SectionTitle>
-                <p className="mt-5 text-lg text-gray-600 leading-relaxed">Arthur Marbá, Fundador da data2content, une 10 anos de marketing digital para criadores a uma herança familiar de 40 anos no agenciamento de talentos. Ele percebeu que criadores precisam de um especialista para traduzir dados em direcionamento estratégico. O Mobi é a personificação dessa filosofia.</p>
-                <blockquote className="mt-5 pl-5 border-l-4 border-brand-pink italic text-gray-700 text-lg">
-                  "Democratizamos a consultoria estratégica, tornando-a acessível, proativa e capaz de evoluir com cada criador, tudo via WhatsApp."
-                  <cite className="mt-4 block text-base font-semibold text-brand-dark not-italic">- Arthur Marbá, Fundador</cite>
-                </blockquote>
-              </AnimatedSection>
-
-              <AnimatedSection delay={0.1}>
-                <FounderVideo videoId={videoId} />
-              </AnimatedSection>
-            </div>
           </section>
 
           <section id="faq" className="snap-start py-10 sm:py-14 bg-white">


### PR DESCRIPTION
## Summary
- remove FounderVideo import and usage
- drop founder section from landing page

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; TextEncoder is not defined)*
- `CI=1 npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: failed to fetch font `Poppins` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6892941e0edc832eb0896ebb8b778aa4