### PR TITLE
Link hero transcript and enrich screenshot alt text

### DIFF
--- a/public/hero-transcript.vtt
+++ b/public/hero-transcript.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00.000 --> 00:05.000
+Demonstração da IA analisando conversas no WhatsApp.

--- a/src/app/landing/components/LegacyHero.tsx
+++ b/src/app/landing/components/LegacyHero.tsx
@@ -75,13 +75,16 @@ export default function LegacyHero() {
           >
             <track
               kind="captions"
-              src="/videos/hero-demo.vtt"
+              src="/hero-transcript.vtt"
               label="Português"
               default
             />
           </video>
           <p className="mt-2 text-sm text-gray-600">
             Vídeo demonstrando a IA do Instagram analisando conversas no WhatsApp.
+            <a href="/hero-transcript.vtt" className="ml-1 underline">
+              Transcrição do vídeo
+            </a>
           </p>
           {reducedData && !shouldLoad && (
             <button

--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 import { motion, PanInfo, useMotionValueEvent, useScroll } from 'framer-motion';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import { altTextService } from '@/services/altTextService';
 
 interface Screenshot {
   title: string;
@@ -51,7 +52,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
     }
   };
 
-  const ScreenshotCard = ({ imageUrl, title }: { imageUrl: string; title: string }) => {
+  const ScreenshotCard = ({ imageUrl, title, description }: { imageUrl: string; title: string; description: string }) => {
     const [isTouch, setIsTouch] = useState(false);
 
     useEffect(() => {
@@ -76,7 +77,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
         >
           <Image
             src={imageUrl}
-            alt={title}
+            alt={altTextService(title, description)}
             fill
             className="object-cover"
             loading="lazy"
@@ -124,7 +125,11 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
           {items.map((item, index) => (
             <div key={index} className="flex flex-col items-start gap-2 flex-shrink-0 snap-center">
               <h3 className="font-bold text-lg text-gray-600 pl-1">{item.title}</h3>
-              <ScreenshotCard imageUrl={item.imageUrl} title={item.title} />
+              <ScreenshotCard
+                imageUrl={item.imageUrl}
+                title={item.title}
+                description={item.description}
+              />
             </div>
           ))}
         </div>

--- a/src/services/altTextService.ts
+++ b/src/services/altTextService.ts
@@ -1,0 +1,3 @@
+export function altTextService(title: string, description?: string): string {
+  return description ? `${title}: ${description}` : title;
+}


### PR DESCRIPTION
## Summary
- reference hero video transcript via track and accessible link
- generate enriched screenshot image alt text with altTextService

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and TextEncoder is not defined)*
- `npm run lint` *(fails: Jest encountered an unexpected token and TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6894c1540cdc832e9a97b685eb034b4b