### PR TITLE
Handle non-renewing Stripe subscriptions

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -62,7 +62,7 @@ export async function POST(req: NextRequest) {
               affUser.affiliateRank = (affUser.affiliateRank || 1) + 1;
             }
             affUser.commissionLog = affUser.commissionLog || [];
-            affUser.commissionLog.push({
+          affUser.commissionLog.push({
               date: new Date(),
               amount: commission,
               description: `Comissão (1ª cobrança) de ${user.email || user._id}`,
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
             });
             await affUser.save();
           }
-          user.affiliateUsed = undefined; // limpa para não pagar em renovações
+          user.affiliateUsed = null; // limpa para não pagar em renovações
         }
 
         user.lastPaymentError = undefined;
@@ -114,7 +114,10 @@ export async function POST(req: NextRequest) {
         if (sub.current_period_end) {
           update.planExpiresAt = new Date(sub.current_period_end * 1000);
         }
-        await User.updateOne({ stripeCustomerId: customerId }, { $set: update });
+        await User.updateOne(
+          { stripeCustomerId: customerId },
+          { $set: { ...update, lastProcessedEventId: event.id } }
+        );
         break;
       }
 


### PR DESCRIPTION
## Summary
- Treat cancel_at_period_end as non_renewing in plan status fallback
- Query all subscription statuses when syncing plan status
- Clear affiliateUsed with null and track lastProcessedEventId in Stripe webhook

## Testing
- `npm test` *(fails: TextEncoder is not defined, Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6899446a4470832e89a7497738dbe7ce