### PR TITLE
Improve webhook and subscription handling

### DIFF
--- a/src/app/api/plan/cancel/route.ts
+++ b/src/app/api/plan/cancel/route.ts
@@ -23,6 +23,8 @@ export async function POST(req: NextRequest) {
     await mercadopago.preapproval.update(user.paymentGatewaySubscriptionId, { status: "cancelled" });
 
     user.planStatus = "canceled";
+    user.paymentGatewaySubscriptionId = undefined;
+    user.planType = undefined;
     await user.save();
 
     return NextResponse.json({ message: "Assinatura cancelada." });

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -234,7 +234,7 @@ export interface IUser extends Document {
   agency?: Types.ObjectId | null;
   pendingAgency?: Types.ObjectId | null;
   planStatus?: PlanStatus;
-  planType?: 'monthly' | 'annual';
+  planType?: 'monthly' | 'annual' | 'annual_one_time';
   paymentGatewaySubscriptionId?: string;
   planExpiresAt?: Date | null;
   autoRenewConsentAt?: Date | null;
@@ -338,7 +338,7 @@ const userSchema = new Schema<IUser>(
         select: false
     },
     planStatus: { type: String, enum: PLAN_STATUSES, default: "inactive", index: true }, // OTIMIZAÇÃO: Mantido índice.
-    planType: { type: String, enum: ['monthly', 'annual'], default: 'monthly' },
+    planType: { type: String, enum: ['monthly', 'annual', 'annual_one_time'], default: 'monthly' },
     paymentGatewaySubscriptionId: { type: String },
     inferredExpertiseLevel: {
         type: String,


### PR DESCRIPTION
## Summary
- Compute webhook signatures using original data.id
- Sync authorized_payment handling with payment branch
- Reset subscription identifiers on cancellation

## Testing
- `npm test` *(fails: Cannot find module, ReferenceError: TextEncoder is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68961b7ee938832ea3d9e7c74b7e03a8