### PR TITLE
feat: add affiliate maturation cron

### DIFF
--- a/src/app/api/internal/affiliate/health/route.ts
+++ b/src/app/api/internal/affiliate/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/internal/affiliate/mature/route.ts
+++ b/src/app/api/internal/affiliate/mature/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/app/lib/logger';
+import matureAffiliateCommissions from '@/cron/matureAffiliateCommissions';
+import {
+  MATURATION_BATCH_USERS,
+  MATURATION_MAX_ENTRIES_PER_USER,
+  MATURATION_CRON_ENABLED,
+} from '@/config/affiliates';
+import { checkRateLimit } from '@/utils/rateLimit';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const TAG = '[api internal affiliate mature]';
+  const secret = req.headers.get('x-job-secret');
+  const expected = process.env.AFFILIATE_JOB_SECRET;
+  if (!secret || secret !== expected) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const { allowed } = await checkRateLimit('affiliate_mature', 10, 60);
+  if (!allowed) {
+    return NextResponse.json({ error: 'rate limit exceeded' }, { status: 429 });
+  }
+
+  if (!MATURATION_CRON_ENABLED) {
+    logger.warn(`${TAG} disabled`);
+    return NextResponse.json({ ok: false, disabled: true });
+  }
+
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  const dryRun = body.dryRun ?? false;
+  const maxUsers = body.maxUsers ?? MATURATION_BATCH_USERS;
+  const maxEntriesPerUser =
+    body.maxEntriesPerUser ?? MATURATION_MAX_ENTRIES_PER_USER;
+
+  const result = await matureAffiliateCommissions({
+    dryRun,
+    maxUsers,
+    maxEntriesPerUser,
+  });
+
+  return NextResponse.json(result);
+}

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -530,6 +530,12 @@ const userSchema = new Schema<IUser>(
   { timestamps: true }
 );
 
+// Índice para acelerar a maturação de comissões pendentes
+userSchema.index(
+  { 'commissionLog.status': 1, 'commissionLog.availableAt': 1 },
+  { name: 'idx_commission_pending_due' }
+);
+
 userSchema.pre<IUser>("save", function (next) {
   const TAG_PRE_SAVE = '[User.ts pre-save v1.9.20]';
   if (this.isNew && !this.affiliateCode) {

--- a/src/config/affiliates.ts
+++ b/src/config/affiliates.ts
@@ -3,3 +3,16 @@ export const AFFILIATE_HOLD_DAYS = Number(process.env.AFFILIATE_HOLD_DAYS || 7);
 export const COMMISSION_RATE = Number(process.env.COMMISSION_RATE || 0.10);
 export const COMMISSION_BASE = (process.env.COMMISSION_BASE as 'amount_paid' | 'subtotal_after_discount' | undefined) || 'amount_paid';
 export const CURRENCY_DECIMALS: Record<string, number> = { brl: 2, usd: 2 };
+
+// Maturation cron configuration
+export const MATURATION_CRON_ENABLED =
+  process.env.MATURATION_CRON_ENABLED !== 'false';
+export const MATURATION_BATCH_USERS = Number(
+  process.env.MATURATION_BATCH_USERS || 200
+);
+export const MATURATION_MAX_ENTRIES_PER_USER = Number(
+  process.env.MATURATION_MAX_ENTRIES_PER_USER || 100
+);
+export const MATURATION_TIMEOUT_MS = Number(
+  process.env.MATURATION_TIMEOUT_MS || 25000
+);

--- a/src/cron/matureAffiliateCommissions.ts
+++ b/src/cron/matureAffiliateCommissions.ts
@@ -1,0 +1,146 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import { logger } from '@/app/lib/logger';
+import {
+  MATURATION_BATCH_USERS,
+  MATURATION_MAX_ENTRIES_PER_USER,
+  MATURATION_TIMEOUT_MS,
+} from '@/config/affiliates';
+
+interface MatureOptions {
+  dryRun?: boolean;
+  maxUsers?: number;
+  maxEntriesPerUser?: number;
+}
+
+interface MatureResult {
+  ok: boolean;
+  dryRun: boolean;
+  window: string;
+  processedUsers: number;
+  promotedCount: number;
+  byCurrency: Record<string, number>;
+  errors: number;
+  durationMs: number;
+  hasMore: boolean;
+}
+
+export async function matureAffiliateCommissions(
+  opts: MatureOptions = {}
+): Promise<MatureResult> {
+  const TAG = '[affiliate:mature]';
+  const dryRun = opts.dryRun ?? false;
+  const maxUsers = opts.maxUsers ?? MATURATION_BATCH_USERS;
+  const maxEntriesPerUser =
+    opts.maxEntriesPerUser ?? MATURATION_MAX_ENTRIES_PER_USER;
+  const start = Date.now();
+  const nowUtc = new Date();
+
+  await connectToDatabase();
+
+  const query = {
+    commissionLog: {
+      $elemMatch: { status: 'pending', availableAt: { $lte: nowUtc } },
+    },
+  };
+  const projection = {
+    commissionLog: 1,
+    affiliateBalances: 1,
+  };
+
+  const users = await User.find(query, projection).limit(maxUsers).lean();
+
+  let processedUsers = 0;
+  let promotedCount = 0;
+  const byCurrency: Record<string, number> = {};
+  let errors = 0;
+
+  for (const u of users) {
+    processedUsers++;
+    const due = (u.commissionLog || [])
+      .filter(
+        (e: any) =>
+          e.status === 'pending' && new Date(e.availableAt) <= nowUtc
+      )
+      .slice(0, maxEntriesPerUser);
+
+    for (const e of due) {
+      if (Date.now() - start > MATURATION_TIMEOUT_MS) {
+        logger.warn(`${TAG} timeout`);
+        return {
+          ok: true,
+          dryRun,
+          window: nowUtc.toISOString(),
+          processedUsers,
+          promotedCount,
+          byCurrency,
+          errors,
+          durationMs: Date.now() - start,
+          hasMore: true,
+        };
+      }
+
+      if (dryRun) {
+        promotedCount++;
+        byCurrency[e.currency] = (byCurrency[e.currency] || 0) + 1;
+        continue;
+      }
+
+      try {
+        const res = await User.updateOne(
+          {
+            _id: u._id,
+            'commissionLog._id': e._id,
+            'commissionLog.status': 'pending',
+            'commissionLog.availableAt': { $lte: nowUtc },
+          },
+          {
+            $set: {
+              'commissionLog.$.status': 'available',
+              'commissionLog.$.updatedAt': nowUtc,
+            },
+            $inc: { [`affiliateBalances.${e.currency}`]: e.amountCents },
+          }
+        );
+        if (res.modifiedCount === 1) {
+          promotedCount++;
+          byCurrency[e.currency] = (byCurrency[e.currency] || 0) + 1;
+          logger.info(`${TAG} promoted`, {
+            userId: u._id,
+            entryId: e._id,
+            currency: e.currency,
+            amountCents: e.amountCents,
+          });
+        } else {
+          logger.warn(`${TAG} skip_concurrent`, {
+            userId: u._id,
+            entryId: e._id,
+          });
+        }
+      } catch (err) {
+        errors++;
+        logger.error(`${TAG} error_update`, {
+          userId: u._id,
+          entryId: e._id,
+          error: err,
+        });
+      }
+    }
+  }
+
+  const remaining = await User.countDocuments(query);
+
+  return {
+    ok: true,
+    dryRun,
+    window: nowUtc.toISOString(),
+    processedUsers,
+    promotedCount,
+    byCurrency,
+    errors,
+    durationMs: Date.now() - start,
+    hasMore: remaining > 0,
+  };
+}
+
+export default matureAffiliateCommissions;

--- a/tests/affiliateMatureWorker.test.ts
+++ b/tests/affiliateMatureWorker.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+import matureAffiliateCommissions from '@/cron/matureAffiliateCommissions';
+import User from '@/app/models/User';
+
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({ logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@/app/models/User', () => ({
+  __esModule: true,
+  default: {
+    find: jest.fn(),
+    updateOne: jest.fn(),
+    countDocuments: jest.fn(),
+  },
+}));
+
+const mockFind = (User as any).find as jest.Mock;
+const mockUpdateOne = (User as any).updateOne as jest.Mock;
+const mockCount = (User as any).countDocuments as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCount.mockResolvedValue(0);
+});
+
+describe('matureAffiliateCommissions', () => {
+  it('promotes entries and is idempotent', async () => {
+    const user = {
+      _id: 'u1',
+      commissionLog: [
+        { _id: 'e1', status: 'pending', currency: 'brl', amountCents: 449, availableAt: new Date() },
+        { _id: 'e2', status: 'pending', currency: 'usd', amountCents: 299, availableAt: new Date() },
+        { _id: 'e3', status: 'pending', currency: 'brl', amountCents: 999, availableAt: new Date() },
+      ],
+    };
+    mockFind.mockResolvedValue([user]);
+    mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+
+    const first = await matureAffiliateCommissions({ maxUsers: 1, maxEntriesPerUser: 10 });
+    expect(first.promotedCount).toBe(3);
+    expect(first.byCurrency).toEqual({ brl: 2, usd: 1 });
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'u1', 'commissionLog._id': 'e1' }),
+      expect.objectContaining({ $inc: { 'affiliateBalances.brl': 449 } })
+    );
+
+    mockUpdateOne.mockResolvedValue({ modifiedCount: 0 });
+    const second = await matureAffiliateCommissions({ maxUsers: 1, maxEntriesPerUser: 10 });
+    expect(second.promotedCount).toBe(0);
+  });
+
+  it('supports dry-run without updating', async () => {
+    const user = {
+      _id: 'u2',
+      commissionLog: [
+        { _id: 'e1', status: 'pending', currency: 'brl', amountCents: 100, availableAt: new Date() },
+      ],
+    };
+    mockFind.mockResolvedValue([user]);
+    const res = await matureAffiliateCommissions({ dryRun: true });
+    expect(res.promotedCount).toBe(1);
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('handles concurrent calls safely', async () => {
+    const user = {
+      _id: 'u3',
+      commissionLog: [
+        { _id: 'e1', status: 'pending', currency: 'brl', amountCents: 100, availableAt: new Date() },
+      ],
+    };
+    mockFind.mockResolvedValue([user]);
+    mockUpdateOne
+      .mockResolvedValueOnce({ modifiedCount: 1 })
+      .mockResolvedValueOnce({ modifiedCount: 0 });
+
+    const [r1, r2] = await Promise.all([
+      matureAffiliateCommissions({ maxUsers: 1, maxEntriesPerUser: 1 }),
+      matureAffiliateCommissions({ maxUsers: 1, maxEntriesPerUser: 1 }),
+    ]);
+
+    expect(r1.promotedCount + r2.promotedCount).toBe(1);
+    expect(mockUpdateOne).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add internal endpoint and worker to mature pending affiliate commissions
- track balances atomically and expose health endpoint
- document and test maturation workflow with concurrency and dry-run

## Testing
- `npm test` *(fails: Por favor, defina a variável de ambiente MONGODB_URI dentro de .env.local)*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689d1338876c832e87b995c8404322b5