### PR TITLE
Standardize redemption statuses and admin note handling

### DIFF
--- a/src/app/api/admin/redemptions/[id]/route.ts
+++ b/src/app/api/admin/redemptions/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import Redemption from "@/app/models/Redemption";
+
+export const runtime = "nodejs";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.role || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { notes } = await req.json();
+  await connectToDatabase();
+  const red = await Redemption.findById(params.id);
+  if (!red) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  red.notes = String(notes ?? "").slice(0, 1000);
+  await red.save();
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/admin/redemptions/route.ts
+++ b/src/app/api/admin/redemptions/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const statusFilter = searchParams.get("status") || 'pending';
+    const statusFilter = searchParams.get("status") || 'requested';
     const searchQuery = searchParams.get("searchQuery");
     const exportType = searchParams.get("export");
 
@@ -116,7 +116,7 @@ export async function GET(request: NextRequest) {
       const csvDelimiter = ';';
       const csvHeaders = [
         "ID Resgate", "Data Solicitacao", "Status", "Nome Afiliado", "Email Afiliado",
-        "Valor (BRL)", "Moeda", "Chave PIX", "Banco", "Agencia", "Conta", "Notas Admin"
+        "Valor", "Moeda", "Chave PIX", "Banco", "Agencia", "Conta", "Notas Admin"
       ];
       let csvContent = csvHeaders.join(csvDelimiter) + "\r\n";
       
@@ -131,14 +131,13 @@ export async function GET(request: NextRequest) {
           escapeCsvValue(r.status, csvDelimiter),
           escapeCsvValue(user.name || '', csvDelimiter),
           escapeCsvValue(user.email || '', csvDelimiter),
-          escapeCsvValue(r.amount.toFixed(2).replace('.', ','), csvDelimiter),
-          escapeCsvValue(r.currency, csvDelimiter), // Campo adicionado
+          escapeCsvValue((r.amountCents / 100).toFixed(2).replace('.', ','), csvDelimiter),
+          escapeCsvValue(r.currency, csvDelimiter),
           escapeCsvValue(paymentInfo.pixKey || '', csvDelimiter),
           escapeCsvValue(paymentInfo.bankName || '', csvDelimiter),
           escapeCsvValue(paymentInfo.bankAgency || '', csvDelimiter),
           escapeCsvValue(paymentInfo.bankAccount || '', csvDelimiter),
-          // <<< ALTERAÇÃO 8: Usando 'adminNotes'
-          escapeCsvValue(r.adminNotes || '', csvDelimiter)
+          escapeCsvValue(r.notes || '', csvDelimiter)
         ];
         csvContent += row.join(csvDelimiter) + "\r\n";
       });

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -281,7 +281,7 @@ export interface IUser extends Document {
     bankAgency?: string;
     bankAccount?: string;
     stripeAccountId?: string | null;
-    stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled';
+    stripeAccountStatus?: 'pending' | 'verified' | 'disabled';
     stripeAccountDefaultCurrency?: string;
   };
   affiliatePayoutMode?: 'connect' | 'manual';
@@ -474,7 +474,7 @@ const userSchema = new Schema<IUser>(
       bankAgency: { type: String, default: "" },
       bankAccount: { type: String, default: "" },
       stripeAccountId: { type: String, default: null },
-      stripeAccountStatus: { type: String, enum: ['pending', 'verified', 'restricted', 'disabled'], default: undefined },
+      stripeAccountStatus: { type: String, enum: ['pending', 'verified', 'disabled'], default: undefined },
       stripeAccountDefaultCurrency: { type: String, default: undefined },
     },
 

--- a/src/lib/services/adminCreatorService.test.ts
+++ b/src/lib/services/adminCreatorService.test.ts
@@ -283,12 +283,12 @@ describe('AdminCreatorService', () => {
       mockExecForFetchRedemptions.mockResolvedValueOnce([]);
       mockExecForFetchRedemptions.mockResolvedValueOnce([{ totalCount: 0 }]);
 
-      const params: AdminRedemptionListParams = { status: 'pending' };
+      const params: AdminRedemptionListParams = { status: 'requested' };
       await fetchRedemptions(params);
 
       const firstPipeline = (mongoose.model('Redemption').aggregate as jest.Mock).mock.calls[0][0];
       const initialMatchStage = firstPipeline.find((stage: any) => stage.$match && stage.$match.status);
-      expect(initialMatchStage?.$match).toEqual({ status: 'pending' });
+      expect(initialMatchStage?.$match).toEqual({ status: 'requested' });
     });
 
     it('should include $match for date range if dateFrom and dateTo are provided', async () => {
@@ -328,16 +328,16 @@ describe('AdminCreatorService', () => {
     });
 
     it('should call RedemptionModel.findByIdAndUpdate with correct parameters', async () => {
-      const mockUpdatedRedemption = { _id: 'redemption1', status: 'approved', adminNotes: 'Approved by admin' };
+      const mockUpdatedRedemption = { _id: 'redemption1', status: 'paid', notes: 'Approved by admin' };
       mockExecForUpdateRedemption.mockResolvedValueOnce(mockUpdatedRedemption);
 
       const redemptionId = 'redemption1';
-      const payload: AdminRedemptionUpdateStatusPayload = { status: 'approved', adminNotes: 'Approved by admin' };
+      const payload: AdminRedemptionUpdateStatusPayload = { status: 'paid', notes: 'Approved by admin' };
       const result = await updateRedemptionStatus(redemptionId, payload);
 
       expect(mongoose.model('Redemption').findByIdAndUpdate).toHaveBeenCalledWith(
         redemptionId,
-        { $set: expect.objectContaining({ status: 'approved', adminNotes: 'Approved by admin' }) },
+        { $set: expect.objectContaining({ status: 'paid', notes: 'Approved by admin' }) },
         { new: true, runValidators: true }
       );
       expect(result).toEqual(mockUpdatedRedemption);
@@ -345,11 +345,11 @@ describe('AdminCreatorService', () => {
 
     it('should throw error if redemption not found', async () => {
       mockExecForUpdateRedemption.mockResolvedValueOnce(null);
-      await expect(updateRedemptionStatus('notFoundId', { status: 'approved' })).rejects.toThrow('Redemption not found.');
+      await expect(updateRedemptionStatus('notFoundId', { status: 'paid' })).rejects.toThrow('Redemption not found.');
     });
 
     it('should throw error for invalid redemptionId format', async () => {
-      await expect(updateRedemptionStatus('invalid-id', { status: 'approved' })).rejects.toThrow('Invalid redemptionId format.');
+      await expect(updateRedemptionStatus('invalid-id', { status: 'paid' })).rejects.toThrow('Invalid redemptionId format.');
     });
   });
 });

--- a/src/lib/services/adminCreatorService.ts
+++ b/src/lib/services/adminCreatorService.ts
@@ -337,8 +337,8 @@ export async function fetchRedemptions(
     search,
     status,
     userId,
-    minAmount,
-    maxAmount,
+    minAmountCents,
+    maxAmountCents,
     dateFrom,
     dateTo,
     sortBy = 'requestedAt',
@@ -361,11 +361,11 @@ export async function fetchRedemptions(
       query.userId = null;
     }
   }
-  if (typeof minAmount === 'number') {
-    query.amount = { ...query.amount, $gte: minAmount };
+  if (typeof minAmountCents === 'number') {
+    query.amountCents = { ...query.amountCents, $gte: minAmountCents };
   }
-  if (typeof maxAmount === 'number') {
-    query.amount = { ...query.amount, $lte: maxAmount };
+  if (typeof maxAmountCents === 'number') {
+    query.amountCents = { ...query.amountCents, $lte: maxAmountCents };
   }
   if (dateFrom) {
     query.requestedAt = { ...query.requestedAt, $gte: new Date(dateFrom) };
@@ -433,14 +433,14 @@ export async function fetchRedemptions(
       userId: doc.userId.toString(),
       userName: doc.userDetails?.name || 'Usuário Desconhecido',
       userEmail: doc.userDetails?.email || 'N/A',
-      amount: doc.amount,
+      amountCents: doc.amountCents,
       currency: doc.currency,
       status: doc.status,
       requestedAt: doc.requestedAt,
       updatedAt: doc.updatedAt,
       paymentMethod: doc.paymentMethod,
       paymentDetails: doc.paymentDetails,
-      adminNotes: doc.adminNotes,
+      notes: doc.notes,
     }));
 
     logger.info(`${TAG} Successfully fetched ${redemptions.length} redemptions. Total: ${totalRedemptions}.`);
@@ -467,11 +467,11 @@ export async function updateRedemptionStatus(
     throw new Error('Invalid redemptionId format.');
   }
 
-  const { status, adminNotes, transactionId } = payload;
+  const { status, notes, transactionId } = payload;
   const updateData: Partial<IRedemption> = { status };
-  
-  if (adminNotes !== undefined) {
-    updateData.adminNotes = adminNotes;
+
+  if (notes !== undefined) {
+    updateData.notes = notes;
   }
   if (transactionId !== undefined) {
     updateData.transactionId = transactionId;

--- a/src/types/admin/redemptions.ts
+++ b/src/types/admin/redemptions.ts
@@ -2,33 +2,22 @@
 
 // Define os possíveis status de um pedido de resgate
 export type RedemptionStatus =
-  | 'pending'       // Solicitação recebida, aguardando aprovação
-  | 'approved'      // Solicitação aprovada, aguardando pagamento
-  | 'rejected'      // Solicitação rejeitada pelo admin
-  | 'processing'    // Pagamento em processamento (ex: enviado para gateway)
-  | 'paid'          // Pagamento concluído com sucesso
-  | 'failed'        // Pagamento falhou
-  | 'cancelled';    // Solicitação cancelada pelo usuário (se aplicável)
+  | 'requested'
+  | 'paid'
+  | 'rejected';
 
 // Interface para os itens da lista de resgates na área de administração
 export interface AdminRedemptionListItem {
-  _id: string; // ID do resgate
-  userId: string; // ID do usuário que solicitou (referência ao UserModel)
-  userName: string; // Nome do usuário (para exibição fácil)
-  userEmail: string; // Email do usuário (para contato/identificação)
-
-  amount: number; // Valor do resgate
-  currency: string; // Moeda (ex: 'BRL', 'USD')
-
+  _id: string;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  amountCents: number;
+  currency: string;
   status: RedemptionStatus;
-
-  requestedAt: Date | string; // Data da solicitação
-  updatedAt?: Date | string; // Data da última atualização de status
-
-  paymentMethod?: string; // Método de pagamento preferido (ex: 'PIX', 'BankTransfer')
-  paymentDetails?: Record<string, any>; // Detalhes específicos do método (ex: chave PIX, dados bancários) - pode ser genérico
-
-  adminNotes?: string; // Notas internas do administrador
+  requestedAt: Date | string;
+  updatedAt?: Date | string;
+  notes?: string;
 }
 
 // Interface para os parâmetros de query da API de listagem de resgates
@@ -38,8 +27,8 @@ export interface AdminRedemptionListParams {
   search?: string; // Para buscar por nome/email do usuário, ID do resgate
   status?: RedemptionStatus; // Para filtrar por status do resgate
   userId?: string; // Para filtrar resgates de um usuário específico
-  minAmount?: number;
-  maxAmount?: number;
+  minAmountCents?: number;
+  maxAmountCents?: number;
   dateFrom?: string; // Data de início do período de solicitação
   dateTo?: string;   // Data de fim do período de solicitação
   sortBy?: keyof AdminRedemptionListItem | string; // Campo para ordenação
@@ -49,18 +38,14 @@ export interface AdminRedemptionListParams {
 // Interface para o payload da API ao atualizar o status de um resgate
 export interface AdminRedemptionUpdateStatusPayload {
   status: RedemptionStatus;
-  adminNotes?: string; // Notas do admin sobre a mudança de status
+  notes?: string; // Notas do admin sobre a mudança de status
   transactionId?: string; // ID da transação de pagamento, se aplicável
   // Outros campos relevantes para a atualização podem ser adicionados
 }
 
 // Constantes para as opções de status de resgate, úteis para UIs de filtro
 export const REDEMPTION_STATUS_OPTIONS: ReadonlyArray<{ value: RedemptionStatus; label: string }> = [
-  { value: 'pending', label: 'Pendente' },
-  { value: 'approved', label: 'Aprovado (Aguardando Pagamento)' },
-  { value: 'rejected', label: 'Rejeitado' },
-  { value: 'processing', label: 'Processando Pagamento' },
+  { value: 'requested', label: 'Em processamento' },
   { value: 'paid', label: 'Pago' },
-  { value: 'failed', label: 'Falhou' },
-  { value: 'cancelled', label: 'Cancelado' },
+  { value: 'rejected', label: 'Rejeitado' },
 ];

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -28,7 +28,7 @@ declare module "next-auth" {
       affiliateRank?: number;
       affiliateInvites?: number;
 
-      stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled' | null;
+      stripeAccountStatus?: 'pending' | 'verified' | 'disabled' | null;
       stripeAccountDefaultCurrency?: string | null;
 
       // Campos do Instagram que o frontend (InstagramConnectCard) espera:
@@ -70,7 +70,7 @@ declare module "next-auth" {
     affiliateRank?: number;
     affiliateInvites?: number;
 
-    stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled' | null;
+    stripeAccountStatus?: 'pending' | 'verified' | 'disabled' | null;
     stripeAccountDefaultCurrency?: string | null;
     
     // Campos do Instagram como vêm do DB ou são processados antes do JWT
@@ -114,7 +114,7 @@ declare module "next-auth/jwt" {
     lastInstagramSyncAttempt?: Date | string | null; // Pode ser Date ou string (após encode)
     lastInstagramSyncSuccess?: boolean | null;
 
-    stripeAccountStatus?: 'pending' | 'verified' | 'restricted' | 'disabled' | null;
+    stripeAccountStatus?: 'pending' | 'verified' | 'disabled' | null;
     stripeAccountDefaultCurrency?: string | null;
     
     // picture pode ser usado por NextAuth, image é mais comum


### PR DESCRIPTION
## Summary
- Use requested/paid/rejected statuses consistently and expose amountCents and currency in admin list
- Allow admins to update redemption notes via new `/api/admin/redemptions/[id]` PATCH route
- Remove deprecated stripe `restricted` status from user typings

## Testing
- `npm test` *(fails: Cannot find module '@/utils/calculateFollowerGrowthRate' and TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a91761fe8832e8899723c200714b8