### PR TITLE
Adjust heading levels on landing page

### DIFF
--- a/src/app/landing/components/IntroSlide.tsx
+++ b/src/app/landing/components/IntroSlide.tsx
@@ -19,7 +19,7 @@ export function IntroSlide() {
       id="intro"
     >
       <Container className="text-center">
-        <h1 className="text-4xl md:text-5xl font-bold">Bem-vindo ao Data2Content</h1>
+        <h2 className="text-4xl md:text-5xl font-bold">Bem-vindo ao Data2Content</h2>
       </Container>
       <ScrollCue targetId="features" />
     </motion.section>


### PR DESCRIPTION
## Summary
- demote IntroSlide heading to `<h2>` to keep LegacyHero as the only `<h1>`

## Testing
- `npm test` *(fails: Test Suites: 114 failed, 18 passed, 132 total)*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894077f2804832ea3d583b915969dbf