### PR TITLE
chore: tighten admin checks and webhook handling

### DIFF
--- a/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
+++ b/src/app/api/admin/users/__tests__/generate-media-kit-token.test.ts
@@ -6,15 +6,25 @@ import UserModel from '@/app/models/User';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { getServerSession } from 'next-auth/next';
 
+const VALID_ID = '507f1f77bcf86cd799439011';
+
 jest.mock('@/lib/getAdminSession', () => ({
   getAdminSession: jest.fn(),
 }));
 jest.mock('@/utils/rateLimit', () => ({
   checkRateLimit: jest.fn(),
 }));
-jest.mock('@/app/models/User', () => ({
-  findByIdAndUpdate: jest.fn(),
-}));
+jest.mock('@/app/models/User', () => {
+  const chain = (val: any) => ({ select: () => ({ lean: async () => val }) });
+  return {
+    __esModule: true,
+    default: {
+      findById: jest.fn().mockImplementation((id: string) => chain({ _id: id, name: 'Usuário Teste' })),
+      findOne: jest.fn().mockResolvedValue(null),
+      findByIdAndUpdate: jest.fn().mockResolvedValue({ _id: VALID_ID, mediaKitSlug: 'usuario-teste' }),
+    },
+  };
+});
 jest.mock('@/app/lib/mongoose', () => ({
   connectToDatabase: jest.fn(),
 }));
@@ -25,7 +35,7 @@ jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
 
 const mockGetAdminSession = getAdminSession as jest.Mock;
 const mockCheckRateLimit = checkRateLimit as jest.Mock;
-const mockFindByIdAndUpdate = UserModel.findByIdAndUpdate as jest.Mock;
+const mockFindByIdAndUpdate = (UserModel as any).findByIdAndUpdate as jest.Mock;
 
 function createRequest(userId: string): NextRequest {
   return new NextRequest(`http://localhost/api/admin/users/${userId}/generate-media-kit-token`, {
@@ -39,11 +49,11 @@ describe('POST /api/admin/users/[userId]/generate-media-kit-token', () => {
     jest.clearAllMocks();
     mockGetAdminSession.mockResolvedValue({ user: { role: 'admin' } });
     mockCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 4 });
-    mockFindByIdAndUpdate.mockResolvedValue({ _id: '1', mediaKitSlug: 'slug' });
+    mockFindByIdAndUpdate.mockResolvedValue({ _id: VALID_ID, mediaKitSlug: 'usuario-teste' });
   });
 
   it('returns 200 and slug on success', async () => {
-    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    const res = await POST(createRequest(VALID_ID), { params: { userId: VALID_ID } });
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.slug).toBeDefined();
@@ -51,13 +61,13 @@ describe('POST /api/admin/users/[userId]/generate-media-kit-token', () => {
 
   it('returns 401 when session is invalid', async () => {
     mockGetAdminSession.mockResolvedValueOnce(null);
-    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    const res = await POST(createRequest(VALID_ID), { params: { userId: VALID_ID } });
     expect(res.status).toBe(401);
   });
 
   it('returns 429 when rate limit exceeded', async () => {
     mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, remaining: 0 });
-    const res = await POST(createRequest('1'), { params: { userId: '1' } });
+    const res = await POST(createRequest(VALID_ID), { params: { userId: VALID_ID } });
     expect(res.status).toBe(429);
   });
 });


### PR DESCRIPTION
## Summary
- require explicit admin role for media-kit token APIs and retry slug generation on duplicate keys
- use centralized logger and return 500 on Stripe webhook errors
- update media-kit token tests with valid ObjectId and model mocks

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' ... TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6899647e404c832eb7fe4d26b02edaae