### PR TITLE
chore: improve affiliate admin retry and rate limits

### DIFF
--- a/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
@@ -4,23 +4,37 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import User from "@/app/models/User";
 import stripe from "@/app/lib/stripe";
+import { checkRateLimit } from "@/utils/rateLimit";
+import { logger } from "@/app/lib/logger";
 
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: { invoiceId: string } }) {
   try {
-    const session = await getServerSession({ req, ...authOptions });
+    const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'admin') {
       return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
     }
 
+    const ip = req.headers.get('x-forwarded-for') || req.ip || 'unknown';
+    const { allowed } = await checkRateLimit(`admin_retry:${session.user.id ?? 'anon'}:${ip}`, 5, 60);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Muitas tentativas, tente novamente mais tarde.' }, { status: 429 });
+    }
+
+    logger.info('[admin/affiliate/commissions/retry] attempt', {
+      adminUserId: session.user.id,
+      ip,
+      invoiceId: params.invoiceId,
+    });
+
     await connectToDatabase();
-    const commissionId = params.id;
-    const affUser = await User.findOne({ "commissionLog.sourcePaymentId": commissionId });
+    const invoiceId = params.invoiceId;
+    const affUser = await User.findOne({ "commissionLog.sourcePaymentId": invoiceId });
     if (!affUser) {
       return NextResponse.json({ error: 'Comissão não encontrada' }, { status: 404 });
     }
-    const entry = affUser.commissionLog?.find(e => e.sourcePaymentId === commissionId);
+    const entry = affUser.commissionLog?.find(e => e.sourcePaymentId === invoiceId);
     if (!entry || !['failed', 'fallback'].includes(entry.status)) {
       return NextResponse.json({ error: 'Comissão não elegível para reprocessamento' }, { status: 400 });
     }
@@ -45,13 +59,13 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
     entry.status = 'paid';
     entry.transferId = transfer.id;
-    affUser.affiliateBalance = Math.max((affUser.affiliateBalance || 0) - amountCents / 100, 0);
     affUser.affiliateBalanceCents = Math.max((affUser.affiliateBalanceCents || 0) - amountCents, 0);
+    affUser.markModified('commissionLog');
     await affUser.save();
 
     return NextResponse.json({ success: true, transferId: transfer.id });
   } catch (err) {
-    console.error('[admin/affiliate/commissions/retry] error:', err);
+    logger.error('[admin/affiliate/commissions/retry] error', err);
     return NextResponse.json({ error: 'Erro ao reprocessar comissão' }, { status: 500 });
   }
 }

--- a/src/app/api/affiliate/commission-log/route.ts
+++ b/src/app/api/affiliate/commission-log/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
     // 1. Obter a sessão do usuário
     // Usaremos getServerSession para ter acesso ao objeto User completo da sessão, se necessário,
     // mas para este caso, apenas o ID do usuário (token.sub) seria suficiente se usássemos getToken.
-    const session = await getServerSession({ req: request, ...authOptions });
+    const session = await getServerSession(authOptions);
     // console.debug(`${TAG} Sessão obtida:`, session);
 
     if (!session?.user?.id) {

--- a/src/app/api/affiliate/connect/login-link/route.ts
+++ b/src/app/api/affiliate/connect/login-link/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import User from "@/app/models/User";
 import stripe from "@/app/lib/stripe";
+import { checkRateLimit } from "@/utils/rateLimit";
 
 export const runtime = "nodejs";
 
@@ -12,9 +13,14 @@ export async function POST(req: NextRequest) {
     if (process.env.STRIPE_CONNECT_MODE !== "express") {
       return NextResponse.json({ error: "Stripe Connect deve estar configurado como Express" }, { status: 400 });
     }
-    const session = await getServerSession({ req, ...authOptions });
+    const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+    }
+    const ip = req.headers.get('x-forwarded-for') || req.ip || 'unknown';
+    const { allowed } = await checkRateLimit(`connect_login:${session.user.id}:${ip}`, 5, 60);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Muitas tentativas, tente novamente mais tarde.' }, { status: 429 });
     }
 
     await connectToDatabase();

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -9,7 +9,7 @@ export const runtime = "nodejs";
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await getServerSession({ req, ...authOptions });
+    const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
     }
@@ -27,9 +27,9 @@ export async function GET(req: NextRequest) {
       try {
         const account = await stripe.accounts.retrieve(accountId);
         let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending' | null = 'pending';
-        if ((account as any).disabled_reason) newStatus = 'disabled';
-        else if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
+        if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
         else if (account.requirements?.disabled_reason) newStatus = 'restricted';
+        else if ((account as any).disabled_reason) newStatus = 'disabled';
         status = newStatus;
         user.paymentInfo = user.paymentInfo || {};
         user.paymentInfo.stripeAccountStatus = status;


### PR DESCRIPTION
## Summary
- ensure admin commission retry updates commissionLog and balance cents
- add session and rate limit handling to affiliate connect and billing routes
- standardize getServerSession usage and connect status mapping

## Testing
- `npm test` *(fails: Cannot find module '@utils/calculateFollowerGrowthRate', TextEncoder is not defined, Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68995e27cf58832ebba53a11b8828304