### PR TITLE
Fix manual redemption balance handling and admin checks

### DIFF
--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
@@ -66,6 +66,9 @@ export async function PATCH(
     if (error.message === 'Invalid redemptionId format.' || error.message === 'Redemption not found.') {
         return apiError(error.message, 404);
     }
+    if (error.message === 'Saldo insuficiente ou alterado.') {
+        return apiError(error.message, 409);
+    }
     return apiError(error.message || 'Ocorreu um erro interno no servidor.', 500);
   }
 }

--- a/src/app/api/admin/redemptions/route.test.ts
+++ b/src/app/api/admin/redemptions/route.test.ts
@@ -4,6 +4,7 @@ import { GET } from './route';
 import { fetchRedemptions } from '@/lib/services/adminCreatorService'; // Ajuste se o nome do serviço mudou
 import { NextRequest } from 'next/server';
 import { AdminRedemptionListParams } from '@/types/admin/redemptions';
+import { getAdminSession } from '@/lib/getAdminSession';
 
 jest.mock('@/lib/services/adminCreatorService', () => ({
   fetchRedemptions: jest.fn(),
@@ -19,6 +20,7 @@ function createMockRedemptionRequest(searchParams: URLSearchParams = new URLSear
 
 describe('API Route: GET /api/admin/redemptions', () => {
   const mockFetchRedemptions = fetchRedemptions as jest.Mock;
+  const mockGetAdminSession = getAdminSession as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -45,5 +47,12 @@ describe('API Route: GET /api/admin/redemptions', () => {
 
     expect(res.status).toBe(500);
     expect(body.error).toBe('Redemption service DB error');
+  });
+
+  it('should return 401 if user is not admin', async () => {
+    mockGetAdminSession.mockResolvedValueOnce({ user: { role: 'user', name: 'User' } });
+    const req = createMockRedemptionRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(401);
   });
 });

--- a/src/app/api/admin/redemptions/route.ts
+++ b/src/app/api/admin/redemptions/route.ts
@@ -17,7 +17,7 @@ function escapeCsvValue(value: any, delimiter = ';'): string {
 
 export async function GET(req: NextRequest) {
   const session = await getAdminSession(req);
-  if (!session?.user) {
+  if (!session?.user || session.user.role !== 'admin') {
     return NextResponse.json({ error: 'Acesso não autorizado.' }, { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- debit affiliate balance and log commission when admin marks queued redemption as paid
- enforce admin role check on redemption listing and status update routes
- return 409 on insufficient balance and expand test coverage

## Testing
- `npm test` *(fails: invariant expected app router to be mounted, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aae998dc0832eb029a02b0cc0035a