### PR TITLE
feat: add Stripe billing endpoints and webhook

### DIFF
--- a/src/app/api/billing/cancel/route.ts
+++ b/src/app/api/billing/cancel/route.ts
@@ -1,27 +1,42 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
-import { connectToDatabase } from '@/app/lib/mongoose';
-import User from '@/app/models/User';
-import stripe from '@/app/lib/stripe';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
-  const session = await getServerSession({ req, ...authOptions });
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  try {
+    const session = await getServerSession({ req, ...authOptions });
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    const user = await User.findOne({ email: session.user.email });
+    if (!user?.stripeSubscriptionId) {
+      return NextResponse.json({ error: "Assinatura Stripe não encontrada" }, { status: 404 });
+    }
+
+    const sub = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+      cancel_at_period_end: true,
+    });
+
+    // Reflete imediatamente na UI
+    user.planStatus = "non_renewing";
+    if (sub.current_period_end) {
+      user.planExpiresAt = new Date(sub.current_period_end * 1000);
+    }
+    await user.save();
+
+    return NextResponse.json({
+      message: "Renovação cancelada. Seu acesso permanece até o fim do período já pago.",
+    });
+  } catch (err: any) {
+    console.error("[billing/cancel] error:", err);
+    return NextResponse.json({ error: err?.message || "Erro ao cancelar renovação" }, { status: 500 });
   }
-
-  await connectToDatabase();
-  const user = await User.findOne({ email: session.user.email });
-  if (!user || !user.stripeSubscriptionId) {
-    return NextResponse.json({ error: 'Assinatura não encontrada' }, { status: 404 });
-  }
-
-  await stripe.subscriptions.update(user.stripeSubscriptionId, { cancel_at_period_end: true });
-  user.planStatus = 'non_renewing';
-  await user.save();
-
-  return NextResponse.json({ ok: true });
 }
+

--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -1,72 +1,109 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
-import { connectToDatabase } from '@/app/lib/mongoose';
-import User from '@/app/models/User';
-import stripe from '@/app/lib/stripe';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
-function getPriceId(plan: 'monthly' | 'annual', currency: string): string | null {
-  const key = `STRIPE_PRICE_${plan === 'monthly' ? 'MONTHLY' : 'ANNUAL'}_${currency}`.toUpperCase();
-  return process.env[key] || null;
+type Plan = "monthly" | "annual";
+type Currency = "BRL" | "USD";
+
+function getPriceId(plan: Plan, currency: Currency) {
+  if (plan === "monthly" && currency === "BRL") return process.env.STRIPE_PRICE_MONTHLY_BRL!;
+  if (plan === "annual"  && currency === "BRL") return process.env.STRIPE_PRICE_ANNUAL_BRL!;
+  if (plan === "monthly" && currency === "USD") return process.env.STRIPE_PRICE_MONTHLY_USD!;
+  if (plan === "annual"  && currency === "USD") return process.env.STRIPE_PRICE_ANNUAL_USD!;
+  throw new Error("PriceId não configurado para este plano/moeda");
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getServerSession({ req, ...authOptions });
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
-  }
+  try {
+    const session = await getServerSession({ req, ...authOptions });
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+    }
 
-  const body = (await req.json()) as { plan: 'monthly' | 'annual'; currency?: string; affiliateCode?: string };
-  const { plan, currency = 'BRL', affiliateCode } = body;
+    const body = await req.json();
+    const plan: Plan = body?.plan ?? "monthly";
+    const currency: Currency = body?.currency ?? "BRL";
+    const affiliateCode: string | undefined = body?.affiliateCode;
 
-  await connectToDatabase();
-  const user = await User.findOne({ email: session.user.email });
-  if (!user) {
-    return NextResponse.json({ error: 'Usuário não encontrado' }, { status: 404 });
-  }
+    await connectToDatabase();
+    const user = await User.findOne({ email: session.user.email });
+    if (!user) return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
 
-  if (!user.stripeCustomerId) {
-    const customer = await stripe.customers.create({ email: user.email });
-    user.stripeCustomerId = customer.id;
-  }
+    // Garante customer no Stripe
+    if (!user.stripeCustomerId) {
+      const customer = await stripe.customers.create({
+        email: user.email,
+        name: user.name || undefined,
+        metadata: { userId: String(user._id) },
+      });
+      user.stripeCustomerId = customer.id;
+    }
 
-  const priceId = getPriceId(plan, currency);
-  if (!priceId) {
-    return NextResponse.json({ error: 'Plano indisponível' }, { status: 400 });
-  }
-
-  let subscription;
-  if (user.stripeSubscriptionId) {
-    subscription = await stripe.subscriptions.update(user.stripeSubscriptionId, {
-      items: [{ price: priceId }],
-      payment_behavior: 'default_incomplete',
-      proration_behavior: 'create_prorations',
-      expand: ['latest_invoice.payment_intent'],
-    });
-  } else {
-    subscription = await stripe.subscriptions.create({
-      customer: user.stripeCustomerId,
-      items: [{ price: priceId }],
-      payment_behavior: 'default_incomplete',
-      expand: ['latest_invoice.payment_intent'],
-    });
-    user.stripeSubscriptionId = subscription.id;
-  }
-
-  if (affiliateCode) {
-    const aff = await User.findOne({ affiliateCode });
-    if (aff && !aff._id.equals(user._id)) {
+    // (Opcional) valida cupom/afiliado e evita auto-uso
+    if (affiliateCode) {
+      const aff = await User.findOne({ affiliateCode });
+      if (!aff) return NextResponse.json({ error: "Código de afiliado inválido." }, { status: 400 });
+      if (String(aff._id) === String(user._id)) {
+        return NextResponse.json({ error: "Você não pode usar seu próprio código." }, { status: 400 });
+      }
       user.affiliateUsed = affiliateCode;
     }
+
+    const priceId = getPriceId(plan, currency);
+
+    // Se já tem assinatura Stripe, atualiza para o novo price (caso de “reativar/trocar” por aqui)
+    if (user.stripeSubscriptionId) {
+      const sub = await stripe.subscriptions.retrieve(user.stripeSubscriptionId);
+      const itemId = sub.items.data[0]?.id;
+      if (!itemId) throw new Error("Item da assinatura não encontrado");
+
+      const updated = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+        items: [{ id: itemId, price: priceId }],
+        payment_behavior: "default_incomplete",
+        proration_behavior: "create_prorations",
+        billing_cycle_anchor: "now",
+        expand: ["latest_invoice.payment_intent"],
+        metadata: { plan },
+      });
+
+      await user.save();
+
+      const pi = (updated.latest_invoice as any)?.payment_intent;
+      return NextResponse.json({
+        subscriptionId: updated.id,
+        clientSecret: pi?.client_secret || null,
+        requiresAction: !!pi && ["requires_action", "requires_payment_method"].includes(pi.status),
+      });
+    }
+
+    // Cria assinatura do zero
+    const created = await stripe.subscriptions.create({
+      customer: user.stripeCustomerId,
+      items: [{ price: priceId }],
+      payment_behavior: "default_incomplete",
+      expand: ["latest_invoice.payment_intent"],
+      metadata: { plan },
+    });
+
+    user.stripeSubscriptionId = created.id;
+    user.planType = plan;      // mantém coerência na sessão
+    user.planStatus = "pending";
+    await user.save();
+
+    const pi = (created.latest_invoice as any)?.payment_intent;
+    return NextResponse.json({
+      subscriptionId: created.id,
+      clientSecret: pi?.client_secret || null,
+      requiresAction: !!pi && ["requires_action", "requires_payment_method"].includes(pi.status),
+    });
+  } catch (err: any) {
+    console.error("[billing/subscribe] error:", err);
+    return NextResponse.json({ error: err?.message || "Erro ao iniciar assinatura" }, { status: 500 });
   }
-
-  user.planType = plan;
-  user.currency = currency;
-  user.planStatus = 'pending';
-  await user.save();
-
-  const paymentIntent = (subscription.latest_invoice as any)?.payment_intent;
-  return NextResponse.json({ clientSecret: paymentIntent?.client_secret || null });
 }
+

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,79 +1,162 @@
-import { NextRequest, NextResponse } from 'next/server';
-import stripe from '@/app/lib/stripe';
-import { connectToDatabase } from '@/app/lib/mongoose';
-import User from '@/app/models/User';
+import { NextRequest, NextResponse } from "next/server";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
+
+// ⚠️ IMPORTANTE: No Stripe Dashboard, aponte o webhook para /api/stripe/webhook
+// Eventos mínimos: invoice.payment_succeeded, invoice.payment_failed,
+// customer.subscription.updated, customer.subscription.deleted
 
 export async function POST(req: NextRequest) {
-  const sig = req.headers.get('stripe-signature') || '';
-  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+  if (!sig) return NextResponse.json({ error: "Missing signature" }, { status: 400 });
 
   let event;
   try {
-    event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
+    const payload = await req.text(); // precisa do raw body
+    event = stripe.webhooks.constructEvent(payload, sig, process.env.STRIPE_WEBHOOK_SECRET!);
   } catch (err: any) {
-    return new NextResponse(`Webhook Error: ${err.message}`, { status: 400 });
+    console.error("[stripe/webhook] signature error:", err?.message);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  await connectToDatabase();
+  try {
+    await connectToDatabase();
 
-  switch (event.type) {
-    case 'invoice.payment_succeeded': {
-      const invoice = event.data.object as any;
-      const user = await User.findOne({ stripeCustomerId: invoice.customer });
-      if (user && user.lastProcessedEventId !== event.id) {
-        user.lastProcessedEventId = event.id;
-        user.planStatus = 'active';
-        const interval = invoice.lines.data[0].price?.recurring?.interval;
-        user.planType = interval === 'year' ? 'annual' : 'monthly';
-        user.planExpiresAt = new Date(invoice.lines.data[0].period.end * 1000);
-        if (invoice.billing_reason === 'subscription_create' && user.affiliateUsed) {
-          const commission = (invoice.total / 100) * 0.1;
-          user.affiliateBalance = (user.affiliateBalance || 0) + commission;
-          user.commissionLog = user.commissionLog || [];
-          user.commissionLog.push({
-            date: new Date(),
-            amount: commission,
-            description: 'Affiliate commission',
-            sourcePaymentId: invoice.id,
-            referredUserId: user._id,
-          });
-          user.affiliateUsed = undefined;
+    switch (event.type) {
+      case "invoice.payment_succeeded": {
+        const invoice = event.data.object as Stripe.Invoice;
+        const subId = typeof invoice.subscription === "string" ? invoice.subscription : invoice.subscription?.id;
+        const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+
+        if (!customerId) break;
+        const user = await User.findOne({ stripeCustomerId: customerId });
+        if (!user) break;
+
+        // Define plano e expiração a partir da própria invoice
+        const line = invoice.lines?.data?.[0];
+        const periodEnd = line?.period?.end ? new Date(line.period.end * 1000) : null;
+        const interval = line?.price?.recurring?.interval; // "month" | "year"
+
+        if (interval === "month") user.planType = "monthly";
+        if (interval === "year")  user.planType = "annual";
+        user.planStatus = "active";
+        if (periodEnd) user.planExpiresAt = periodEnd;
+        if (subId) user.stripeSubscriptionId = subId;
+
+        // Comissão somente na 1ª cobrança da assinatura
+        if (invoice.billing_reason === "subscription_create" && user.affiliateUsed) {
+          const affUser = await User.findOne({ affiliateCode: user.affiliateUsed });
+          if (affUser) {
+            const gross = (invoice.total ?? 0) / 100; // total já em moeda
+            const commission = gross * 0.10; // ajuste a taxa se necessário
+            affUser.affiliateBalance = (affUser.affiliateBalance || 0) + commission;
+            affUser.affiliateInvites = (affUser.affiliateInvites || 0) + 1;
+            if (affUser.affiliateInvites % 5 === 0) {
+              affUser.affiliateRank = (affUser.affiliateRank || 1) + 1;
+            }
+            affUser.commissionLog = affUser.commissionLog || [];
+            affUser.commissionLog.push({
+              date: new Date(),
+              amount: commission,
+              description: `Comissão (1ª cobrança) de ${user.email || user._id}`,
+              sourcePaymentId: String(invoice.id),
+              referredUserId: user._id,
+            });
+            await affUser.save();
+          }
+          user.affiliateUsed = undefined; // limpa para não pagar em renovações
         }
+
+        user.lastPaymentError = undefined;
         await user.save();
+        break;
       }
-      break;
-    }
-    case 'invoice.payment_failed': {
-      const invoice = event.data.object as any;
-      const user = await User.findOne({ stripeCustomerId: invoice.customer });
-      if (user && user.lastProcessedEventId !== event.id) {
-        user.lastProcessedEventId = event.id;
+
+      case "invoice.payment_failed": {
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+        if (!customerId) break;
+        const user = await User.findOne({ stripeCustomerId: customerId });
+        if (!user) break;
+
         user.lastPaymentError = {
           at: new Date(),
-          status: 'failed',
-          statusDetail: invoice.last_payment_error?.message || 'unknown',
-        } as any;
+          paymentId: String(invoice.id),
+          status: "failed",
+          statusDetail: String(invoice.last_finalization_error?.message || "unknown"),
+        };
         await user.save();
+        break;
       }
-      break;
-    }
-    case 'customer.subscription.deleted': {
-      const sub = event.data.object as any;
-      const user = await User.findOne({ stripeCustomerId: sub.customer });
-      if (user && user.lastProcessedEventId !== event.id) {
-        user.lastProcessedEventId = event.id;
-        user.planStatus = 'inactive';
-        user.planExpiresAt = null;
-        user.stripeSubscriptionId = null;
-        await user.save();
-      }
-      break;
-    }
-    default:
-      break;
-  }
 
-  return NextResponse.json({ received: true });
+      case "customer.subscription.updated": {
+        const sub = event.data.object as Stripe.Subscription;
+        const customerId = typeof sub.customer === "string" ? sub.customer : sub.customer?.id;
+        if (!customerId) break;
+        const user = await User.findOne({ stripeCustomerId: customerId });
+        if (!user) break;
+
+        if (sub.cancel_at_period_end) {
+          user.planStatus = "non_renewing";
+        } else if (sub.status === "active" || sub.status === "trialing") {
+          user.planStatus = "active";
+        }
+        if (sub.current_period_end) {
+          user.planExpiresAt = new Date(sub.current_period_end * 1000);
+        }
+        await user.save();
+        break;
+      }
+
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as Stripe.Subscription;
+        const customerId = typeof sub.customer === "string" ? sub.customer : sub.customer?.id;
+        if (!customerId) break;
+        const user = await User.findOne({ stripeCustomerId: customerId });
+        if (!user) break;
+
+        user.planStatus = "inactive";
+        user.planExpiresAt = null;
+        await user.save();
+        break;
+      }
+
+      default:
+        // opcional: log leve para monitorar
+        // console.debug("[stripe/webhook] ignorado:", event.type);
+        break;
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (err: any) {
+    console.error("[stripe/webhook] handler error:", err);
+    // Sempre 2xx para evitar replays agressivos; logamos o erro para reprocessar manualmente se preciso
+    return NextResponse.json({ received: true, error: "logged" }, { status: 200 });
+  }
 }
+
+// Tipos Stripe (evita import global pesado)
+// Se o projeto já tiver os tipos, pode remover este bloco e usar diretamente Stripe.* acima.
+declare namespace Stripe {
+  export interface Invoice {
+    id: string;
+    total: number | null;
+    subscription: string | { id: string } | null;
+    customer: string | { id: string } | null;
+    billing_reason?: string;
+    last_finalization_error?: { message?: string };
+    lines: { data: Array<{ period: { start: number; end: number }, price?: { recurring?: { interval?: "day"|"week"|"month"|"year" } } }> };
+  }
+  export interface Subscription {
+    id: string;
+    customer: string | { id: string };
+    status: "active" | "trialing" | "past_due" | "unpaid" | "canceled" | "incomplete" | "incomplete_expired" | "paused";
+    cancel_at_period_end: boolean | null;
+    current_period_end: number;
+    items: { data: Array<{ id: string, price: { id: string } }> };
+  }
+}
+

--- a/src/app/lib/stripe.ts
+++ b/src/app/lib/stripe.ts
@@ -1,10 +1,13 @@
-import Stripe from 'stripe';
+import Stripe from "stripe";
 
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || '';
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY!;
 if (!STRIPE_SECRET_KEY) {
-  console.warn('STRIPE_SECRET_KEY not set');
+  console.warn("STRIPE_SECRET_KEY não está definido!");
 }
 
-const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: "2024-06-20",
+});
 
 export default stripe;
+


### PR DESCRIPTION
## Summary
- replace billing subscribe endpoint to create or update Stripe subscriptions
- add plan change and cancel endpoints
- handle Stripe webhooks for invoices and subscription lifecycle
- expose Stripe client with 2024 API version

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68981a01e7dc832e9364189bfb39b906