### PR TITLE
feat: add sitemap and robots metadata routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "").replace(/\/$/, "");
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "").replace(/\/$/, "");
+
+  const routes = [
+    "",
+    "/termos-e-condicoes",
+    "/politica-de-privacidade",
+    "/afiliados",
+    "/assinar",
+    "/landing",
+    "/login",
+  ];
+
+  return routes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+  }));
+}


### PR DESCRIPTION
## Summary
- add sitemap function listing public routes
- configure robots file with crawl rules and sitemap link

## Testing
- `npm test` *(fails: Test Suites: 114 failed)*
- `npm run lint` *(fails: prompt "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_e_68941f609c3c832eaf9c104e757924d7