### PR TITLE
fix: improve subscription handling

### DIFF
--- a/src/app/api/plan/cancel/route.ts
+++ b/src/app/api/plan/cancel/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
     user.planStatus = "canceled";
     user.paymentGatewaySubscriptionId = undefined;
     user.planType = undefined;
+    user.planExpiresAt = null;
     await user.save();
 
     return NextResponse.json({ message: "Assinatura cancelada." });


### PR DESCRIPTION
## Summary
- fetch payment details in webhook when transaction amount missing
- clear plan expiry on cancellation

## Testing
- `npm test` *(fails: Request is not defined, missing modules, TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68961d96f92c832eac0d0460ba121d3b