### PR TITLE
fix: ensure hero video spans full width

### DIFF
--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -71,7 +71,7 @@ export default function HeroSection() {
             </motion.div>
 
             <motion.div variants={heroItemVariants} className="mt-12 px-6">
-              <div className="relative max-w-4xl mx-auto aspect-video rounded-2xl shadow-xl overflow-hidden border border-gray-200">
+              <div className="relative max-w-4xl mx-auto w-full aspect-video rounded-2xl shadow-xl overflow-hidden border border-gray-200">
                 <iframe
                   className="absolute top-0 left-0 w-full h-full"
                   src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}`}


### PR DESCRIPTION
## Summary
- ensure landing hero video container spans full width

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined)*
- `npm run dev` *(fails: Por favor, defina a variável de ambiente MONGODB_URI dentro de .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689516821654832ebf45017794be01d4