### PR TITLE
feat: enable SSR for landing components

### DIFF
--- a/src/app/landing/components/withViewport.tsx
+++ b/src/app/landing/components/withViewport.tsx
@@ -6,7 +6,12 @@ import React from "react";
 export default function withViewport<P>(Component: React.ComponentType<P>) {
   return function WrappedComponent(props: P) {
     const { ref, inView } = useInView({ triggerOnce: true, rootMargin: "200px" });
-    return <div ref={ref}>{inView ? <Component {...props} /> : null}</div>;
+    const isServer = typeof window === "undefined";
+    return (
+      <div ref={isServer ? undefined : ref} suppressHydrationWarning>
+        {isServer || inView ? <Component {...props} /> : null}
+      </div>
+    );
   };
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,26 +12,25 @@ import faqItems from "@/data/faq";
 import { landingJsonLd, landingMetadata } from "@/seo/landing";
 import Container from "./components/Container";
 import ButtonPrimary from "./landing/components/ButtonPrimary";
-const LegacyHero = dynamic(() => import("./landing/components/LegacyHero"), { ssr: false });
+const LegacyHero = dynamic(() => import("./landing/components/LegacyHero"));
 const IntroSlide = withViewport(
-  dynamic(() => import("./landing/components/IntroSlide"), { ssr: false })
+  dynamic(() => import("./landing/components/IntroSlide"))
 );
 const FeaturesSlide = withViewport(
-  dynamic(() => import("./landing/components/FeaturesSlide"), { ssr: false })
+  dynamic(() => import("./landing/components/FeaturesSlide"))
 );
 const ExamplesSlide = withViewport(
-  dynamic(() => import("./landing/components/ExamplesSlide"), { ssr: false })
+  dynamic(() => import("./landing/components/ExamplesSlide"))
 );
 
 const AnimatedSection = withViewport(
-  dynamic(() => import("./landing/components/AnimatedSection"), { ssr: false })
+  dynamic(() => import("./landing/components/AnimatedSection"))
 );
 const LandingHeader = dynamic(
-  () => import("./landing/components/LandingHeader"),
-  { ssr: false }
+  () => import("./landing/components/LandingHeader")
 ) as React.ComponentType<{ showLoginButton?: boolean }>;
 const CallToAction = withViewport(
-  dynamic(() => import("./landing/components/CallToAction"), { ssr: false })
+  dynamic(() => import("./landing/components/CallToAction"))
 );
 
 const SectionTitle = ({ children, className = "" }: { children: React.ReactNode; className?: string }) => (


### PR DESCRIPTION
## Summary
- enable server-side rendering for landing page components by removing ssr:false options
- render components on the server when outside viewport for SEO-friendly fallbacks

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, ReferenceError: Response is not defined, etc.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689405008c50832ebfce93a889b54837