### PR TITLE
Add organization JSON-LD to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   landingProductJsonLd,
   landingMetadata,
   landingFaqJsonLd,
+  landingOrganizationJsonLd,
 } from "@/seo/landing";
 import Container from "./components/Container";
 import ButtonPrimary from "./landing/components/ButtonPrimary";
@@ -107,6 +108,7 @@ export default function FinalCompleteLandingPage() {
             landingJsonLd,
             landingProductJsonLd,
             landingFaqJsonLd,
+            landingOrganizationJsonLd,
           ]),
         }}
       />

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -48,6 +48,20 @@ export const landingProductJsonLd = {
   },
 };
 
+export const landingOrganizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "data2content",
+  url: "https://data2content.ai",
+  logo: "https://data2content.ai/images/Colorido-Simbolo.png",
+  sameAs: [
+    "https://github.com/data2content",
+    "https://www.linkedin.com/company/data2content",
+    "https://twitter.com/data2content",
+    "https://www.instagram.com/data2content",
+  ],
+};
+
 export const landingFaqJsonLd = {
   "@context": "https://schema.org",
   "@type": "FAQPage",


### PR DESCRIPTION
## Summary
- add organization schema with site metadata and social links
- inject organization schema in landing page JSON-LD bundle

## Testing
- `npm test` (fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined)
- `npm run lint` (fails: prompts for interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68942b598b5c832eb3e2197200e1b018