### PR TITLE
chore: exclude login from sitemap and robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,6 +6,10 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
+        userAgent: "*",
+        disallow: "/login",
+      },
+      {
         userAgent: "Google-Extended",
         allow: "/",
       },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,7 +10,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/afiliados",
     "/assinar",
     "/landing",
-    "/login",
     "/api/ai-summary",
   ];
 


### PR DESCRIPTION
## Summary
- remove `/login` from sitemap routes
- block `/login` in robots.txt rules
- confirm login page is marked noindex and nofollow

## Testing
- `npm test` *(fails: Request is not defined, TextEncoder is not defined, and other module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894d592e484832e8dbb5dafc859a3e9