### PR TITLE
feat: toast notifications and billing status refetch

### DIFF
--- a/src/app/components/ui/ToastProvider.tsx
+++ b/src/app/components/ui/ToastProvider.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+
+type ToastVariant = "success" | "error" | "info";
+type ToastItem = {
+  id: string;
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number; // ms
+};
+
+type ToastContextValue = {
+  toast: (t: Omit<ToastItem, "id">) => void;
+  dismiss: (id: string) => void;
+  dismissAll: () => void;
+};
+
+const ToastCtx = createContext<ToastContextValue | null>(null);
+
+export function useToast() {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
+  return ctx;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+  const timersRef = useRef<Record<string, any>>({});
+
+  const dismiss = useCallback((id: string) => {
+    setItems((prev) => prev.filter((t) => t.id !== id));
+    if (timersRef.current[id]) {
+      clearTimeout(timersRef.current[id]);
+      delete timersRef.current[id];
+    }
+  }, []);
+
+  const toast = useCallback(
+    (t: Omit<ToastItem, "id">) => {
+      const id = crypto.randomUUID();
+      const duration = t.duration ?? 4000;
+      const next: ToastItem = { id, variant: "info", ...t };
+      setItems((prev) => [...prev, next]);
+
+      if (duration > 0) {
+        timersRef.current[id] = setTimeout(() => dismiss(id), duration);
+      }
+    },
+    [dismiss]
+  );
+
+  const dismissAll = useCallback(() => {
+    Object.values(timersRef.current).forEach(clearTimeout);
+    timersRef.current = {};
+    setItems([]);
+  }, []);
+
+  const value = useMemo(() => ({ toast, dismiss, dismissAll }), [toast, dismiss, dismissAll]);
+
+  return (
+    <ToastCtx.Provider value={value}>
+      {children}
+      {/* Container */}
+      <div className="fixed bottom-4 right-4 z-50 space-y-2">
+        {items.map((t) => (
+          <div
+            key={t.id}
+            className={[
+              "w-[320px] shadow-lg rounded-lg p-3 text-sm transition-all animate-[fadeIn_.15s_ease-out]",
+              t.variant === "success" && "bg-green-600 text-white",
+              t.variant === "error" && "bg-red-600 text-white",
+              (!t.variant || t.variant === "info") && "bg-gray-900 text-white",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            role="status"
+          >
+            <div className="flex items-start gap-2">
+              <div className="grow">
+                {t.title && <div className="font-medium">{t.title}</div>}
+                {t.description && <div className="opacity-90">{t.description}</div>}
+              </div>
+              <button
+                onClick={() => dismiss(t.id)}
+                className="opacity-80 hover:opacity-100 focus:outline-none"
+                aria-label="Fechar"
+                title="Fechar"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* animação básica */}
+      <style jsx global>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(6px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </ToastCtx.Provider>
+  );
+}
+

--- a/src/app/dashboard/billing/CancelRenewalCard.tsx
+++ b/src/app/dashboard/billing/CancelRenewalCard.tsx
@@ -2,9 +2,14 @@
 
 import React, { useState } from "react";
 import { useSession } from "next-auth/react";
+import { useToast } from "@/app/components/ui/ToastProvider";
+import { useBillingStatus } from "@/app/hooks/useBillingStatus";
 
 export default function CancelRenewalCard() {
   const { data: session, update } = useSession();
+  const userId = (session?.user as any)?.id as string | undefined;
+  const { refetch } = useBillingStatus({ userId, auto: false });
+  const { toast } = useToast();
   const planStatus = (session?.user as any)?.planStatus as
     | "active"
     | "non_renewing"
@@ -34,9 +39,21 @@ export default function CancelRenewalCard() {
       setOkMsg(
         "Renovação cancelada. Seu acesso permanece até o fim do período já pago."
       );
+      toast({
+        variant: "success",
+        title: "Renovação cancelada",
+        description: "Você manterá acesso até expirar.",
+      });
       await update().catch(() => {});
+      refetch();
     } catch (e: any) {
-      setErr(e?.message || "Erro inesperado");
+      const msg = e?.message || "Erro inesperado";
+      setErr(msg);
+      toast({
+        variant: "error",
+        title: "Falha ao cancelar",
+        description: String(msg),
+      });
     } finally {
       setLoading(false);
     }

--- a/src/app/hooks/useBillingStatus.ts
+++ b/src/app/hooks/useBillingStatus.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type PlanStatus = "active" | "non_renewing" | "inactive" | "pending" | "expired";
+type BillingStatus = {
+  planStatus: PlanStatus | null;
+  planExpiresAt: string | null;
+};
+
+type Options = {
+  userId?: string | null;
+  auto?: boolean;        // se true, carrega imediatamente
+  pollOn?: PlanStatus[]; // estados que devem ligar polling automático
+  intervalMs?: number;   // período do polling
+};
+
+export function useBillingStatus(opts: Options = {}) {
+  const {
+    userId = null,
+    auto = true,
+    pollOn = ["pending"],
+    intervalMs = 4000,
+  } = opts;
+
+  const [data, setData] = useState<BillingStatus>({ planStatus: null, planExpiresAt: null });
+  const [loading, setLoading] = useState<boolean>(!!auto);
+  const [error, setError] = useState<string | null>(null);
+
+  const pollingRef = useRef<any>(null);
+
+  const fetchOnce = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/plan/status?userId=${encodeURIComponent(userId)}`, { cache: "no-store" });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j?.error || "Falha ao obter status");
+      setData({
+        planStatus: j?.planStatus ?? null,
+        planExpiresAt: j?.planExpiresAt ?? null,
+      });
+    } catch (e: any) {
+      setError(e?.message || "Erro inesperado");
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  const refetch = useCallback(() => fetchOnce(), [fetchOnce]);
+
+  const startPolling = useCallback(() => {
+    if (pollingRef.current || !userId) return;
+    pollingRef.current = setInterval(fetchOnce, intervalMs);
+  }, [fetchOnce, intervalMs, userId]);
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  // auto-load
+  useEffect(() => {
+    if (auto) fetchOnce();
+    return () => stopPolling();
+  }, [auto, fetchOnce, stopPolling]);
+
+  // liga/desliga polling baseado em estado
+  useEffect(() => {
+    if (!data.planStatus) return;
+    if (pollOn.includes(data.planStatus)) startPolling();
+    else stopPolling();
+  }, [data.planStatus, pollOn, startPolling, stopPolling]);
+
+  return useMemo(
+    () => ({
+      ...data,
+      isLoading: loading,
+      error,
+      refetch,
+      startPolling,
+      stopPolling,
+    }),
+    [data, loading, error, refetch, startPolling, stopPolling]
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { Providers } from "./providers";
 import AuthRedirectHandler from "./components/auth/AuthRedirectHandler";
 import ClientHooksWrapper from "./components/ClientHooksWrapper";
 import MainContentWrapper from "./components/MainContentWrapper"; // ✅ IMPORTADO O NOVO COMPONENTE
+import { ToastProvider } from "@/app/components/ui/ToastProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -55,19 +56,21 @@ export default async function RootLayout({
           text-brand-dark
         `}
       >
-        <Providers session={serializableSession}>
-          <ClientHooksWrapper />
-          <AuthRedirectHandler>
-            <Header />
+        <ToastProvider>
+          <Providers session={serializableSession}>
+            <ClientHooksWrapper />
+            <AuthRedirectHandler>
+              <Header />
 
-            {/* ✅ O wrapper agora é usado aqui para aplicar o padding condicionalmente */}
-            <MainContentWrapper>
-              {children}
-            </MainContentWrapper>
-            
-            <Footer />
-          </AuthRedirectHandler>
-        </Providers>
+              {/* ✅ O wrapper agora é usado aqui para aplicar o padding condicionalmente */}
+              <MainContentWrapper>
+                {children}
+              </MainContentWrapper>
+
+              <Footer />
+            </AuthRedirectHandler>
+          </Providers>
+        </ToastProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add global ToastProvider for minimal success/error/info toasts
- implement billing status hook with refetch and polling
- wire toasts and billing refetch into change plan and cancel renewal flows

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: @stripe/stripe-js@^2.5.0 not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689822331238832e8991fc1c967222c6