### PR TITLE
feat: add landing FAQ JSON-LD

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
   landingJsonLd,
   landingProductJsonLd,
   landingMetadata,
+  landingFaqJsonLd,
 } from "@/seo/landing";
 import Container from "./components/Container";
 import ButtonPrimary from "./landing/components/ButtonPrimary";
@@ -102,7 +103,11 @@ export default function FinalCompleteLandingPage() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify([landingJsonLd, landingProductJsonLd]),
+          __html: JSON.stringify([
+            landingJsonLd,
+            landingProductJsonLd,
+            landingFaqJsonLd,
+          ]),
         }}
       />
 

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import faqItems from "@/data/faq";
 
 export const landingMetadata: Metadata = {
   title: "data2content - Menos análise, mais criação.",
@@ -45,4 +46,17 @@ export const landingProductJsonLd = {
     price: "0",
     priceCurrency: "BRL",
   },
+};
+
+export const landingFaqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqItems.map((item) => ({
+    "@type": "Question",
+    name: item.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.a,
+    },
+  })),
 };


### PR DESCRIPTION
## Summary
- add `landingFaqJsonLd` to expose FAQPage schema using `faqItems`
- embed FAQ structured data alongside existing JSON-LD on landing page

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, etc.)*
- `NEXT_DISABLE_ESLINT_PROMPT=1 npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689422e51414832e879cfa0d544629c7