### PR TITLE
Refine Mercado Pago subscription handling

### DIFF
--- a/src/app/api/plan/cancel/route.ts
+++ b/src/app/api/plan/cancel/route.ts
@@ -24,11 +24,10 @@ export async function POST(req: NextRequest) {
     await mercadopago.preapproval.update(user.paymentGatewaySubscriptionId, { status: "cancelled" });
 
     user.planStatus = "non_renewing";
-    user.paymentGatewaySubscriptionId = undefined;
     await user.save();
 
     return NextResponse.json({
-      message: "Assinatura cancelada. Seu acesso permanece até o fim do período já pago."
+      message: "Assinatura cancelada."
     });
   } catch (error: unknown) {
     console.error("Erro em /api/plan/cancel:", error);

--- a/src/app/api/plan/status/route.ts
+++ b/src/app/api/plan/status/route.ts
@@ -21,7 +21,9 @@ export async function GET(request: NextRequest) {
 
     // 2) Extrai o token JWT dos cookies ou headers
     const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
-    console.debug("[plan/status] Token extraído:", token);
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[plan/status] Token extraído:", token);
+    }
     if (!token || !token.sub) {
       return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
     }

--- a/src/app/api/plan/webhook/route.ts
+++ b/src/app/api/plan/webhook/route.ts
@@ -95,8 +95,10 @@ function validateWebhookSignature(
  * ATUALIZADO: Adiciona entrada ao commissionLog do afiliado.
  */
 export async function POST(request: NextRequest) {
-  console.log("--- [plan/webhook] Nova requisição recebida ---");
-  // console.log("[plan/webhook] URL da requisição:", request.url);
+  if (process.env.NODE_ENV !== "production") {
+    console.debug("--- [plan/webhook] Nova requisição recebida ---");
+    // console.debug("[plan/webhook] URL da requisição:", request.url);
+  }
 
   try {
     const { searchParams } = request.nextUrl;
@@ -115,8 +117,10 @@ export async function POST(request: NextRequest) {
     // console.log("[plan/webhook] Conectado ao banco.");
 
     const body = await request.json();
-    // Log básico do tipo e dados recebidos
-    console.log("[plan/webhook] type:", body.type, "data:", body.data);
+    if (process.env.NODE_ENV !== "production") {
+      // Log básico do tipo e dados recebidos
+      console.debug("[plan/webhook] type:", body.type, "data:", body.data);
+    }
 
     if (!body.data || !body.data.id) {
       // console.log("[plan/webhook] Notificação sem 'data.id' no corpo.");
@@ -154,6 +158,7 @@ export async function POST(request: NextRequest) {
               status: String(p.status),
               statusDetail: String(p.status_detail || "unknown"),
             };
+            user.planStatus = "inactive";
             await user.save();
           }
           return NextResponse.json({ received: true, noted: "payment-rejected" }, { status: 200 });


### PR DESCRIPTION
## Summary
- add Mercado Pago webhook URL and optional differential pricing for annual payments
- cancel subscriptions without clearing expiry and streamline logging
- ensure webhook marks users inactive on failed payments and reduce debug noise

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68966e241c10832ea0e7dcc60fca8eb4