### PR TITLE
feat: add landing product schema

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,11 @@ import { FaStar } from "react-icons/fa";
 import { FaQuestionCircle } from "react-icons/fa";
 import testimonials from "@/data/testimonials";
 import faqItems from "@/data/faq";
-import { landingJsonLd, landingMetadata } from "@/seo/landing";
+import {
+  landingJsonLd,
+  landingProductJsonLd,
+  landingMetadata,
+} from "@/seo/landing";
 import Container from "./components/Container";
 import ButtonPrimary from "./landing/components/ButtonPrimary";
 const LegacyHero = dynamic(() => import("./landing/components/LegacyHero"));
@@ -97,7 +101,9 @@ export default function FinalCompleteLandingPage() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(landingJsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([landingJsonLd, landingProductJsonLd]),
+        }}
       />
 
       <div className="bg-white text-gray-800 font-sans">

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -32,3 +32,17 @@ export const landingJsonLd = {
   name: "data2content",
   url: "https://data2content.ai"
 };
+
+export const landingProductJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "data2content",
+  description:
+    "Seu estrategista de conteúdo pessoal que analisa seu Instagram e te diz exatamente o que fazer para crescer.",
+  applicationCategory: "MarketingApplication",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "BRL",
+  },
+};


### PR DESCRIPTION
## Summary
- add SoftwareApplication schema to landing page metadata
- expose both website and product JSON-LD in landing page

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate')*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689414085fb4832e81764b31b92c7c9c