### PR TITLE
Handle plan interval and webhook idempotency

### DIFF
--- a/src/app/api/plan/status/route.ts
+++ b/src/app/api/plan/status/route.ts
@@ -26,6 +26,16 @@ export async function GET(req: Request) {
     });
   }
 
+  if (!user.stripeCustomerId) {
+    return NextResponse.json({
+      ok: true,
+      status: user.planStatus ?? null,
+      interval: user.planInterval ?? null,
+      priceId: user.stripePriceId ?? null,
+      planExpiresAt: user.planExpiresAt ?? null,
+    });
+  }
+
   const subs = await stripe.subscriptions.list({
     customer: user.stripeCustomerId,
     status: "active",


### PR DESCRIPTION
## Summary
- update invoice payment handler to save plan interval and guard against repeated events
- guard plan status endpoint when user lacks stripe customer id

## Testing
- `npm test` (fails: ReferenceError: Request is not defined; Test Suites: 114 failed, 18 passed)

------
https://chatgpt.com/codex/tasks/task_e_68994281eba8832ebe4810987d6f12c8