### PR TITLE
feat: finalize billing endpoint

### DIFF
--- a/src/app/api/billing/finalize/route.ts
+++ b/src/app/api/billing/finalize/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import stripe from "@/app/lib/stripe";
+import { normCur } from "@/utils/normCur";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { subscriptionId } = await req.json();
+    if (!subscriptionId)
+      return NextResponse.json(
+        { error: "subscriptionId is required" },
+        { status: 400 }
+      );
+
+    const session = await getServerSession(authOptions as any);
+    if (!session?.user?.id)
+      return NextResponse.json(
+        { error: "unauthenticated" },
+        { status: 401 }
+      );
+
+    await connectToDatabase();
+    const user = await User.findById(session.user.id);
+    if (!user)
+      return NextResponse.json({ error: "user not found" }, { status: 404 });
+
+    const sub = await stripe.subscriptions.retrieve(subscriptionId, {
+      expand: [
+        "latest_invoice.payment_intent",
+        "latest_invoice.discount.coupon",
+      ],
+    });
+    const invoice: any = sub.latest_invoice;
+    const paid: boolean =
+      Boolean(invoice?.paid) || invoice?.payment_intent?.status === "succeeded";
+    const reason = invoice?.billing_reason ?? "";
+    const isFirstCycle =
+      reason === "subscription_create" || reason === "subscription_cycle";
+
+    // 1) Ativar plano imediatamente
+    if (paid && (sub.status === "active" || sub.status === "trialing")) {
+      (user as any).planStatus = "active";
+      (user as any).stripeSubscriptionId = sub.id;
+      (user as any).stripeCustomerId =
+        (typeof sub.customer === "string"
+          ? sub.customer
+          : (sub.customer as any)?.id) || (user as any).stripeCustomerId;
+    }
+
+    // 2) Comissão do afiliado (1ª fatura, sem cupom manual)
+    const couponId: string | null = invoice?.discount?.coupon?.id || null;
+    const AFF_BRL = process.env.STRIPE_COUPON_AFFILIATE10_ONCE_BRL;
+    const AFF_USD = process.env.STRIPE_COUPON_AFFILIATE10_ONCE_USD;
+    const isAffiliateCoupon =
+      couponId && (couponId === AFF_BRL || couponId === AFF_USD);
+    const manualCouponUsed = Boolean(couponId && !isAffiliateCoupon);
+
+    if (
+      paid &&
+      isFirstCycle &&
+      !manualCouponUsed &&
+      !user.hasAffiliateCommissionPaid &&
+      user.affiliateUsed
+    ) {
+      const affUser = await User.findOne({
+        affiliateCode: user.affiliateUsed,
+      });
+      if (affUser && String(affUser._id) !== String(user._id)) {
+        if (!affUser.affiliateBalances)
+          affUser.affiliateBalances = new Map<string, number>();
+        const percent =
+          Number(process.env.AFFILIATE_COMMISSION_PERCENT || 10) / 100;
+        const subtotalCents =
+          invoice?.amount_subtotal ?? invoice?.amount_paid ?? 0;
+        const amountCents = Math.round(subtotalCents * percent);
+        const cur = normCur(invoice.currency);
+        let status: "paid" | "fallback" | "failed" = "paid";
+        let transactionId: string | null = null;
+        try {
+          if (affUser.paymentInfo?.stripeAccountId) {
+            const account = await stripe.accounts.retrieve(
+              affUser.paymentInfo.stripeAccountId
+            );
+            const payoutsEnabled = Boolean((account as any).payouts_enabled);
+            const destCurrency = normCur((account as any).default_currency);
+            if (!payoutsEnabled || destCurrency !== cur) {
+              status = "fallback";
+            } else {
+              const transfer = await stripe.transfers.create(
+                {
+                  amount: amountCents,
+                  currency: destCurrency,
+                  destination: affUser.paymentInfo.stripeAccountId,
+                  description: `Comissão de ${user.email || user._id}`,
+                  metadata: {
+                    invoiceId: String(invoice.id),
+                    referredUserId: String(user._id),
+                    affiliateUserId: String(affUser._id),
+                    affiliateCode: affUser.affiliateCode || "",
+                  },
+                },
+                {
+                  idempotencyKey: `commission_${invoice.id}_${affUser._id}`,
+                }
+              );
+              transactionId = transfer.id;
+            }
+          } else {
+            status = "fallback";
+          }
+        } catch (e) {
+          status = "failed";
+        }
+
+        if (status !== "paid") {
+          const prev = affUser.affiliateBalances.get(cur) ?? 0;
+          affUser.affiliateBalances.set(cur, prev + amountCents);
+          affUser.markModified("affiliateBalances");
+        }
+        (affUser.commissionLog ??= []).push({
+          date: new Date(),
+          description: `Comissão (1ª cobrança) de ${user.email || user._id}`,
+          sourcePaymentId: String(invoice.id),
+          referredUserId: user._id,
+          status,
+          transactionId,
+          currency: cur,
+          amountCents,
+        });
+        (affUser.commissionPaidInvoiceIds ??= []).push(String(invoice.id));
+        affUser.affiliateInvites = (affUser.affiliateInvites || 0) + 1;
+        if (affUser.affiliateInvites % 5 === 0)
+          affUser.affiliateRank = (affUser.affiliateRank || 1) + 1;
+        await affUser.save();
+
+        user.hasAffiliateCommissionPaid = true as any;
+      }
+      // limpar marcação de uso do afiliado após a 1ª cobrança
+      user.affiliateUsed = null;
+    }
+
+    await user.save();
+    return NextResponse.json({
+      ok: true,
+      planStatus: (user as any).planStatus,
+      subStatus: sub.status,
+      invoicePaid: paid,
+    });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "finalize_failed" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/dashboard/billing/CheckoutForm.tsx
+++ b/src/app/dashboard/billing/CheckoutForm.tsx
@@ -41,12 +41,25 @@ export default function CheckoutForm({ subscriptionId, onBack }: Props) {
         return;
       }
 
-      try {
-        await update();
-      } catch {}
-
       if (paymentIntent?.status === "succeeded") {
-        router.push("/dashboard/billing/success?ok=1");
+        // ativa plano e processa comissão sem depender do webhook
+        if (subscriptionId) {
+          try {
+            await fetch("/api/billing/finalize", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ subscriptionId }),
+            });
+          } catch {}
+        }
+        try {
+          await update();
+        } catch {}
+        router.push(
+          `/dashboard/billing/success?ok=1${
+            subscriptionId ? `&sid=${subscriptionId}` : ""
+          }`
+        );
         return;
       }
 

--- a/src/app/dashboard/billing/success/page.tsx
+++ b/src/app/dashboard/billing/success/page.tsx
@@ -3,17 +3,35 @@
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
 
 export default function SuccessPage() {
   const params = useSearchParams();
   const [status, setStatus] = useState<
     "checking" | "succeeded" | "requires_action" | "processing" | "failed"
   >("checking");
+  const sid = params.get("sid");
+  const { update } = useSession?.() ?? ({} as any);
 
   useEffect(() => {
-    // Ajuste conforme seu fluxo real (você pode checar algo no backend).
     const ok = params.get("ok");
-    setStatus(ok === "1" ? "succeeded" : "succeeded");
+    (async () => {
+      try {
+        if (sid) {
+          await fetch("/api/billing/finalize", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ subscriptionId: sid }),
+          });
+        }
+        if (update) {
+          try {
+            await update();
+          } catch {}
+        }
+      } catch {}
+      setStatus(ok === "1" ? "succeeded" : "succeeded");
+    })();
   }, [params]);
 
   return (


### PR DESCRIPTION
## Summary
- add billing finalize endpoint to activate subscription and affiliate commission
- finalize subscription after checkout and refresh session
- finalize from success page for idempotent plan activation

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_689bc47a256c832ebb376b6e8a3b7def