### PR TITLE
fix: mark API routes as dynamic

### DIFF
--- a/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
+++ b/src/app/api/admin/affiliate/commissions/[invoiceId]/retry/route.ts
@@ -9,6 +9,8 @@ import { checkRateLimit } from "@/utils/rateLimit";
 import { logger } from "@/app/lib/logger";
 import { getClientIp } from "@/utils/getClientIp";
 import { normCur } from "@/utils/normCur";
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = "nodejs";
 

--- a/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
+++ b/src/app/api/admin/affiliates/[affiliateId]/status/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { updateAffiliateStatus } from '@/lib/services/adminCreatorService';
 import { AdminAffiliateUpdateStatusPayload } from '@/types/admin/affiliates';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 const SERVICE_TAG = '[api/admin/affiliates/[affiliateId]/status]';
 

--- a/src/app/api/admin/creators/[creatorId]/status/route.ts
+++ b/src/app/api/admin/creators/[creatorId]/status/route.ts
@@ -5,6 +5,8 @@ import { logger } from '@/app/lib/logger';
 import { updateCreatorStatus } from '@/lib/services/adminCreatorService';
 import { AdminCreatorUpdateStatusPayload } from '@/types/admin/creators';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 const SERVICE_TAG = '[api/admin/creators/[creatorId]/status]';
 

--- a/src/app/api/admin/dashboard/cohorts/compare/route.ts
+++ b/src/app/api/admin/dashboard/cohorts/compare/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for comparing performance across user cohorts.
  * @version 1.0.0

--- a/src/app/api/admin/dashboard/content-segments/compare/route.ts
+++ b/src/app/api/admin/dashboard/content-segments/compare/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for fetching and comparing performance data for multiple content segments.
  * @version 2.0.0 - Updated to support 5-dimension classification (format, proposal, context, tone, references).

--- a/src/app/api/admin/dashboard/content/performance-by-type/route.ts
+++ b/src/app/api/admin/dashboard/content/performance-by-type/route.ts
@@ -5,6 +5,8 @@ import { fetchContentPerformanceByType } from '@/app/lib/dataService/marketAnaly
 import { DatabaseError } from '@/app/lib/errors';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
 
 const TAG = '/api/admin/dashboard/content/performance-by-type';
 

--- a/src/app/api/admin/dashboard/contexts/route.ts
+++ b/src/app/api/admin/dashboard/contexts/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
 import { DatabaseError } from '@/app/lib/errors';
+export const dynamic = 'force-dynamic';
+
 
 const SERVICE_TAG = '[api/admin/dashboard/contexts]';
 

--- a/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.ts
+++ b/src/app/api/admin/dashboard/creators/[creatorId]/time-series/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for fetching creator-specific time series data.
  * @version 1.0.0

--- a/src/app/api/admin/dashboard/creators/compare/route.ts
+++ b/src/app/api/admin/dashboard/creators/compare/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for fetching data for creator comparison.
  * @version 1.0.0

--- a/src/app/api/admin/dashboard/demographics/route.ts
+++ b/src/app/api/admin/dashboard/demographics/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(request: NextRequest) {
   const session = await getAdminSession(request);

--- a/src/app/api/admin/dashboard/highlights/performance-summary/route.ts
+++ b/src/app/api/admin/dashboard/highlights/performance-summary/route.ts
@@ -5,6 +5,8 @@ import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPer
 import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 import { aggregatePlatformDayPerformance } from '@/utils/aggregatePlatformDayPerformance';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 interface PerformanceHighlight {
   name: string;

--- a/src/app/api/admin/dashboard/performance/average-engagement/route.ts
+++ b/src/app/api/admin/dashboard/performance/average-engagement/route.ts
@@ -12,6 +12,8 @@ import {
   EngagementMetricField,
 } from '@/app/lib/constants/timePeriods';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 // Tipo local para agrupamento
 type GroupingType = 'format' | 'context' | 'proposal';

--- a/src/app/api/admin/dashboard/performance/time-distribution/route.ts
+++ b/src/app/api/admin/dashboard/performance/time-distribution/route.ts
@@ -5,6 +5,8 @@ import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 import { getCategoryById } from '@/app/lib/classification';
 import { aggregatePlatformTimePerformance } from '@/utils/aggregatePlatformTimePerformance';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 function getPortugueseWeekdayName(day: number): string {
   const days = ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado'];

--- a/src/app/api/admin/dashboard/platform-kpis/periodic-comparison/route.ts
+++ b/src/app/api/admin/dashboard/platform-kpis/periodic-comparison/route.ts
@@ -7,6 +7,8 @@ import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneri
 import { Types } from 'mongoose';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 // Tipos de dados para a resposta
 interface MiniChartDataPoint {

--- a/src/app/api/admin/dashboard/platform-kpis/summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-kpis/summary/route.ts
@@ -3,6 +3,8 @@ import UserModel from '@/app/models/User'; // Descomentado para contagem real
 import { connectToDatabase } from '@/app/lib/mongoose'; // Added
 import { logger } from '@/app/lib/logger'; // Added
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 // Interface para a resposta do endpoint
 interface PlatformKpisSummaryResponse {

--- a/src/app/api/admin/dashboard/platform-summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.ts
@@ -4,6 +4,8 @@ import { logger } from '@/app/lib/logger';
 import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 import { DatabaseError } from '@/app/lib/errors';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 const TAG = '/api/admin/dashboard/platform-summary';
 

--- a/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
+++ b/src/app/api/admin/dashboard/posts/[postId]/details/route.ts
@@ -6,6 +6,8 @@ import { fetchPostDetails, IPostDetailsData } from '@/app/lib/dataService/market
 import { DatabaseError } from '@/app/lib/errors';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+export const dynamic = 'force-dynamic';
+
 
 const TAG = '/api/admin/dashboard/posts/[postId]/details';
 

--- a/src/app/api/admin/dashboard/top-movers/route.ts
+++ b/src/app/api/admin/dashboard/top-movers/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for fetching Top Movers data (content or creators).
  * @version 2.0.0 - Updated to support 5-dimension classification.

--- a/src/app/api/admin/dashboard/trends/follower-change/route.ts
+++ b/src/app/api/admin/dashboard/trends/follower-change/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChangePoint { date: string; change: number | null; }
 interface FollowerChangeResponse { chartData: ApiChangePoint[]; insightSummary?: string; }

--- a/src/app/api/admin/dashboard/trends/followers/route.ts
+++ b/src/app/api/admin/dashboard/trends/followers/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChartDataPoint {
   date: string;

--- a/src/app/api/admin/dashboard/trends/moving-average-engagement/route.ts
+++ b/src/app/api/admin/dashboard/trends/moving-average-engagement/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { addDays, formatDateYYYYMMDD } from '@/utils/dateHelpers';
 import { Types } from 'mongoose';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 interface MovingAverageDataPoint { date: string; movingAverageEngagement: number | null; }
 interface ResponseData { series: MovingAverageDataPoint[]; insightSummary?: string; }

--- a/src/app/api/admin/dashboard/trends/reach-engagement/route.ts
+++ b/src/app/api/admin/dashboard/trends/reach-engagement/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChartDataPoint { date: string; reach: number | null; totalInteractions: number | null; }
 interface ChartResponse { chartData: ApiChartDataPoint[]; insightSummary?: string; averageReach?: number; averageInteractions?: number; }

--- a/src/app/api/admin/dashboard/users/[userId]/performance/time-distribution/route.ts
+++ b/src/app/api/admin/dashboard/users/[userId]/performance/time-distribution/route.ts
@@ -6,6 +6,8 @@ import { Types } from 'mongoose';
 import { getCategoryById } from '@/app/lib/classification';
 import { aggregateUserTimePerformance } from '@/utils/aggregateUserTimePerformance';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 function getPortugueseWeekdayName(day: number): string {
   const days = ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado'];

--- a/src/app/api/admin/intelligence-query/route.ts
+++ b/src/app/api/admin/intelligence-query/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview Endpoint da API para a Central de Inteligência.
  * @version 5.0.0

--- a/src/app/api/admin/monitoring/summary/route.ts
+++ b/src/app/api/admin/monitoring/summary/route.ts
@@ -8,6 +8,8 @@ import {
   AGENCY_GUEST_ANNUAL_MONTHLY_PRICE,
   AGENCY_MONTHLY_PRICE,
 } from '@/config/pricing.config';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET() {
   const activeAgencies = await AgencyModel.countDocuments({ planStatus: 'active' });

--- a/src/app/api/admin/plan-guard/metrics/route.ts
+++ b/src/app/api/admin/plan-guard/metrics/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminSession } from '@/lib/getAdminSession';
 import { getPlanGuardMetrics } from '@/app/lib/planGuard';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(req: NextRequest) {
   const session = await getAdminSession(req);

--- a/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
+++ b/src/app/api/admin/redemptions/[redemptionId]/status/route.ts
@@ -5,6 +5,8 @@ import { logger } from '@/app/lib/logger';
 import { updateRedemptionStatus } from '@/lib/services/adminCreatorService';
 import { AdminRedemptionUpdateStatusPayload } from '@/types/admin/redemptions';
 import { getAdminSession } from '@/lib/getAdminSession';
+export const dynamic = 'force-dynamic';
+
 
 const SERVICE_TAG = '[api/admin/redemptions/[redemptionId]/status]';
 

--- a/src/app/api/admin/users/[userId]/role/route.ts
+++ b/src/app/api/admin/users/[userId]/role/route.ts
@@ -5,6 +5,8 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { USER_ROLES, PLAN_STATUSES } from '@/types/enums';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 const bodySchema = z.object({
   role: z.enum(USER_ROLES),

--- a/src/app/api/admin/users/convert-guest/route.ts
+++ b/src/app/api/admin/users/convert-guest/route.ts
@@ -5,6 +5,8 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import UserModel from '@/app/models/User';
 import { PLAN_STATUSES } from '@/types/enums';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 const bodySchema = z.object({
   userId: z.string(),

--- a/src/app/api/admin/users/search/route.ts
+++ b/src/app/api/admin/users/search/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminSession } from '@/lib/getAdminSession';
 import UserModel from '@/app/models/User';
 import { connectToDatabase } from '@/app/lib/mongoose';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/affiliate/connect/status/route.ts
+++ b/src/app/api/affiliate/connect/status/route.ts
@@ -7,6 +7,8 @@ import stripe from "@/app/lib/stripe";
 import { checkRateLimit } from "@/utils/rateLimit";
 import { getClientIp } from "@/utils/getClientIp";
 import { mapStripeAccountInfo } from "@/app/services/stripe/mapAccountInfo";
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = "nodejs";
 

--- a/src/app/api/agency/accept-invite/route.ts
+++ b/src/app/api/agency/accept-invite/route.ts
@@ -6,6 +6,8 @@ import UserModel from '@/app/models/User';
 import AgencyModel from '@/app/models/Agency';
 import { logger } from '@/app/lib/logger';
 import { z } from 'zod';
+export const dynamic = 'force-dynamic';
+
 
 const bodySchema = z.object({
   inviteCode: z.string(),

--- a/src/app/api/agency/dashboard/contexts/route.ts
+++ b/src/app/api/agency/dashboard/contexts/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import { getAvailableContexts } from '@/app/lib/dataService/marketAnalysis/cohortsService';
 import { DatabaseError } from '@/app/lib/errors';
+export const dynamic = 'force-dynamic';
+
 
 const SERVICE_TAG = '[api/agency/dashboard/contexts]';
 

--- a/src/app/api/agency/dashboard/demographics/route.ts
+++ b/src/app/api/agency/dashboard/demographics/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(request: NextRequest) {
   const session = await getAgencySession(request);

--- a/src/app/api/agency/dashboard/highlights/performance-summary/route.ts
+++ b/src/app/api/agency/dashboard/highlights/performance-summary/route.ts
@@ -5,6 +5,8 @@ import aggregatePlatformPerformanceHighlights from '@/utils/aggregatePlatformPer
 import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 import { aggregatePlatformDayPerformance } from '@/utils/aggregatePlatformDayPerformance';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 interface PerformanceHighlight {
   name: string;

--- a/src/app/api/agency/dashboard/performance/average-engagement/route.ts
+++ b/src/app/api/agency/dashboard/performance/average-engagement/route.ts
@@ -12,6 +12,8 @@ import {
   EngagementMetricField,
 } from '@/app/lib/constants/timePeriods';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 // Tipo local para agrupamento
 type GroupingType = 'format' | 'context' | 'proposal';

--- a/src/app/api/agency/dashboard/performance/time-distribution/route.ts
+++ b/src/app/api/agency/dashboard/performance/time-distribution/route.ts
@@ -5,6 +5,8 @@ import { timePeriodToDays } from '@/utils/timePeriodHelpers';
 import { getCategoryById } from '@/app/lib/classification';
 import { aggregatePlatformTimePerformance } from '@/utils/aggregatePlatformTimePerformance';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 function getPortugueseWeekdayName(day: number): string {
   const days = ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado'];

--- a/src/app/api/agency/dashboard/platform-kpis/periodic-comparison/route.ts
+++ b/src/app/api/agency/dashboard/platform-kpis/periodic-comparison/route.ts
@@ -7,6 +7,8 @@ import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneri
 import { Types } from 'mongoose';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 // Tipos de dados para a resposta
 interface MiniChartDataPoint {

--- a/src/app/api/agency/dashboard/platform-kpis/summary/route.ts
+++ b/src/app/api/agency/dashboard/platform-kpis/summary/route.ts
@@ -3,6 +3,8 @@ import UserModel from '@/app/models/User'; // Descomentado para contagem real
 import { connectToDatabase } from '@/app/lib/mongoose'; // Added
 import { logger } from '@/app/lib/logger'; // Added
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 // Interface para a resposta do endpoint
 interface PlatformKpisSummaryResponse {

--- a/src/app/api/agency/dashboard/platform-summary/route.ts
+++ b/src/app/api/agency/dashboard/platform-summary/route.ts
@@ -4,6 +4,8 @@ import { logger } from '@/app/lib/logger';
 import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashboardService';
 import { DatabaseError } from '@/app/lib/errors';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 const TAG = '/api/agency/dashboard/platform-summary';
 

--- a/src/app/api/agency/dashboard/posts/[postId]/details/route.ts
+++ b/src/app/api/agency/dashboard/posts/[postId]/details/route.ts
@@ -7,6 +7,8 @@ import { logger } from '@/app/lib/logger';
 import { fetchPostDetails, IPostDetailsData } from '@/app/lib/dataService/marketAnalysis/postsService';
 import { DatabaseError } from '@/app/lib/errors';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 const TAG = '/api/agency/dashboard/posts/[postId]/details';
 

--- a/src/app/api/agency/dashboard/top-movers/route.ts
+++ b/src/app/api/agency/dashboard/top-movers/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /**
  * @fileoverview API Endpoint for fetching Top Movers data (content or creators).
  * @version 2.1.3 - Added explicit type guard for agencyId.

--- a/src/app/api/agency/dashboard/trends/follower-change/route.ts
+++ b/src/app/api/agency/dashboard/trends/follower-change/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChangePoint { date: string; change: number | null; }
 interface FollowerChangeResponse { chartData: ApiChangePoint[]; insightSummary?: string; }

--- a/src/app/api/agency/dashboard/trends/followers/route.ts
+++ b/src/app/api/agency/dashboard/trends/followers/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChartDataPoint {
   date: string;

--- a/src/app/api/agency/dashboard/trends/moving-average-engagement/route.ts
+++ b/src/app/api/agency/dashboard/trends/moving-average-engagement/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { addDays, formatDateYYYYMMDD } from '@/utils/dateHelpers';
 import { Types } from 'mongoose';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 interface MovingAverageDataPoint { date: string; movingAverageEngagement: number | null; }
 interface ResponseData { series: MovingAverageDataPoint[]; insightSummary?: string; }

--- a/src/app/api/agency/dashboard/trends/reach-engagement/route.ts
+++ b/src/app/api/agency/dashboard/trends/reach-engagement/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getAgencySession } from '@/lib/getAgencySession';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChartDataPoint { date: string; reach: number | null; totalInteractions: number | null; }
 interface ChartResponse { chartData: ApiChartDataPoint[]; insightSummary?: string; averageReach?: number; averageInteractions?: number; }

--- a/src/app/api/agency/dashboard/users/[userId]/performance/time-distribution/route.ts
+++ b/src/app/api/agency/dashboard/users/[userId]/performance/time-distribution/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /*
 ================================================================================
 ARQUIVO 2/4: .../performance/time-distribution/route.ts

--- a/src/app/api/agency/guests/route.ts
+++ b/src/app/api/agency/guests/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAgencySession } from '@/lib/getAgencySession';
 import UserModel from '@/app/models/User';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 

--- a/src/app/api/agency/info/[inviteCode]/route.ts
+++ b/src/app/api/agency/info/[inviteCode]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import AgencyModel from '@/app/models/Agency';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 

--- a/src/app/api/agency/invite-code/route.ts
+++ b/src/app/api/agency/invite-code/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/invite-code]';

--- a/src/app/api/agency/profile/route.ts
+++ b/src/app/api/agency/profile/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/profile]';

--- a/src/app/api/agency/register/route.ts
+++ b/src/app/api/agency/register/route.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import AgencyModel from '@/app/models/Agency';
 import UserModel from '@/app/models/User';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 

--- a/src/app/api/agency/subscription/cancel/route.ts
+++ b/src/app/api/agency/subscription/cancel/route.ts
@@ -3,6 +3,8 @@ import { logger } from '@/app/lib/logger';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
 import mercadopago from '@/app/lib/mercadopago';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/cancel]';

--- a/src/app/api/agency/subscription/create-checkout/route.ts
+++ b/src/app/api/agency/subscription/create-checkout/route.ts
@@ -8,6 +8,8 @@ import {
   AGENCY_ANNUAL_MONTHLY_PRICE,
   AGENCY_MONTHLY_PRICE,
 } from '@/config/pricing.config';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/create-checkout]';

--- a/src/app/api/agency/subscription/manage-portal/route.ts
+++ b/src/app/api/agency/subscription/manage-portal/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/manage-portal]';

--- a/src/app/api/agency/subscription/webhook/route.ts
+++ b/src/app/api/agency/subscription/webhook/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
 import AgencyModel from '@/app/models/Agency';
 import mercadopago from '@/app/lib/mercadopago';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/subscription/webhook]';

--- a/src/app/api/agency/summary/route.ts
+++ b/src/app/api/agency/summary/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAgencySession } from '@/lib/getAgencySession';
 import AgencyModel from '@/app/models/Agency';
 import { logger } from '@/app/lib/logger';
+export const dynamic = 'force-dynamic';
+
 
 export const runtime = 'nodejs';
 const SERVICE_TAG = '[api/agency/summary]';

--- a/src/app/api/agency/users/search/route.ts
+++ b/src/app/api/agency/users/search/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAgencySession } from '@/lib/getAgencySession';
 import UserModel from '@/app/models/User';
 import { connectToDatabase } from '@/app/lib/mongoose';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/v1/platform/charts/monthly-engagement-stacked/route.ts
+++ b/src/app/api/v1/platform/charts/monthly-engagement-stacked/route.ts
@@ -6,6 +6,8 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger';
 import dateHelpers from '@/utils/dateHelpers';
 import { ALLOWED_TIME_PERIODS as BASE_ALLOWED_TIME_PERIODS } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 interface MonthlyEngagementDataPoint {
   month: string;

--- a/src/app/api/v1/platform/demographics/route.ts
+++ b/src/app/api/v1/platform/demographics/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import aggregatePlatformDemographics from '@/utils/aggregatePlatformDemographics';
+export const dynamic = 'force-dynamic';
+
 
 export async function GET(request: Request) {
   try {

--- a/src/app/api/v1/platform/highlights/performance-summary/route.ts
+++ b/src/app/api/v1/platform/highlights/performance-summary/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /*
 ================================================================================
 ARQUIVO 2/2: src/app/api/v1/platform/highlights/performance-summary/route.ts

--- a/src/app/api/v1/platform/kpis/periodic-comparison/route.ts
+++ b/src/app/api/v1/platform/kpis/periodic-comparison/route.ts
@@ -6,6 +6,8 @@ import calculateAverageEngagementPerPost from '@/utils/calculateAverageEngagemen
 import { addDays, getStartDateFromTimePeriod as getStartDateFromTimePeriodGeneric } from '@/utils/dateHelpers';
 import { Types } from 'mongoose';
 import { connectToDatabase } from '@/app/lib/mongoose';
+export const dynamic = 'force-dynamic';
+
 
 // Tipos de dados para a resposta
 interface MiniChartDataPoint {

--- a/src/app/api/v1/platform/kpis/summary/route.ts
+++ b/src/app/api/v1/platform/kpis/summary/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import UserModel from '@/app/models/User'; // Descomentado para contagem real
 import { connectToDatabase } from '@/app/lib/mongoose'; // Added
 import { logger } from '@/app/lib/logger'; // Added
+export const dynamic = 'force-dynamic';
+
 
 // Interface para a resposta do endpoint
 interface PlatformKpisSummaryResponse {

--- a/src/app/api/v1/platform/performance/average-engagement/route.ts
+++ b/src/app/api/v1/platform/performance/average-engagement/route.ts
@@ -11,6 +11,8 @@ import {
   TimePeriod,
   EngagementMetricField,
 } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 // Tipo local para agrupamento
 type GroupingType = 'format' | 'context' | 'proposal';

--- a/src/app/api/v1/platform/performance/conversion-metrics/route.ts
+++ b/src/app/api/v1/platform/performance/conversion-metrics/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
 import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
 import { fetchPlatformConversionMetrics } from '@/app/lib/dataService/marketAnalysisService';
+export const dynamic = 'force-dynamic';
+
 
 
 interface PlatformConversionMetricsResponse {

--- a/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/engagement-distribution-format/route.ts
@@ -7,6 +7,8 @@ import {
   TimePeriod,
   EngagementMetricField, // CORREÇÃO: O tipo foi corrigido de EngagementMetric para EngagementMetricField
 } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 // Define FormatType enum locally if the import is not available
 enum FormatType {
   IMAGE = "IMAGE",

--- a/src/app/api/v1/platform/performance/post-distribution-format/route.ts
+++ b/src/app/api/v1/platform/performance/post-distribution-format/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import MetricModel from '@/app/models/Metric'; // Descomente para implementação real
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 // Defina FormatType localmente se o módulo não existir
 export enum FormatType {
   IMAGE = "IMAGE",

--- a/src/app/api/v1/platform/performance/time-distribution/route.ts
+++ b/src/app/api/v1/platform/performance/time-distribution/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 /*
 ================================================================================
 ARQUIVO 2/3: src/app/api/v1/platform/performance/time-distribution/route.ts

--- a/src/app/api/v1/platform/performance/video-metrics/route.ts
+++ b/src/app/api/v1/platform/performance/video-metrics/route.ts
@@ -5,6 +5,8 @@ import MetricModel from '@/app/models/Metric';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { getStartDateFromTimePeriod } from '@/utils/dateHelpers';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 const DEFAULT_VIDEO_TYPES: string[] = ['REEL', 'VIDEO'];
 

--- a/src/app/api/v1/platform/trends/follower-change/route.ts
+++ b/src/app/api/v1/platform/trends/follower-change/route.ts
@@ -4,6 +4,8 @@ import getFollowerDailyChangeData from '@/charts/getFollowerDailyChangeData';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 
 interface ApiChangePoint {

--- a/src/app/api/v1/platform/trends/followers/route.ts
+++ b/src/app/api/v1/platform/trends/followers/route.ts
@@ -5,6 +5,8 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import { logger } from '@/app/lib/logger';
 import { Types } from 'mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 // Tipos para os dados da API
 interface ApiChartDataPoint {

--- a/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/moving-average-engagement/route.ts
@@ -9,6 +9,8 @@ import {
     formatDateYYYYMMDD,
     getStartDateFromTimePeriod,
 } from '@/utils/dateHelpers';
+export const dynamic = 'force-dynamic';
+
 
 // Tipos de dados para a resposta
 interface MovingAverageDataPoint {

--- a/src/app/api/v1/platform/trends/reach-engagement/route.ts
+++ b/src/app/api/v1/platform/trends/reach-engagement/route.ts
@@ -7,6 +7,8 @@ import { getPlatformReachEngagementTrendChartData } from '@/charts/getReachInter
 // --- FIM DA CORREÇÃO ---
 import { connectToDatabase } from '@/app/lib/mongoose';
 import { ALLOWED_TIME_PERIODS, TimePeriod } from '@/app/lib/constants/timePeriods';
+export const dynamic = 'force-dynamic';
+
 
 interface ApiChartDataPoint {
   date: string;


### PR DESCRIPTION
## Summary
- mark admin API routes as dynamic
- mark agency and platform API routes as dynamic
- mark affiliate connect status route as dynamic

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689d4cb11888832eb89153c4c57444ce