### PR TITLE
Log Mercado Pago webhook signature headers

### DIFF
--- a/src/app/api/plan/webhook/route.ts
+++ b/src/app/api/plan/webhook/route.ts
@@ -100,7 +100,11 @@ function validateWebhookSignature(
 export async function POST(request: NextRequest) {
   if (!isProd) {
     console.debug("--- [plan/webhook] Nova requisição recebida ---");
-    // console.debug("[plan/webhook] URL da requisição:", request.url);
+    console.debug("[plan/webhook] headers:", {
+      xSignature: request.headers.get("x-signature"),
+      xRequestId: request.headers.get("x-request-id"),
+    });
+    console.debug("[plan/webhook] query:", request.nextUrl.search);
   }
 
   try {


### PR DESCRIPTION
## Summary
- log Mercado Pago webhook headers and query string in development for easier debugging

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, etc.)*
- `npm run lint` *(interactive prompt, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6897afb791f4832e917c5410e37b73a1