### PR TITLE
Ensure affiliate balances available on sign-in

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -486,6 +486,10 @@ export const authOptions: NextAuthOptions = {
           (authUserFromProvider as NextAuthUserArg).planInterval = dbUserRecord.planInterval;
           (authUserFromProvider as NextAuthUserArg).planExpiresAt = dbUserRecord.planExpiresAt;
           (authUserFromProvider as NextAuthUserArg).affiliateCode = dbUserRecord.affiliateCode;
+          (authUserFromProvider as any).affiliateBalances =
+            dbUserRecord.affiliateBalances
+              ? Object.fromEntries(dbUserRecord.affiliateBalances as any)
+              : {};
           (authUserFromProvider as NextAuthUserArg).agency = dbUserRecord.agency ? dbUserRecord.agency.toString() : undefined;
           
           logger.debug(`${TAG_SIGNIN} [${provider}] FINAL signIn. authUser.id (interno): '${authUserFromProvider.id}', name: '${authUserFromProvider.name}', provider (final): '${(authUserFromProvider as NextAuthUserArg).provider}', planStatus: ${(authUserFromProvider as NextAuthUserArg).planStatus}, igAccountsCount: ${(authUserFromProvider as NextAuthUserArg).availableIgAccounts?.length ?? 0}, igLlatSet: ${!!(authUserFromProvider as NextAuthUserArg).instagramAccessToken}`);
@@ -531,6 +535,10 @@ export const authOptions: NextAuthOptions = {
         token.planInterval = (userFromSignIn as NextAuthUserArg).planInterval;
         token.planExpiresAt = (userFromSignIn as NextAuthUserArg).planExpiresAt;
         token.affiliateCode = (userFromSignIn as NextAuthUserArg).affiliateCode;
+        const anyUser = userFromSignIn as any;
+        if (anyUser.affiliateBalances && typeof anyUser.affiliateBalances === 'object') {
+          token.affiliateBalances = anyUser.affiliateBalances;
+        }
 
         token.agencyId = (userFromSignIn as NextAuthUserArg).agency ?? null;
         if (token.agencyId) {

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -1,0 +1,12 @@
+// src/app/billing/success/page.tsx
+export default function BillingSuccessPage() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="mb-2 text-2xl font-semibold">Pagamento confirmado</h1>
+      <p className="text-gray-600">Obrigado! Sua assinatura está ativa.</p>
+      <a className="mt-4 inline-block rounded-xl bg-black px-4 py-2 text-white" href="/app">
+        Ir para o app
+      </a>
+    </div>
+  );
+}

--- a/src/components/affiliate/AffiliateCard.tsx
+++ b/src/components/affiliate/AffiliateCard.tsx
@@ -40,12 +40,15 @@ export default function AffiliateCard() {
 
         <div className="rounded-xl bg-gray-50 p-3">
           <p className="text-xs text-gray-600">Link de indicação</p>
-          <p className="break-all text-sm">
-            {typeof window !== 'undefined'
-              ? `${window.location.origin}/?ref=${session?.user?.affiliateCode}`
-              : `/?ref=${session?.user?.affiliateCode}`
-            }
-          </p>
+          {session?.user?.affiliateCode ? (
+            <p className="break-all text-sm">
+              {typeof window !== 'undefined'
+                ? `${window.location.origin}/?ref=${session.user.affiliateCode}`
+                : `/?ref=${session.user.affiliateCode}`}
+            </p>
+          ) : (
+            <p className="text-sm text-gray-500">Seu código será gerado após o primeiro login.</p>
+          )}
         </div>
 
         <div className="rounded-xl bg-gray-50 p-3">

--- a/src/components/billing/PaymentStep.tsx
+++ b/src/components/billing/PaymentStep.tsx
@@ -3,7 +3,9 @@ import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-
 import { loadStripe } from '@stripe/stripe-js';
 import { useState } from 'react';
 
-const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+const pk = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+if (!pk) console.warn('[PaymentStep] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ausente');
+const stripePromise = loadStripe(pk!);
 
 function InnerPayment({ clientSecret, onClose }: { clientSecret: string; onClose: () => void }) {
   const stripe = useStripe();


### PR DESCRIPTION
## Summary
- hydrate affiliate balances on initial sign-in
- warn if Stripe publishable key is missing
- show placeholder when affiliate code not yet generated
- add billing success confirmation page

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined, etc.)*
- `CI=1 npm run lint` *(interactive prompt: "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_e_689a1ba717d0832ebcca3a702d2bc250