### PR TITLE
Improve subscription handling and plan interval support

### DIFF
--- a/src/app/api/plan/status/route.ts
+++ b/src/app/api/plan/status/route.ts
@@ -28,10 +28,10 @@ export async function GET(req: Request) {
 
   const subs = await stripe.subscriptions.list({
     customer: user.stripeCustomerId,
-    status: "all",
+    status: "active",
     limit: 1,
   });
-  const sub = subs.data[0];
+  const sub = subs.data.find((s) => !s.cancel_at_period_end) ?? subs.data[0];
   const item = sub?.items.data[0];
   const interval = item?.price.recurring?.interval ?? null;
 

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
         if (!user) break;
 
         // Define plano e expiração a partir da própria invoice
-        const line = invoice.lines?.data?.[0];
+        const line = invoice.lines?.data?.find((l) => l?.price?.recurring);
         const periodEnd = line?.period?.end ? new Date(line.period.end * 1000) : null;
         const interval = line?.price?.recurring?.interval; // "month" | "year"
 

--- a/src/app/dashboard/billing/CancelRenewalCard.tsx
+++ b/src/app/dashboard/billing/CancelRenewalCard.tsx
@@ -6,16 +6,9 @@ import { useToast } from "@/app/components/ui/ToastA11yProvider";
 import { useBillingStatus } from "@/app/hooks/useBillingStatus";
 
 export default function CancelRenewalCard() {
-  const { data: session, update } = useSession();
-  const { refetch } = useBillingStatus({ auto: false });
+  const { update } = useSession();
+  const { planStatus, planExpiresAt, refetch } = useBillingStatus();
   const { toast } = useToast();
-  const planStatus = (session?.user as any)?.planStatus as
-    | "active"
-    | "non_renewing"
-    | "inactive"
-    | "pending"
-    | undefined;
-  const planExpiresAt = (session?.user as any)?.planExpiresAt as string | undefined;
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- ensure plan status fetch only considers active subscriptions and avoids cancelled ones
- pick recurring line item in Stripe invoice webhooks
- expose real-time billing info and plan interval in frontend and NextAuth session

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and others)*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68993fb16628832e908cf780de5fb548