### PR TITLE
feat: apply inter font globally

### DIFF
--- a/src/app/answer/[query]/page.tsx
+++ b/src/app/answer/[query]/page.tsx
@@ -76,7 +76,7 @@ export default function AnswerPage() {
 
       <main className="px-8 py-16 pt-24 space-y-8">
         <div className="text-center">
-          <h1 className="text-4xl font-bold mb-2 font-poppins">
+          <h1 className="text-4xl font-bold mb-2 font-sans">
             data2content
           </h1>
           <div className="mx-auto" style={{ maxWidth: "400px" }}>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -31,7 +31,7 @@ export default function SignUpPage() {
   return (
     <div className="min-h-screen bg-white flex items-center justify-center px-4">
       <div className="max-w-md w-full p-8 border border-gray-200 rounded-lg shadow-sm">
-        <h1 className="text-3xl font-bold text-center mb-6 font-poppins">Cadastre-se</h1>
+        <h1 className="text-3xl font-bold text-center mb-6 font-sans">Cadastre-se</h1>
         {error && <p className="text-red-500 text-center mb-4">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -24,7 +24,7 @@ const Header: React.FC = () => {
 
   // Se não for '/dashboard', renderiza o Header normalmente
   return (
-    <header className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-sm shadow-sm font-poppins">
+    <header className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-sm shadow-sm font-sans">
       <div className="max-w-6xl mx-auto flex items-center justify-between py-3 px-4">
         {/* Logo */}
         <div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,8 +6,8 @@
 @tailwind components;
 @tailwind utilities;
 
-/* REMOVIDO: @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap'); */
-/* A fonte Poppins agora é carregada via next/font/google no layout.tsx */
+/* REMOVIDO: @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap'); */
+/* A fonte Inter agora é carregada via next/font/google no layout.tsx */
 
 /* REMOVIDO: Bloco :root com variáveis CSS */
 /* As cores base são aplicadas via classes Tailwind no layout.tsx, usando o tailwind.config.ts */

--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -80,7 +80,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
     <div className="relative mt-6">
       <motion.div
         ref={carouselRef}
-        className="overflow-hidden snap-x snap-mandatory hide-scrollbar"
+        className="overflow-hidden snap-x snap-mandatory scrollbar-hide"
         drag="x"
         dragConstraints={{ left: 0, right: 0 }}
         dragElastic={0.05}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 
 import type { Metadata } from "next";
-import { Poppins } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
 
 // Imports do NextAuth para buscar a sessão no servidor
@@ -15,11 +15,10 @@ import AuthRedirectHandler from "./components/auth/AuthRedirectHandler";
 import ClientHooksWrapper from "./components/ClientHooksWrapper";
 import MainContentWrapper from "./components/MainContentWrapper"; // ✅ IMPORTADO O NOVO COMPONENTE
 
-const poppins = Poppins({
-  weight: ["300", "400", "500", "600", "700", "800"],
+const inter = Inter({
   subsets: ["latin"],
   display: 'swap',
-  variable: "--font-poppins",
+  variable: "--font-inter",
 });
 
 
@@ -38,7 +37,7 @@ export default async function RootLayout({
   const serializableSession = session ? JSON.parse(JSON.stringify(session)) : null;
 
   return (
-    <html lang="pt-BR" className={`${poppins.variable} h-full`}>
+    <html lang="pt-BR" className={`${inter.variable} h-full`}>
       <head>
         <link rel="preconnect" href="https://www.youtube.com" />
         <link rel="preconnect" href="https://www.google.com" />
@@ -46,7 +45,7 @@ export default async function RootLayout({
       </head>
       <body
         className={`
-          ${poppins.className}
+          ${inter.className}
           antialiased
           flex
           flex-col

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,18 +169,6 @@ export default function FinalCompleteLandingPage() {
         </footer>
       </div>
 
-      <style jsx global>{`
-        html {
-          font-family: 'Inter', sans-serif;
-        }
-        .hide-scrollbar::-webkit-scrollbar {
-          display: none;
-        }
-        .hide-scrollbar {
-          -ms-overflow-style: none;
-          scrollbar-width: none;
-        }
-      `}</style>
     </>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,8 +11,8 @@ const config: Config = { // Define o tipo da configuração
   theme: {
     extend: {
       fontFamily: {
-        // Define Poppins como a fonte principal 'sans'
-        sans: ['Poppins', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+        // Define Inter como a fonte principal 'sans'
+        sans: ['var(--font-inter)', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
         mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary
- remove inline Inter style from landing page
- load Inter via next/font and expose CSS variable
- update components and Tailwind config to use new font

## Testing
- `npm test` (fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined)
- `npm run lint` (fails: interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68937f47230c832ebd15a76f169a84f3