### PR TITLE
feat: multi-currency affiliate balance display and retry dedupe

### DIFF
--- a/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
@@ -77,6 +77,10 @@ export async function POST(req: NextRequest, { params }: { params: { invoiceId: 
 
     entry.status = 'paid';
     entry.transferId = transfer.id;
+    affUser.commissionPaidInvoiceIds = affUser.commissionPaidInvoiceIds || [];
+    if (entry.sourcePaymentId && !affUser.commissionPaidInvoiceIds.includes(entry.sourcePaymentId)) {
+      affUser.commissionPaidInvoiceIds.push(entry.sourcePaymentId);
+    }
     affUser.affiliateBalances ||= new Map();
     const prev = affUser.affiliateBalances.get(currency) ?? 0;
     affUser.affiliateBalances.set(currency, Math.max(prev - amountCents, 0));


### PR DESCRIPTION
## Summary
- avoid duplicate affiliate commission retries by tracking processed invoices
- show affiliate balances by currency on dashboard

## Testing
- `npm test` *(fails: TextEncoder is not defined, Response is not defined, etc)*

------
https://chatgpt.com/codex/tasks/task_e_689a790e0f44832e90e9d7ee3deab8b0