### PR TITLE
feat: improve affiliate tracking and payouts

### DIFF
--- a/src/app/api/admin/affiliate/commissions/[id]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[id]/retry/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession({ req, ...authOptions });
+    if (session?.user?.role !== 'admin') {
+      return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
+    }
+
+    await connectToDatabase();
+    const commissionId = params.id;
+    const affUser = await User.findOne({ "commissionLog.sourcePaymentId": commissionId });
+    if (!affUser) {
+      return NextResponse.json({ error: 'Comissão não encontrada' }, { status: 404 });
+    }
+    const entry = affUser.commissionLog?.find(e => e.sourcePaymentId === commissionId);
+    if (!entry || !['failed', 'fallback'].includes(entry.status)) {
+      return NextResponse.json({ error: 'Comissão não elegível para reprocessamento' }, { status: 400 });
+    }
+    if (!affUser.paymentInfo?.stripeAccountId || affUser.paymentInfo.stripeAccountStatus !== 'verified') {
+      return NextResponse.json({ error: 'Conta do afiliado não verificada' }, { status: 400 });
+    }
+
+    const amountCents = entry.amountCents ?? Math.round(entry.amount * 100);
+    const currency = entry.currency || 'usd';
+    const transfer = await stripe.transfers.create({
+      amount: amountCents,
+      currency,
+      destination: affUser.paymentInfo.stripeAccountId,
+      description: entry.description,
+      metadata: {
+        invoiceId: entry.sourcePaymentId || '',
+        referredUserId: entry.referredUserId ? String(entry.referredUserId) : '',
+        affiliateUserId: String(affUser._id),
+        affiliateCode: affUser.affiliateCode || ''
+      }
+    }, { idempotencyKey: `commission_${entry.sourcePaymentId}_${affUser._id}` });
+
+    entry.status = 'paid';
+    entry.transferId = transfer.id;
+    affUser.affiliateBalance = Math.max((affUser.affiliateBalance || 0) - amountCents / 100, 0);
+    affUser.affiliateBalanceCents = Math.max((affUser.affiliateBalanceCents || 0) - amountCents, 0);
+    await affUser.save();
+
+    return NextResponse.json({ success: true, transferId: transfer.id });
+  } catch (err) {
+    console.error('[admin/affiliate/commissions/retry] error:', err);
+    return NextResponse.json({ error: 'Erro ao reprocessar comissão' }, { status: 500 });
+  }
+}

--- a/src/app/api/affiliate/connect/login-link/route.ts
+++ b/src/app/api/affiliate/connect/login-link/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  try {
+    if (process.env.STRIPE_CONNECT_MODE !== "express") {
+      return NextResponse.json({ error: "Stripe Connect deve estar configurado como Express" }, { status: 400 });
+    }
+    const session = await getServerSession({ req, ...authOptions });
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    const user = await User.findById(session.user.id);
+    if (!user) {
+      return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
+    }
+    const accountId = user.paymentInfo?.stripeAccountId;
+    if (!accountId) {
+      return NextResponse.json({ error: "Conta Stripe Connect não encontrada" }, { status: 400 });
+    }
+
+    const link = await stripe.accounts.createLoginLink(accountId);
+    return NextResponse.json({ url: link.url });
+  } catch (err) {
+    console.error("[affiliate/connect/login-link] error:", err);
+    return NextResponse.json({ error: "Erro ao gerar login link" }, { status: 500 });
+  }
+}

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -116,11 +116,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const balance = user.affiliateBalance || 0;
-    const MINIMUM_REDEEM_AMOUNT = 50;
-    if (balance < MINIMUM_REDEEM_AMOUNT) {
+    const balanceCents = user.affiliateBalanceCents ?? Math.round((user.affiliateBalance || 0) * 100);
+    const balance = balanceCents / 100;
+    const MINIMUM_REDEEM_AMOUNT_CENTS = 50 * 100;
+    if (balanceCents < MINIMUM_REDEEM_AMOUNT_CENTS) {
       return NextResponse.json(
-        { error: `Saldo insuficiente. O valor mínimo para resgate é R$ ${MINIMUM_REDEEM_AMOUNT.toFixed(2)}.` },
+        { error: `Saldo insuficiente. O valor mínimo para resgate é R$ ${(MINIMUM_REDEEM_AMOUNT_CENTS / 100).toFixed(2)}.` },
         { status: 400 }
       );
     }
@@ -135,6 +136,7 @@ export async function POST(request: NextRequest) {
     });
 
     user.affiliateBalance = 0;
+    user.affiliateBalanceCents = 0;
     await user.save();
 
     return NextResponse.json({

--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -72,7 +72,7 @@ export async function POST(req: NextRequest) {
           proration_behavior: "create_prorations",
           billing_cycle_anchor: "now",
           expand: ["latest_invoice.payment_intent"],
-          metadata: { plan },
+          metadata: { plan, currency },
         });
 
         await user.save();
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest) {
       items: [{ price: priceId }],
       payment_behavior: "default_incomplete",
       expand: ["latest_invoice.payment_intent"],
-      metadata: { plan, ...(affiliateCode ? { affiliateCode, affiliateUserId: String(aff!._id) } : {}) },
+      metadata: { plan, currency, ...(affiliateCode ? { affiliateCode, affiliateUserId: String(aff!._id) } : {}) },
       ...(affiliateCode ? { discounts: [{ coupon: process.env.STRIPE_PROMO_COUPON_ID_10OFF_ONCE! }] } : {}),
     });
 

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -85,10 +85,12 @@ export async function POST(req: NextRequest) {
                   console.error('[stripe/webhook] transfer error:', { err, currency: (invoice as any).currency, amountCents });
                   status = 'failed';
                   affUser.affiliateBalance = (affUser.affiliateBalance || 0) + amountCents / 100;
+                  affUser.affiliateBalanceCents = (affUser.affiliateBalanceCents || 0) + amountCents;
                 }
               } else {
                 status = 'fallback';
                 affUser.affiliateBalance = (affUser.affiliateBalance || 0) + amountCents / 100;
+                affUser.affiliateBalanceCents = (affUser.affiliateBalanceCents || 0) + amountCents;
               }
 
               affUser.commissionLog = affUser.commissionLog || [];
@@ -100,6 +102,8 @@ export async function POST(req: NextRequest) {
                 referredUserId: user._id,
                 status,
                 transferId,
+                currency: (invoice as any).currency,
+                amountCents,
               });
               affUser.commissionPaidInvoiceIds = affUser.commissionPaidInvoiceIds || [];
               affUser.commissionPaidInvoiceIds.push(String(invoice.id));

--- a/src/app/dashboard/PaymentSettings.tsx
+++ b/src/app/dashboard/PaymentSettings.tsx
@@ -41,6 +41,8 @@ interface PaymentInfoApiResponse {
         bankName?: string;
         bankAgency?: string;
         bankAccount?: string;
+        stripeAccountId?: string | null;
+        stripeAccountStatus?: string | null;
     };
     error?: string;
 }
@@ -127,6 +129,22 @@ export default function PaymentSettings({ userId, availableBalance = 0 }: Paymen
   // Histórico de resgates
   const [redemptions, setRedemptions] = useState<Redemption[]>([]);
   const [loadingRedemptions, setLoadingRedemptions] = useState(false);
+  const [stripeAccountId, setStripeAccountId] = useState<string | null>(null);
+  const [stripeAccountStatus, setStripeAccountStatus] = useState<string | null>(null);
+
+  const openStripeDashboard = useCallback(async () => {
+    try {
+      const res = await fetch('/api/affiliate/connect/login-link', { method: 'POST' });
+      const data = await res.json();
+      if (res.ok && data.url) {
+        window.open(data.url, '_blank');
+      } else {
+        console.error(data.error || 'Falha ao gerar link');
+      }
+    } catch (error) {
+      console.error('[PaymentSettings] Erro ao abrir painel do Stripe:', error);
+    }
+  }, []);
 
   /**
    * Busca os dados de pagamento do usuário.
@@ -155,6 +173,8 @@ export default function PaymentSettings({ userId, availableBalance = 0 }: Paymen
         setBankName(data.paymentInfo.bankName || "");
         setBankAgency(data.paymentInfo.bankAgency || "");
         setBankAccount(data.paymentInfo.bankAccount || "");
+        setStripeAccountId(data.paymentInfo.stripeAccountId || null);
+        setStripeAccountStatus(data.paymentInfo.stripeAccountStatus || null);
       } else {
          // Não mostra erro se apenas não encontrou dados (status 404)
          if (res.status !== 404) {
@@ -166,6 +186,8 @@ export default function PaymentSettings({ userId, availableBalance = 0 }: Paymen
          setBankName("");
          setBankAgency("");
          setBankAccount("");
+         setStripeAccountId(null);
+         setStripeAccountStatus(null);
       }
     } catch (error) {
       console.error("[PaymentSettings] Erro ao buscar paymentInfo:", error);
@@ -331,6 +353,17 @@ export default function PaymentSettings({ userId, availableBalance = 0 }: Paymen
   return (
     // Container principal com espaçamento vertical
     <div className="space-y-8">
+      {stripeAccountId && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={openStripeDashboard}
+            className="px-4 py-2 bg-black text-white rounded-md text-sm hover:opacity-90"
+          >
+            Abrir painel do Stripe
+          </button>
+        </div>
+      )}
 
       {/* Formulário de dados bancários */}
       <form onSubmit={handleSave} className="border border-gray-200 p-4 sm:p-6 rounded-lg shadow-sm bg-white">

--- a/src/app/dashboard/components/types.ts
+++ b/src/app/dashboard/components/types.ts
@@ -47,6 +47,7 @@ export interface ExtendedUser {
   planType?: PlanType;
   affiliateCode?: string | null;
   affiliateBalance?: number;
+  affiliateBalanceCents?: number;
   affiliateRank?: number;
   affiliateInvites?: number;
   provider?: string;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -36,6 +36,7 @@ interface ExtendedUser {
   planExpiresAt?: string | null;
   affiliateCode?: string | null;
   affiliateBalance?: number;
+  affiliateBalanceCents?: number;
   affiliateRank?: number;
   affiliateInvites?: number;
   provider?: string;
@@ -56,6 +57,8 @@ interface CommissionLogItem {
   description: string;
   sourcePaymentId?: string;
   referredUserId?: string;
+  currency?: string;
+  amountCents?: number;
 }
 
 const SkeletonLoader = ({ className = "" }: { className?: string }) => (
@@ -92,6 +95,7 @@ const AffiliateCardContent: React.FC<{
   canRedeem,
   userId
 }) => {
+  const balance = (user?.affiliateBalanceCents ?? Math.round((user?.affiliateBalance ?? 0) * 100)) / 100;
   return (
     <div className="bg-white p-6 rounded-xl shadow-lg border-t-4 border-brand-pink">
       <div className="flex justify-between items-center mb-6">
@@ -104,7 +108,7 @@ const AffiliateCardContent: React.FC<{
       <div className="space-y-5 text-sm">
         <div className="text-center p-4 bg-brand-light rounded-lg border border-gray-200">
           <span className="text-xs text-gray-500 uppercase tracking-wider block mb-1">Saldo Disponível</span>
-          <span className="font-bold text-3xl text-green-600 block">R$ {(user?.affiliateBalance ?? 0).toFixed(2)}</span>
+          <span className="font-bold text-3xl text-green-600 block">R$ {balance.toFixed(2)}</span>
         </div>
         
         <div className="space-y-1.5">
@@ -147,7 +151,15 @@ const AffiliateCardContent: React.FC<{
                 <div key={logItem.sourcePaymentId || `commission-${index}`} className="p-2.5 bg-gray-50 rounded-lg border border-gray-200/80 text-xs hover:shadow-sm transition-shadow">
                   <div className="flex justify-between items-start">
                     <span className="font-medium text-gray-700">{new Date(logItem.date).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' })}</span>
-                    <span className="font-semibold text-green-600 text-sm">+ {logItem.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</span>
+                    {(() => {
+                      const amt = logItem.amountCents !== undefined ? logItem.amountCents / 100 : logItem.amount;
+                      const curr = (logItem.currency || 'BRL').toUpperCase();
+                      return (
+                        <span className="font-semibold text-green-600 text-sm">
+                          + {amt.toLocaleString('pt-BR', { style: 'currency', currency: curr })}
+                        </span>
+                      );
+                    })()}
                   </div>
                   <p className="text-gray-600 mt-1 text-[11px] leading-relaxed">{logItem.description}</p>
                 </div>
@@ -391,11 +403,11 @@ export default function MainDashboard() {
   const paymentPanelUserProps = {
     planStatus: user.planStatus,
     planExpiresAt: user.planExpiresAt,
-    affiliateBalance: user.affiliateBalance,
+    affiliateBalance: (user.affiliateBalanceCents ?? Math.round((user.affiliateBalance || 0) * 100)) / 100,
     affiliateCode: affiliateCode === null ? undefined : affiliateCode,
     planType: user.planType, // ✅ agora tipado corretamente
   };
-  const canRedeem = (user.affiliateBalance ?? 0) > 0;
+  const canRedeem = (user.affiliateBalanceCents ?? Math.round((user.affiliateBalance ?? 0) * 100)) > 0;
 
   const videoGuidesData: VideoData[] = [
     { id: 'intro-plataforma', title: 'Bem-vindo à Data2Content!', youtubeVideoId: 'BHACKCNDMW8' },

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -159,6 +159,8 @@ export interface ICommissionLogEntry {
   referredUserId?: Types.ObjectId;
   status: 'paid' | 'failed' | 'fallback';
   transferId?: string | null;
+  currency?: string;
+  amountCents?: number;
 }
 export interface ILastCommunityInspirationShown {
   date: Date;
@@ -261,6 +263,7 @@ export interface IUser extends Document {
   affiliateCode?: string;
   affiliateUsed?: string;
   affiliateBalance?: number;
+  affiliateBalanceCents?: number;
   commissionLog?: ICommissionLogEntry[];
   paymentInfo?: {
     pixKey?: string;
@@ -310,6 +313,8 @@ const commissionLogEntrySchema = new Schema<ICommissionLogEntry>({
   referredUserId: { type: Schema.Types.ObjectId, ref: 'User' },
   status: { type: String, enum: ['paid', 'failed', 'fallback'], required: true },
   transferId: { type: String, default: null },
+  currency: { type: String },
+  amountCents: { type: Number },
 }, { _id: false });
 const lastCommunityInspirationShownSchema = new Schema<ILastCommunityInspirationShown>({
   date: { type: Date, required: true },
@@ -428,6 +433,7 @@ const userSchema = new Schema<IUser>(
     affiliateCode: { type: String, unique: true, sparse: true },
     affiliateUsed: { type: String, default: null },
     affiliateBalance: { type: Number, default: 0 },
+    affiliateBalanceCents: { type: Number, default: 0 },
     commissionLog: { type: [commissionLogEntrySchema], default: [] },
     affiliatePayoutMode: { type: String, enum: ['connect', 'manual'], default: 'manual' },
     commissionPaidInvoiceIds: { type: [String], default: [] },

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,6 +3,7 @@
 
 import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth"; // Importe o tipo Session do NextAuth
+import { useEffect } from "react";
 
 interface ProvidersProps {
   children: React.ReactNode;
@@ -10,15 +11,21 @@ interface ProvidersProps {
 }
 
 export function Providers({ children, session }: ProvidersProps) {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('ref') || params.get('aff');
+      if (code) {
+        document.cookie = `aff_code=${code}; Max-Age=${60 * 60 * 24 * 30}; Path=/; SameSite=Lax`;
+      }
+    }
+  }, []);
+
   return (
     <SessionProvider
-      session={session} // ✅ Passa a session recebida para o SessionProvider
-      // Revalida a sessão a cada 5 minutos (300s)
+      session={session}
       refetchInterval={5 * 60}
-      // Revalida a sessão ao focar a janela
       refetchOnWindowFocus
-      // É uma boa prática definir o basePath se suas rotas de API do NextAuth
-      // estão no local padrão /api/auth (o que parece ser o seu caso)
       basePath="/api/auth"
     >
       {children}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -25,6 +25,7 @@ declare module "next-auth" {
       planExpiresAt?: string | null; // Mantido como string (ISO) para o cliente
       affiliateCode?: string;
       affiliateBalance?: number;
+      affiliateBalanceCents?: number;
       affiliateRank?: number;
       affiliateInvites?: number;
 
@@ -64,6 +65,7 @@ declare module "next-auth" {
     planExpiresAt?: Date | null; // Pode ser Date aqui
     affiliateCode?: string | null;
     affiliateBalance?: number;
+    affiliateBalanceCents?: number;
     affiliateRank?: number;
     affiliateInvites?: number;
     
@@ -94,6 +96,8 @@ declare module "next-auth/jwt" {
     agencyPlanType?: AgencyPlanType | null;
     provider?: string | null;
     planStatus?: PlanStatus | null;
+    affiliateBalance?: number;
+    affiliateBalanceCents?: number;
     
     isNewUserForOnboarding?: boolean;
     onboardingCompletedAt?: Date | string | null; // Pode ser Date ou string (após encode)


### PR DESCRIPTION
## Summary
- track commission currency/amount in cents and maintain balance in cents
- capture affiliate referral codes via cookie and forward on checkout
- add Stripe Connect login link and admin commission retry endpoint

## Testing
- `npm test` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689959214828832ea0d8188b9aaea2c0