### PR TITLE
feat: handle affiliate refunds with debt tracking

### DIFF
--- a/src/app/api/affiliate/redeem/route.test.ts
+++ b/src/app/api/affiliate/redeem/route.test.ts
@@ -66,6 +66,20 @@ describe('POST /api/affiliate/redeem', () => {
     expect(res.status).toBe(400);
   });
 
+  it('blocks when user has debt in currency', async () => {
+    User.findById.mockResolvedValueOnce({
+      _id: 'u1',
+      currency: 'brl',
+      affiliateBalances: new Map([['brl', 2000]]),
+      affiliateDebtByCurrency: new Map([['brl', 500]]),
+      paymentInfo: { stripeAccountId: 'acct1' },
+    });
+    const res = await POST(mockRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/dívida/);
+  });
+
   it('returns ok true on success', async () => {
     const res = await POST(mockRequest());
     const body = await res.json();

--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -52,6 +52,16 @@ export async function POST(req: NextRequest) {
 
     const balances: Map<string, number> = user.affiliateBalances || new Map();
     const current = balances.get(destCurrency) ?? 0;
+    const debtMap: Map<string, number> = user.affiliateDebtByCurrency || new Map();
+    const debt = debtMap.get(destCurrency) ?? 0;
+    if (debt > 0) {
+      return NextResponse.json(
+        {
+          error: `Você possui uma dívida de ${(debt / 100).toFixed(2)} ${destCurrency.toUpperCase()} devido a reembolsos. Seus próximos ganhos compensarão automaticamente; tente novamente quando a dívida for quitada.`,
+        },
+        { status: 400 }
+      );
+    }
     const min = minForCurrency(destCurrency);
 
     if (current <= 0) return NextResponse.json({ error: "Sem saldo disponível." }, { status: 400 });

--- a/src/app/models/AffiliateRefundProgress.ts
+++ b/src/app/models/AffiliateRefundProgress.ts
@@ -1,0 +1,25 @@
+import { Schema, Types, model, models, Document } from 'mongoose';
+
+export interface IAffiliateRefundProgress extends Document {
+  invoiceId: string;
+  affiliateUserId: Types.ObjectId;
+  refundedPaidCentsTotal: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const affiliateRefundProgressSchema = new Schema<IAffiliateRefundProgress>(
+  {
+    invoiceId: { type: String, required: true, index: true },
+    affiliateUserId: { type: Schema.Types.ObjectId, required: true, index: true },
+    refundedPaidCentsTotal: { type: Number, required: true, default: 0 },
+  },
+  { timestamps: true }
+);
+
+affiliateRefundProgressSchema.index(
+  { invoiceId: 1, affiliateUserId: 1 },
+  { unique: true, name: 'uniq_refund_progress' }
+);
+
+export default models.AffiliateRefundProgress || model<IAffiliateRefundProgress>('AffiliateRefundProgress', affiliateRefundProgressSchema);

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -536,6 +536,12 @@ userSchema.index(
   { name: 'idx_commission_pending_due' }
 );
 
+// Índice auxiliar para consultas de dívida por moeda
+userSchema.index(
+  { 'affiliateDebtByCurrency.brl': 1, 'affiliateDebtByCurrency.usd': 1 },
+  { name: 'idx_affiliate_debt_by_currency' }
+);
+
 userSchema.pre<IUser>("save", function (next) {
   const TAG_PRE_SAVE = '[User.ts pre-save v1.9.20]';
   if (this.isNew && !this.affiliateCode) {

--- a/src/app/services/affiliate/refundCommission.ts
+++ b/src/app/services/affiliate/refundCommission.ts
@@ -1,0 +1,129 @@
+import { Types } from 'mongoose';
+import AffiliateRefundProgress from '@/app/models/AffiliateRefundProgress';
+import User from '@/app/models/User';
+import { COMMISSION_RATE } from '@/config/affiliates';
+import { logger } from '@/app/lib/logger';
+
+/** Utility: obtain total refunded paid amount from Stripe invoice or charge */
+export function getRefundedPaidTotal(obj: any): number {
+  if (!obj) return 0;
+  if (obj.object === 'invoice') {
+    if (typeof obj.amount_paid_refunded === 'number') return obj.amount_paid_refunded;
+    // fallback: sum refunds from charges
+    if (Array.isArray(obj.charge)) {
+      return obj.charge.reduce((s: number, c: any) => s + (c.amount_refunded || 0), 0);
+    }
+    return 0;
+  }
+  if (obj.object === 'charge') {
+    return obj.amount_refunded || 0;
+  }
+  return 0;
+}
+
+async function computeDelta(invoiceId: string, affiliateUserId: Types.ObjectId, eventTotal: number) {
+  const progress = await AffiliateRefundProgress.findOneAndUpdate(
+    { invoiceId, affiliateUserId },
+    { $setOnInsert: { refundedPaidCentsTotal: 0 } },
+    { upsert: true, new: true }
+  );
+  const prev = progress?.refundedPaidCentsTotal || 0;
+  const delta = Math.max(0, eventTotal - prev);
+  return { progress, prev, delta };
+}
+
+export async function processAffiliateRefund(invoiceId: string, refundedPaidTotalCents: number) {
+  if (!invoiceId) return;
+
+  const owner = await User.findOne({ 'commissionLog.invoiceId': invoiceId });
+  if (!owner) return;
+
+  const entry = (owner.commissionLog || []).find((e: any) => e.invoiceId === invoiceId && e.type === 'commission');
+  if (!entry) return;
+
+  const affiliateUserId = owner._id as Types.ObjectId;
+
+  const { delta } = await computeDelta(invoiceId, affiliateUserId, refundedPaidTotalCents);
+  logger.info('[affiliate:refund] delta', { invoiceId, affiliateUserId: String(affiliateUserId), delta });
+  if (delta === 0) return;
+
+  const rate = entry.commissionRateBps ? entry.commissionRateBps / 10000 : COMMISSION_RATE;
+  let reverse = Math.round(delta * rate);
+
+  const alreadyReversed = (owner.commissionLog || [])
+    .filter((e: any) => e.invoiceId === invoiceId && e.type === 'adjustment' && e.status === 'reversed')
+    .reduce((s: number, e: any) => s + Math.abs(Number(e.amountCents || 0)), 0);
+  const origCommission = Math.abs(Number(entry.amountCents || 0));
+  const maxReversable = origCommission - alreadyReversed;
+  if (maxReversable <= 0) {
+    await AffiliateRefundProgress.updateOne(
+      { invoiceId, affiliateUserId },
+      { $set: { refundedPaidCentsTotal: refundedPaidTotalCents } }
+    );
+    return;
+  }
+  reverse = Math.min(reverse, maxReversable);
+  if (reverse <= 0) return;
+
+  const cur = entry.currency;
+  owner.affiliateBalances ||= new Map();
+  owner.affiliateDebtByCurrency ||= new Map();
+
+  if (entry.status === 'pending') {
+    if (reverse >= entry.amountCents) {
+      entry.amountCents = 0;
+      entry.status = 'canceled';
+    } else {
+      entry.amountCents -= reverse;
+    }
+  } else if (entry.status === 'available') {
+    const prevBal = owner.affiliateBalances.get(cur) ?? 0;
+    let balDec = reverse;
+    let debtInc = 0;
+    if (prevBal < reverse) {
+      balDec = prevBal;
+      debtInc = reverse - prevBal;
+    }
+    owner.affiliateBalances.set(cur, Math.max(prevBal - balDec, 0));
+    if (debtInc > 0) {
+      const prevDebt = owner.affiliateDebtByCurrency.get(cur) ?? 0;
+      owner.affiliateDebtByCurrency.set(cur, prevDebt + debtInc);
+      owner.markModified('affiliateDebtByCurrency');
+    }
+    owner.markModified('affiliateBalances');
+    owner.commissionLog.push({
+      type: 'adjustment',
+      status: 'reversed',
+      invoiceId,
+      affiliateUserId,
+      currency: cur,
+      amountCents: -reverse,
+      note: 'refund partial/total',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+  } else if (entry.status === 'paid') {
+    const prevDebt = owner.affiliateDebtByCurrency.get(cur) ?? 0;
+    owner.affiliateDebtByCurrency.set(cur, prevDebt + reverse);
+    owner.markModified('affiliateDebtByCurrency');
+    owner.commissionLog.push({
+      type: 'adjustment',
+      status: 'reversed',
+      invoiceId,
+      affiliateUserId,
+      currency: cur,
+      amountCents: -reverse,
+      note: 'refund partial/total',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+  }
+
+  await owner.save();
+  await AffiliateRefundProgress.updateOne(
+    { invoiceId, affiliateUserId },
+    { $set: { refundedPaidCentsTotal: refundedPaidTotalCents } }
+  );
+}
+
+export { computeDelta };

--- a/tests/affiliateRefund.test.ts
+++ b/tests/affiliateRefund.test.ts
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+import { Types } from 'mongoose';
+import { computeDelta, processAffiliateRefund } from '@/app/services/affiliate/refundCommission';
+import AffiliateRefundProgress from '@/app/models/AffiliateRefundProgress';
+import User from '@/app/models/User';
+
+jest.mock('@/app/models/AffiliateRefundProgress', () => ({
+  findOneAndUpdate: jest.fn(),
+  updateOne: jest.fn(),
+}));
+jest.mock('@/app/models/User', () => ({
+  findOne: jest.fn(),
+}));
+
+describe('affiliate refund', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delta idempotent', async () => {
+    (AffiliateRefundProgress.findOneAndUpdate as jest.Mock)
+      .mockResolvedValueOnce({ refundedPaidCentsTotal: 0 })
+      .mockResolvedValueOnce({ refundedPaidCentsTotal: 1000 });
+    const { delta } = await computeDelta('inv1', new Types.ObjectId(), 1000);
+    expect(delta).toBe(1000);
+    const { delta: delta2 } = await computeDelta('inv1', new Types.ObjectId(), 1000);
+    expect(delta2).toBe(0);
+  });
+
+  it('paid commission increases debt and logs adjustment', async () => {
+    const user = {
+      _id: new Types.ObjectId(),
+      commissionLog: [
+        { type: 'commission', status: 'paid', invoiceId: 'inv1', currency: 'brl', amountCents: 500 },
+      ],
+      affiliateBalances: new Map<string, number>(),
+      affiliateDebtByCurrency: new Map<string, number>(),
+      save: jest.fn(),
+      markModified: jest.fn(),
+    } as any;
+    (AffiliateRefundProgress.findOneAndUpdate as jest.Mock).mockResolvedValue({ refundedPaidCentsTotal: 0 });
+    (AffiliateRefundProgress.updateOne as jest.Mock).mockResolvedValue({});
+    (User.findOne as jest.Mock).mockResolvedValue(user);
+    await processAffiliateRefund('inv1', 1000);
+    expect(user.affiliateDebtByCurrency.get('brl')).toBe(100);
+    expect(
+      user.commissionLog.some(
+        (e: any) => e.type === 'adjustment' && e.status === 'reversed' && e.amountCents === -100
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add affiliate refund progress model and debt index
- handle Stripe refund events and track commission reversals
- block affiliate redeem when user has refund debt

## Testing
- `npm test` *(fails: MONGODB_URI not defined and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_689d16ad927c832e9cfbb01c2b2183f3