### PR TITLE
feat: add in-app renewal cancellation

### DIFF
--- a/src/app/components/modals/ConfirmActionModal.tsx
+++ b/src/app/components/modals/ConfirmActionModal.tsx
@@ -15,6 +15,11 @@ interface ConfirmActionModalProps {
   cancelButtonText?: string;
   isProcessing?: boolean; // Para mostrar estado de processamento no botão de confirmação
   isDestructiveAction?: boolean; // Para estilizar o botão de confirmação como destrutivo
+  secondaryButtonText?: string;
+  onSecondaryAction?: () => void;
+  secondaryButtonDisabled?: boolean;
+  secondaryButtonProcessing?: boolean;
+  feedbackMessage?: { type: 'success' | 'error'; text: string } | null;
 }
 
 export default function ConfirmActionModal({
@@ -27,6 +32,11 @@ export default function ConfirmActionModal({
   cancelButtonText = "Cancelar",
   isProcessing = false,
   isDestructiveAction = false,
+  secondaryButtonText,
+  onSecondaryAction,
+  secondaryButtonDisabled = false,
+  secondaryButtonProcessing = false,
+  feedbackMessage = null,
 }: ConfirmActionModalProps) {
   return (
     <Transition.Root show={isOpen} as={Fragment}>
@@ -92,6 +102,20 @@ export default function ConfirmActionModal({
                   >
                     {isProcessing ? 'A processar...' : confirmButtonText}
                   </button>
+                  {secondaryButtonText && onSecondaryAction && (
+                    <button
+                      type="button"
+                      disabled={secondaryButtonDisabled || secondaryButtonProcessing}
+                      className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto disabled:opacity-50"
+                      onClick={() => {
+                        if (!secondaryButtonDisabled && !secondaryButtonProcessing) {
+                          onSecondaryAction();
+                        }
+                      }}
+                    >
+                      {secondaryButtonProcessing ? 'Processando...' : secondaryButtonText}
+                    </button>
+                  )}
                   <button
                     type="button"
                     disabled={isProcessing}
@@ -101,6 +125,11 @@ export default function ConfirmActionModal({
                     {cancelButtonText}
                   </button>
                 </div>
+                {feedbackMessage && (
+                  <p className={`px-6 pb-4 text-sm ${feedbackMessage.type === 'success' ? 'text-green-600' : 'text-red-600'}`}>
+                    {feedbackMessage.text}
+                  </p>
+                )}
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -282,7 +282,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
         ) : (
           <p className="text-sm mb-1 pl-9">
             Renova automaticamente em <strong className="font-medium">{expires}</strong>.{' '}
-            <a href="/dashboard/settings" className="underline text-brand-pink">Gerencie/cancele nas configurações</a>.
+            <a href="/dashboard/settings#subscription-management-title" className="underline text-brand-pink">Gerencie/cancele nas configurações</a>.
           </p>
         )}
 
@@ -395,7 +395,7 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
           />
           <span>
             Esta assinatura renova automaticamente{' '}
-            <a href="/dashboard/settings" className="underline text-brand-pink">
+            <a href="/dashboard/settings#subscription-management-title" className="underline text-brand-pink">
               Gerir assinatura
             </a>
           </span>

--- a/src/app/dashboard/components/types.ts
+++ b/src/app/dashboard/components/types.ts
@@ -35,11 +35,23 @@ export interface Indicator {
 /** Tipos adicionados para ProDashboard **/
 
 // Interface estendida para a sessão do usuário
+import type { PlanStatus, PlanType } from "@/types/enums";
+
 export interface ExtendedUser {
   id: string;
   name?: string | null;
   email?: string | null;
   image?: string | null;
+  planStatus?: PlanStatus;
+  planExpiresAt?: string | null;
+  planType?: PlanType;
+  affiliateCode?: string | null;
+  affiliateBalance?: number;
+  affiliateRank?: number;
+  affiliateInvites?: number;
+  provider?: string;
+  isInstagramConnected?: boolean;
+  whatsappVerified?: boolean;
 }
 
 // Tipo para cada item de métrica


### PR DESCRIPTION
## Summary
- expose `planType` on session tokens and user types to fix dashboard type errors
- allow subscribers to cancel Mercado Pago renewals directly from settings and delete-account modal
- extend confirm modal with optional secondary action and feedback messaging

## Testing
- `npm test` *(fails: TextEncoder/Response not defined, module resolution issues)*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689642696054832eb91d979261097f4e