### PR TITLE
Finalize multi-currency affiliate backend tweaks

### DIFF
--- a/scripts/migrateAffiliateBalances.ts
+++ b/scripts/migrateAffiliateBalances.ts
@@ -14,6 +14,7 @@ import { normCur } from '@/utils/normCur';
       }
     }
     u.affiliateBalances = map;
+    u.markModified('affiliateBalances');
     u.affiliateBalance = 0;
     u.affiliateBalanceCents = 0;
     await u.save();

--- a/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
@@ -77,9 +77,11 @@ export async function POST(req: NextRequest, { params }: { params: { invoiceId: 
 
     entry.status = 'paid';
     entry.transferId = transfer.id;
-    const prev = affUser.affiliateBalances?.get(currency) ?? 0;
-    affUser.affiliateBalances?.set(currency, Math.max(prev - amountCents, 0));
+    affUser.affiliateBalances ||= new Map();
+    const prev = affUser.affiliateBalances.get(currency) ?? 0;
+    affUser.affiliateBalances.set(currency, Math.max(prev - amountCents, 0));
     affUser.markModified('commissionLog');
+    affUser.markModified('affiliateBalances');
     await affUser.save();
 
     return NextResponse.json({ success: true, transferId: transfer.id });

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -127,7 +127,8 @@ export async function POST(request: NextRequest) {
     }
 
     const cur = normCur(currency);
-    const balanceCents = user.affiliateBalances?.get(cur) ?? 0;
+    user.affiliateBalances ||= new Map();
+    const balanceCents = user.affiliateBalances.get(cur) ?? 0;
 
     const MINIMUM_REDEEM_AMOUNT_CENTS = 50 * 100;
     if (balanceCents < MINIMUM_REDEEM_AMOUNT_CENTS) {
@@ -148,7 +149,8 @@ export async function POST(request: NextRequest) {
       currency: cur,
     });
 
-    user.affiliateBalances?.set(cur, 0);
+    user.affiliateBalances.set(cur, 0);
+    user.markModified('affiliateBalances');
     await user.save();
 
     return NextResponse.json({

--- a/src/app/api/affiliate/route.ts
+++ b/src/app/api/affiliate/route.ts
@@ -27,10 +27,12 @@ export async function GET(request: NextRequest) {
   try {
     // 1) Log do cookie recebido (para debug)
     const rawCookie = request.headers.get("cookie");
-    console.debug("[affiliate:GET] Cookie recebido:", rawCookie || "NENHUM COOKIE");
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug("[affiliate:GET] Cookie recebido:", rawCookie || "NENHUM COOKIE");
+    }
 
     // 2) Obtém a sessão usando getServerSession
-    const session = (await getServerSession({ req: request, ...authOptions })) as Session | null;
+    const session = (await getServerSession(authOptions)) as Session | null;
     console.debug("[affiliate:GET] Sessão retornada:", session);
 
     if (!session) {

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -202,7 +202,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true });
   } catch (err: any) {
     logger.error("[stripe/webhook] handler error:", err);
-    return NextResponse.json({ error: "logged" }, { status: 500 });
+    return NextResponse.json({ received: true, error: "logged" }, { status: 200 });
   }
 }
 


### PR DESCRIPTION
## Summary
- Return 200 on Stripe webhook errors to avoid aggressive retries
- Standardize affiliate session handling and disable cookie logs in production
- Initialize and persist affiliate balance maps during retries, redemptions, and migrations

## Testing
- `npm test src/utils/affiliateBalances.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68996dca57d4832ebb0f08586d0dc6e9