### PR TITLE
Handle Mercado Pago payment rejections and expose last error

### DIFF
--- a/src/app/api/plan/last-error/route.ts
+++ b/src/app/api/plan/last-error/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession({ req, ...authOptions });
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    const user = await User.findOne({ email: session.user.email });
+    if (!user) {
+      return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
+    }
+
+    return NextResponse.json({ lastPaymentError: user.lastPaymentError || null });
+  } catch (error: unknown) {
+    console.error("Erro em /api/plan/last-error:", error);
+    const message = error instanceof Error ? error.message : "Erro desconhecido.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/plan/subscribe/route.ts
+++ b/src/app/api/plan/subscribe/route.ts
@@ -125,6 +125,7 @@ export async function POST(req: NextRequest) {
     const total = fromCents(totalCents);
 
     // 7) status pendente
+    user.lastPaymentError = undefined;
     user.planStatus = "pending";
     user.autoRenewConsentAt = new Date();
     await user.save();

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -32,6 +32,7 @@ export default function SettingsPage() {
   const [cancelMessage, setCancelMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [modalCancelLoading, setModalCancelLoading] = useState(false);
   const [modalCancelMessage, setModalCancelMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [lastPaymentError, setLastPaymentError] = useState<{ statusDetail: string; at: string } | null>(null);
 
   useEffect(() => {
     // Definir o título da página dinamicamente no cliente
@@ -41,6 +42,21 @@ export default function SettingsPage() {
       router.replace('/login');
     }
   }, [status, router]);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    (async () => {
+      try {
+        const res = await fetch('/api/plan/last-error');
+        if (res.ok) {
+          const data = await res.json();
+          setLastPaymentError(data.lastPaymentError);
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, [status]);
 
   if (status === "loading") {
     return (
@@ -204,6 +220,16 @@ export default function SettingsPage() {
             <section aria-labelledby="subscription-management-title" id="subscription-management-title">
               <h2 className="text-xl font-semibold text-gray-700">Minha Assinatura</h2>
               <div className="mt-4 space-y-3">
+                {lastPaymentError && (
+                  <>
+                    <p className="text-sm text-red-600">
+                      Última tentativa de pagamento foi recusada ({lastPaymentError.statusDetail}) em {new Date(lastPaymentError.at).toLocaleDateString('pt-BR')}.
+                    </p>
+                    <a href="/dashboard#payment-section" className="text-sm text-brand-pink underline">
+                      Tentar novamente
+                    </a>
+                  </>
+                )}
                 {planExpiresFormatted && (
                   <p className="text-sm text-gray-600">
                     Seu acesso expira em <strong className="font-medium">{planExpiresFormatted}</strong>.

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -259,6 +259,12 @@ export interface IUser extends Document {
     bankAgency?: string;
     bankAccount?: string;
   };
+  lastPaymentError?: {
+    at: Date;
+    paymentId: string;
+    status: string;
+    statusDetail: string;
+  };
   lastProcessedPaymentId?: string;
   communityInspirationOptIn?: boolean;
   communityInspirationOptInDate?: Date | null;
@@ -400,6 +406,12 @@ const userSchema = new Schema<IUser>(
       bankName: { type: String, default: "" },
       bankAgency: { type: String, default: "" },
       bankAccount: { type: String, default: "" },
+    },
+    lastPaymentError: {
+      at: { type: Date },
+      paymentId: { type: String },
+      status: { type: String },
+      statusDetail: { type: String },
     },
     lastProcessedPaymentId: { type: String, default: null, index: true },
     communityInspirationOptIn: { type: Boolean, default: false },


### PR DESCRIPTION
## Summary
- log Mercado Pago `payment` events and record rejection details on the user
- add `lastPaymentError` field with `/api/plan/last-error` endpoint and reset on new subscribe
- show last payment rejection in PaymentPanel and Settings when plan is pending

## Testing
- `npm test` *(fails: TextEncoder is not defined; many suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_689653a3624c832e82500442f47db420