### PR TITLE
feat: add stripe payment element checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "recharts": "^2.15.3",
     "redis": "^4.7.0",
     "stripe": "^12.0.0",
+    "@stripe/react-stripe-js": "^2.6.2",
+    "@stripe/stripe-js": "^2.5.0",
     "swiper": "^11.2.6",
     "swr": "^2.3.4",
     "uuid": "^11.1.0",

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { FaSpinner, FaCheckCircle, FaInfoCircle, FaTimesCircle, FaLock } from "react-icons/fa";
 import {
   MONTHLY_PRICE,
@@ -320,6 +321,14 @@ export default function PaymentPanel({ user }: PaymentPanelProps) {
 
   return (
     <div className="mx-auto w-full max-w-md">
+      <div className="mb-4 text-center">
+        <Link
+          href="/dashboard/billing"
+          className="px-4 py-2 rounded bg-black text-white inline-block"
+        >
+          Assinar agora
+        </Link>
+      </div>
       {isPending && (
         <div className="border border-yellow-300 rounded-xl shadow-sm p-4 sm:p-5 bg-yellow-50 text-yellow-800 mb-4">
           <div className="flex items-center gap-3 mb-2">

--- a/src/app/dashboard/billing/CheckoutForm.tsx
+++ b/src/app/dashboard/billing/CheckoutForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { useState } from "react";
+import { PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+
+type Props = {
+  subscriptionId: string | null;
+  onBack: () => void;
+};
+
+export default function CheckoutForm({ subscriptionId, onBack }: Props) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const router = useRouter();
+  const { update } = useSession();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    try {
+      setSubmitting(true);
+      setErr(null);
+
+      const returnUrl = `${window.location.origin}/dashboard/billing/success`;
+
+      const { error } = await stripe.confirmPayment({
+        elements,
+        confirmParams: { return_url: returnUrl },
+        redirect: "if_required",
+      });
+
+      if (error) {
+        setErr(error.message || "Falha ao confirmar pagamento");
+        setSubmitting(false);
+        return;
+      }
+
+      try {
+        await update();
+      } catch {}
+
+      router.push("/dashboard");
+    } catch (e: any) {
+      setErr(e?.message || "Erro inesperado");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 border rounded p-4">
+      <div className="flex items-center justify-between">
+        <button type="button" onClick={onBack} className="text-sm underline">
+          Voltar
+        </button>
+        {subscriptionId && (
+          <span className="text-xs text-gray-500">Sub: {subscriptionId}</span>
+        )}
+      </div>
+
+      <PaymentElement />
+
+      {err && <p className="text-sm text-red-600">{err}</p>}
+
+      <button
+        type="submit"
+        disabled={!stripe || !elements || submitting}
+        className="w-full px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+      >
+        {submitting ? "Processando..." : "Pagar e ativar assinatura"}
+      </button>
+
+      <p className="text-xs text-gray-500">
+        Ao confirmar, você concorda com a renovação automática conforme o plano
+        selecionado. Você pode cancelar a renovação em Configurações &gt; Assinatura.
+      </p>
+    </form>
+  );
+}
+

--- a/src/app/dashboard/billing/CheckoutPage.tsx
+++ b/src/app/dashboard/billing/CheckoutPage.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { useState } from "react";
+import { Elements } from "@stripe/react-stripe-js";
+import type { StripeElementsOptions } from "@stripe/stripe-js";
+import { stripePromise } from "@/app/lib/stripe-browser";
+import CheckoutForm from "./CheckoutForm";
+
+type Plan = "monthly" | "annual";
+type Currency = "BRL" | "USD";
+
+export default function CheckoutPage() {
+  const [step, setStep] = useState<"config" | "pay">("config");
+  const [plan, setPlan] = useState<Plan>("monthly");
+  const [currency, setCurrency] = useState<Currency>("BRL");
+  const [affiliateCode, setAffiliateCode] = useState<string>("");
+  const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [subscriptionId, setSubscriptionId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function startCheckout() {
+    try {
+      setLoading(true);
+      setErr(null);
+
+      const res = await fetch("/api/billing/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plan,
+          currency,
+          affiliateCode: affiliateCode.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Falha ao iniciar assinatura");
+
+      if (!data.clientSecret) throw new Error("clientSecret ausente");
+      setClientSecret(data.clientSecret);
+      setSubscriptionId(data.subscriptionId || null);
+      setStep("pay");
+    } catch (e: any) {
+      setErr(e?.message || "Erro inesperado");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const options: StripeElementsOptions | undefined = clientSecret
+    ? {
+        clientSecret,
+        appearance: { theme: "stripe" },
+        locale: "auto",
+      }
+    : undefined;
+
+  return (
+    <div className="max-w-xl w-full space-y-6">
+      <h1 className="text-2xl font-semibold">Assinar Plano</h1>
+
+      {step === "config" && (
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Plano</label>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPlan("monthly")}
+                className={`px-3 py-2 rounded border ${plan === "monthly" ? "bg-gray-100" : ""}`}
+              >
+                Mensal
+              </button>
+              <button
+                onClick={() => setPlan("annual")}
+                className={`px-3 py-2 rounded border ${plan === "annual" ? "bg-gray-100" : ""}`}
+              >
+                Anual
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              O anual é cobrado à vista e renova automaticamente a cada 12 meses.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Moeda</label>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setCurrency("BRL")}
+                className={`px-3 py-2 rounded border ${currency === "BRL" ? "bg-gray-100" : ""}`}
+              >
+                BRL (R$)
+              </button>
+              <button
+                onClick={() => setCurrency("USD")}
+                className={`px-3 py-2 rounded border ${currency === "USD" ? "bg-gray-100" : ""}`}
+              >
+                USD ($)
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Código de afiliado (opcional)</label>
+            <input
+              value={affiliateCode}
+              onChange={(e) => setAffiliateCode(e.target.value)}
+              placeholder="EX: ABC123"
+              className="w-full px-3 py-2 border rounded"
+            />
+          </div>
+
+          {err && <p className="text-sm text-red-600">{err}</p>}
+
+          <button
+            onClick={startCheckout}
+            disabled={loading}
+            className="w-full px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+          >
+            {loading ? "Preparando..." : "Continuar para pagamento"}
+          </button>
+        </div>
+      )}
+
+      {step === "pay" && clientSecret && options && (
+        <Elements stripe={stripePromise} options={options} key={clientSecret}>
+          <CheckoutForm subscriptionId={subscriptionId} onBack={() => setStep("config")} />
+        </Elements>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -1,0 +1,9 @@
+import CheckoutPage from "./CheckoutPage";
+
+export default function Page() {
+  return (
+    <div className="p-6">
+      <CheckoutPage />
+    </div>
+  );
+}

--- a/src/app/lib/stripe-browser.ts
+++ b/src/app/lib/stripe-browser.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { loadStripe } from "@stripe/stripe-js";
+
+export const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY as string
+);


### PR DESCRIPTION
## Summary
- add Stripe client and checkout components for subscriptions
- expose billing route and link from payment panel
- add Stripe packages to dependencies

## Testing
- `npm test` *(fails: TextEncoder is not defined, multiple failing test suites)*
- `CI=true npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68981cb30b48832eabb0dd940efea90c