### PR TITLE
Add search page and enhance landing JSON-LD

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,42 @@
+import faqItems from "@/data/faq";
+
+interface SearchPageProps {
+  searchParams: { q?: string };
+}
+
+export default function SearchPage({ searchParams }: SearchPageProps) {
+  const query = (searchParams.q || "").toLowerCase();
+  const results = query
+    ? faqItems.filter(
+        (item) =>
+          item.q.toLowerCase().includes(query) ||
+          item.a.toLowerCase().includes(query)
+      )
+    : [];
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">
+        Resultados para "{searchParams.q || ""}"
+      </h1>
+      {query === "" ? (
+        <p>Digite um termo de busca acima.</p>
+      ) : results.length === 0 ? (
+        <p>Nenhum resultado encontrado.</p>
+      ) : (
+        <ul className="space-y-6">
+          {results.map((item, idx) => (
+            <li key={idx} className="border-b pb-4">
+              <h2 className="font-semibold text-lg">{item.q}</h2>
+              <div
+                className="mt-2 text-sm text-gray-700"
+                dangerouslySetInnerHTML={{ __html: item.a }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,6 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/assinar",
     "/landing",
     "/api/ai-summary",
+    "/search",
   ];
 
   return routes.map((route) => ({

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -31,7 +31,12 @@ export const landingJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: "data2content",
-  url: "https://data2content.ai"
+  url: "https://data2content.ai",
+  potentialAction: {
+    "@type": "SearchAction",
+    target: "https://data2content.ai/search?q={search_term_string}",
+    "query-input": "required name=search_term_string",
+  }
 };
 
 export const landingProductJsonLd = {


### PR DESCRIPTION
## Summary
- expose search capability in landing JSON-LD
- add basic FAQ-driven search page
- include search route in sitemap

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; TextEncoder is not defined)*
- `npm run lint` *(interactive prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd82ff2c832e9b3e959680907f28