### PR TITLE
fix Jest alias and environment for admin redemption tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -13,11 +13,14 @@ const customJestConfig = {
       // --- CORREÇÃO APLICADA AQUI ---
       // Adicionado para lidar com a importação otimizada de lucide-react pelo Next.js
       '^modularize-import-loader\\?name=([a-zA-Z0-9_-]+)&from=default&as=default&join=../esm/icons/([a-zA-Z0-9_-]+)!lucide-react$': '<rootDir>/__mocks__/lucide-react.js',
-      
+
       // Mapeamentos existentes
       '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
       '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
-      '^@/app/(.*)$': '<rootDir>/src/app/$1',
+
+      // Permite que imports usando o alias "@" apontem para a pasta src
+      '^@/(.*)$': '<rootDir>/src/$1',
+
       '^@heroicons/react/24/(solid|outline)/esm/.*$': '<rootDir>/__mocks__/heroicons/24/$1.js',
       '^@heroicons/react/(.*)$': '<rootDir>/__mocks__/heroicons/$1.js',
     },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom';
+
+// Polyfills for Next.js API routes during testing
+import { TextEncoder, TextDecoder } from 'util';
+
+// Ensure encoding APIs exist in the test environment
+global.TextEncoder = TextEncoder;
+// @ts-ignore
+global.TextDecoder = TextDecoder;

--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.test.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 // src/app/api/admin/redemptions/[redemptionId]/status/route.test.ts
 import { PATCH } from './route';
 import { updateRedemptionStatus } from '@/lib/services/adminCreatorService'; // Ajuste se o nome do serviço mudou

--- a/src/app/api/admin/redemptions/route.test.ts
+++ b/src/app/api/admin/redemptions/route.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 // src/app/api/admin/redemptions/route.test.ts
 import { GET } from './route';
 import { fetchRedemptions } from '@/lib/services/adminCreatorService'; // Ajuste se o nome do serviço mudou


### PR DESCRIPTION
## Summary
- add generic `@` path mapping in Jest config
- polyfill encoding APIs for tests
- run admin redemption route tests in Node environment

## Testing
- `npx jest src/app/api/admin/redemptions/route.test.ts`
- `npx jest src/app/api/admin/redemptions/\[redemptionId\]/status/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a9caf0078832ea29a9bf7f46b0682