### PR TITLE
feat: add multi-currency affiliate balances

### DIFF
--- a/scripts/migrateAffiliateBalances.ts
+++ b/scripts/migrateAffiliateBalances.ts
@@ -1,0 +1,22 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import { normCur } from '@/utils/normCur';
+
+(async () => {
+  await connectToDatabase();
+  const users = await User.find({});
+  for (const u of users) {
+    const map = new Map<string, number>();
+    for (const e of u.commissionLog || []) {
+      if (['fallback','failed'].includes(e.status) && e.amountCents && e.currency) {
+        const cur = normCur(e.currency);
+        map.set(cur, (map.get(cur) ?? 0) + e.amountCents);
+      }
+    }
+    u.affiliateBalances = map;
+    u.affiliateBalance = 0;
+    u.affiliateBalanceCents = 0;
+    await u.save();
+  }
+  process.exit(0);
+})();

--- a/src/app/api/affiliate/balances/route.ts
+++ b/src/app/api/affiliate/balances/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+  await connectToDatabase();
+  const user = await User.findById(session.user.id);
+  if (!user) {
+    return NextResponse.json({ error: 'Usuário não encontrado.' }, { status: 404 });
+  }
+  return NextResponse.json(Object.fromEntries(user.affiliateBalances || []));
+}

--- a/src/app/api/affiliate/route.ts
+++ b/src/app/api/affiliate/route.ts
@@ -58,8 +58,7 @@ export async function GET(request: NextRequest) {
     // 5) Retorna os dados do afiliado
     return NextResponse.json({
       affiliate_code: dbUser.affiliateCode,
-      affiliate_balance: dbUser.affiliateBalance,
-      // Você pode incluir outros campos conforme necessário
+      affiliate_balances: Object.fromEntries(dbUser.affiliateBalances || []),
     });
   } catch (error: unknown) {
     console.error("[affiliate:GET] Erro:", error);

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -262,8 +262,7 @@ export interface IUser extends Document {
   affiliateInvites?: number;
   affiliateCode?: string;
   affiliateUsed?: string;
-  affiliateBalance?: number;
-  affiliateBalanceCents?: number;
+  affiliateBalances?: Map<string, number>;
   commissionLog?: ICommissionLogEntry[];
   paymentInfo?: {
     pixKey?: string;
@@ -432,8 +431,10 @@ const userSchema = new Schema<IUser>(
     affiliateInvites: { type: Number, default: 0 },
     affiliateCode: { type: String, unique: true, sparse: true },
     affiliateUsed: { type: String, default: null },
-    affiliateBalance: { type: Number, default: 0 },
+    affiliateBalances: { type: Map, of: Number, default: {} },
+    // legacy fields:
     affiliateBalanceCents: { type: Number, default: 0 },
+    affiliateBalance: { type: Number },
     commissionLog: { type: [commissionLogEntrySchema], default: [] },
     affiliatePayoutMode: { type: String, enum: ['connect', 'manual'], default: 'manual' },
     commissionPaidInvoiceIds: { type: [String], default: [] },

--- a/src/utils/affiliateBalances.test.ts
+++ b/src/utils/affiliateBalances.test.ts
@@ -1,0 +1,13 @@
+import { normCur } from './normCur';
+
+describe('affiliateBalances map', () => {
+  it('increments and zeros per currency', () => {
+    const user: { affiliateBalances: Map<string, number> } = { affiliateBalances: new Map() };
+    const cur = normCur('BRL');
+    const prev = user.affiliateBalances.get(cur) ?? 0;
+    user.affiliateBalances.set(cur, prev + 500);
+    expect(user.affiliateBalances.get('brl')).toBe(500);
+    user.affiliateBalances.set(cur, 0);
+    expect(user.affiliateBalances.get('brl')).toBe(0);
+  });
+});

--- a/src/utils/normCur.test.ts
+++ b/src/utils/normCur.test.ts
@@ -1,0 +1,10 @@
+import { normCur } from './normCur';
+
+describe('normCur', () => {
+  it('defaults to usd', () => {
+    expect(normCur()).toBe('usd');
+  });
+  it('lowercases input', () => {
+    expect(normCur('BRL')).toBe('brl');
+  });
+});

--- a/src/utils/normCur.ts
+++ b/src/utils/normCur.ts
@@ -1,0 +1,2 @@
+export const normCur = (c?: string) => (c || 'usd').toLowerCase();
+export default normCur;

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -24,8 +24,7 @@ declare module "next-auth" {
       planStatus?: PlanStatus;
       planExpiresAt?: string | null; // Mantido como string (ISO) para o cliente
       affiliateCode?: string;
-      affiliateBalance?: number;
-      affiliateBalanceCents?: number;
+      affiliateBalances?: Record<string, number>;
       affiliateRank?: number;
       affiliateInvites?: number;
 
@@ -64,8 +63,7 @@ declare module "next-auth" {
     planStatus?: PlanStatus | null;
     planExpiresAt?: Date | null; // Pode ser Date aqui
     affiliateCode?: string | null;
-    affiliateBalance?: number;
-    affiliateBalanceCents?: number;
+    affiliateBalances?: Record<string, number>;
     affiliateRank?: number;
     affiliateInvites?: number;
     
@@ -96,8 +94,7 @@ declare module "next-auth/jwt" {
     agencyPlanType?: AgencyPlanType | null;
     provider?: string | null;
     planStatus?: PlanStatus | null;
-    affiliateBalance?: number;
-    affiliateBalanceCents?: number;
+    affiliateBalances?: Record<string, number>;
     
     isNewUserForOnboarding?: boolean;
     onboardingCompletedAt?: Date | string | null; // Pode ser Date ou string (após encode)


### PR DESCRIPTION
## Summary
- track affiliate balances per currency in user model
- handle currency-specific commissions, retries, and redeems
- add balances endpoint, migration script, and tests

## Testing
- `npm test` *(fails: Element type is invalid...)*
- `npm test src/utils/normCur.test.ts src/utils/affiliateBalances.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899677ea0f0832eb23fdc71fb094ee8