### PR TITLE
refactor: use monthly recurring billing

### DIFF
--- a/src/app/api/plan/subscribe/route.ts
+++ b/src/app/api/plan/subscribe/route.ts
@@ -134,7 +134,8 @@ export async function POST(req: NextRequest) {
     if (!appUrl) throw new Error("NEXT_PUBLIC_APP_URL ou NEXTAUTH_URL não está definida");
 
     // Para recorrência mensal, sempre usamos o valor mensal (no anual é o mensal com desconto)
-    const txAmount = monthly; // número com 2 casas (apenas p/ logs)
+    // Sempre recorrência mensal; no Anual usamos o valor mensal com desconto
+    const txAmount = monthly;
 
     console.debug("plan/subscribe -> Valores:", {
       planType,
@@ -154,9 +155,9 @@ export async function POST(req: NextRequest) {
       external_reference: user._id.toString(),
       payer_email: user.email,
       auto_recurring: {
-        frequency: 1, // mensal
+        frequency: 1, // sempre mensal
         frequency_type: "months",
-        transaction_amount: monthly, // mensal (com desconto se annual)
+        transaction_amount: txAmount,
         currency_id: "BRL",
       },
     } as any;
@@ -185,7 +186,9 @@ export async function POST(req: NextRequest) {
       initPoint,
       subscriptionId,
       message: "Assinatura criada. Redirecione o usuário para esse link.",
-      price: planType === "annual" ? total : monthly,
+      // Preço que será cobrado por ciclo
+      chargedMonthlyPrice: monthly,
+      planBillingCycle: "monthly",
     });
   } catch (error: unknown) {
     console.error("Erro em /api/plan/subscribe:", error);

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -268,36 +268,27 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
     const expires = user.planExpiresAt
       ? new Date(user.planExpiresAt).toLocaleDateString("pt-BR")
       : "Data Indefinida";
-    const isOneTime = userPlanType === "annual_one_time";
     return (
       <div className="border border-green-300 rounded-xl shadow-sm p-4 sm:p-6 bg-green-50 text-green-800">
         <div className="flex items-center gap-3 mb-2">
           <FaCheckCircle className="w-6 h-6 text-green-600" />
           <h2 className="text-lg font-semibold">Seu plano está ativo!</h2>
         </div>
-        {isOneTime ? (
-          <p className="text-sm mb-1 pl-9">
-            Plano ativo até <strong className="font-medium">{expires}</strong>. Não renova automaticamente.
-          </p>
-        ) : (
-          <p className="text-sm mb-1 pl-9">
-            Renova automaticamente em <strong className="font-medium">{expires}</strong>.{' '}
-            <a href="/dashboard/settings" className="underline text-brand-pink">
-              Gerencie/cancele nas configurações
-            </a>.
-          </p>
-        )}
-        {!isOneTime && (
-          <p className="text-sm mt-2 pl-9">
-            <button
-              onClick={handleCancel}
-              disabled={loading}
-              className="underline text-brand-pink"
-            >
-              cancelar assinatura
-            </button>
-          </p>
-        )}
+        <p className="text-sm mb-1 pl-9">
+          Renova automaticamente em <strong className="font-medium">{expires}</strong>.{' '}
+          <a href="/dashboard/settings" className="underline text-brand-pink">
+            Gerencie/cancele nas configurações
+          </a>.
+        </p>
+        <p className="text-sm mt-2 pl-9">
+          <button
+            onClick={handleCancel}
+            disabled={loading}
+            className="underline text-brand-pink"
+          >
+            cancelar assinatura
+          </button>
+        </p>
         {statusMessage && (
           <FeedbackMessage message={statusMessage.message} type={statusMessage.type} />
         )}
@@ -317,9 +308,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
             Estamos aguardando a confirmação do seu pagamento.
           </p>
           <p className="text-sm mt-2 pl-9">
-            {userPlanType === "annual_one_time"
-              ? "Após aprovação, o plano ficará ativo por 12 meses e não renova automaticamente."
-              : "Após aprovação, o plano será ativado e renovará automaticamente. Você poderá gerenciá-lo nas configurações."}
+            Após aprovação, o plano será ativado e renovará automaticamente. Você poderá gerenciá-lo nas configurações.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- ensure subscriptions always bill monthly with discounted amount for annual plan
- avoid duplicate gateway subscriptions and track monthly price/cycle
- remove non-recurring annual UI references

## Testing
- `npm test` *(fails: Cannot find module '@/**', TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689636753f5c832e8ddf24758c60ec9f