### PR TITLE
feat: refine hero messaging for WhatsApp AI activation

### DIFF
--- a/src/app/components/Container.tsx
+++ b/src/app/components/Container.tsx
@@ -6,8 +6,12 @@ interface ContainerProps {
   padding?: string;
 }
 
-const Container: React.FC<ContainerProps> = ({ children, className = "", padding = "" }) => {
-  return <div className={`max-w-screen-xl mx-auto px-6 ${padding} ${className}`}>{children}</div>;
+const Container: React.FC<ContainerProps> = ({
+  children,
+  className = "",
+  padding = "px-4 sm:px-6 lg:px-8",
+}) => {
+  return <div className={`max-w-screen-xl mx-auto ${padding} ${className}`}>{children}</div>;
 };
 
 export default Container;

--- a/src/app/landing/components/ButtonPrimary.tsx
+++ b/src/app/landing/components/ButtonPrimary.tsx
@@ -11,7 +11,7 @@ interface ButtonPrimaryProps {
 }
 
 export default function ButtonPrimary({ href, onClick, children, className = '' }: ButtonPrimaryProps) {
-  const commonClasses = `group inline-flex items-center justify-center gap-3 rounded-full bg-gradient-to-r from-brand-pink to-brand-red px-8 py-4 text-lg font-bold text-white shadow-lg shadow-pink-500/30 transition-all duration-300 hover:shadow-xl hover:shadow-pink-500/40 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 ${className}`;
+  const commonClasses = `group inline-flex items-center justify-center gap-3 rounded-full bg-gradient-to-r from-brand-pink to-brand-red px-8 py-4 text-base sm:text-lg font-bold text-white shadow-lg shadow-pink-500/30 transition-all duration-300 hover:shadow-xl hover:shadow-pink-500/40 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 ${className}`;
   if (href) {
     return (
       <Link href={href} onClick={onClick} className={commonClasses}>

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -34,25 +34,25 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
           <span className="text-brand-pink">[2]</span>
           <span>data2content</span>
         </Link>
-        <nav className="flex items-center gap-5">
+        <nav className="flex items-center gap-6">
           {session ? (
             <Link
               href="/dashboard"
-              className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors"
+              className="text-base font-semibold text-gray-600 hover:text-brand-pink transition-colors"
             >
               Meu Painel
             </Link>
           ) : showLoginButton ? (
             <ButtonPrimary href="/login" onClick={() => trackEvent('login_button_click')}>
-              Fazer Login
+              Ative sua IA do Instagram no WhatsApp
             </ButtonPrimary>
           ) : (
             <Link
               href="/login"
               onClick={() => trackEvent('login_link_click')}
-              className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors"
+              className="text-base font-semibold text-gray-600 hover:text-brand-pink transition-colors"
             >
-              Fazer Login
+              Ative sua IA do Instagram no WhatsApp
             </Link>
           )}
           <ButtonPrimary href="/register" onClick={() => trackEvent('cta_start_now_click')}>

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -10,25 +10,23 @@ const TypingEffect = dynamic(() => import('./TypingEffect'), { ssr: false });
 
 export default function LegacyHero() {
   return (
-    <section className="snap-start relative flex flex-col h-screen pt-20 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
+    <section className="snap-start relative flex flex-col h-screen pt-24 md:pt-28 bg-gradient-to-b from-white via-brand-pink/5 to-gray-50 text-center overflow-x-hidden">
       <Container className="flex-grow flex flex-col justify-center">
-        <div className="flex flex-col items-center space-y-6">
-          <h1 className="text-5xl md:text-7xl font-semibold tracking-tight text-brand-dark">
+        <div className="flex flex-col items-center space-y-8 md:space-y-10">
+          <h1 className="max-w-3xl text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-semibold leading-tight tracking-tight text-brand-dark">
             O fim da dúvida: o que postar hoje
           </h1>
           <TypingEffect
             sequence={[
-              'Uma inteligência artificial',
+              'uma inteligência artificial conectada ao seu Instagram.',
               1000,
-              'conectada ao Instagram',
-              1000,
-              'que conversa no WhatsApp',
+              'uma inteligência artificial para conversar no WhatsApp',
               1000,
             ]}
-            className="text-lg md:text-xl text-gray-600"
+            className="max-w-2xl text-base sm:text-lg md:text-xl text-gray-600"
           />
           <ButtonPrimary href="/login">
-            Fazer Login
+            Ative sua IA do Instagram no WhatsApp
           </ButtonPrimary>
           <video
             autoPlay
@@ -37,17 +35,17 @@ export default function LegacyHero() {
             playsInline
             poster="/images/tuca-analise-whatsapp.png"
             src="/videos/hero-demo.mp4"
-            className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video mt-8"
+            className="w-full max-w-4xl mx-auto rounded-2xl shadow-xl aspect-video"
             loading="lazy"
             decoding="async"
           />
         </div>
       </Container>
-      <div className="mt-8 space-y-2 overflow-hidden">
+      <div className="mt-10 space-y-2 overflow-hidden">
         <Marquee direction="left" />
         <Marquee direction="right" />
       </div>
-      <div className="relative mt-6 h-12">
+      <div className="relative mt-8 h-12">
         <ScrollCue targetId="intro" />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- revise typing effect phrases to highlight Instagram connection and WhatsApp chat
- update CTA buttons to "Ative sua IA do Instagram no WhatsApp"
- polish layout spacing and typography for clearer landing experience

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892757f63e0832e9f699eeca2fefedc