### PR TITLE
feat: enhance one-time plan checkout

### DIFF
--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -457,7 +457,9 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           {loading ? <FaSpinner className="w-5 h-5 animate-spin" /> : "Assinar agora"}
         </button>
         <p className="mt-2 text-center text-xs text-gray-500">
-          Pagamento seguro via Mercado Pago. Sem fidelidade — cancele quando quiser.
+          {planType === "annual_one_time"
+            ? "Pagamento processado no cartão em 12 parcelas sem juros. Você recebe acesso por 12 meses (não renova automaticamente)."
+            : "Pagamento seguro via Mercado Pago. Sem fidelidade — cancele quando quiser."}
         </p>
 
         {/* Mensagens */}


### PR DESCRIPTION
## Summary
- require Mercado Pago differential pricing id, use binary mode and card-only payments for 12x plan
- cancel existing preapprovals before one-time checkout and log Mercado Pago preference id
- extend one-time plan from current expiration in webhook and adjust UI copy for 12x offer

## Testing
- `npm test` *(fails: Request is not defined, TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689627b17e0c832e8c456c069a3564e9