### PR TITLE
feat: allow Google-Extended in robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,6 +6,10 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
+        userAgent: "Google-Extended",
+        allow: "/",
+      },
+      {
         userAgent: "*",
         allow: "/",
       },


### PR DESCRIPTION
## Summary
- allow Google-Extended in robots.txt while keeping sitemap reference

## Testing
- `node --loader ts-node/esm -e "import robots from './src/app/robots.ts'; console.log(JSON.stringify(robots(), null, 2));"`
- `npm run build` *(fails: Failed to fetch font `Inter`)*
- `npm run lint` *(interactive ESLint setup prompt)*
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate')*

------
https://chatgpt.com/codex/tasks/task_e_6894296cb7f8832eac97f28bf11632a3