### PR TITLE
feat: enhance hero marquee design

### DIFF
--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -5,6 +5,7 @@ import { signIn } from 'next-auth/react';
 import ButtonPrimary from './ButtonPrimary';
 import TypingEffect from './TypingEffect';
 import Marquee from './Marquee';
+import heroQuestions from '@/data/heroQuestions';
 
 export default function HeroSection() {
   const handleSignIn = () => {
@@ -63,8 +64,8 @@ export default function HeroSection() {
             </div>
 
             <motion.div variants={heroItemVariants} className="mt-10 md:mt-12 w-full space-y-4">
-              <Marquee direction="left" />
-              <Marquee direction="right" />
+              <Marquee items={heroQuestions} direction="left" />
+              <Marquee items={[...heroQuestions].reverse()} direction="right" />
             </motion.div>
           </motion.div>
         </div>

--- a/src/app/landing/components/Marquee.tsx
+++ b/src/app/landing/components/Marquee.tsx
@@ -1,28 +1,30 @@
 "use client";
 
+import React, { useMemo } from "react";
 import { motion } from "framer-motion";
-import heroQuestions from "@/data/heroQuestions";
 
 interface MarqueeProps {
+  items: string[];
   direction?: "left" | "right";
 }
 
-export default function Marquee({ direction = "left" }: MarqueeProps) {
-  const questions = [...heroQuestions, ...heroQuestions];
-  const animateFrom = direction === "left" ? "0%" : "-100%";
-  const animateTo = direction === "left" ? "-100%" : "0%";
-
+export default function Marquee({ items, direction = "left" }: MarqueeProps) {
+  const marqueeContent = useMemo(() => [...items, ...items], [items]);
   return (
-    <div className="overflow-hidden whitespace-nowrap">
+    <div className="relative w-full overflow-hidden">
       <motion.div
-        className="flex gap-8"
-        animate={{ x: [animateFrom, animateTo] }}
-        transition={{ repeat: Infinity, ease: "linear", duration: 30 }}
+        className="flex gap-4"
+        initial={{ x: direction === "left" ? 0 : "-50%" }}
+        animate={{ x: direction === "left" ? "-50%" : 0 }}
+        transition={{ duration: 40, repeat: Infinity, ease: "linear" }}
       >
-        {questions.map((q, idx) => (
-          <span key={idx} className="text-sm md:text-base text-gray-600">
-            {q}
-          </span>
+        {marqueeContent.map((item, index) => (
+          <div
+            key={index}
+            className="flex-shrink-0 whitespace-nowrap px-6 py-3 rounded-full bg-gray-200/80 text-gray-600 font-medium"
+          >
+            {item}
+          </div>
         ))}
       </motion.div>
     </div>


### PR DESCRIPTION
## Summary
- refine Marquee to accept items and render pill-style scrolling content
- wire hero section to supply question sequences for alternating marquee lines

## Testing
- `npm test -- src/charts/getRadarChartData.test.ts` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate')*


------
https://chatgpt.com/codex/tasks/task_e_68950a481f00832e8e54fa849042a1f8