### PR TITLE
Atualiza cancelamento para refletir plano non_renewing imediatamente

### DIFF
--- a/src/app/api/billing/cancel/route.ts
+++ b/src/app/api/billing/cancel/route.ts
@@ -16,23 +16,53 @@ export async function POST(req: NextRequest) {
 
     await connectToDatabase();
     const user = await User.findOne({ email: session.user.email });
-    if (!user?.stripeSubscriptionId) {
+    if (!user) {
+      return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
+    }
+
+    if (user.planStatus === "non_renewing") {
+      return NextResponse.json({
+        message:
+          "Renovação cancelada. Seu acesso permanece até o fim do período já pago.",
+      });
+    }
+
+    let subscriptionId = user.stripeSubscriptionId;
+    if (!subscriptionId && user.stripeCustomerId) {
+      const subs = await stripe.subscriptions.list({
+        customer: user.stripeCustomerId,
+        status: "active",
+        limit: 1,
+      });
+      subscriptionId = subs.data[0]?.id;
+    }
+    if (!subscriptionId) {
       return NextResponse.json({ error: "Assinatura Stripe não encontrada" }, { status: 404 });
     }
 
-    const sub = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    const sub = await stripe.subscriptions.update(subscriptionId, {
       cancel_at_period_end: true,
     });
 
-    // Reflete imediatamente na UI
-    user.planStatus = "non_renewing";
-    if (sub.current_period_end) {
-      user.planExpiresAt = new Date(sub.current_period_end * 1000);
-    }
-    await user.save();
+    await User.updateOne(
+      { _id: user._id },
+      {
+        $set: {
+          planStatus: "non_renewing",
+          planInterval:
+            sub.items.data[0]?.price.recurring?.interval ?? user.planInterval,
+          planExpiresAt: sub.current_period_end
+            ? new Date(sub.current_period_end * 1000)
+            : user.planExpiresAt,
+          stripeSubscriptionId: sub.id,
+        },
+        $unset: { lastPaymentError: 1 },
+      }
+    );
 
     return NextResponse.json({
-      message: "Renovação cancelada. Seu acesso permanece até o fim do período já pago.",
+      message:
+        "Renovação cancelada. Seu acesso permanece até o fim do período já pago.",
     });
   } catch (err: any) {
     console.error("[billing/cancel] error:", err);


### PR DESCRIPTION
## Resumo
- Atualiza `/api/billing/cancel` para buscar assinatura ativa se necessário
- Sincroniza status `non_renewing`, intervalo e data de expiração no banco
- Limpa `lastPaymentError` e retorna resposta idempotente

## Testes
- `npm test` *(falha: Cannot find module, TextEncoder is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68994775aa1c832e949e389f80b8ac8e