### PR TITLE
fix: ensure subscription fields avoid null enums

### DIFF
--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -111,7 +111,12 @@ export async function POST(req: NextRequest) {
     user.stripeSubscriptionId = sub.id;
     user.planType = plan;
     user.planStatus = "pending";
+    user.planInterval = plan === "annual" ? "year" : "month";
     user.stripePriceId = priceId;
+
+    if (user.paymentInfo?.stripeAccountStatus === null) {
+      delete (user as any).paymentInfo.stripeAccountStatus;
+    }
     await user.save();
 
     const clientSecret = (sub.latest_invoice as any)?.payment_intent?.client_secret;

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -247,7 +247,7 @@ export interface IUser extends Document {
   stripeCustomerId?: string;
   stripeSubscriptionId?: string | null;
   stripePriceId?: string | null;
-  planInterval?: 'month' | 'year' | null;
+  planInterval?: 'month' | 'year';
   currentPeriodEnd?: Date | null;
   currency?: string;
   lastProcessedEventId?: string;
@@ -282,7 +282,7 @@ export interface IUser extends Document {
     bankAgency?: string;
     bankAccount?: string;
     stripeAccountId?: string | null;
-    stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled' | null;
+    stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled';
   };
   affiliatePayoutMode?: 'connect' | 'manual';
   commissionPaidInvoiceIds?: string[];
@@ -389,7 +389,7 @@ const userSchema = new Schema<IUser>(
     stripeCustomerId: { type: String, index: true },
     stripeSubscriptionId: { type: String, default: null },
     stripePriceId: { type: String, default: null },
-    planInterval: { type: String, enum: ['month', 'year'], default: null },
+    planInterval: { type: String, enum: ['month', 'year'], default: undefined },
     currentPeriodEnd: { type: Date, default: null },
     currency: { type: String, default: 'BRL' },
     lastProcessedEventId: { type: String },
@@ -475,7 +475,7 @@ const userSchema = new Schema<IUser>(
       bankAgency: { type: String, default: "" },
       bankAccount: { type: String, default: "" },
       stripeAccountId: { type: String, default: null },
-      stripeAccountStatus: { type: String, enum: ['pending', 'verified', 'restricted', 'disabled'], default: null },
+      stripeAccountStatus: { type: String, enum: ['pending', 'verified', 'restricted', 'disabled'], default: undefined },
     },
 
     lastPaymentError: {


### PR DESCRIPTION
## Summary
- set `planInterval` and clean null `stripeAccountStatus` when subscribing
- avoid default `null` for enum fields in `User` schema

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', TextEncoder is not defined)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a36044aa8832e90e9f295b7d6650b