### PR TITLE
fix: add nofollow to login links and metadata

### DIFF
--- a/src/app/landing/components/ButtonPrimary.tsx
+++ b/src/app/landing/components/ButtonPrimary.tsx
@@ -8,13 +8,14 @@ interface ButtonPrimaryProps {
   onClick?: () => void;
   children: React.ReactNode;
   className?: string;
+  rel?: string;
 }
 
-export default function ButtonPrimary({ href, onClick, children, className = '' }: ButtonPrimaryProps) {
+export default function ButtonPrimary({ href, onClick, children, className = '', rel }: ButtonPrimaryProps) {
   const commonClasses = `group inline-flex items-center justify-center gap-3 rounded-full bg-gradient-to-r from-brand-pink to-brand-red px-8 py-4 text-lg font-bold text-white shadow-lg shadow-pink-500/30 transition-all duration-300 hover:shadow-xl hover:shadow-pink-500/40 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 ${className}`;
   if (href) {
     return (
-      <Link href={href} onClick={onClick} className={commonClasses}>
+      <Link href={href} onClick={onClick} className={commonClasses} rel={rel}>
         {children}
       </Link>
     );

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -59,6 +59,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
               <ButtonPrimary
                 href="/login"
                 onClick={() => trackEvent('login_button_click')}
+                rel="nofollow"
               >
                 Ative sua IA do Instagram no WhatsApp
               </ButtonPrimary>
@@ -67,6 +68,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
                 href="/login"
                 onClick={() => trackEvent('login_link_click')}
                 className="text-sm font-semibold text-gray-600 hover:text-brand-pink transition-colors"
+                rel="nofollow"
               >
                 Ative sua IA do Instagram no WhatsApp
               </Link>
@@ -111,6 +113,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
                   }}
                   className="px-4 py-2 text-sm hover:bg-gray-100"
                   ref={firstLinkRef}
+                  rel="nofollow"
                 >
                   Entrar
                 </Link>

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -58,7 +58,7 @@ export default function LegacyHero() {
             ]}
             className="text-lg md:text-xl text-gray-600"
           />
-          <ButtonPrimary href="/login">
+          <ButtonPrimary href="/login" rel="nofollow">
             Ative sua IA do Instagram no WhatsApp
           </ButtonPrimary>
           <video

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,11 @@
 import { signIn } from "next-auth/react";
 import { useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function LoginPage() {
   const searchParams = useSearchParams();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -161,7 +161,7 @@ export default function FinalCompleteLandingPage() {
           <CallToAction />
           {showStickyLogin && (
             <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white/80 backdrop-blur-md shadow-md">
-              <ButtonPrimary href="/login">Ative sua IA do Instagram no WhatsApp</ButtonPrimary>
+              <ButtonPrimary href="/login" rel="nofollow">Ative sua IA do Instagram no WhatsApp</ButtonPrimary>
             </div>
           )}
         </main>


### PR DESCRIPTION
## Summary
- prevent login page from being indexed
- add nofollow to home page login links

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, ReferenceError: Request/Response is not defined, etc.)*
- `CI=true npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894172d2fd4832eada22484bf36bedb