### PR TITLE
feat: add affiliate card mobile foundations

### DIFF
--- a/src/components/affiliate/AffiliateCard.tsx
+++ b/src/components/affiliate/AffiliateCard.tsx
@@ -1,21 +1,39 @@
-// ./src/components/affiliate/AffiliateCard.tsx
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
-import { useAffiliateSummary, canRedeem } from '@/hooks/useAffiliateSummary';
+import {
+  useAffiliateSummary,
+  canRedeem,
+  getRedeemBlockReason,
+} from '@/hooks/useAffiliateSummary';
+import { REDEEM_BLOCK_MESSAGES, RULES_COPY } from '@/copy/affiliates';
+import EmptyState from '@/components/ui/EmptyState';
+import SkeletonRow from '@/components/ui/SkeletonRow';
+import ErrorState from '@/components/ui/ErrorState';
 
 function fmt(amountCents: number, cur: string) {
   const n = amountCents / 100;
-  const locale = cur === 'brl' ? 'pt-BR' : 'en-US';
   const currency = cur.toUpperCase();
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(n);
+  const locale = currency === 'BRL' ? 'pt-BR' : 'en-US';
+  const formatted = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+  }).format(n);
+  return `${formatted} ${currency}`;
+}
+
+function daysUntil(dateStr?: string) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  const diff = Math.ceil((d.getTime() - Date.now()) / 86400000);
+  return diff > 0 ? diff : null;
 }
 
 export default function AffiliateCard() {
   const { data: session } = useSession();
-  const { summary, status, loading, refresh } = useAffiliateSummary();
+  const { summary, status, loading, error, refresh } = useAffiliateSummary();
   const [redeemCur, setRedeemCur] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -24,6 +42,24 @@ export default function AffiliateCard() {
       (window as any).gtag('event', event, props);
     }
   };
+
+  useEffect(() => {
+    if (summary) {
+      const currencies = Object.keys(summary.byCurrency);
+      const hasPending = currencies.some(c => summary.byCurrency[c].pendingCents > 0);
+      const hasDebt = currencies.some(c => summary.byCurrency[c].debtCents > 0);
+      track('affiliate_view_card', { currencies, hasPending, hasDebt });
+    }
+  }, [summary]);
+
+  useEffect(() => {
+    if (summary && status) {
+      Object.keys(summary.byCurrency).forEach(cur => {
+        const reason = getRedeemBlockReason(status, summary, cur);
+        if (reason) track('affiliate_tooltip_reason_shown', { reason });
+      });
+    }
+  }, [summary, status]);
 
   const handleCopyCode = () => {
     if (session?.user?.affiliateCode) {
@@ -55,17 +91,16 @@ export default function AffiliateCard() {
   const openRedeem = (cur: string) => {
     setRedeemCur(cur);
     track('affiliate_redeem_click', {
-      userId: session?.user?.id,
       currency: cur,
-      balanceCents: summary?.balances?.[cur] ?? 0,
+      enabled: canRedeem(status, summary, cur),
+      reason: getRedeemBlockReason(status, summary, cur) || undefined,
     });
   };
 
   const confirmRedeem = async () => {
-    if (!redeemCur) return;
-    const amount = summary?.balances?.[redeemCur] ?? 0;
+    if (!redeemCur || !summary) return;
+    const amount = summary.byCurrency[redeemCur]?.availableCents ?? 0;
     track('affiliate_redeem_confirm', {
-      userId: session?.user?.id,
       currency: redeemCur,
       amountCents: amount,
     });
@@ -78,20 +113,20 @@ export default function AffiliateCard() {
       const data = await res.json();
       if (!res.ok) {
         track('affiliate_redeem_error', {
-          userId: session?.user?.id,
           currency: redeemCur,
-          code: res.status,
-          message: data.error || data.message,
+          code: data.code,
         });
-        toast.error(data.error || data.message || 'Falha ao solicitar resgate.');
+        toast.error(data.message || 'Falha ao solicitar resgate.');
       } else {
         track('affiliate_redeem_success', {
-          userId: session?.user?.id,
           currency: redeemCur,
-          mode: data.mode,
-          transactionId: data.transactionId,
+          amountCents: amount,
         });
-        toast.success(data.mode === 'auto' ? 'Transferência criada' : 'Solicitação registrada');
+        toast.success(
+          data.mode === 'auto'
+            ? 'Transferência criada'
+            : 'Solicitação registrada',
+        );
         await refresh();
       }
     } catch (e) {
@@ -102,158 +137,226 @@ export default function AffiliateCard() {
     }
   };
 
-  if (loading || !summary || !status) {
+  if (loading) {
     return (
-      <div className="rounded-2xl border p-4">
-        <p className="text-sm text-gray-500">Carregando dados do afiliado...</p>
+      <div className="rounded-2xl border p-4 space-y-2">
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
       </div>
     );
   }
 
-  return (
-    <div className="rounded-2xl border p-4">
-      <h3 className="mb-3 text-lg font-semibold">Programa de Afiliados</h3>
-      <div className="space-y-2">
-        <div className="rounded-xl bg-gray-50 p-3 flex items-center justify-between">
-          <div>
-            <p className="text-xs text-gray-600">Cód. Afiliado</p>
-            <p className="font-mono text-sm">{session?.user?.affiliateCode || '—'}</p>
-          </div>
-          {session?.user?.affiliateCode && (
-            <button onClick={handleCopyCode} className="text-xs underline">
-              Copiar
-            </button>
-          )}
-        </div>
-
-        <div className="rounded-xl bg-gray-50 p-3 flex items-center justify-between">
-          <div className="flex-1">
-            <p className="text-xs text-gray-600">Link de indicação</p>
-            {session?.user?.affiliateCode ? (
-              <p className="break-all text-sm">
-                {typeof window !== 'undefined'
-                  ? `${window.location.origin}/?ref=${session.user.affiliateCode}`
-                  : `/?ref=${session.user.affiliateCode}`}
-              </p>
-            ) : (
-              <p className="text-sm text-gray-500">Seu código será gerado após o primeiro login.</p>
-            )}
-          </div>
-          {session?.user?.affiliateCode && (
-            <button onClick={handleCopyLink} className="text-xs underline ml-2">
-              Copiar
-            </button>
-          )}
-        </div>
-
-        <div className="rounded-xl bg-gray-50 p-3 text-sm space-y-2">
-          <div className="flex items-center justify-between">
-            <span>Status Stripe Connect:</span>
-            <span className="font-medium">
-              {status.payouts_enabled ? 'Verificada' : status.needsOnboarding ? 'Pendente' : 'Desabilitada'}
-            </span>
-          </div>
-          <div className="flex items-center justify-between text-xs text-gray-600">
-            <span>Moeda destino:</span>
-            <span className="uppercase">{status.default_currency}</span>
-          </div>
-          {status.disabled_reason && (
-            <p className="text-xs text-red-600">{status.disabled_reason}</p>
-          )}
-          {status.needsOnboarding && (
-            <button
-              onClick={handleOnboard}
-              className="mt-1 w-full rounded bg-brand-pink px-3 py-1.5 text-white text-xs font-medium hover:opacity-90"
-            >
-              Configurar Stripe
-            </button>
-          )}
-          <button
-            onClick={() => {
-              refresh();
-              track('affiliate_refresh_status', { userId: session?.user?.id });
-            }}
-            className="w-full rounded border px-3 py-1.5 text-xs font-medium"
-          >
-            Atualizar status
-          </button>
-        </div>
-
-        <div className="rounded-xl bg-gray-50 p-3">
-          <p className="mb-2 text-xs text-gray-600">Saldos</p>
-          {!Object.keys(summary.balances || {}).length && (
-            <p className="text-sm text-gray-500">Sem saldo ainda.</p>
-          )}
-          {!!Object.keys(summary.balances || {}).length && (
-            <ul className="space-y-2">
-              {Object.entries(summary.balances).map(([cur, cents]) => {
-                const debt = summary.debt?.[cur] ?? 0;
-                const incompatible = cur !== status.default_currency;
-                return (
-                  <li key={cur} className="space-y-1">
-                    <div className="flex items-center justify-between">
-                      <span className="uppercase text-xs text-gray-500">{cur}</span>
-                      <span className="font-medium">{fmt(cents, cur)}</span>
-                    </div>
-                    {debt > 0 && (
-                      <p className="text-xs text-red-600">Dívida: {fmt(debt, cur)}</p>
-                    )}
-                    {incompatible && (
-                      <p className="text-xs text-amber-600">
-                        Sua conta Stripe recebe em {status.default_currency.toUpperCase()}. Saldos em {cur.toUpperCase()} não podem ser sacados.
-                      </p>
-                    )}
-                    <button
-                      onClick={() => openRedeem(cur)}
-                      disabled={!canRedeem(status, summary, cur)}
-                      title={
-                        !status.payouts_enabled
-                          ? 'Conecte sua conta Stripe para sacar.'
-                          : debt > 0
-                          ? `Você possui dívida de ${fmt(debt, cur)} por reembolsos.`
-                          : cents < (summary.min[cur] || 0)
-                          ? `Mínimo para saque: ${fmt(summary.min[cur] || 0, cur)}.`
-                          : incompatible
-                          ? `Sua conta recebe em ${status.default_currency.toUpperCase()}; converta ou use outra conta.`
-                          : ''
-                      }
-                      className="mt-1 w-full rounded bg-brand-pink px-3 py-1.5 text-white text-xs font-medium disabled:opacity-50"
-                    >
-                      Resgatar {cur.toUpperCase()}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
+  if (error || !summary || !status) {
+    return (
+      <div className="rounded-2xl border p-4">
+        <ErrorState
+          message="Erro ao carregar saldos."
+          onRetry={refresh}
+        />
       </div>
+    );
+  }
 
-      {redeemCur && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded p-4 w-80 space-y-3">
-            <h4 className="font-medium text-sm">
-              {/* Fallback para evitar number | undefined */}
-              Resgatar {fmt(summary.balances[redeemCur] ?? 0, redeemCur)} {redeemCur.toUpperCase()}
-            </h4>
-            <p className="text-xs text-gray-600">
-              Você vai transferir todo o saldo disponível em {redeemCur.toUpperCase()} para sua conta Stripe Connect.
-            </p>
-            <div className="flex gap-2 justify-end pt-2">
-              <button onClick={() => setRedeemCur(null)} className="px-3 py-1 text-sm">
-                Cancelar
-              </button>
-              <button
-                disabled={submitting}
-                onClick={confirmRedeem}
-                className="px-3 py-1 rounded bg-brand-pink text-white text-sm disabled:opacity-50"
-              >
-                {submitting ? 'Enviando...' : 'Confirmar'}
-              </button>
-            </div>
-          </div>
-        </div>
+  const currencies = Object.keys(summary.byCurrency);
+
+  return (
+  <div className="rounded-2xl border p-4 space-y-3">
+    <h3 className="text-lg font-semibold">Programa de Afiliados</h3>
+
+    <div className="rounded-xl bg-gray-50 p-3 flex items-center justify-between">
+      <div>
+        <p className="text-xs text-gray-600">Cód. Afiliado</p>
+        <p className="font-mono text-sm">{session?.user?.affiliateCode || '—'}</p>
+      </div>
+      {session?.user?.affiliateCode && (
+        <button onClick={handleCopyCode} className="text-xs underline">
+          Copiar
+        </button>
       )}
     </div>
+
+    <div className="rounded-xl bg-gray-50 p-3 flex items-center justify-between">
+      <div className="flex-1">
+        <p className="text-xs text-gray-600">Link de indicação</p>
+        {session?.user?.affiliateCode ? (
+          <p className="break-all text-sm">
+            {typeof window !== 'undefined'
+              ? `${window.location.origin}/?ref=${session.user.affiliateCode}`
+              : `/?ref=${session.user.affiliateCode}`}
+          </p>
+        ) : (
+          <p className="text-sm text-gray-500">
+            Seu código será gerado após o primeiro login.
+          </p>
+        )}
+      </div>
+      {session?.user?.affiliateCode && (
+        <button onClick={handleCopyLink} className="text-xs underline ml-2">
+          Copiar
+        </button>
+      )}
+    </div>
+
+    <div className="rounded-xl bg-gray-50 p-3 text-sm space-y-2">
+      <div className="flex items-center justify-between">
+        <span>Status Stripe Connect:</span>
+        <span className="font-medium">
+          {status.payouts_enabled
+            ? 'Verificada'
+            : status.needsOnboarding
+            ? 'Pendente'
+            : 'Desabilitada'}
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-xs text-gray-600">
+        <span>Moeda destino:</span>
+        <span className="uppercase">{status.default_currency}</span>
+      </div>
+      {status.disabled_reason && (
+        <p className="text-xs text-red-600">{status.disabled_reason}</p>
+      )}
+      {status.needsOnboarding && (
+        <button
+          onClick={handleOnboard}
+          className="mt-1 w-full rounded bg-brand-pink px-3 py-1.5 text-white text-xs font-medium hover:opacity-90"
+        >
+          Configurar Stripe
+        </button>
+      )}
+      <button
+        onClick={() => {
+          refresh();
+          track('affiliate_refresh_status');
+        }}
+        className="w-full rounded border px-3 py-1.5 text-xs font-medium"
+      >
+        Atualizar status
+      </button>
+    </div>
+
+    <div className="rounded-xl bg-gray-50 p-3">
+      <p className="mb-2 text-xs text-gray-600">Saldos</p>
+      {currencies.length === 0 && (
+        <EmptyState text="Assim que um indicado fizer o 1º pagamento, sua comissão aparece aqui." />
+      )}
+      {currencies.map(cur => {
+        const info = summary.byCurrency[cur];
+        const reason = getRedeemBlockReason(status, summary, cur);
+        let reasonText: string | null = null;
+        if (reason) {
+          switch (reason) {
+            case 'needsOnboarding':
+              reasonText = REDEEM_BLOCK_MESSAGES.needsOnboarding;
+              break;
+            case 'payouts_disabled':
+              reasonText = REDEEM_BLOCK_MESSAGES.payouts_disabled;
+              break;
+            case 'below_min':
+              reasonText = REDEEM_BLOCK_MESSAGES.below_min(
+                fmt(info.minRedeemCents || 0, cur),
+              );
+              break;
+            case 'has_debt':
+              reasonText = REDEEM_BLOCK_MESSAGES.has_debt(
+                fmt(info.debtCents, cur),
+              );
+              break;
+            case 'currency_mismatch':
+              reasonText = REDEEM_BLOCK_MESSAGES.currency_mismatch(
+                status.default_currency.toUpperCase(),
+                cur.toUpperCase(),
+              );
+              break;
+          }
+        }
+        const days = daysUntil(info.nextMatureAt);
+        const badge =
+          info.pendingCents > 0 && days
+            ? `libera em ${days}d`
+            : info.pendingCents > 0 && info.nextMatureAt
+            ? new Date(info.nextMatureAt).toLocaleDateString('pt-BR')
+            : null;
+        return (
+          <div key={cur} className="mb-4 last:mb-0">
+            <div className="flex justify-between text-green-600">
+              <span>Disponível</span>
+              <span>{fmt(info.availableCents, cur)}</span>
+            </div>
+            <div className="flex justify-between text-gray-600 items-center">
+              <span>Pendente</span>
+              <span className="flex items-center gap-2">
+                {fmt(info.pendingCents, cur)}
+                {badge && (
+                  <span className="rounded bg-gray-200 px-1 text-[10px]">
+                    {badge}
+                  </span>
+                )}
+              </span>
+            </div>
+            {info.debtCents > 0 && (
+              <div className="flex justify-between text-red-600">
+                <span>Dívida</span>
+                <span>{fmt(info.debtCents, cur)}</span>
+              </div>
+            )}
+            <button
+              onClick={() => openRedeem(cur)}
+              disabled={!canRedeem(status, summary, cur)}
+              className="mt-2 w-full rounded bg-brand-pink px-3 py-1.5 text-white text-xs font-medium disabled:opacity-50"
+            >
+              Resgatar {cur.toUpperCase()}
+            </button>
+            {reason && (
+              <div className="mt-1 flex items-start text-xs text-gray-700">
+                <span className="mr-1">⚠️</span>
+                <span>
+                  {reasonText}
+                  {reason === 'needsOnboarding' && (
+                    <button
+                      onClick={handleOnboard}
+                      className="ml-1 underline"
+                    >
+                      Configurar Stripe
+                    </button>
+                  )}
+                </span>
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <ul className="mt-4 list-disc pl-4 text-[11px] text-gray-600 space-y-1">
+        {RULES_COPY.map((r, i) => (
+          <li key={i}>{r}</li>
+        ))}
+      </ul>
+    </div>
+
+    {redeemCur && (
+      <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+        <div className="bg-white rounded p-4 w-80 space-y-3">
+          <h4 className="font-medium text-sm">
+            Resgatar {fmt(summary.byCurrency[redeemCur]?.availableCents || 0, redeemCur)}
+          </h4>
+          <p className="text-xs text-gray-600">
+            Você vai transferir todo o saldo disponível em {redeemCur.toUpperCase()} para sua conta Stripe Connect.
+          </p>
+          <div className="flex gap-2 justify-end pt-2">
+            <button onClick={() => setRedeemCur(null)} className="px-3 py-1 text-sm">
+              Cancelar
+            </button>
+            <button
+              disabled={submitting}
+              onClick={confirmRedeem}
+              className="px-3 py-1 rounded bg-brand-pink text-white text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Enviando...' : 'Confirmar'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+  </div>
   );
 }

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  icon?: ReactNode;
+  text: string;
+  action?: ReactNode;
+}
+
+export default function EmptyState({ icon, text, action }: Props) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-sm text-gray-500">
+      {icon && <div className="mb-2">{icon}</div>}
+      <p>{text}</p>
+      {action && <div className="mt-2">{action}</div>}
+    </div>
+  );
+}

--- a/src/components/ui/ErrorState.tsx
+++ b/src/components/ui/ErrorState.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  message: string;
+  onRetry?: () => void;
+  actionLabel?: string;
+  icon?: ReactNode;
+}
+
+export default function ErrorState({ message, onRetry, actionLabel = 'Tentar novamente', icon }: Props) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-sm text-red-600">
+      {icon && <div className="mb-2">{icon}</div>}
+      <p className="mb-2">{message}</p>
+      {onRetry && (
+        <button onClick={onRetry} className="rounded bg-red-600 px-3 py-1 text-white text-xs">
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/SkeletonRow.tsx
+++ b/src/components/ui/SkeletonRow.tsx
@@ -1,0 +1,3 @@
+export default function SkeletonRow() {
+  return <div className="animate-pulse h-4 bg-gray-200 rounded" />;
+}

--- a/src/copy/affiliates.ts
+++ b/src/copy/affiliates.ts
@@ -1,0 +1,12 @@
+export const REDEEM_BLOCK_MESSAGES = {
+  needsOnboarding: 'Conecte sua conta Stripe para sacar.',
+  payouts_disabled: 'Sua conta Stripe precisa de verificação de documentos.',
+  below_min: (min: string) => `Mínimo para saque: ${min}.`,
+  has_debt: (amount: string) => `Você possui dívida de ${amount} por reembolsos.`,
+  currency_mismatch: (dst: string, cur: string) => `Sua conta Stripe recebe em ${dst}; este saldo está em ${cur}.`,
+} as const;
+
+export const RULES_COPY = [
+  'Pagamos 10% apenas no 1º pagamento real do indicado (trial/descontos 100% não contam).',
+  'Mantemos por 7 dias para cobrir reembolsos.',
+];

--- a/src/hooks/__snapshots__/useAffiliateSummary.test.ts.snap
+++ b/src/hooks/__snapshots__/useAffiliateSummary.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redeem block messages snapshot of messages 1`] = `
+{
+  "below_min": [Function],
+  "currency_mismatch": [Function],
+  "has_debt": [Function],
+  "needsOnboarding": "Conecte sua conta Stripe para sacar.",
+  "payouts_disabled": "Sua conta Stripe precisa de verificação de documentos.",
+}
+`;

--- a/src/hooks/useAffiliateSummary.test.ts
+++ b/src/hooks/useAffiliateSummary.test.ts
@@ -1,11 +1,17 @@
-import { canRedeem } from './useAffiliateSummary';
+import { canRedeem, AffiliateSummary, AffiliateStatus } from './useAffiliateSummary';
+import { REDEEM_BLOCK_MESSAGES } from '@/copy/affiliates';
 
 describe('canRedeem', () => {
-  const status = { payouts_enabled: true, default_currency: 'brl' } as any;
-  const summary = {
+  const status: AffiliateStatus = { payouts_enabled: true, default_currency: 'brl' } as any;
+  const summary: AffiliateSummary = {
     balances: { brl: 10000, usd: 0 },
     debt: { brl: 0 },
-    min: { brl: 5000 }
+    min: { brl: 5000 },
+    pending: {},
+    byCurrency: {
+      brl: { availableCents: 10000, pendingCents: 0, debtCents: 0, minRedeemCents: 5000 },
+      usd: { availableCents: 0, pendingCents: 0, debtCents: 0 },
+    },
   } as any;
 
   test('allows redeem when all conditions met', () => {
@@ -17,16 +23,28 @@ describe('canRedeem', () => {
   });
 
   test('blocks when debt exists', () => {
-    const s = { ...summary, debt: { brl: 100 } };
+    const s = {
+      ...summary,
+      byCurrency: { ...summary.byCurrency, brl: { ...summary.byCurrency.brl, debtCents: 100 } },
+    };
     expect(canRedeem(status, s, 'brl')).toBe(false);
   });
 
   test('blocks when below minimum', () => {
-    const s = { ...summary, balances: { brl: 1000 }, min: { brl: 5000 } };
+    const s = {
+      ...summary,
+      byCurrency: { ...summary.byCurrency, brl: { ...summary.byCurrency.brl, availableCents: 1000 } },
+    };
     expect(canRedeem(status, s, 'brl')).toBe(false);
   });
 
   test('blocks when currency mismatch', () => {
     expect(canRedeem(status, summary, 'usd')).toBe(false);
+  });
+});
+
+describe('redeem block messages', () => {
+  test('snapshot of messages', () => {
+    expect(REDEEM_BLOCK_MESSAGES).toMatchSnapshot();
   });
 });

--- a/src/hooks/useAffiliateSummary.ts
+++ b/src/hooks/useAffiliateSummary.ts
@@ -1,13 +1,26 @@
+import { useMemo } from 'react';
 import useSWR from 'swr';
 
-interface AffiliateSummary {
+export type CurrencyCode = 'BRL' | 'USD' | string;
+export interface CurrencySummary {
+  availableCents: number;
+  pendingCents: number;
+  nextMatureAt?: string;
+  debtCents: number;
+  minRedeemCents?: number;
+}
+
+export interface AffiliateSummary {
+  byCurrency: Record<CurrencyCode, CurrencySummary>;
+  // legacy fields for retrocompatibility
   balances: Record<string, number>;
   debt: Record<string, number>;
   min: Record<string, number>;
   pendingNextDates?: Record<string, string>;
+  pending?: Record<string, number>;
 }
 
-interface AffiliateStatus {
+export interface AffiliateStatus {
   payouts_enabled: boolean;
   disabled_reason?: string;
   default_currency: string;
@@ -17,21 +30,74 @@ interface AffiliateStatus {
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
 export function useAffiliateSummary() {
-  const { data: summary, mutate: mutateSummary } = useSWR<AffiliateSummary>('/api/affiliate/summary', fetcher);
-  const { data: status, mutate: mutateStatus } = useSWR<AffiliateStatus>('/api/affiliate/connect/status', fetcher);
+  const { data: rawSummary, error: summaryError, mutate: mutateSummary } = useSWR<AffiliateSummary>('/api/affiliate/summary', fetcher);
+  const { data: status, error: statusError, mutate: mutateStatus } = useSWR<AffiliateStatus>('/api/affiliate/connect/status', fetcher);
+
+  const summary = useMemo<AffiliateSummary | undefined>(() => {
+    if (!rawSummary) return undefined;
+    const currencies = new Set<string>([
+      ...Object.keys(rawSummary.balances || {}),
+      ...Object.keys(rawSummary.pending || {}),
+      ...Object.keys(rawSummary.debt || {}),
+      ...Object.keys(rawSummary.min || {}),
+    ]);
+    const byCurrency: Record<string, CurrencySummary> = {};
+    currencies.forEach(cur => {
+      byCurrency[cur] = {
+        availableCents: rawSummary.balances?.[cur] ?? 0,
+        pendingCents: rawSummary.pending?.[cur] ?? 0,
+        nextMatureAt: rawSummary.pendingNextDates?.[cur],
+        debtCents: rawSummary.debt?.[cur] ?? 0,
+        minRedeemCents: rawSummary.min?.[cur],
+      };
+    });
+    return { ...rawSummary, byCurrency };
+  }, [rawSummary]);
+
   const loading = !summary || !status;
+  const error = summaryError || statusError;
   const refresh = async () => {
     await Promise.all([mutateSummary(), mutateStatus()]);
   };
-  return { summary, status, loading, refresh };
+  return { summary, status, loading, refresh, error };
 }
 
-export function canRedeem(status: AffiliateStatus | undefined, summary: AffiliateSummary | undefined, cur: string) {
+export function canRedeem(
+  status: AffiliateStatus | undefined,
+  summary: AffiliateSummary | undefined,
+  cur: string,
+) {
   if (!status?.payouts_enabled) return false;
   if (!summary) return false;
   if (cur !== status.default_currency) return false;
-  const balance = summary.balances?.[cur] ?? 0;
-  const min = summary.min?.[cur] ?? 0;
-  const debt = summary.debt?.[cur] ?? 0;
-  return balance >= min && debt === 0;
+  const curSummary = summary.byCurrency?.[cur];
+  if (!curSummary) return false;
+  const min = curSummary.minRedeemCents ?? 0;
+  return curSummary.availableCents >= min && curSummary.debtCents === 0;
+}
+
+export type RedeemBlockReason =
+  | 'needsOnboarding'
+  | 'payouts_disabled'
+  | 'currency_mismatch'
+  | 'below_min'
+  | 'has_debt';
+
+export function getRedeemBlockReason(
+  status: AffiliateStatus | undefined,
+  summary: AffiliateSummary | undefined,
+  cur: string,
+): RedeemBlockReason | null {
+  if (!status) return null;
+  if (!status.payouts_enabled) {
+    return status.needsOnboarding ? 'needsOnboarding' : 'payouts_disabled';
+  }
+  if (!summary) return null;
+  if (cur !== status.default_currency) return 'currency_mismatch';
+  const curSummary = summary.byCurrency?.[cur];
+  if (!curSummary) return null;
+  if (curSummary.debtCents > 0) return 'has_debt';
+  const min = curSummary.minRedeemCents ?? 0;
+  if (curSummary.availableCents < min) return 'below_min';
+  return null;
 }


### PR DESCRIPTION
## Summary
- add microcopy definitions for affiliate flows
- expose affiliate summary per currency with blocking reasons
- redesign affiliate card with pending/debt lines and rule copy

## Testing
- `npm test src/hooks/useAffiliateSummary.test.ts --updateSnapshot`
- `npm test` *(fails: ReferenceError: Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d5ffa7bf8832eb0b09fbddc90559b