### PR TITLE
Add sizes attributes to fill Images

### DIFF
--- a/src/app/dashboard/components/InstagramProfile.tsx
+++ b/src/app/dashboard/components/InstagramProfile.tsx
@@ -24,6 +24,7 @@ const InstagramProfile: React.FC<InstagramProfileProps> = ({
           src={image}
           alt={name}
           fill
+          sizes="128px"
           // or width={128} height={128} se preferir fixo
           className="rounded-full object-cover border border-gray-200"
         />

--- a/src/app/landing/components/ScreenshotCarousel.tsx
+++ b/src/app/landing/components/ScreenshotCarousel.tsx
@@ -79,6 +79,7 @@ export default function ScreenshotCarousel({ items }: ScreenshotCarouselProps) {
             src={imageUrl}
             alt={altTextService(title, description)}
             fill
+            sizes="(max-width:768px)60vw,(max-width:1024px)40vw,22vw"
             className="object-cover"
             loading="lazy"
             onError={(e) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ const TestimonialCard = ({ name, handle, quote, avatarUrl }: { name: string; han
     <p className="text-gray-700 italic text-sm flex-grow">"{quote}"</p>
     <div className="flex items-center mt-4">
       <div className="relative w-10 h-10 rounded-full overflow-hidden">
-        <Image src={avatarUrl} alt={`Avatar de ${name}`} fill className="object-cover" />
+        <Image src={avatarUrl} alt={`Avatar de ${name}`} fill sizes="40px" className="object-cover" />
       </div>
       <div className="ml-4">
         <p className="font-semibold text-brand-dark text-sm">{name}</p>


### PR DESCRIPTION
## Summary
- add `sizes="40px"` to TestimonialCard avatar to pair with `fill`
- provide responsive sizes for ScreenshotCarousel images
- specify fixed size for InstagramProfile image using `fill`

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and TextEncoder is not defined)*
- `npm run lint` *(fails: ESLint couldn't find config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6894e05d009c832e9cc9fd84f797ba8d