### PR TITLE
feat(affiliate): extract redeem idempotency key builder

### DIFF
--- a/src/app/api/affiliate/redeem/route.ts
+++ b/src/app/api/affiliate/redeem/route.ts
@@ -7,6 +7,7 @@ import Redemption from "@/app/models/Redemption";
 import stripe from "@/app/lib/stripe";
 import { checkRateLimit } from "@/utils/rateLimit";
 import { getClientIp } from "@/utils/getClientIp";
+import { buildRedeemIdempotencyKey } from "@/app/services/affiliate/buildRedeemIdempotencyKey";
 
 export const runtime = "nodejs";
 
@@ -72,8 +73,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const today = new Date().toISOString().slice(0,10).replace(/-/g,"");
-    const idemKey = `redeem_${session.user.id}_${current}_${today}`;
+    const idemKey = buildRedeemIdempotencyKey(session.user.id, current);
 
     // Tenta "reservar" o saldo antes de chamar a Stripe
     const preUpdate = await User.findOneAndUpdate(

--- a/src/app/services/affiliate/buildRedeemIdempotencyKey.ts
+++ b/src/app/services/affiliate/buildRedeemIdempotencyKey.ts
@@ -1,0 +1,8 @@
+export function buildRedeemIdempotencyKey(
+  userId: string,
+  amountCents: number,
+  date: Date = new Date()
+): string {
+  const yyyymmdd = date.toISOString().slice(0,10).replace(/-/g, "");
+  return `redeem_${userId}_${amountCents}_${yyyymmdd}`;
+}

--- a/tests/buildRedeemIdempotencyKey.test.ts
+++ b/tests/buildRedeemIdempotencyKey.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import { buildRedeemIdempotencyKey } from '@/app/services/affiliate/buildRedeemIdempotencyKey';
+
+describe('buildRedeemIdempotencyKey', () => {
+  it('formats key with date YYYYMMDD', () => {
+    const d = new Date('2024-05-08T03:04:05Z');
+    const key = buildRedeemIdempotencyKey('u1', 2000, d);
+    expect(key).toBe('redeem_u1_2000_20240508');
+  });
+
+  it('uses current date by default', () => {
+    const now = new Date('2024-01-02T10:20:30Z');
+    jest.useFakeTimers().setSystemTime(now);
+    const key = buildRedeemIdempotencyKey('user', 1234);
+    expect(key).toBe('redeem_user_1234_20240102');
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- factor redeem idempotency key generation into helper
- test idempotency key formatting and date defaults
- use helper in affiliate redeem API

## Testing
- `npm test` *(fails: ReferenceError: Response is not defined)*
- `npm test tests/buildRedeemIdempotencyKey.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d241f9e18832e8621081f3b9f99b3