### PR TITLE
Ensure affiliate endpoints respect session user and expose Stripe login link

### DIFF
--- a/src/app/api/affiliate/paymentinfo/route.ts
+++ b/src/app/api/affiliate/paymentinfo/route.ts
@@ -33,8 +33,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Parâmetro 'userId' é obrigatório." }, { status: 400 });
     }
 
-    // 4) Verifica se o userId da query é o mesmo da sessão
-    if (userId !== session.user.id) {
+    // 4) Verifica se o userId da query é o mesmo da sessão (a menos que seja admin)
+    if (userId !== session.user.id && session.user.role !== "admin") {
       return NextResponse.json(
         { error: "Acesso negado: userId não corresponde ao usuário logado." },
         { status: 403 }
@@ -92,8 +92,8 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Parâmetro 'userId' é obrigatório." }, { status: 400 });
     }
 
-    // 4) Verifica se o userId do corpo é o mesmo da sessão
-    if (userId !== session.user.id) {
+    // 4) Verifica se o userId do corpo é o mesmo da sessão (a menos que seja admin)
+    if (userId !== session.user.id && session.user.role !== "admin") {
       return NextResponse.json(
         { error: "Acesso negado: userId não corresponde ao usuário logado." },
         { status: 403 }

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -60,7 +60,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Faltou userId" }, { status: 400 });
     }
 
-    if (userId !== session.user.id) {
+    if (userId !== session.user.id && session.user.role !== "admin") {
       return NextResponse.json(
         { error: "Acesso negado: userId não corresponde ao usuário logado." },
         { status: 403 }
@@ -105,7 +105,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Parâmetro userId é obrigatório." }, { status: 400 });
     }
 
-    if (userId !== session.user.id) {
+    if (userId !== session.user.id && session.user.role !== "admin") {
       return NextResponse.json(
         { error: "Acesso negado: userId não corresponde ao usuário logado." },
         { status: 403 }


### PR DESCRIPTION
## Summary
- allow admin override when validating userId in affiliate payment info API
- enforce session user match (with admin bypass) in affiliate redeem API
- expose POST /api/affiliate/connect/login-link for Stripe dashboard access

## Testing
- `npm test` *(fails: Request is not defined, 115 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a2ed6bc58832e911b19ba62c05dd1