### PR TITLE
feat: improve Stripe Connect status handling

### DIFF
--- a/src/app/affiliate/connect/refresh/page.tsx
+++ b/src/app/affiliate/connect/refresh/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSWRConfig } from 'swr';
+
+export default function ConnectRefreshPage() {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+
+  useEffect(() => {
+    mutate('/api/affiliate/connect/status');
+    const t = setTimeout(() => {
+      router.replace('/dashboard');
+    }, 100);
+    return () => clearTimeout(t);
+  }, [mutate, router]);
+
+  return (
+    <div className="p-4 text-center text-sm text-gray-600">Redirecionando...</div>
+  );
+}

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -41,12 +41,13 @@ export async function GET(req: NextRequest) {
       }
     }
 
+    const stripeAccountStatus = status === 'verified' ? 'enabled' : 'pending';
+    const needsOnboarding = !accountId || status !== 'verified';
+
     return NextResponse.json({
-      stripeAccountId: accountId,
-      stripeAccountStatus: status,
-      affiliatePayoutMode: user.affiliatePayoutMode,
-      needsOnboarding: status !== 'verified',
+      stripeAccountStatus,
       destCurrency,
+      needsOnboarding,
     });
   } catch (err) {
     console.error("[affiliate/connect/status] error:", err);

--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -72,9 +72,9 @@ export async function POST(req: NextRequest) {
 
     let sub: Stripe.Subscription;
 
-    if (existing && !["canceled", "incomplete_expired"].includes(existing.status)) {
+    if (existing && !["canceled", "incomplete_expired"].includes(existing.status) && existing.items.data[0]) {
       // Atualiza price em assinatura existente
-      const itemId = existing.items.data[0]?.id;
+      const itemId = existing.items.data[0].id;
       sub = await stripe.subscriptions.update(existing.id, {
         items: [{ id: itemId, price: priceId }],
         payment_behavior: "default_incomplete",

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -268,7 +268,7 @@ export interface IUser extends Document {
   affiliateRank?: number;
   affiliateInvites?: number;
   affiliateCode?: string;
-  affiliateUsed?: string | null;           // alinhar com default null do schema
+  affiliateUsed: string | null;            // alinhar com default null do schema
   affiliateBalances?: Map<string, number>; // multimoeda em cents
 
   // LEGACY (mantidos por compatibilidade, não usar):


### PR DESCRIPTION
## Summary
- expose normalized status and currency on affiliate connect status endpoint
- support missing subscription items by creating a new subscription
- add refresh page for Stripe Connect onboarding
- align `affiliateUsed` type with schema

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' ...)*
- `npm run lint` *(interactive prompt: "How would you like to configure ESLint?")*


------
https://chatgpt.com/codex/tasks/task_e_689a2c13c698832ea8a47c0e2a4a6dc6