### PR TITLE
feat: refine redemption admin and transactions

### DIFF
--- a/docs/affiliates.md
+++ b/docs/affiliates.md
@@ -13,7 +13,7 @@ This document describes the affiliate program implementation within the applicat
    - Metadata records `invoiceId`, `referredUserId`, `affiliateUserId` and `affiliateCode`.
    - On transfer failure, the amount is credited to `affiliateBalance` for manual payout (`status: failed`).
 4. **Cleanup**: `user.affiliateUsed` is cleared after the first charge.
-5. **Logging**: Structured logs store `event.id`, `invoice.id`, `customer`, `amountCents`, `currency`, `status` and `transferId`.
+5. **Logging**: Structured logs store `event.id`, `invoice.id`, `customer`, `amountCents`, `currency`, `status` and `transactionId`.
 
 ## Stripe Connect Onboarding
 
@@ -48,7 +48,7 @@ Features:
 
 - **Connect to Stripe** button calling `POST /api/affiliate/connect/create` then `POST /api/affiliate/connect/link` and redirecting to onboarding.
 - **Status badge** showing `pending`, `restricted`, `verified` or `disabled` based on `GET /api/affiliate/connect/status`.
-- **Commission log** table displaying date, amount, currency, status, `invoiceId` and `transferId`.
+- **Commission log** table displaying date, amount, currency, status, `invoiceId` and `transactionId`.
 - Displays `affiliateBalance` and manual payout instructions when the account is not verified.
 - Provides copyable affiliate link `${APP_URL}/?ref=${user.affiliateCode}`.
 
@@ -58,7 +58,7 @@ Route: `/admin/affiliates/commissions`
 
 - List and filter commissions with `status` in `[failed, fallback]`.
 - Action **Reprocess** triggers `POST /api/admin/affiliate/commissions/:id/retry`.
-- If the affiliate account is verified a new `transfer` is attempted; on success the entry is marked `paid` with `transferId`.
+- If the affiliate account is verified a new `transfer` is attempted; on success the entry is marked `paid` with `transactionId`.
 - Access restricted to users with `role=admin` via NextAuth.
 
 ## Monetary Fields
@@ -68,7 +68,7 @@ Route: `/admin/affiliates/commissions`
 
 ## Observability
 
-- Logs (info/error) include `event.id`, `customer`, `invoice.id`, `transferId` and `status`.
+- Logs (info/error) include `event.id`, `customer`, `invoice.id`, `transactionId` and `status`.
 - Alerts should be configured in Sentry or logging platform when commission transfers fail or accounts become `restricted/disabled`.
 - Runbook steps:
   1. Check logs for commission events.

--- a/docs/stripe-multimoeda-release.md
+++ b/docs/stripe-multimoeda-release.md
@@ -53,10 +53,10 @@ Este documento consolida a especificação, checklist e critérios de aceite par
 **Tarefas**
 - Se `destCurrency !== commission.currency` → manter `status='fallback'` (sem mexer no saldo se a comissão já está no Map).
 - Se `destCurrency === commission.currency` → criar `transfer`, setar `status='paid'`; subtrair de `affiliateBalances[cur]` (cents) e `markModified`.
-- Logar tentativa e resultado (`transferId`/`fallback`).
+- Logar tentativa e resultado (`transactionId`/`fallback`).
 
 **Critérios de Aceite**
-- Admin reprocessa com feedback claro: `{success:true, transferId}` ou `{success:true, status:'fallback'}`.
+- Admin reprocessa com feedback claro: `{success:true, transactionId}` ou `{success:true, status:'fallback'}`.
 - Saldos por moeda ajustados corretamente.
 
 ## EPIC 5 — Redeem por moeda (manual)

--- a/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest, { params }: { params: { invoiceId: 
     }, { idempotencyKey: `commission_${entry.sourcePaymentId}_${affUser._id}` });
 
     entry.status = 'paid';
-    entry.transferId = transfer.id;
+    entry.transactionId = transfer.id;
     affUser.commissionPaidInvoiceIds = affUser.commissionPaidInvoiceIds || [];
     if (entry.sourcePaymentId && !affUser.commissionPaidInvoiceIds.includes(entry.sourcePaymentId)) {
       affUser.commissionPaidInvoiceIds.push(entry.sourcePaymentId);
@@ -88,7 +88,7 @@ export async function POST(req: NextRequest, { params }: { params: { invoiceId: 
     affUser.markModified('affiliateBalances');
     await affUser.save();
 
-    return NextResponse.json({ success: true, transferId: transfer.id });
+    return NextResponse.json({ success: true, transactionId: transfer.id });
   } catch (err) {
     logger.error('[admin/affiliate/commissions/retry] error', err);
     return NextResponse.json({ error: 'Erro ao reprocessar comissão' }, { status: 500 });

--- a/src/app/api/admin/redemptions/route.ts
+++ b/src/app/api/admin/redemptions/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: NextRequest) {
 
     if (exportType === 'csv') {
       const delimiter = ';';
-      const headers = ['createdAt', 'name', 'email', 'amount', 'currency', 'status', 'notes'];
+      const headers = ['createdAt', 'name', 'email', 'amount', 'currency', 'status', 'transactionId', 'notes'];
       let csv = headers.join(delimiter) + '\r\n';
       redemptions.forEach(r => {
         csv += [
@@ -51,6 +51,7 @@ export async function GET(req: NextRequest) {
           (r.amountCents / 100).toFixed(2).replace('.', ','),
           r.currency,
           r.status,
+          r.transactionId || '',
           r.notes || ''
         ].map(v => escapeCsvValue(v, delimiter)).join(delimiter) + '\r\n';
       });

--- a/src/app/api/affiliate/redeem/route.test.ts
+++ b/src/app/api/affiliate/redeem/route.test.ts
@@ -5,7 +5,7 @@ jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
 jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
 jest.mock('@/utils/rateLimit', () => ({ checkRateLimit: jest.fn() }));
-jest.mock('@/app/models/User', () => ({ findById: jest.fn(), updateOne: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findById: jest.fn(), updateOne: jest.fn(), findOneAndUpdate: jest.fn() }));
 jest.mock('@/app/models/Redemption', () => ({ create: jest.fn() }));
 jest.mock('@/app/lib/stripe', () => ({
   accounts: { retrieve: jest.fn() },
@@ -36,7 +36,8 @@ describe('POST /api/affiliate/redeem', () => {
       affiliateBalances: new Map([['brl', 2000]]),
       paymentInfo: { stripeAccountId: 'acct1' },
     });
-    User.updateOne.mockResolvedValue({ modifiedCount: 1 });
+    User.findOneAndUpdate.mockResolvedValue({});
+    User.updateOne.mockResolvedValue({});
     Redemption.create.mockImplementation(async (data: any) => ({ _id: 'red1', ...data }));
     stripe.accounts.retrieve.mockResolvedValue({ default_currency: 'brl', charges_enabled: true, payouts_enabled: true });
     stripe.transfers.create.mockResolvedValue({ id: 'tr_1' });

--- a/src/app/components/ClientHooksWrapper.test.tsx
+++ b/src/app/components/ClientHooksWrapper.test.tsx
@@ -16,11 +16,10 @@ describe('ClientHooksWrapper', () => {
     localStorage.clear();
   });
 
-  it('sets cookie when ref param is present', () => {
-    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams('ref=ABCD12'));
+  it('stores agency invite code when codigo_agencia param is present', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams('codigo_agencia=XYZ123'));
     render(<ClientHooksWrapper />);
-    expect(document.cookie).toContain('d2c_ref=ABCD12');
-    expect(localStorage.getItem('affiliateRefCode')).toBeTruthy();
+    expect(localStorage.getItem('agencyInviteCode')).toBeTruthy();
   });
 });
 

--- a/src/app/components/ClientHooksWrapper.tsx
+++ b/src/app/components/ClientHooksWrapper.tsx
@@ -4,8 +4,6 @@
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
-const AFFILIATE_REF_KEY = 'affiliateRefCode';
-const AFFILIATE_REF_EXPIRATION_DAYS = 90;
 const AGENCY_INVITE_KEY = 'agencyInviteCode';
 const AGENCY_INVITE_EXPIRATION_DAYS = 7;
 
@@ -15,24 +13,6 @@ export default function ClientHooksWrapper() {
   useEffect(() => {
     // A lógica do typeof window !== 'undefined' garante execução somente no cliente
     if (typeof window !== 'undefined') {
-      const refCode = searchParams.get('ref');
-      if (refCode && refCode.trim() !== '') {
-        const expiresAt = Date.now() + AFFILIATE_REF_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
-        const refDataToStore = { code: refCode.trim(), expiresAt };
-        try {
-          localStorage.setItem(AFFILIATE_REF_KEY, JSON.stringify(refDataToStore));
-        } catch (error) {
-          console.error('[ClientHooksWrapper] Erro ao salvar código de referência no localStorage:', error);
-        }
-
-        try {
-          const secure = window.location.protocol === 'https:';
-          document.cookie = `d2c_ref=${encodeURIComponent(refCode.trim())}; path=/; max-age=${AFFILIATE_REF_EXPIRATION_DAYS * 24 * 60 * 60}; samesite=lax${secure ? '; secure' : ''}`;
-        } catch (err) {
-          console.error('[ClientHooksWrapper] Erro ao definir cookie de referência:', err);
-        }
-      }
-
       const invite = searchParams.get('codigo_agencia');
       if (invite && invite.trim() !== '') {
         const expiresAt = Date.now() + AGENCY_INVITE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;

--- a/src/app/models/Redemption.ts
+++ b/src/app/models/Redemption.ts
@@ -9,7 +9,7 @@ export interface IRedemption extends Document {
   requestedAt: Date;
   processedAt?: Date | null;
   notes?: string;
-  transferId?: string;
+  transactionId?: string;
 }
 
 const redemptionSchema = new Schema<IRedemption>({
@@ -21,7 +21,7 @@ const redemptionSchema = new Schema<IRedemption>({
   requestedAt: { type: Date, default: Date.now },
   processedAt: { type: Date, default: null },
   notes: { type: String, default: '' },
-  transferId: { type: String, index: true },
+  transactionId: { type: String, index: true },
 }, { timestamps: true });
 
 redemptionSchema.index({ userId: 1, createdAt: -1 });

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -159,7 +159,7 @@ export interface ICommissionLogEntry {
   sourcePaymentId?: string;
   referredUserId?: Types.ObjectId;
   status: 'paid' | 'failed' | 'fallback';
-  transferId?: string | null;
+  transactionId?: string | null;
   currency?: string;
   amountCents: number;
 }
@@ -326,7 +326,7 @@ const commissionLogEntrySchema = new Schema<ICommissionLogEntry>({
   sourcePaymentId: { type: String },
   referredUserId: { type: Schema.Types.ObjectId, ref: 'User' },
   status: { type: String, enum: ['paid', 'failed', 'fallback'], required: true },
-  transferId: { type: String, default: null },
+  transactionId: { type: String, default: null },
   currency: { type: String },
   amountCents: { type: Number, required: true },
 }, { _id: false });

--- a/src/lib/services/adminCreatorService.ts
+++ b/src/lib/services/adminCreatorService.ts
@@ -441,6 +441,8 @@ export async function fetchRedemptions(
       status: doc.status,
       createdAt: doc.createdAt || doc.requestedAt,
       updatedAt: doc.updatedAt,
+      processedAt: doc.processedAt,
+      transactionId: doc.transactionId,
       notes: doc.notes,
     }));
 
@@ -470,6 +472,10 @@ export async function updateRedemptionStatus(
 
   const { status, notes, transactionId } = payload;
   const updateData: Partial<IRedemption> = { status };
+
+  if (status === 'paid' || status === 'rejected') {
+    updateData.processedAt = new Date();
+  }
 
   if (notes !== undefined) {
     updateData.notes = notes;

--- a/src/types/admin/redemptions.ts
+++ b/src/types/admin/redemptions.ts
@@ -15,7 +15,9 @@ export interface AdminRedemptionListItem {
   status: RedemptionStatus;
   createdAt: Date | string;
   updatedAt?: Date | string;
+  processedAt?: Date | string;
   notes?: string;
+  transactionId?: string;
 }
 
 // Interface para os parâmetros de query da API de listagem de resgates


### PR DESCRIPTION
## Summary
- rename transferId to transactionId across models and services
- show and manage transaction IDs in admin redemptions list
- make affiliate redeem atomic before creating Stripe transfer
- streamline client ref capture to agency invites only

## Testing
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization; Por favor, defina a variável de ambiente MONGODB_URI dentro de .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689aab1cbdf0832eb6b89d9a6884cb5c