### PR TITLE
feat: guard account deletion with subscription checks

### DIFF
--- a/src/app/api/account/delete/route.test.ts
+++ b/src/app/api/account/delete/route.test.ts
@@ -1,0 +1,55 @@
+import 'next/dist/server/node-polyfill-fetch';
+import { DELETE } from './route';
+import { getServerSession } from 'next-auth';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ findById: jest.fn(), deleteOne: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFindById = (User as any).findById as jest.Mock;
+const mockDeleteOne = (User as any).deleteOne as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (connectToDatabase as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('DELETE /api/account/delete', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when user not found', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindById.mockResolvedValue(null);
+    const res = await DELETE();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when subscription active', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindById.mockResolvedValue({ _id: 'u1', planStatus: 'active' });
+    const res = await DELETE();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'ERR_ACTIVE_SUBSCRIPTION', message: 'Cancele sua assinatura antes de excluir a conta.' });
+  });
+
+  it('deletes user when permitted', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockFindById.mockResolvedValue({ _id: 'u1', planStatus: 'inactive', affiliateBalances: {} });
+    mockDeleteOne.mockResolvedValue({});
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+    expect(mockDeleteOne).toHaveBeenCalledWith({ _id: 'u1' });
+  });
+});

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import { logger } from "@/app/lib/logger";
+
+export const runtime = "nodejs";
+
+export async function DELETE() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectToDatabase();
+    const user = await User.findById(session.user.id);
+    if (!user) {
+      return NextResponse.json({ error: "NotFound" }, { status: 404 });
+    }
+
+    const blocked = ["active", "trial", "pending"].includes(user.planStatus);
+    if (blocked) {
+      logger.warn("[account.delete] blocked due to active subscription", { userId: user._id });
+      return NextResponse.json(
+        {
+          error: "ERR_ACTIVE_SUBSCRIPTION",
+          message: "Cancele sua assinatura antes de excluir a conta.",
+        },
+        { status: 409 }
+      );
+    }
+
+    const balances =
+      user.affiliateBalances instanceof Map
+        ? Object.fromEntries(user.affiliateBalances as any)
+        : (user.affiliateBalances || {});
+    if (balances && Object.values(balances).some((v: any) => v > 0)) {
+      logger.warn("[account.delete] deleting account with affiliate balances", { userId: user._id, balances });
+    }
+
+    await User.deleteOne({ _id: user._id });
+    logger.info("[account.delete] user deleted", { userId: user._id });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    logger.error("[account.delete] error", e);
+    return NextResponse.json({ error: "InternalError" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -541,8 +541,8 @@ export default function MainDashboard() {
                         </a>
                       </div>
                       <div className="py-1 border-t border-gray-100">
-                        <Link 
-                          href="/dashboard/settings" 
+                        <Link
+                          href="/dashboard/settings#delete-account"
                           className="w-full text-left flex items-center gap-3 px-4 py-2 text-sm text-red-600 hover:bg-red-50 hover:text-brand-red transition-colors rounded-md mx-1 my-0.5"
                           onClick={() => setIsUserMenuOpen(false)}
                         >

--- a/src/app/dashboard/settings/DeleteAccountSection.test.tsx
+++ b/src/app/dashboard/settings/DeleteAccountSection.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DeleteAccountSection from './DeleteAccountSection';
+import { useSession, signOut } from 'next-auth/react';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}));
+jest.mock('react-hot-toast', () => ({ success: jest.fn(), error: jest.fn() }));
+
+describe('DeleteAccountSection', () => {
+  const mockUseSession = useSession as jest.Mock;
+  const mockSignOut = signOut as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows blocked modal when plan active', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { planStatus: 'active', affiliateBalances: {} } } });
+    render(<DeleteAccountSection />);
+    fireEvent.click(screen.getAllByText('Excluir conta')[1]);
+    expect(await screen.findByText('Você precisa cancelar sua assinatura primeiro')).toBeInTheDocument();
+  });
+
+  it('allows deletion when plan inactive after typing EXCLUIR', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { planStatus: 'inactive', affiliateBalances: {} } } });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) }) as any;
+    render(<DeleteAccountSection />);
+    fireEvent.click(screen.getAllByText('Excluir conta')[1]);
+    expect(await screen.findByText('Excluir conta — ação permanente')).toBeInTheDocument();
+    const input = screen.getByPlaceholderText('Digite EXCLUIR');
+    const button = screen.getByText('Excluir definitivamente') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.change(input, { target: { value: 'EXCLUIR' } });
+    expect(button.disabled).toBe(false);
+    fireEvent.click(button);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    await waitFor(() => expect(mockSignOut).toHaveBeenCalled());
+  });
+});

--- a/src/app/dashboard/settings/DeleteAccountSection.tsx
+++ b/src/app/dashboard/settings/DeleteAccountSection.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useSession, signOut } from "next-auth/react";
+import toast from "react-hot-toast";
+import { motion, AnimatePresence } from "framer-motion";
+
+export default function DeleteAccountSection() {
+  const { data: session } = useSession();
+  const planStatus = session?.user?.planStatus;
+  const affiliateBalances = session?.user?.affiliateBalances || {};
+  const hasActive = ["active", "trial", "pending"].includes(planStatus || "");
+
+  const [showBlocked, setShowBlocked] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+
+  const handleClick = () => {
+    if (hasActive) setShowBlocked(true); else setShowConfirm(true);
+  };
+
+  const scrollToManage = () => {
+    setShowBlocked(false);
+    const el = document.getElementById("subscription-management-title");
+    if (el) el.scrollIntoView({ behavior: "smooth" });
+    else window.location.href = "/dashboard/settings#subscription-management-title";
+  };
+
+  const handleDelete = async () => {
+    const res = await fetch("/api/account/delete", { method: "DELETE" });
+    if (res.ok) {
+      toast.success("Conta excluída com sucesso.");
+      await signOut({ callbackUrl: "/" });
+      return;
+    }
+    const data = await res.json().catch(() => null);
+    if (data?.error === "ERR_ACTIVE_SUBSCRIPTION") {
+      toast.error("Cancele sua assinatura antes de excluir a conta.");
+      setShowConfirm(false);
+      setShowBlocked(true);
+    } else {
+      toast.error(data?.message || "Não foi possível excluir sua conta agora.");
+    }
+  };
+
+  const hasAffiliateBalance = Object.values(affiliateBalances).some((v) => v > 0);
+
+  return (
+    <section id="delete-account" className="space-y-4">
+      <h2 className="text-xl font-semibold">Excluir conta</h2>
+      {hasActive && (
+        <p className="text-sm text-yellow-800 bg-yellow-50 p-3 rounded-md">
+          Você possui uma assinatura ativa. Cancele sua assinatura antes de excluir a conta.
+        </p>
+      )}
+      <button
+        className="px-4 py-2 bg-red-600 text-white rounded-md disabled:opacity-50"
+        onClick={handleClick}
+      >
+        Excluir conta
+      </button>
+
+      <AnimatePresence>
+        {showBlocked && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60 p-4"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setShowBlocked(false)}
+          >
+            <motion.div
+              className="bg-white rounded-xl shadow-2xl w-full max-w-md p-6"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="text-lg font-semibold mb-2">Você precisa cancelar sua assinatura primeiro</h3>
+              <p className="text-sm text-gray-600 mb-4">
+                Para excluir sua conta, é necessário cancelar sua assinatura antes. Você pode fazer isso em Gerenciar assinatura.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button className="px-3 py-1 text-sm" onClick={() => setShowBlocked(false)}>Entendi</button>
+                <button className="px-3 py-1 text-sm bg-brand-dark text-white rounded" onClick={scrollToManage}>Gerenciar assinatura</button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {showConfirm && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60 p-4"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setShowConfirm(false)}
+          >
+            <motion.div
+              className="bg-white rounded-xl shadow-2xl w-full max-w-md p-6"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="text-lg font-semibold mb-2">Excluir conta — ação permanente</h3>
+              <p className="text-sm text-gray-600 mb-4">
+                Isto vai remover seus dados do Data2Content. Esta ação não pode ser desfeita.
+              </p>
+              {hasAffiliateBalance && (
+                <div className="mb-4 text-sm text-yellow-800 bg-yellow-50 p-2 rounded">
+                  {Object.entries(affiliateBalances).map(([cur, val]) => (
+                    <div key={cur}>Você tem {val} em {cur}. Considere resgatar antes.</div>
+                  ))}
+                </div>
+              )}
+              <input
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder="Digite EXCLUIR"
+                className="w-full border p-2 mb-4"
+              />
+              <div className="flex justify-end gap-2">
+                <button className="px-3 py-1 text-sm" onClick={() => setShowConfirm(false)}>Cancelar</button>
+                <button
+                  className="px-3 py-1 text-sm bg-red-600 text-white rounded disabled:opacity-50"
+                  disabled={confirmText !== "EXCLUIR"}
+                  onClick={handleDelete}
+                >
+                  Excluir definitivamente
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  );
+}
+

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,5 +1,6 @@
 import ChangePlanCard from "../billing/ChangePlanCard";
 import CancelRenewalCard from "../billing/CancelRenewalCard";
+import DeleteAccountSection from "./DeleteAccountSection";
 
 export default function SettingsPage() {
   return (
@@ -13,6 +14,7 @@ export default function SettingsPage() {
 
       <ChangePlanCard />
       <CancelRenewalCard />
+      <DeleteAccountSection />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add API route to block account deletion when subscription active
- build front-end delete account modals and settings section
- link user menu to delete account section and add tests

## Testing
- `npm test src/app/api/account/delete/route.test.ts src/app/dashboard/settings/DeleteAccountSection.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b62b392d4832e834d901620ff6265