### PR TITLE
feat: expose stripe connect status

### DIFF
--- a/src/app/api/affiliate/connect/status/route.test.ts
+++ b/src/app/api/affiliate/connect/status/route.test.ts
@@ -1,8 +1,16 @@
-import { Response } from 'node-fetch';
-(global as any).Response = Response;
+import fetch, { Request, Response, Headers } from 'node-fetch';
+(global as any).fetch = fetch;
+(global as any).Request = Request;
+(global as any).Response = Response as any;
+(global as any).Headers = Headers;
+(global as any).Response.json = (data: any, init?: any) =>
+  new Response(JSON.stringify(data), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+  });
 
-import { GET } from './route';
-import { NextRequest } from 'next/server';
+const { GET } = require('./route');
+const { NextRequest } = require('next/server');
 import { getServerSession } from 'next-auth/next';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import User from '@/app/models/User';
@@ -45,7 +53,6 @@ describe('GET /api/affiliate/connect/status', () => {
     mockGetServerSession.mockResolvedValue({ user: { id: 'user1' } });
     const mockUser = {
       paymentInfo: { stripeAccountId: 'acct_123', stripeAccountStatus: 'pending' },
-      affiliatePayoutMode: 'connect',
       save: jest.fn().mockResolvedValue(undefined),
     } as any;
     mockFindById.mockResolvedValue(mockUser);
@@ -64,7 +71,6 @@ describe('GET /api/affiliate/connect/status', () => {
     expect(body.destCurrency).toBe('brl');
     expect(body.stripeAccountId).toBe('acct_123');
     expect(body.stripeAccountStatus).toBe('verified');
-    expect(body.affiliatePayoutMode).toBe('connect');
     expect(body.needsOnboarding).toBe(false);
     expect(mockUser.paymentInfo.stripeAccountDefaultCurrency).toBe('brl');
     expect(mockUser.save).toHaveBeenCalled();

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -21,27 +21,31 @@ export async function GET(req: NextRequest) {
     }
 
     const accountId = user.paymentInfo?.stripeAccountId || null;
-    let status: 'verified' | 'restricted' | 'disabled' | 'pending' | null =
-      user.paymentInfo?.stripeAccountStatus || 'pending';
-    let destCurrency = user.paymentInfo?.stripeAccountDefaultCurrency || 'usd';
+    let status: 'verified' | 'pending' | 'disabled' | null =
+      user.paymentInfo?.stripeAccountStatus || null;
+    let destCurrency = user.paymentInfo?.stripeAccountDefaultCurrency || null;
 
     if (accountId) {
       try {
         const account = await stripe.accounts.retrieve(accountId);
-        destCurrency = ((account as any).default_currency || 'usd').toLowerCase();
-        let newStatus: 'verified' | 'restricted' | 'disabled' | 'pending';
-        if (account.charges_enabled && account.payouts_enabled) newStatus = 'verified';
-        else if (account.requirements?.disabled_reason) newStatus = 'restricted';
-        else if ((account as any).disabled_reason) newStatus = 'disabled';
-        else newStatus = 'pending';
-        status = newStatus;
+        destCurrency = ((account as any).default_currency || null)?.toLowerCase() || null;
+        const verified = account.charges_enabled && account.payouts_enabled;
+        status = verified ? 'verified' : 'pending';
+        if (account.requirements?.disabled_reason || (account as any).disabled_reason) {
+          status = 'disabled';
+        }
         user.paymentInfo = user.paymentInfo || {};
         user.paymentInfo.stripeAccountStatus = status;
-        user.paymentInfo.stripeAccountDefaultCurrency = destCurrency;
+        user.paymentInfo.stripeAccountDefaultCurrency = destCurrency || undefined;
         await user.save();
       } catch (err) {
         console.error("[affiliate/connect/status] retrieve error:", err);
       }
+    }
+
+    if (!accountId) {
+      status = null;
+      destCurrency = null;
     }
 
     const needsOnboarding = !accountId || status !== 'verified';
@@ -50,7 +54,6 @@ export async function GET(req: NextRequest) {
       stripeAccountId: accountId,
       stripeAccountStatus: status,
       destCurrency,
-      affiliatePayoutMode: user.affiliatePayoutMode,
       needsOnboarding,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- update Stripe Connect status API
- adjust tests for new response shape

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate', ReferenceError: TextEncoder is not defined, Response is not defined, etc.)*
- `npx jest src/app/api/affiliate/connect/status/route.test.ts`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a814672bc832eaf3900c6793d2ddb