### PR TITLE
Align HeroSection to top of viewport

### DIFF
--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -32,8 +32,8 @@ export default function HeroSection() {
   };
 
   return (
-    <section className="relative flex flex-col min-h-[90vh] bg-gray-100 text-center overflow-x-hidden pt-20 pb-10">
-      <div className="flex-grow flex flex-col justify-center">
+    <section className="relative flex flex-col min-h-screen bg-gray-100 text-center overflow-x-hidden pt-20 pb-10">
+      <div className="flex-grow flex flex-col justify-start">
         <div className="w-full">
           <motion.div variants={heroVariants} initial="hidden" animate="visible" className="w-full">
             <div className="max-w-3xl mx-auto px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- ensure hero section occupies full screen height
- align hero content to the top instead of centered

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, Request/Response is not defined, etc.)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68951b68c828832e9325af7d6a8958d0