### PR TITLE
feat: improve carousel accessibility

### DIFF
--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -40,6 +40,17 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      scrollCarousel('right');
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      scrollCarousel('left');
+    }
+  };
+
   const ScreenshotCard = ({ imageUrl, title }: { imageUrl: string; title: string }) => {
     const [isTouch, setIsTouch] = useState(false);
 
@@ -53,6 +64,8 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
 
     return (
       <div
+        tabIndex={0}
+        aria-label={title}
         className="flex-shrink-0 w-[60vw] sm:w-[40vw] md:w-[28vw] lg:w-[22vw] aspect-[9/16] rounded-3xl bg-gradient-to-br from-gray-100 to-gray-200 p-1 shadow-2xl cursor-grab active:cursor-grabbing"
         style={{ perspective: '1000px', transformStyle: 'preserve-3d' }}
       >
@@ -77,7 +90,11 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
   };
 
   return (
-    <div className="relative mt-6">
+    <div
+      className="relative mt-6"
+      onKeyDown={handleKeyDown}
+      aria-label={`Carrossel de screenshots, slide ${activeIndex + 1} de ${items.length}`}
+    >
       <motion.div
         ref={carouselRef}
         className="overflow-hidden snap-x snap-mandatory scrollbar-hide"
@@ -115,6 +132,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
       <div className="absolute top-1/2 -translate-y-1/2 w-full flex justify-between px-4 pointer-events-none">
         <button
           onClick={() => scrollCarousel('left')}
+          tabIndex={0}
           className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
           aria-label="Anterior"
         >
@@ -122,13 +140,20 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
         </button>
         <button
           onClick={() => scrollCarousel('right')}
+          tabIndex={0}
           className="pointer-events-auto w-12 h-12 rounded-full bg-white/50 backdrop-blur-sm shadow-md flex items-center justify-center text-gray-700 hover:bg-white transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
           aria-label="Pr\u00f3ximo"
         >
           <FaChevronRight />
         </button>
       </div>
-      <p className="mt-4 text-center text-gray-600 max-w-md mx-auto">{items[activeIndex]?.description}</p>
+      <p
+        className="mt-4 text-center text-gray-600 max-w-md mx-auto"
+        aria-live="polite"
+        aria-label={`Slide ${activeIndex + 1} de ${items.length}: ${items[activeIndex]?.description}`}
+      >
+        {items[activeIndex]?.description}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make screenshot cards focusable and labeled
- add keyboard controls and live updates for active slide

## Testing
- `npm test` (fails: TextEncoder is not defined, module missing, etc.)
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68938305c7fc832ebdad0ff127af135d