### PR TITLE
feat: enhance stripe connect setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,6 @@ STRIPE_PRICE_ANNUAL_USD=price_xxx
 STRIPE_COUPON_10OFF_ONCE_BRL=coupon_brl
 STRIPE_COUPON_10OFF_ONCE_USD=coupon_usd
 STRIPE_CONNECT_MODE=express
+STRIPE_CONNECT_RETURN_URL=https://example.com/affiliate/connect/return
+STRIPE_CONNECT_REFRESH_URL=https://example.com/affiliate/connect/refresh
 AFFILIATE_COMMISSION_PERCENT=10

--- a/src/app/api/affiliate/connect/create-link/route.ts
+++ b/src/app/api/affiliate/connect/create-link/route.ts
@@ -47,10 +47,12 @@ export async function POST(req: NextRequest) {
     }
 
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || "http://localhost:3000";
+    const refreshUrl = process.env.STRIPE_CONNECT_REFRESH_URL || `${baseUrl}/affiliate/connect/refresh`;
+    const returnUrl = process.env.STRIPE_CONNECT_RETURN_URL || `${baseUrl}/affiliate/connect/return`;
     const link = await stripe.accountLinks.create({
       account: accountId,
-      refresh_url: `${baseUrl}/dashboard/affiliate`,
-      return_url: `${baseUrl}/dashboard/affiliate`,
+      refresh_url: refreshUrl,
+      return_url: returnUrl,
       type: "account_onboarding",
     });
 

--- a/src/app/api/affiliate/connect/onboard/route.ts
+++ b/src/app/api/affiliate/connect/onboard/route.ts
@@ -44,10 +44,12 @@ export async function POST(req: NextRequest) {
     }
 
     const origin = req.headers.get('origin') || process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    const refreshUrl = process.env.STRIPE_CONNECT_REFRESH_URL || `${origin}/affiliate/connect/refresh`;
+    const returnUrl = process.env.STRIPE_CONNECT_RETURN_URL || `${origin}/affiliate/connect/return`;
     const link = await stripe.accountLinks.create({
       account: accountId!,
-      refresh_url: `${origin}/affiliate/connect/refresh`,
-      return_url: `${origin}/affiliate/connect/return`,
+      refresh_url: refreshUrl,
+      return_url: returnUrl,
       type: 'account_onboarding',
     });
 

--- a/src/app/api/affiliate/connect/status/route.test.ts
+++ b/src/app/api/affiliate/connect/status/route.test.ts
@@ -1,3 +1,6 @@
+import { Response } from 'node-fetch';
+(global as any).Response = Response;
+
 import { GET } from './route';
 import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth/next';
@@ -61,6 +64,9 @@ describe('GET /api/affiliate/connect/status', () => {
     expect(body.destCurrency).toBe('brl');
     expect(body.stripeAccountId).toBe('acct_123');
     expect(body.stripeAccountStatus).toBe('verified');
+    expect(body.affiliatePayoutMode).toBe('connect');
     expect(body.needsOnboarding).toBe(false);
+    expect(mockUser.paymentInfo.stripeAccountDefaultCurrency).toBe('brl');
+    expect(mockUser.save).toHaveBeenCalled();
   });
 });

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -21,32 +21,36 @@ export async function GET(req: NextRequest) {
     }
 
     const accountId = user.paymentInfo?.stripeAccountId || null;
-    let status = user.paymentInfo?.stripeAccountStatus || null;
-    let destCurrency = 'usd';
+    let status: 'verified' | 'restricted' | 'disabled' | 'pending' | null =
+      user.paymentInfo?.stripeAccountStatus || 'pending';
+    let destCurrency = user.paymentInfo?.stripeAccountDefaultCurrency || 'usd';
 
     if (accountId) {
       try {
         const account = await stripe.accounts.retrieve(accountId);
         destCurrency = ((account as any).default_currency || 'usd').toLowerCase();
-        let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending' | null = 'pending';
-        if (account.details_submitted && account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
+        let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending';
+        if (account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
         else if (account.requirements?.disabled_reason) newStatus = 'restricted';
         else if ((account as any).disabled_reason) newStatus = 'disabled';
+        else newStatus = 'pending';
         status = newStatus;
         user.paymentInfo = user.paymentInfo || {};
         user.paymentInfo.stripeAccountStatus = status;
+        user.paymentInfo.stripeAccountDefaultCurrency = destCurrency;
         await user.save();
       } catch (err) {
         console.error("[affiliate/connect/status] retrieve error:", err);
       }
     }
 
-    const stripeAccountStatus = status === 'verified' ? 'enabled' : 'pending';
     const needsOnboarding = !accountId || status !== 'verified';
 
     return NextResponse.json({
-      stripeAccountStatus,
+      stripeAccountId: accountId,
+      stripeAccountStatus: status,
       destCurrency,
+      affiliatePayoutMode: user.affiliatePayoutMode,
       needsOnboarding,
     });
   } catch (err) {

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -283,6 +283,7 @@ export interface IUser extends Document {
     bankAccount?: string;
     stripeAccountId?: string | null;
     stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled';
+    stripeAccountDefaultCurrency?: string;
   };
   affiliatePayoutMode?: 'connect' | 'manual';
   commissionPaidInvoiceIds?: string[];
@@ -476,6 +477,7 @@ const userSchema = new Schema<IUser>(
       bankAccount: { type: String, default: "" },
       stripeAccountId: { type: String, default: null },
       stripeAccountStatus: { type: String, enum: ['pending', 'verified', 'restricted', 'disabled'], default: undefined },
+      stripeAccountDefaultCurrency: { type: String, default: undefined },
     },
 
     lastPaymentError: {


### PR DESCRIPTION
## Summary
- add Stripe Connect return/refresh URL env vars
- persist affiliate Stripe account currency and status
- expose Connect account status and currency in affiliate API

## Testing
- `npm test` *(fails: ReferenceError: Response is not defined)*
- `npx jest src/app/api/affiliate/connect/status/route.test.ts` *(fails: ReferenceError: Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a706a3134832eabe172f4ca01ade0