### PR TITLE
feat: refine hero messaging for WhatsApp AI activation

### DIFF
--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -44,7 +44,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
             </Link>
           ) : showLoginButton ? (
             <ButtonPrimary href="/login" onClick={() => trackEvent('login_button_click')}>
-              Fazer Login
+              Ative sua IA do Instagram no WhatsApp
             </ButtonPrimary>
           ) : (
             <Link
@@ -52,7 +52,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
               onClick={() => trackEvent('login_link_click')}
               className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors"
             >
-              Fazer Login
+              Ative sua IA do Instagram no WhatsApp
             </Link>
           )}
           <ButtonPrimary href="/register" onClick={() => trackEvent('cta_start_now_click')}>

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -18,17 +18,15 @@ export default function LegacyHero() {
           </h1>
           <TypingEffect
             sequence={[
-              'Uma inteligência artificial',
+              'uma inteligência artificial conectada ao seu Instagram.',
               1000,
-              'conectada ao Instagram',
-              1000,
-              'que conversa no WhatsApp',
+              'uma inteligência artificial para conversar no WhatsApp',
               1000,
             ]}
             className="text-lg md:text-xl text-gray-600"
           />
           <ButtonPrimary href="/login">
-            Fazer Login
+            Ative sua IA do Instagram no WhatsApp
           </ButtonPrimary>
           <video
             autoPlay


### PR DESCRIPTION
## Summary
- revise typing effect phrases to highlight Instagram connection and WhatsApp chat
- update CTA buttons to "Ative sua IA do Instagram no WhatsApp"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892757f63e0832e9f699eeca2fefedc