### PR TITLE
Centralize landing bottom button and use gray background

### DIFF
--- a/src/app/LandingPageClient.tsx
+++ b/src/app/LandingPageClient.tsx
@@ -43,7 +43,7 @@ export default function LandingPageClient() {
         <FaqSection />
         <CallToAction />
         {showStickyLogin && (
-          <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white/80 backdrop-blur-md shadow-md animate-fade-in-up md:hidden">
+          <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center p-4 bg-gray-100/80 backdrop-blur-md shadow-md animate-fade-in-up md:hidden">
             <ButtonPrimary href="/login" rel="nofollow">
               Ative IA do Instagram no WhatsApp
             </ButtonPrimary>


### PR DESCRIPTION
## Summary
- centralize sticky call-to-action button on landing page
- give the button bar a light gray background

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate'; ReferenceError: TextEncoder is not defined)*
- `npx eslint src/app/LandingPageClient.tsx` *(fails: ESLint couldn't find the config "next/typescript")*

------
https://chatgpt.com/codex/tasks/task_e_68954caed850832ea4d0faca3cfe484f