### PR TITLE
feat: add ai summary endpoint and sitemap entry

### DIFF
--- a/src/app/api/ai-summary/route.ts
+++ b/src/app/api/ai-summary/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const data = {
+    name: "AI Summary",
+    description: "Summary of the application's AI capabilities.",
+    features: [
+      "Summarizes content",
+      "Provides insights",
+      "Answers questions",
+    ],
+    faq: [
+      {
+        question: "O que é o AI Summary?",
+        answer: "É um endpoint que descreve os recursos de IA do Data2Content.",
+      },
+      {
+        question: "Como posso usar?",
+        answer: "Consuma esta rota para obter informações sobre os recursos disponíveis.",
+      },
+    ],
+  };
+
+  return NextResponse.json(data);
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,6 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/assinar",
     "/landing",
     "/login",
+    "/api/ai-summary",
   ];
 
   return routes.map((route) => ({


### PR DESCRIPTION
## Summary
- expose `/api/ai-summary` endpoint returning overview of AI features
- include the new endpoint in the sitemap for quicker discovery

## Testing
- `npx eslint src/app/api/ai-summary/route.ts src/app/sitemap.ts -c eslint.config.mjs` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm test` *(fails: 114 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68942d5b3910832e8cea1fa4dc1e2284