### PR TITLE
fix: prefill affiliate code on checkout

### DIFF
--- a/src/app/dashboard/billing/CheckoutPage.tsx
+++ b/src/app/dashboard/billing/CheckoutPage.tsx
@@ -57,6 +57,20 @@ export default function CheckoutPage({ affiliateCode: initialAffiliateCode }: Pr
   const [err, setErr] = useState<string | null>(null);
   const [preview, setPreview] = useState<InvoicePreview | null>(null);
 
+  // --- Fallback: busca código no localStorage se não vier do servidor ---
+  useEffect(() => {
+    if (!initialAffiliateCode) {
+      try {
+        const stored = localStorage.getItem("d2c_ref");
+        if (stored) {
+          setAffiliateCode(stored);
+        }
+      } catch {
+        // Ignora se localStorage não estiver disponível
+      }
+    }
+  }, [initialAffiliateCode]);
+
   // --- Efeito para buscar a prévia da fatura ---
   useEffect(() => {
     const fetchPreview = async () => {


### PR DESCRIPTION
## Summary
- use localStorage to prefill affiliate code when not provided by server

## Testing
- `npm test` *(fails: Response is not defined, env missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c0120a948832ebc9d51eda93daa33