### PR TITLE
Refine affiliate payouts and Stripe subscription logic

### DIFF
--- a/src/app/api/affiliate/connect/create-link/route.ts
+++ b/src/app/api/affiliate/connect/create-link/route.ts
@@ -25,6 +25,8 @@ export async function POST(req: NextRequest) {
       const account = await stripe.accounts.create({
         type: process.env.STRIPE_CONNECT_MODE === "express" ? "express" : "standard",
         email: user.email,
+        capabilities: { transfers: { requested: true } },
+        metadata: { userId: String(user._id) },
       });
       accountId = account.id;
       user.paymentInfo = user.paymentInfo || {};

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -26,15 +26,11 @@ export async function GET(req: NextRequest) {
     if (accountId) {
       try {
         const account = await stripe.accounts.retrieve(accountId);
-        if ((account as any).disabled_reason) {
-          status = "disabled";
-        } else if (account.requirements?.disabled_reason) {
-          status = "restricted";
-        } else if (account.details_submitted && account.charges_enabled && account.payouts_enabled) {
-          status = "verified";
-        } else {
-          status = "pending";
-        }
+        let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending' | null = 'pending';
+        if (account.requirements?.disabled_reason) newStatus = 'restricted';
+        if ((account as any).disabled_reason) newStatus = 'disabled';
+        if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
+        status = newStatus;
         user.paymentInfo = user.paymentInfo || {};
         user.paymentInfo.stripeAccountStatus = status;
         await user.save();


### PR DESCRIPTION
## Summary
- prevent duplicate affiliate payouts and log more transfer metadata
- improve Stripe Connect account setup and status reporting
- modernize subscription creation with discounts and handle canceled subs

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, etc.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689951d8b764832e8108e183ca0e04c7