### PR TITLE
feat: add stripe connect redeem and webhook

### DIFF
--- a/src/app/api/affiliate/connect/status/route.test.ts
+++ b/src/app/api/affiliate/connect/status/route.test.ts
@@ -15,6 +15,8 @@ import { getServerSession } from 'next-auth/next';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import User from '@/app/models/User';
 import stripe from '@/app/lib/stripe';
+import { checkRateLimit } from '@/utils/rateLimit';
+import { getClientIp } from '@/utils/getClientIp';
 
 jest.mock('next-auth/next', () => ({
   getServerSession: jest.fn(),
@@ -38,14 +40,26 @@ jest.mock('@/app/lib/stripe', () => ({
   },
 }));
 
+jest.mock('@/utils/rateLimit', () => ({
+  checkRateLimit: jest.fn(),
+}));
+
+jest.mock('@/utils/getClientIp', () => ({
+  getClientIp: jest.fn(),
+}));
+
 const mockGetServerSession = getServerSession as jest.Mock;
 const mockConnect = connectToDatabase as jest.Mock;
 const mockFindById = User.findById as jest.Mock;
 const mockRetrieve = (stripe.accounts.retrieve as unknown) as jest.Mock;
+const mockRate = checkRateLimit as jest.Mock;
+const mockIp = getClientIp as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockConnect.mockResolvedValue(undefined);
+  mockRate.mockResolvedValue({ allowed: true });
+  mockIp.mockReturnValue('127.0.0.1');
 });
 
 describe('GET /api/affiliate/connect/status', () => {

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -4,80 +4,100 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import User from "@/app/models/User";
 import Redemption from "@/app/models/Redemption";
+import stripe from "@/app/lib/stripe";
 import { checkRateLimit } from "@/utils/rateLimit";
 import { getClientIp } from "@/utils/getClientIp";
-import { normCur } from "@/utils/normCur";
 
 export const runtime = "nodejs";
 
 function minForCurrency(cur: string) {
   const upper = cur.toUpperCase();
-  const envKey = `REDEEM_MIN_${upper}`;
-  const fromEnv = Number(process.env[envKey] || 0);
-  if (fromEnv > 0) return Math.round(fromEnv); // já em cents
-  return 50 * 100; // default 50.00
+  const fromEnv = Number(process.env[`REDEEM_MIN_${upper}`] || 0);
+  return fromEnv > 0 ? Math.round(fromEnv) : 50 * 100; // cents
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
-
-  const ip = getClientIp(req);
-  const { allowed } = await checkRateLimit(`redeem:${session.user.id}:${ip}`, 1, 30);
-  if (!allowed) return NextResponse.json({ error: "Muitas tentativas, tente novamente mais tarde." }, { status: 429 });
-
-  const { currency } = await req.json().catch(() => ({}));
-  if (!currency) return NextResponse.json({ error: "currency é obrigatório" }, { status: 400 });
-  const cur = normCur(currency);
-
-  await connectToDatabase();
-  const user = await User.findById(session.user.id);
-  if (!user) return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
-
-  const balances = user.affiliateBalances || new Map<string, number>();
-  const current = balances.get(cur) ?? 0;
-  const min = minForCurrency(cur);
-  if (current <= 0) return NextResponse.json({ error: "Sem saldo para resgate nesta moeda" }, { status: 400 });
-  if (current < min) return NextResponse.json({ error: `Valor mínimo para resgate em ${cur.toUpperCase()}: ${(min/100).toFixed(2)}` }, { status: 400 });
-
-  const payoutMode = user.affiliatePayoutMode || 'manual';
-  let method: 'manual' | 'connect' = 'manual';
-  if (payoutMode === 'connect' && user.paymentInfo?.stripeAccountStatus === 'verified') {
-    method = 'connect';
-  } else {
-    const hasPix = !!user.paymentInfo?.pixKey;
-    const hasBank = !!(user.paymentInfo?.bankName && user.paymentInfo?.bankAgency && user.paymentInfo?.bankAccount);
-    if (!hasPix && !hasBank) {
-      return NextResponse.json({ error: "Defina seus dados de pagamento (Pix ou bancários) antes de solicitar." }, { status: 400 });
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
     }
+
+    const ip = getClientIp(req);
+    const { allowed } = await checkRateLimit(`redeem_connect:${session.user.id}:${ip}`, 2, 60);
+    if (!allowed) return NextResponse.json({ error: "Muitas tentativas; tente novamente." }, { status: 429 });
+
+    await connectToDatabase();
+    const user = await User.findById(session.user.id);
+    if (!user) return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
+
+    const acctId = user.paymentInfo?.stripeAccountId || null;
+    const status = user.paymentInfo?.stripeAccountStatus || null;
+    if (!acctId || status !== "verified") {
+      return NextResponse.json({ error: "Conecte e verifique sua conta Stripe antes do saque." }, { status: 400 });
+    }
+
+    // Obtemos a moeda destino direto da Stripe para garantir precisão
+    const account = await stripe.accounts.retrieve(acctId);
+    const destCurrency = ((account as any).default_currency || "").toLowerCase();
+    if (!destCurrency) {
+      return NextResponse.json({ error: "Moeda destino não disponível; finalize o onboarding da Stripe." }, { status: 400 });
+    }
+
+    // O resgate SEMPRE é na moeda destino
+    const balances: Map<string, number> = user.affiliateBalances || new Map();
+    const current = balances.get(destCurrency) ?? 0;
+    const min = minForCurrency(destCurrency);
+    if (current <= 0) return NextResponse.json({ error: "Sem saldo disponível." }, { status: 400 });
+    if (current < min)
+      return NextResponse.json({ error: `Valor mínimo: ${(min / 100).toFixed(2)} ${destCurrency.toUpperCase()}` }, { status: 400 });
+
+    // Cria um registro de Redemption (estado 'requested') para ter trilha
+    const redemption = await Redemption.create({
+      userId: user._id,
+      currency: destCurrency,
+      amountCents: current,
+      status: "requested",
+      method: "connect",
+      notes: "Redeem via Connect",
+    });
+
+    // Transfer Stripe → conta conectada do afiliado
+    const idemKey = `redeem_${session.user.id}_${destCurrency}_${current}_${redemption._id}`;
+    const transfer = await stripe.transfers.create(
+      {
+        amount: current,
+        currency: destCurrency,
+        destination: acctId,
+        description: `Affiliate redeem ${destCurrency.toUpperCase()} ${current / 100}`,
+        metadata: {
+          redemptionId: String(redemption._id),
+          affiliateUserId: String(user._id),
+        },
+      },
+      { idempotencyKey: idemKey }
+    );
+
+    // Zera saldo daquela moeda e dá baixa no redemption
+    balances.set(destCurrency, 0);
+    user.markModified("affiliateBalances");
+    await user.save();
+
+    redemption.status = "paid"; // Transferência criada com sucesso (saldo na conta Connect)
+    redemption.transferId = transfer.id;
+    redemption.processedAt = new Date();
+    await redemption.save();
+
+    const plainBalances = Object.fromEntries(balances.entries());
+    return NextResponse.json({
+      success: true,
+      transferId: transfer.id,
+      currency: destCurrency,
+      amountCents: current,
+      newBalances: plainBalances,
+    });
+  } catch (err: any) {
+    console.error("[affiliate/redeem] error:", err);
+    return NextResponse.json({ error: "Erro ao processar resgate." }, { status: 500 });
   }
-
-  const redemption = await Redemption.create({
-    userId: user._id,
-    currency: cur,
-    amountCents: current,
-    status: 'requested',
-    method
-  });
-
-  balances.set(cur, 0);
-  user.markModified('affiliateBalances');
-  await user.save();
-
-  const plainBalances = Object.fromEntries(balances.entries());
-  return NextResponse.json({
-    redemptionId: String(redemption._id),
-    currency: cur,
-    amountCents: current,
-    newBalances: plainBalances
-  });
-}
-
-export async function GET(req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
-
-  await connectToDatabase();
-  const redemptions = await Redemption.find({ userId: session.user.id }).sort({ requestedAt: -1 });
-  return NextResponse.json(redemptions);
 }

--- a/src/app/dashboard/PaymentModal.tsx
+++ b/src/app/dashboard/PaymentModal.tsx
@@ -11,13 +11,11 @@ import PaymentSettings from "./PaymentSettings";
 interface PaymentModalProps {
   isOpen: boolean;
   onClose: () => void;
-  userId: string;
 }
 
 export default function PaymentModal({
   isOpen,
   onClose,
-  userId,
 }: PaymentModalProps) {
   // Usa AnimatePresence para animar entrada/saída
   return (
@@ -64,7 +62,7 @@ export default function PaymentModal({
             {/* Conteúdo do Modal com Scroll */}
             <div className="p-4 sm:p-6 overflow-y-auto max-h-[75vh]"> {/* Altura máxima e scroll */}
               {/* Componente que gerencia dados bancários e exibe o histórico de saques */}
-              <PaymentSettings userId={userId} />
+              <PaymentSettings />
             </div>
 
           </motion.div> {/* Fim motion.div container */}

--- a/src/app/dashboard/PaymentSettings.tsx
+++ b/src/app/dashboard/PaymentSettings.tsx
@@ -1,547 +1,63 @@
-// src/app/dashboard/PaymentSettings.tsx
 "use client";
-
-import React, { useState, useEffect, useCallback } from "react";
-// Importando ícones para feedback e loading
-import { FaSpinner, FaCheckCircle, FaTimesCircle, FaInfoCircle } from "react-icons/fa";
-// Importando Framer Motion para animações
-import { motion, AnimatePresence } from "framer-motion";
-// Importando useSession para atualizar o saldo
+import { useCallback } from "react";
 import { useSession } from "next-auth/react";
+import useSWR from "swr";
 
-/**
- * Estrutura mínima para o objeto de "resgate" (redeem).
- */
-interface Redemption {
-  _id: string;
-  amountCents: number;
-  currency: string;
-  status: 'requested' | 'approved' | 'rejected' | 'paid' | string;
-  requestedAt: string;
-}
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+const fmt = (cents: number, cur: string) =>
+  new Intl.NumberFormat(cur === 'brl' ? 'pt-BR' : 'en-US', { style: 'currency', currency: cur.toUpperCase() }).format(cents / 100);
 
-/** Props para o componente PaymentSettings */
-interface PaymentSettingsProps {
-  userId: string;
-}
-
-// Interface para a resposta da API de resgate
-interface RedeemApiResponse {
-    message?: string;
-    error?: string;
-    redemption?: any; // Detalhes do resgate criado
- }
-
-// Interface para a resposta da API de busca de dados de pagamento
-interface PaymentInfoApiResponse {
-    paymentInfo?: {
-        pixKey?: string;
-        bankName?: string;
-        bankAgency?: string;
-        bankAccount?: string;
-        stripeAccountId?: string | null;
-        stripeAccountStatus?: string | null;
-    };
-    error?: string;
-}
-
-
-// Componente auxiliar para mensagens de feedback
-const FeedbackMessage = ({ message, type }: { message: string; type: 'success' | 'error' | 'info' }) => {
-  const iconMap = {
-    success: <FaCheckCircle className="text-green-500" />,
-    error: <FaTimesCircle className="text-red-500" />,
-    info: <FaInfoCircle className="text-blue-500" />,
-  };
-  const colorMap = {
-    success: 'text-green-600 bg-green-50 border-green-200',
-    error: 'text-red-600 bg-red-50 border-red-200',
-    info: 'text-blue-600 bg-blue-50 border-blue-200',
-  };
-
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: -10 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0 }}
-      className={`flex items-center gap-2 text-xs font-medium p-2 rounded border ${colorMap[type]} mt-2`}
-    >
-      {iconMap[type]}
-      <span>{message}</span>
-    </motion.div>
-  );
-};
-
-// Componente auxiliar para Badges de Status
-const StatusBadge = ({ status }: { status: string }) => {
-  let colorClasses = 'bg-gray-100 text-gray-600 border-gray-300';
-  let text = status.charAt(0).toUpperCase() + status.slice(1);
-
-  switch (status.toLowerCase()) {
-    case 'paid':
-      colorClasses = 'bg-green-100 text-green-700 border-green-300';
-      text = 'Pago';
-      break;
-    case 'approved':
-      colorClasses = 'bg-blue-100 text-blue-700 border-blue-300';
-      text = 'Aprovado';
-      break;
-    case 'requested':
-      colorClasses = 'bg-yellow-100 text-yellow-700 border-yellow-300';
-      text = 'Solicitado';
-      break;
-    case 'rejected':
-      colorClasses = 'bg-red-100 text-red-700 border-red-300';
-      text = 'Rejeitado';
-      break;
-  }
-
-  return (
-    <span className={`inline-block px-2 py-0.5 rounded-full border text-xs font-medium ${colorClasses}`}>
-      {text}
-    </span>
-  );
-};
-
-
-/**
- * Componente que gerencia os dados de pagamento (Pix/Conta) e exibe
- * o histórico de saques do afiliado, permitindo também solicitar novo saque.
- */
-function fmt(amountCents:number, cur:string){
-  const n = amountCents/100;
-  const locale = cur === 'brl' ? 'pt-BR' : 'en-US';
-  return new Intl.NumberFormat(locale,{style:'currency',currency:cur.toUpperCase()}).format(n);
-}
-
-export default function PaymentSettings({ userId }: PaymentSettingsProps) {
-  // Hook useSession para atualizar dados
+export default function PaymentSettings() {
   const { data: session, update: updateSession } = useSession();
+  const { data: connectStatus, mutate } = useSWR('/api/affiliate/connect/status', fetcher, { revalidateOnFocus: false });
+
   const balances: Record<string, number> = session?.user?.affiliateBalances || {};
-  const currencyOptions = Object.entries(balances).filter(([,c])=>c>0);
-  const [selectedCurrency, setSelectedCurrency] = useState(currencyOptions[0]?.[0] || 'brl');
-  const availableBalance = balances[selectedCurrency] ? balances[selectedCurrency]/100 : 0;
+  const destCurrency = connectStatus?.destCurrency || null;
+  const balanceCents = destCurrency ? (balances[destCurrency] ?? 0) : 0;
 
-  // Estados para os dados bancários
-  const [pixKey, setPixKey] = useState("");
-  const [bankName, setBankName] = useState("");
-  const [bankAgency, setBankAgency] = useState("");
-  const [bankAccount, setBankAccount] = useState("");
-  const [saveStatus, setSaveStatus] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
-
-  // Estados para resgate (agora usando 'idle', 'processing', etc.)
-  const [redeemMessage, setRedeemMessage] = useState("");
-  const [redeemStatusState, setRedeemStatusState] = useState<'idle' | 'processing' | 'success' | 'error'>('idle');
-
-  // Histórico de resgates
-  const [redemptions, setRedemptions] = useState<Redemption[]>([]);
-  const [loadingRedemptions, setLoadingRedemptions] = useState(false);
-  const [stripeAccountId, setStripeAccountId] = useState<string | null>(null);
-  const [stripeAccountStatus, setStripeAccountStatus] = useState<string | null>(null);
-
-  const openStripeDashboard = useCallback(async () => {
-    try {
-      const res = await fetch('/api/affiliate/connect/create-link', { method: 'POST' });
-      const data = await res.json();
-      if (res.ok && data.url) {
-        window.open(data.url, '_blank');
-      } else {
-        console.error(data.error || 'Falha ao gerar link');
-      }
-    } catch (error) {
-      console.error('[PaymentSettings] Erro ao abrir painel do Stripe:', error);
-    }
+  const openStripe = useCallback(async () => {
+    const res = await fetch('/api/affiliate/connect/create-link', { method: 'POST' });
+    const data = await res.json();
+    if (data.url) window.open(data.url, '_blank');
   }, []);
 
-  /**
-   * Busca os dados de pagamento do usuário.
-   * <<< CORRIGIDO para ler data.paymentInfo >>>
-   */
-  const fetchPaymentInfo = useCallback(async () => {
-    console.debug("[PaymentSettings] Buscando dados de pagamento para userId =", userId);
-    setSaveStatus(null);
-    if (!userId) {
-      setSaveStatus({ message: "ID do usuário não encontrado.", type: 'error' });
-      return;
-    }
-
-    try {
-      const res = await fetch(`/api/affiliate/paymentinfo?userId=${userId}`, {
-        credentials: "include",
-      });
-      // Define o tipo esperado da resposta da API
-      const data: PaymentInfoApiResponse = await res.json();
-      console.debug("[PaymentSettings] Resposta de paymentInfo:", data);
-
-      // Verifica se a resposta está OK e se existe o objeto paymentInfo
-      if (res.ok && data.paymentInfo) {
-        // <<< CORREÇÃO: Acessa os dados dentro de data.paymentInfo >>>
-        setPixKey(data.paymentInfo.pixKey || "");
-        setBankName(data.paymentInfo.bankName || "");
-        setBankAgency(data.paymentInfo.bankAgency || "");
-        setBankAccount(data.paymentInfo.bankAccount || "");
-        setStripeAccountId(data.paymentInfo.stripeAccountId || null);
-        setStripeAccountStatus(data.paymentInfo.stripeAccountStatus || null);
-      } else {
-         // Não mostra erro se apenas não encontrou dados (status 404)
-         if (res.status !== 404) {
-             setSaveStatus({ message: data.error || "Erro ao buscar dados de pagamento.", type: 'error' });
-         }
-         console.warn("Dados de pagamento não encontrados ou erro:", data.error || res.status);
-         // Garante que os campos fiquem vazios se não houver dados
-         setPixKey("");
-         setBankName("");
-         setBankAgency("");
-         setBankAccount("");
-         setStripeAccountId(null);
-         setStripeAccountStatus(null);
-      }
-    } catch (error) {
-      console.error("[PaymentSettings] Erro ao buscar paymentInfo:", error);
-      setSaveStatus({ message: "Ocorreu um erro de rede ao buscar dados.", type: 'error' });
-    }
-  }, [userId]); // Mantém userId como dependência
-
-  /**
-   * Busca o histórico de resgates do usuário.
-   */
-  const fetchRedemptions = useCallback(async () => {
-    setLoadingRedemptions(true);
-    setRedeemMessage(""); // Limpa mensagem de resgate ao buscar histórico
-    setRedeemStatusState('idle'); // Reseta estado do resgate
-    if (!userId) {
-      setLoadingRedemptions(false);
-      return;
-    }
-
-      try {
-        const res = await fetch(`/api/affiliate/redeem`, {
-          credentials: "include",
-        });
-        const data = await res.json();
-        console.debug("[PaymentSettings] Resposta de redemptions:", data);
-        if (Array.isArray(data)) {
-          setRedemptions(data);
-        } else if (data.error) {
-          console.error("Erro ao buscar histórico:", data.error);
-          setRedemptions([]);
-        } else {
-          setRedemptions([]);
-        }
-      } catch (error) {
-        console.error("[PaymentSettings] Erro ao buscar redemptions:", error);
-        setRedemptions([]);
-      } finally {
-        setLoadingRedemptions(false);
-      }
-    }, [userId]);
-
-  // Chama as funções de fetch ao montar ou quando o userId mudar
-  useEffect(() => {
-    if (!userId) {
-      console.warn("[PaymentSettings] userId vazio. Abortando fetch.");
-      return;
-    }
-    void fetchPaymentInfo();
-    void fetchRedemptions();
-  }, [userId, fetchPaymentInfo, fetchRedemptions]);
-
-  /**
-   * Salva os dados de pagamento (PATCH).
-   */
-  async function handleSave(e: React.FormEvent) {
-    e.preventDefault();
-    setIsSaving(true);
-    setSaveStatus(null);
-    if (!userId) {
-      setSaveStatus({ message: "ID do usuário não encontrado.", type: 'error' });
-      setIsSaving(false);
-      return;
-    }
-
-    try {
-      console.debug("[PaymentSettings] Enviando PATCH para salvar dados...");
-      const res = await fetch("/api/affiliate/paymentinfo", {
-        method: "PATCH",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          userId,
-          pixKey,
-          bankName,
-          bankAgency,
-          bankAccount,
-        }),
-      });
-      const data = await res.json();
-      console.debug("[PaymentSettings] Resposta do PATCH:", data);
-      if (res.ok && !data.error) {
-        setSaveStatus({ message: data.message || "Dados salvos com sucesso!", type: 'success' });
-        // Limpa mensagem de sucesso após um tempo
-        setTimeout(() => {
-            // Verifica se o estado ainda é de sucesso antes de limpar
-            setSaveStatus(prev => (prev?.type === 'success' ? null : prev));
-        }, 4000);
-      } else {
-        setSaveStatus({ message: data.error || "Erro ao salvar dados.", type: 'error' });
-      }
-    } catch (error) {
-      console.error("[PaymentSettings] Erro no handleSave:", error);
-      setSaveStatus({ message: "Ocorreu um erro de rede ao salvar.", type: 'error' });
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
-  /**
-   * Solicita o resgate do saldo (POST).
-   * Lógica já alinhada com MainDashboard.
-   */
   const handleRedeem = useCallback(async () => {
-     if (!userId) {
-        setRedeemMessage("Erro: ID do usuário não encontrado.");
-        setRedeemStatusState('error');
-        return;
-     }
-
-     setRedeemMessage(""); // Limpa mensagem anterior
-     setRedeemStatusState('processing'); // Define como processando
-
-     try {
-       const response = await fetch('/api/affiliate/redeem', {
-           method: 'POST',
-           headers: {
-               'Content-Type': 'application/json',
-           },
-           body: JSON.stringify({ currency: selectedCurrency }),
-       });
-
-        const data: RedeemApiResponse = await response.json();
-
-        if (!response.ok) {
-            setRedeemMessage(data.error || `Erro ${response.status}: Falha ao solicitar resgate.`);
-            setRedeemStatusState('error');
-            console.error("Erro da API de resgate:", data.error || response.statusText);
-            setTimeout(() => {
-                setRedeemStatusState(prev => (prev === 'error' ? 'idle' : prev));
-                setRedeemMessage(prevMsg => (redeemStatusState === 'error' ? "" : prevMsg)); // Limpa msg só se ainda for erro
-            }, 5000);
-            return;
-        }
-
-        // Sucesso!
-        setRedeemMessage("Solicitação enviada! O pagamento será processado manualmente em até 72 horas.");
-        setRedeemStatusState('success');
-        setTimeout(() => {
-             setRedeemStatusState(prev => (prev === 'success' ? 'idle' : prev));
-             setRedeemMessage(prevMsg => (redeemStatusState === 'success' ? "" : prevMsg)); // Limpa msg só se ainda for sucesso
-        }, 7000);
-
-        // Atualiza sessão e histórico
-        await updateSession();
-        void fetchRedemptions();
-
-    } catch (error: unknown) {
-        console.error("[handleRedeem - PaymentSettings] Erro no fetch:", error);
-        const message = error instanceof Error ? error.message : "Erro inesperado ao conectar com o servidor.";
-        setRedeemMessage(`Erro: ${message}`);
-        setRedeemStatusState('error');
-         setTimeout(() => {
-             setRedeemStatusState(prev => (prev === 'error' ? 'idle' : prev));
-             setRedeemMessage(prevMsg => (redeemStatusState === 'error' ? "" : prevMsg));
-        }, 5000);
-    }
-   // Adiciona saveStatus como dependência para evitar stale closure nos setTimeouts
-   }, [userId, fetchRedemptions, updateSession, redeemStatusState, saveStatus, selectedCurrency]);
-
-   // Condição para habilitar o botão de resgate no modal
-   const canRedeemModal = availableBalance > 0 && redeemStatusState !== 'processing';
+    const res = await fetch('/api/affiliate/redeem', { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error || "Erro no resgate"); return; }
+    await updateSession?.();
+    await mutate();
+    alert("Resgate solicitado! Verifique sua conta Stripe.");
+  }, [updateSession, mutate]);
 
   return (
-    // Container principal com espaçamento vertical
-    <div className="space-y-8">
-      {stripeAccountId && (
-        <div className="flex justify-end">
-          <button
-            type="button"
-            onClick={openStripeDashboard}
-            className="px-4 py-2 bg-black text-white rounded-md text-sm hover:opacity-90"
-          >
-            Abrir painel do Stripe
+    <div className="space-y-4">
+      <div className="rounded-lg border p-4 bg-white">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-600">Stripe Connect</p>
+            <p className="text-base font-semibold">
+              {connectStatus?.stripeAccountStatus ?? '—'}{destCurrency ? ` · ${destCurrency.toUpperCase()}` : ''}
+            </p>
+          </div>
+          <button onClick={openStripe} className="px-4 py-2 rounded bg-black text-white text-sm">
+            {connectStatus?.needsOnboarding ? "Configurar Stripe" : "Abrir painel Stripe"}
           </button>
         </div>
-      )}
-
-      {/* Formulário de dados bancários */}
-      <form onSubmit={handleSave} className="border border-gray-200 p-4 sm:p-6 rounded-lg shadow-sm bg-white">
-         {/* ... (campos do formulário mantidos como antes) ... */}
-          <h3 className="text-lg font-semibold mb-4 text-brand-dark">Seus Dados de Pagamento</h3>
-        <div className="space-y-4">
-            <div>
-                <label htmlFor="pixKey" className="block text-sm font-medium text-gray-700 mb-1">
-                Chave Pix (Recomendado)
-                </label>
-                <input
-                    id="pixKey"
-                    type="text"
-                    value={pixKey}
-                    onChange={(e) => setPixKey(e.target.value)}
-                    disabled={isSaving}
-                    className="block w-full border border-gray-300 rounded-md px-3 py-2 text-sm shadow-sm focus:ring-1 focus:ring-brand-pink focus:border-brand-pink transition disabled:opacity-50 disabled:bg-gray-50"
-                    placeholder="Email, CPF/CNPJ, Telefone ou Chave Aleatória"
-                />
-            </div>
-             <div className="relative my-4">
-                <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                    <div className="w-full border-t border-gray-200" />
-                </div>
-                <div className="relative flex justify-center">
-                    <span className="bg-white px-2 text-xs text-gray-500">OU</span>
-                </div>
-            </div>
-            <div className="space-y-4 p-4 border border-gray-200 rounded-md bg-gray-50/50">
-                 <h4 className="text-sm font-medium text-gray-600 mb-2">Conta Bancária (Opcional)</h4>
-                 <div>
-                    <label htmlFor="bankName" className="block text-xs font-medium text-gray-700 mb-1">
-                    Nome do Banco
-                    </label>
-                    <input
-                        id="bankName"
-                        type="text"
-                        value={bankName}
-                        onChange={(e) => setBankName(e.target.value)}
-                        disabled={isSaving}
-                        className="block w-full border border-gray-300 rounded-md px-3 py-1.5 text-sm shadow-sm focus:ring-1 focus:ring-brand-pink focus:border-brand-pink transition disabled:opacity-50 disabled:bg-gray-50"
-                        placeholder="Ex: Banco do Brasil, Nubank"
-                    />
-                 </div>
-                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div>
-                        <label htmlFor="bankAgency" className="block text-xs font-medium text-gray-700 mb-1">
-                        Agência (sem dígito)
-                        </label>
-                        <input
-                            id="bankAgency"
-                            type="text"
-                            inputMode="numeric"
-                            value={bankAgency}
-                            onChange={(e) => setBankAgency(e.target.value.replace(/\D/g, ''))}
-                            disabled={isSaving}
-                            className="block w-full border border-gray-300 rounded-md px-3 py-1.5 text-sm shadow-sm focus:ring-1 focus:ring-brand-pink focus:border-brand-pink transition disabled:opacity-50 disabled:bg-gray-50"
-                            placeholder="Ex: 1234"
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="bankAccount" className="block text-xs font-medium text-gray-700 mb-1">
-                        Conta Corrente (com dígito)
-                        </label>
-                        <input
-                            id="bankAccount"
-                            type="text"
-                            value={bankAccount}
-                            onChange={(e) => setBankAccount(e.target.value)}
-                            disabled={isSaving}
-                            className="block w-full border border-gray-300 rounded-md px-3 py-1.5 text-sm shadow-sm focus:ring-1 focus:ring-brand-pink focus:border-brand-pink transition disabled:opacity-50 disabled:bg-gray-50"
-                            placeholder="Ex: 12345-6"
-                        />
-                    </div>
-                 </div>
-            </div>
-        </div>
-
-        {/* Feedback de Salvamento */}
-        <AnimatePresence>
-            {saveStatus && <FeedbackMessage message={saveStatus.message} type={saveStatus.type} />}
-        </AnimatePresence>
-
-        {/* Botão Salvar */}
-        <button
-          type="submit"
-          disabled={isSaving}
-          className="mt-5 px-5 py-2 bg-brand-pink text-white text-sm font-semibold rounded-full hover:opacity-90 transition-default disabled:opacity-50 disabled:cursor-not-allowed shadow-sm flex items-center justify-center gap-2"
-        >
-          {isSaving ? (
-            <> <FaSpinner className="animate-spin w-4 h-4" /> <span>Salvando...</span> </>
-          ) : ( "Salvar Dados" )}
-        </button>
-      </form>
-
-      {/* Seção de Resgate */}
-      <div className="border border-gray-200 p-4 sm:p-6 rounded-lg shadow-sm bg-white">
-         <h3 className="text-lg font-semibold mb-2 text-brand-dark">Solicitar Resgate</h3>
-         <div className="mb-4 flex items-center gap-2">
-           <select value={selectedCurrency} onChange={e=>setSelectedCurrency(e.target.value)} className="rounded border px-2 py-1 text-sm">
-             {currencyOptions.map(([cur]) => (
-               <option key={cur} value={cur}>{cur.toUpperCase()}</option>
-             ))}
-           </select>
-           <span className="text-sm text-gray-600">Saldo: <strong className="text-green-600">{fmt(balances[selectedCurrency]||0, selectedCurrency)}</strong></span>
-         </div>
-         <p className="text-xs text-gray-500 mb-4">O pagamento será processado manualmente em até 72 horas após a solicitação.</p>
-
-         {/* Botão de Resgate Atualizado */}
-         <button
-          onClick={handleRedeem}
-          disabled={!canRedeemModal}
-          className="px-5 py-2 bg-green-600 text-white text-sm font-semibold rounded-full hover:bg-green-700 transition-default disabled:opacity-50 disabled:cursor-not-allowed shadow-sm flex items-center justify-center gap-2"
-         >
-          {redeemStatusState === 'processing' ? (
-            <> <FaSpinner className="animate-spin w-4 h-4" /> <span>Processando...</span> </>
-          ) : ( "Resgatar" )}
-        </button>
-
-        {/* Feedback de Resgate */}
-        <AnimatePresence>
-            {redeemMessage && (
-                 <FeedbackMessage
-                    message={redeemMessage}
-                    type={redeemStatusState === 'error' ? 'error' : redeemStatusState === 'success' ? 'success' : 'info'}
-                 />
-            )}
-        </AnimatePresence>
       </div>
 
-
-      {/* Histórico de Saques */}
-      <div className="border border-gray-200 p-4 sm:p-6 rounded-lg shadow-sm bg-white">
-        {/* ... (código do histórico mantido como antes) ... */}
-        <h3 className="text-lg font-semibold mb-4 text-brand-dark">Histórico de Resgates</h3>
-        {loadingRedemptions ? (
-          <div className="flex items-center justify-center text-sm text-gray-500 py-4">
-             <FaSpinner className="animate-spin w-5 h-5 mr-2" />
-             Carregando histórico...
-          </div>
-        ) : redemptions.length === 0 ? (
-          <p className="text-sm text-center text-gray-500 py-4">Nenhum resgate realizado ainda.</p>
-        ) : (
-          <div className="overflow-x-auto">
-             <table className="w-full text-sm border-collapse">
-                <thead className="bg-gray-50">
-                <tr>
-                    <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Data</th>
-                    <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Valor</th>
-                    <th className="px-3 py-2 text-left font-medium text-gray-600 border-b border-gray-200">Status</th>
-                </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-100">
-                {redemptions.map((r) => (
-                    <tr key={r._id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-3 py-2 text-gray-700">
-                          {new Date(r.requestedAt).toLocaleString("pt-BR", { dateStyle: 'short', timeStyle: 'short' })}
-                      </td>
-                      <td className="px-3 py-2 text-gray-700">
-                          {fmt(r.amountCents, (r.currency || 'brl').toLowerCase())}
-                      </td>
-                    <td className="px-3 py-2">
-                        <StatusBadge status={r.status} />
-                    </td>
-                    </tr>
-                ))}
-                </tbody>
-            </table>
-          </div>
-        )}
+      <div className="rounded-lg border p-4 bg-white">
+        <p className="text-sm text-gray-600">Saldo disponível</p>
+        <p className="text-2xl font-bold">
+          {destCurrency ? fmt(balanceCents, destCurrency) : "—"}
+        </p>
+        <button
+          disabled={!destCurrency || balanceCents <= 0 || connectStatus?.stripeAccountStatus !== 'verified'}
+          onClick={handleRedeem}
+          className="mt-3 px-4 py-2 rounded bg-green-600 text-white text-sm disabled:opacity-50"
+        >
+          Resgatar agora
+        </button>
       </div>
     </div>
   );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -473,13 +473,12 @@ export default function MainDashboard() {
     handleRedeemBalance,
     setShowPaymentModal,
     canRedeem,
-    userId
   };
 
   return (
     <>
       <Head><title>Dashboard - Data2Content</title></Head>
-      <PaymentModal isOpen={showPaymentModal} onClose={() => setShowPaymentModal(false)} userId={userId} />
+      <PaymentModal isOpen={showPaymentModal} onClose={() => setShowPaymentModal(false)} />
 
       <div className="min-h-screen bg-brand-light">
         {/* --- HEADER RESTAURADO --- */}

--- a/src/app/models/Redemption.ts
+++ b/src/app/models/Redemption.ts
@@ -9,6 +9,7 @@ export interface IRedemption extends Document {
   requestedAt: Date;
   processedAt?: Date | null;
   notes?: string;
+  transferId?: string;
 }
 
 const redemptionSchema = new Schema<IRedemption>({
@@ -20,7 +21,10 @@ const redemptionSchema = new Schema<IRedemption>({
   requestedAt: { type: Date, default: Date.now },
   processedAt: { type: Date, default: null },
   notes: { type: String, default: '' },
+  transferId: { type: String, index: true },
 }, { timestamps: true });
+
+redemptionSchema.index({ userId: 1, createdAt: -1 });
 
 const Redemption: Model<IRedemption> = mongoose.models.Redemption || mongoose.model<IRedemption>('Redemption', redemptionSchema);
 export default Redemption;

--- a/src/app/services/affiliate/creditCommission.ts
+++ b/src/app/services/affiliate/creditCommission.ts
@@ -1,0 +1,41 @@
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+
+export type CreditArgs = {
+  affiliateUserId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  sourcePaymentId?: string;
+  referredUserId?: string;
+};
+
+export async function creditAffiliateCommission(args: CreditArgs) {
+  const { affiliateUserId, amountCents, currency, description, sourcePaymentId, referredUserId } = args;
+  await connectToDatabase();
+
+  const user = await User.findById(affiliateUserId);
+  if (!user) throw new Error("Affiliate user not found");
+
+  user.commissionLog ||= [];
+  user.commissionLog.push({
+    date: new Date(),
+    description,
+    sourcePaymentId,
+    referredUserId,
+    currency: currency.toLowerCase(),
+    amountCents,
+    status: "accrued",
+  });
+
+  user.affiliateBalances ||= new Map();
+  const cur = currency.toLowerCase();
+  const prev = user.affiliateBalances.get(cur) ?? 0;
+  user.affiliateBalances.set(cur, prev + amountCents);
+
+  user.markModified("commissionLog");
+  user.markModified("affiliateBalances");
+  await user.save();
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- support transfer tracking with `transferId` on redemptions
- add connect-only redeem endpoint using Stripe transfers and idempotency
- handle Stripe Connect `account.updated` and `transfer.reversed` events
- throttle connect status checks and credit commissions util
- simplify payment settings UI for Stripe Connect flow

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689a8aa97b24832e8eea84c19fa3ad0e