### PR TITLE
fix billing and affiliate flows

### DIFF
--- a/src/app/affiliate/connect/return/page.tsx
+++ b/src/app/affiliate/connect/return/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSWRConfig } from 'swr';
+
+export default function ConnectReturnPage() {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+
+  useEffect(() => {
+    mutate('/api/affiliate/connect/status');
+    const t = setTimeout(() => {
+      router.replace('/dashboard');
+    }, 100);
+    return () => clearTimeout(t);
+  }, [mutate, router]);
+
+  return (
+    <div className="p-4 text-center text-sm text-gray-600">Redirecionando...</div>
+  );
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -60,6 +60,9 @@ export async function POST(req: NextRequest) {
         if (user.affiliateUsed) {
           const affUser = await User.findOne({ affiliateCode: user.affiliateUsed });
           if (affUser) {
+            if (!affUser.affiliateBalances || !(affUser.affiliateBalances instanceof Map)) {
+              affUser.affiliateBalances = new Map<string, number>();
+            }
             const alreadyPaidForThisReferral = (affUser.commissionLog || []).some(
               (e) => String(e.referredUserId) === String(user._id) && e.status === 'paid'
             );
@@ -132,9 +135,7 @@ export async function POST(req: NextRequest) {
         }
         // Sempre limpa affiliateUsed após processar a cobrança inicial
         if (user.affiliateUsed) {
-          // ajuste de tipo: propriedade é string | undefined no tipo
-          user.affiliateUsed = undefined;
-          // ou: delete user.affiliateUsed;
+          user.affiliateUsed = null; // padroniza com o schema (string | null)
         }
 
         user.lastPaymentError = undefined;

--- a/src/app/dashboard/PaymentSettings.tsx
+++ b/src/app/dashboard/PaymentSettings.tsx
@@ -15,6 +15,7 @@ import { useSession } from "next-auth/react";
 interface Redemption {
   _id: string;
   amount: number;
+  currency?: string;
   status: 'pending' | 'paid' | 'failed' | string; // Tipos comuns de status
   createdAt: string;
   // Adicione outros campos se a API retornar (ex: transactionId, paidAt)
@@ -520,7 +521,7 @@ export default function PaymentSettings({ userId }: PaymentSettingsProps) {
                 <thead className="bg-gray-50">
                 <tr>
                     <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Data</th>
-                    <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Valor (R$)</th>
+                    <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Valor</th>
                     <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Status</th>
                 </tr>
                 </thead>
@@ -530,7 +531,9 @@ export default function PaymentSettings({ userId }: PaymentSettingsProps) {
                     <td className="px-3 py-2 text-gray-700">
                         {new Date(r.createdAt).toLocaleString("pt-BR", { dateStyle: 'short', timeStyle: 'short' })}
                     </td>
-                    <td className="px-3 py-2 text-gray-700">{r.amount.toFixed(2)}</td>
+                    <td className="px-3 py-2 text-gray-700">
+                        {fmt(Math.round(r.amount*100), (r.currency || 'brl').toLowerCase())}
+                    </td>
                     <td className="px-3 py-2">
                         <StatusBadge status={r.status} />
                     </td>


### PR DESCRIPTION
## Summary
- normalize currency and prevent duplicate subscriptions in billing endpoint
- ensure affiliate balances map is initialized and clear affiliateUsed after first charge
- refresh affiliate status after onboarding and support multi-currency redemption history

## Testing
- `npm test` *(fails: TextEncoder is not defined, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_689a24da9d60832e83c0649615ccec8d