### PR TITLE
Add subscription modal, affiliate card, and subscription-safe account deletion

### DIFF
--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -271,9 +271,9 @@ export interface IUser extends Document {
   affiliateUsed?: string | null;           // alinhar com default null do schema
   affiliateBalances?: Map<string, number>; // multimoeda em cents
 
-  // LEGACY (mantidos por compatibilidade/migração)
-  affiliateBalanceCents?: number;          // <- adicionado para alinhar com schema
-  affiliateBalance?: number;               // <- adicionado para alinhar com schema
+  // LEGACY (mantidos por compatibilidade, não usar):
+  affiliateBalance?: number;
+  affiliateBalanceCents?: number;
 
   commissionLog?: ICommissionLogEntry[];
   paymentInfo?: {

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+
+export default function AccountSettingsPage() {
+  const { data: session } = useSession();
+  const [loading, setLoading] = useState(false);
+  const planStatus = session?.user?.planStatus ?? 'inactive';
+  const canDelete = !['active','trialing','past_due'].includes(planStatus);
+
+  async function handleDelete() {
+    if (!canDelete) return;
+    if (!confirm('Tem certeza que deseja excluir sua conta? Essa ação é irreversível.')) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/user/account', { method: 'DELETE' });
+      if (!res.ok) {
+        const b = await res.json().catch(()=>({}));
+        alert(b?.error || 'Falha ao excluir');
+      } else {
+        // redirecionar para logout/home
+        window.location.href = '/';
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCancelSubscription() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/billing/cancel', { method: 'POST' });
+      const b = await res.json();
+      if (!res.ok) throw new Error(b?.error || 'Falha ao cancelar');
+      alert('Assinatura marcada para não renovar.');
+      window.location.reload();
+    } catch (e:any) {
+      alert(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-6">
+      <section className="rounded-2xl border p-4">
+        <h2 className="mb-2 text-lg font-semibold">Assinatura</h2>
+        <p className="text-sm text-gray-600">Status atual: <b>{planStatus}</b></p>
+        <div className="mt-3 flex gap-2">
+          <button
+            className="rounded-xl border px-4 py-2"
+            onClick={handleCancelSubscription}
+            disabled={loading}
+          >
+            Cancelar assinatura
+          </button>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border p-4">
+        <h2 className="mb-2 text-lg font-semibold text-red-600">Excluir conta</h2>
+        {!canDelete && (
+          <div className="rounded-xl bg-yellow-50 p-3 text-sm text-yellow-800">
+            Você possui uma assinatura ativa. Cancele primeiro para liberar a exclusão da conta.
+          </div>
+        )}
+        <button
+          className={`mt-3 rounded-xl px-4 py-2 text-white ${canDelete? 'bg-red-600' : 'bg-red-300 cursor-not-allowed'}`}
+          onClick={handleDelete}
+          disabled={!canDelete || loading}
+        >
+          Excluir minha conta
+        </button>
+      </section>
+    </div>
+  );
+}
+

--- a/src/components/affiliate/AffiliateCard.tsx
+++ b/src/components/affiliate/AffiliateCard.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import { useMemo } from 'react';
+
+const fetcher = (url:string) => fetch(url).then(r=>r.json());
+
+function fmt(amountCents:number, cur:string) {
+  const n = amountCents/100;
+  const locale = cur === 'brl' ? 'pt-BR' : 'en-US';
+  const currency = cur.toUpperCase();
+  return new Intl.NumberFormat(locale, { style:'currency', currency }).format(n);
+}
+
+export default function AffiliateCard() {
+  const { data: session } = useSession();
+
+  const { data: connectStatus } = useSWR(
+    '/api/affiliate/connect/status', fetcher, { revalidateOnFocus:false }
+  );
+
+  // saldo por moeda vindos da sessão (já serializados no JWT/session callback)
+  const balances: Record<string, number> = (session?.user as any)?.affiliateBalances || {};
+
+  const entries = useMemo(
+    () => Object.entries(balances).sort(([a],[b]) => a.localeCompare(b)),
+    [balances]
+  );
+
+  return (
+    <div className="rounded-2xl border p-4">
+      <h3 className="mb-3 text-lg font-semibold">Programa de Afiliados</h3>
+
+      <div className="space-y-2">
+        <div className="rounded-xl bg-gray-50 p-3">
+          <p className="text-xs text-gray-600">Cód. Afiliado</p>
+          <p className="font-mono text-sm">{session?.user?.affiliateCode}</p>
+        </div>
+
+        <div className="rounded-xl bg-gray-50 p-3">
+          <p className="text-xs text-gray-600">Link de indicação</p>
+          <p className="break-all text-sm">
+            {typeof window !== 'undefined'
+              ? `${window.location.origin}/?ref=${session?.user?.affiliateCode}`
+              : `/?ref=${session?.user?.affiliateCode}`
+            }
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-gray-50 p-3">
+          <p className="mb-2 text-xs text-gray-600">Saldos por moeda</p>
+          {!entries.length && <p className="text-sm text-gray-500">Sem saldo ainda.</p>}
+          {!!entries.length && (
+            <ul className="space-y-1">
+              {entries.map(([cur, cents]) => (
+                <li key={cur} className="flex items-center justify-between">
+                  <span className="uppercase text-xs text-gray-500">{cur}</span>
+                  <span className="font-medium">{fmt(cents, cur)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {!!connectStatus && (
+          <div className="rounded-xl bg-gray-50 p-3 text-sm">
+            <div className="mb-1 flex items-center justify-between">
+              <span>Status Stripe Connect:</span>
+              <span className="font-medium">
+                {connectStatus.stripeAccountStatus ?? '—'}
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-xs text-gray-600">
+              <span>Moeda destino (Connect):</span>
+              <span className="uppercase">{connectStatus.destCurrency}</span>
+            </div>
+            {connectStatus.destCurrency &&
+              Object.keys(balances).some(cur => cur !== connectStatus.destCurrency) && (
+              <p className="mt-2 text-xs text-amber-700">
+                Observação: saldos em moeda diferente de <b>{connectStatus.destCurrency.toUpperCase()}</b>{' '}
+                serão mantidos como saldo interno (fallback) até conversão/pagamento manual.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/billing/SubscribeModal.tsx
+++ b/src/components/billing/SubscribeModal.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+
+type Plan = 'monthly'|'annual';
+type Cur = 'brl'|'usd';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  prices: { // vindo da sua API
+    monthly: { brl: number; usd: number }; // valores exibidos (não IDs)
+    annual: { brl: number; usd: number };
+  }
+}
+
+export default function SubscribeModal({ open, onClose, prices }: Props) {
+  const { data: session } = useSession();
+  const [step, setStep] = useState<1|2|3>(1);
+  const [plan, setPlan] = useState<Plan>('monthly');
+  const [currency, setCurrency] = useState<Cur>('brl');
+  const [affiliateCode, setAffiliateCode] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [clientSecret, setClientSecret] = useState<string|null>(null);
+  const [error, setError] = useState<string|null>(null);
+
+  if (!open) return null;
+
+  const priceShown = plan === 'monthly' ? prices.monthly[currency] : prices.annual[currency];
+
+  async function handleStart() {
+    setLoading(true); setError(null);
+    try {
+      const res = await fetch('/api/billing/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type':'application/json' },
+        body: JSON.stringify({ plan, currency, affiliateCode: affiliateCode.trim() || undefined })
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || 'Falha ao iniciar assinatura');
+      setClientSecret(body.clientSecret ?? null);
+      setStep(3);
+    } catch (e:any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Assinar plano</h2>
+          <button className="text-sm text-gray-500" onClick={onClose}>Fechar</button>
+        </div>
+
+        {/* Steps header */}
+        <div className="mb-6 flex items-center gap-2 text-xs">
+          <span className={`rounded-full px-2 py-1 ${step===1?'bg-black text-white':'bg-gray-100'}`}>1. Plano & Moeda</span>
+          <span>—</span>
+          <span className={`rounded-full px-2 py-1 ${step===2?'bg-black text-white':'bg-gray-100'}`}>2. Cupom</span>
+          <span>—</span>
+          <span className={`rounded-full px-2 py-1 ${step===3?'bg-black text-white':'bg-gray-100'}`}>3. Pagamento</span>
+        </div>
+
+        {step === 1 && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <button onClick={()=>setPlan('monthly')}
+                className={`rounded-xl border p-3 ${plan==='monthly'?'border-black':'border-gray-200'}`}>
+                Mensal
+              </button>
+              <button onClick={()=>setPlan('annual')}
+                className={`rounded-xl border p-3 ${plan==='annual'?'border-black':'border-gray-200'}`}>
+                Anual
+              </button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <button onClick={()=>setCurrency('brl')}
+                className={`rounded-xl border p-3 ${currency==='brl'?'border-black':'border-gray-200'}`}>
+                BRL (R$)
+              </button>
+              <button onClick={()=>setCurrency('usd')}
+                className={`rounded-xl border p-3 ${currency==='usd'?'border-black':'border-gray-200'}`}>
+                USD ($)
+              </button>
+            </div>
+
+            <div className="rounded-xl bg-gray-50 p-4">
+              <p className="text-sm text-gray-600">Valor:</p>
+              <p className="text-2xl font-semibold">
+                {currency === 'brl' ? 'R$ ' : '$ '}
+                {priceShown.toFixed(2)} {plan==='monthly'?'/ mês':'/ ano'}
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button className="rounded-xl border px-4 py-2" onClick={onClose}>Cancelar</button>
+              <button className="rounded-xl bg-black px-4 py-2 text-white" onClick={()=>setStep(2)}>
+                Continuar
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-4">
+            <label className="block text-sm">Cupom / Código de Afiliado (opcional)</label>
+            <input
+              value={affiliateCode}
+              onChange={e=>setAffiliateCode(e.target.value)}
+              placeholder="Ex.: ABC123"
+              className="w-full rounded-xl border px-3 py-2"
+            />
+            <div className="flex justify-between">
+              <button className="rounded-xl border px-4 py-2" onClick={()=>setStep(1)}>Voltar</button>
+              <button disabled={loading} className="rounded-xl bg-black px-4 py-2 text-white" onClick={handleStart}>
+                {loading ? 'Processando...' : 'Ir para pagamento'}
+              </button>
+            </div>
+            {error && <p className="text-sm text-red-600">{error}</p>}
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-4">
+            {!clientSecret && (
+              <div className="rounded-xl bg-yellow-50 p-4 text-sm">
+                Falta confirmar o pagamento. Recarregue e tente novamente.
+              </div>
+            )}
+            {/* Aqui você pode renderizar o PaymentElement do Stripe */}
+            <div className="rounded-xl border p-4">
+              <p className="text-sm text-gray-600">Finalize o pagamento na etapa seguinte.</p>
+              {/* se já usa Checkout Session, pode também redirecionar aqui */}
+            </div>
+            <div className="flex justify-end">
+              <button className="rounded-xl bg-black px-4 py-2 text-white" onClick={onClose}>Concluir</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- expose legacy affiliate balance fields in User type
- safeguard account deletion when a subscription is active
- add subscription modal, affiliate dashboard card, and account settings page

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a1446681c832eb4414ba19d582799