### PR TITLE
fix landing page video scaling

### DIFF
--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -73,15 +73,8 @@ export default function HeroSection() {
           </motion.div>
 
           <motion.div variants={heroItemVariants} className="mt-12 px-6">
-            <div
-              className="relative max-w-3xl mx-auto w-full rounded-lg overflow-hidden shadow-lg"
-              style={{
-                paddingTop: '56.25%', // Mantém a proporção 16:9
-              }}
-            >
-              {/* --- CÓDIGO CORRIGIDO --- */}
+            <div className="relative max-w-3xl mx-auto w-full rounded-lg overflow-hidden shadow-lg aspect-w-16 aspect-h-9">
               <iframe
-                // Classes do Tailwind para preencher o contêiner pai perfeitamente
                 className="absolute top-0 left-0 w-full h-full"
                 src={youtubeEmbedUrl}
                 title="Demo do data2content"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ export default async function RootLayout({
   return (
     <html lang="pt-BR" className={`${inter.variable} h-full`}>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="preconnect" href="https://www.youtube.com" />
         <link rel="preconnect" href="https://www.google.com" />
         <link rel="preconnect" href="https://img.youtube.com" />


### PR DESCRIPTION
## Summary
- ensure default zoom by adding viewport meta tag
- adjust landing hero video container with 16:9 aspect ratio classes

## Testing
- `npm test` *(fails: TextEncoder is not defined and other module errors)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689543ca80cc832ea1f170e388a8df53