### PR TITLE
fix affiliate subscription and connect handling

### DIFF
--- a/src/app/api/affiliate/connect/create-link/route.ts
+++ b/src/app/api/affiliate/connect/create-link/route.ts
@@ -9,6 +9,9 @@ export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   try {
+    if (process.env.STRIPE_CONNECT_MODE !== "express") {
+      return NextResponse.json({ error: "Stripe Connect deve estar configurado como Express" }, { status: 400 });
+    }
     const session = await getServerSession({ req, ...authOptions });
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
@@ -23,7 +26,7 @@ export async function POST(req: NextRequest) {
     let accountId = user.paymentInfo?.stripeAccountId;
     if (!accountId) {
       const account = await stripe.accounts.create({
-        type: process.env.STRIPE_CONNECT_MODE === "express" ? "express" : "standard",
+        type: "express",
         email: user.email,
         capabilities: { transfers: { requested: true } },
         metadata: { userId: String(user._id) },

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -27,9 +27,9 @@ export async function GET(req: NextRequest) {
       try {
         const account = await stripe.accounts.retrieve(accountId);
         let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending' | null = 'pending';
-        if (account.requirements?.disabled_reason) newStatus = 'restricted';
         if ((account as any).disabled_reason) newStatus = 'disabled';
-        if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
+        else if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
+        else if (account.requirements?.disabled_reason) newStatus = 'restricted';
         status = newStatus;
         user.paymentInfo = user.paymentInfo || {};
         user.paymentInfo.stripeAccountStatus = status;


### PR DESCRIPTION
## Summary
- ensure affiliate codes only saved on new subscriptions with audit metadata
- enforce Express mode for affiliate Stripe Connect and adjust status precedence
- always clear `affiliateUsed` after processing initial invoice

## Testing
- `npm test` *(fails: ReferenceError: TextEncoder is not defined, Response is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689956c62260832e9807c983f8e339f1