### PR TITLE
fix: validate affiliate inputs

### DIFF
--- a/src/app/api/affiliate/paymentinfo/route.ts
+++ b/src/app/api/affiliate/paymentinfo/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     await connectToDatabase();
 
     // 2) Obtém a sessão via getServerSession
-    const session = await getServerSession({ req: request, ...authOptions });
+    const session = await getServerSession(authOptions);
     console.debug("[paymentinfo:GET] Sessão retornada:", session);
 
     if (!session?.user?.id) {
@@ -79,7 +79,7 @@ export async function PATCH(request: NextRequest) {
     await connectToDatabase();
 
     // 2) Obtém a sessão via getServerSession
-    const session = await getServerSession({ req: request, ...authOptions });
+    const session = await getServerSession(authOptions);
     console.debug("[paymentinfo:PATCH] Sessão retornada:", session);
 
     if (!session?.user?.id) {
@@ -113,6 +113,7 @@ export async function PATCH(request: NextRequest) {
 
     // 7) Atualiza os dados de paymentInfo
     user.paymentInfo = {
+      ...(user.paymentInfo || {}),
       pixKey: (pixKey || "").trim(),
       bankName: (bankName || "").trim(),
       bankAgency: (bankAgency || "").trim(),

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -104,6 +104,9 @@ export async function POST(request: NextRequest) {
     if (!userId) {
       return NextResponse.json({ error: "Parâmetro userId é obrigatório." }, { status: 400 });
     }
+    if (!currency || typeof currency !== "string") {
+      return NextResponse.json({ error: "Parâmetro currency é obrigatório." }, { status: 400 });
+    }
 
     if (userId !== session.user.id && session.user.role !== "admin") {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- fetch session in affiliate payment info routes without passing `req`
- merge affiliate `paymentInfo` updates to preserve Stripe fields
- validate currency in affiliate redemption requests

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' from 'src/charts/getRadarChartData.test.ts', ReferenceError: TextEncoder is not defined, etc.)*
- `npx eslint src/app/api/affiliate/redeem/route.ts src/app/api/affiliate/paymentinfo/route.ts` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689a31791d40832eb65e2e5753f5c901