### PR TITLE
feat: export landing metadata with canonical link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { FaStar } from "react-icons/fa";
 import { FaQuestionCircle } from "react-icons/fa";
 import testimonials from "@/data/testimonials";
 import faqItems from "@/data/faq";
-import { landingJsonLd } from "@/seo/landing";
+import { landingJsonLd, landingMetadata } from "@/seo/landing";
 import Container from "./components/Container";
 import ButtonPrimary from "./landing/components/ButtonPrimary";
 const LegacyHero = dynamic(() => import("./landing/components/LegacyHero"), { ssr: false });
@@ -75,6 +75,8 @@ const exampleScreenshots = [
     description: "Aprenda com outros criadores e compartilhe experiências na comunidade.",
   },
 ];
+
+export const metadata = landingMetadata;
 
 export default function FinalCompleteLandingPage() {
   const [showStickyLogin, setShowStickyLogin] = useState(false);

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -4,6 +4,7 @@ export const landingMetadata: Metadata = {
   title: "data2content - Menos análise, mais criação.",
   description:
     "Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer.",
+  alternates: { canonical: "https://data2content.ai/" },
   openGraph: {
     title: "data2content - Menos análise, mais criação.",
     description:


### PR DESCRIPTION
## Summary
- export landing page metadata from page component
- add canonical alternate URL to landing page metadata

## Testing
- `npm test` *(fails: 114 failed, 18 passed)*
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6893dd92f24c832e88dba71b7d4db6d3