### PR TITLE
feat: add affiliate history module

### DIFF
--- a/src/app/api/affiliate/history/route.ts
+++ b/src/app/api/affiliate/history/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  // For now this is a mocked endpoint used for tests and development.
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get('cursor');
+  const items = [
+    {
+      id: cursor ? 'second' : 'first',
+      currency: 'BRL',
+      amountCents: 1000,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      availableAt: new Date(Date.now() + 7 * 86400000).toISOString(),
+      invoiceId: 'in_123',
+    },
+  ];
+  const nextCursor = cursor ? null : 'next';
+  return NextResponse.json({ items, nextCursor });
+}

--- a/src/components/affiliate/history/AffiliateHistory.tsx
+++ b/src/components/affiliate/history/AffiliateHistory.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React, { useState } from 'react';
+import { useAffiliateHistory, HistoryItem as Item } from '@/hooks/useAffiliateHistory';
+import HistoryItem from './HistoryItem';
+import HistoryDrawer from './HistoryDrawer';
+import EmptyState from '@/components/ui/EmptyState';
+import SkeletonRow from '@/components/ui/SkeletonRow';
+import ErrorState from '@/components/ui/ErrorState';
+
+export default function AffiliateHistory() {
+  const { items, loading, error, loadMore, hasMore } = useAffiliateHistory();
+  const [selected, setSelected] = useState<Item | null>(null);
+
+  if (error) return <ErrorState message="Erro ao carregar histórico." onRetry={() => location.reload()} />;
+  return (
+    <div>
+      {loading && (
+        <ul role="list" className="mb-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li key={i} className="p-3 border rounded mb-2" role="listitem">
+              <SkeletonRow />
+            </li>
+          ))}
+        </ul>
+      )}
+      {!loading && items.length === 0 && <EmptyState text="Nenhum registro no período selecionado." />}
+      <ul role="list">
+        {items.map(item => (
+          <HistoryItem key={item.id} item={item} onSelect={setSelected} />
+        ))}
+      </ul>
+      {hasMore && (
+        <button className="mt-2 w-full border rounded p-2" onClick={loadMore} aria-label="Carregar mais">
+          Carregar mais
+        </button>
+      )}
+      <HistoryDrawer item={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+}

--- a/src/components/affiliate/history/HistoryDrawer.tsx
+++ b/src/components/affiliate/history/HistoryDrawer.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { useEffect, useRef } from 'react';
+import { HistoryItem } from '@/hooks/useAffiliateHistory';
+import StatusBadge from './StatusBadge';
+import { humanizeReason } from '@/copy/affiliateHistory';
+import { format } from 'date-fns';
+
+interface Props {
+  item: HistoryItem | null;
+  onClose: () => void;
+}
+
+export default function HistoryDrawer({ item, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (item) ref.current?.focus();
+  }, [item]);
+  if (!item) return null;
+  const amount = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: item.currency }).format(
+    item.amountCents / 100,
+  );
+  return (
+    <div className="fixed inset-0 bg-black/30 flex justify-end" onClick={onClose}>
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className="w-80 bg-white dark:bg-gray-800 h-full p-4 overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <button className="mb-4" onClick={onClose} aria-label="Fechar">✕</button>
+        <h2 className="text-lg font-bold mb-2">Detalhes</h2>
+        <div className="mb-2"><StatusBadge status={item.status} size="md" /></div>
+        <p className="mb-1">Valor: {amount} ({item.currency})</p>
+        {item.availableAt && (
+          <p className="mb-1">Libera em: {format(new Date(item.availableAt), 'dd/MM/yyyy')}</p>
+        )}
+        {item.invoiceId && (
+          <p className="mb-1">invoiceId: {item.invoiceId}</p>
+        )}
+        {item.subscriptionId && (
+          <p className="mb-1">subscriptionId: {item.subscriptionId}</p>
+        )}
+        {item.transferId && (
+          <p className="mb-1">transferId: {item.transferId}</p>
+        )}
+        {item.reasonCode && (
+          <p className="mb-1">Motivo: {humanizeReason(item.reasonCode)}</p>
+        )}
+        {item.notes && <p className="mb-1">Obs: {item.notes}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/affiliate/history/HistoryItem.tsx
+++ b/src/components/affiliate/history/HistoryItem.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React from 'react';
+import { HistoryItem as Item, daysUntil } from '@/hooks/useAffiliateHistory';
+import StatusBadge from './StatusBadge';
+import { InformationCircleIcon } from '@heroicons/react/24/solid';
+import { format } from 'date-fns';
+
+interface Props {
+  item: Item;
+  onSelect: (item: Item) => void;
+}
+
+function formatAmount(item: Item) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: item.currency,
+  }).format(item.amountCents / 100);
+}
+
+export default function HistoryItem({ item, onSelect }: Props) {
+  const pendingDays = item.status === 'pending' ? daysUntil(item.availableAt) : 0;
+  const liberaEm = pendingDays > 0 ? `libera em ${pendingDays}d` : undefined;
+  return (
+    <li
+      className="flex justify-between items-center border rounded p-3 mb-2 cursor-pointer" role="listitem" onClick={() => onSelect(item)}
+    >
+      <div className="flex flex-col">
+        <span className="font-semibold">{formatAmount(item)} ({item.currency})</span>
+        <span className="text-xs text-gray-500">
+          {format(new Date(item.createdAt), 'dd/MM/yyyy')}
+          {liberaEm && <span className="ml-2 inline-block bg-gray-100 text-gray-600 px-1 rounded">{liberaEm}</span>}
+        </span>
+      </div>
+      <div className="flex items-center space-x-2">
+        <StatusBadge status={item.status} />
+        <InformationCircleIcon className="w-5 h-5 text-gray-500" />
+      </div>
+    </li>
+  );
+}

--- a/src/components/affiliate/history/StatusBadge.tsx
+++ b/src/components/affiliate/history/StatusBadge.tsx
@@ -1,0 +1,41 @@
+'use client';
+import React from 'react';
+import {
+  ClockIcon,
+  CheckCircleIcon,
+  ArrowUpRightIcon,
+  XCircleIcon,
+  ArrowUturnLeftIcon,
+} from '@heroicons/react/24/solid';
+import { HistoryStatus } from '@/hooks/useAffiliateHistory';
+import { STATUS_LABEL } from '@/copy/affiliateHistory';
+
+const config: Record<HistoryStatus, { color: string; Icon: React.ElementType }> = {
+  pending: { color: 'bg-gray-100 text-gray-700 dark:bg-gray-700/30 dark:text-gray-300', Icon: ClockIcon },
+  available: { color: 'bg-green-100 text-green-700 dark:bg-green-700/30 dark:text-green-300', Icon: CheckCircleIcon },
+  paid: { color: 'bg-blue-100 text-blue-700 dark:bg-blue-700/30 dark:text-blue-300', Icon: ArrowUpRightIcon },
+  canceled: { color: 'bg-red-100 text-red-700 dark:bg-red-700/30 dark:text-red-300', Icon: XCircleIcon },
+  reversed: { color: 'bg-orange-100 text-orange-700 dark:bg-orange-700/30 dark:text-orange-300', Icon: ArrowUturnLeftIcon },
+};
+
+export interface StatusBadgeProps {
+  status: HistoryStatus;
+  size?: 'sm' | 'md';
+}
+
+export default function StatusBadge({ status, size = 'sm' }: StatusBadgeProps) {
+  const { color, Icon } = config[status];
+  const padding = size === 'sm' ? 'px-2 py-0.5' : 'px-3 py-1';
+  const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
+  const iconSize = size === 'sm' ? 'w-3 h-3' : 'w-4 h-4';
+  const label = STATUS_LABEL[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full font-medium ${padding} ${textSize} ${color}`}
+      aria-label={`Status: ${label}`}
+    >
+      <Icon className={`${iconSize} mr-1`} />
+      {label}
+    </span>
+  );
+}

--- a/src/copy/__tests__/__snapshots__/affiliateHistory.test.ts.snap
+++ b/src/copy/__tests__/__snapshots__/affiliateHistory.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`affiliateHistory copy maps reason labels snapshot 1`] = `
+{
+  "adjustment_after_redeem": "Ajuste pós-resgate.",
+  "admin_manual_correction": "Correção manual pela equipe.",
+  "chargeback": "Estorno por contestação do pagamento.",
+  "coupon_100": "Pagamento com 100% de desconto não gera comissão.",
+  "currency_mismatch": "Moeda incompatível para saque.",
+  "duplicate_prevented": "Entrada duplicada ignorada.",
+  "refund_after_payout": "Reembolso após liberação (ajuste aplicado).",
+  "refund_within_hold": "Reembolso dentro do período de 7 dias.",
+  "self_referral_blocked": "Autoindicação não é elegível a comissão.",
+  "trial_no_commission": "Período de teste gratuito não gera comissão.",
+}
+`;
+
+exports[`affiliateHistory copy maps status labels snapshot 1`] = `
+{
+  "available": "Disponível",
+  "canceled": "Cancelado",
+  "paid": "Pago",
+  "pending": "Pendente",
+  "reversed": "Revertido",
+}
+`;

--- a/src/copy/__tests__/affiliateHistory.test.ts
+++ b/src/copy/__tests__/affiliateHistory.test.ts
@@ -1,0 +1,16 @@
+import { STATUS_LABEL, REASON_LABEL, humanizeReason } from '../affiliateHistory';
+
+describe('affiliateHistory copy maps', () => {
+  test('status labels snapshot', () => {
+    expect(STATUS_LABEL).toMatchSnapshot();
+  });
+
+  test('reason labels snapshot', () => {
+    expect(REASON_LABEL).toMatchSnapshot();
+  });
+
+  test('humanizeReason fallback', () => {
+    expect(humanizeReason('unknown')).toBe('Ajuste no registro.');
+    expect(humanizeReason()).toBe('Ajuste no registro.');
+  });
+});

--- a/src/copy/affiliateHistory.ts
+++ b/src/copy/affiliateHistory.ts
@@ -1,0 +1,25 @@
+export const STATUS_LABEL: Record<string, string> = {
+  pending: 'Pendente',
+  available: 'Disponível',
+  paid: 'Pago',
+  canceled: 'Cancelado',
+  reversed: 'Revertido',
+};
+
+export const REASON_LABEL: Record<string, string> = {
+  refund_within_hold: 'Reembolso dentro do período de 7 dias.',
+  refund_after_payout: 'Reembolso após liberação (ajuste aplicado).',
+  chargeback: 'Estorno por contestação do pagamento.',
+  adjustment_after_redeem: 'Ajuste pós-resgate.',
+  self_referral_blocked: 'Autoindicação não é elegível a comissão.',
+  coupon_100: 'Pagamento com 100% de desconto não gera comissão.',
+  trial_no_commission: 'Período de teste gratuito não gera comissão.',
+  currency_mismatch: 'Moeda incompatível para saque.',
+  duplicate_prevented: 'Entrada duplicada ignorada.',
+  admin_manual_correction: 'Correção manual pela equipe.',
+};
+
+export function humanizeReason(code?: string | null): string {
+  if (!code) return 'Ajuste no registro.';
+  return REASON_LABEL[code] ?? 'Ajuste no registro.';
+}

--- a/src/hooks/__tests__/useAffiliateHistory.test.tsx
+++ b/src/hooks/__tests__/useAffiliateHistory.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAffiliateHistory, HistoryResponse } from '../useAffiliateHistory';
+
+describe('useAffiliateHistory', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockImplementation((url: string) => {
+      const u = new URL(url, 'http://localhost');
+      const cursor = u.searchParams.get('cursor');
+      const page: HistoryResponse = {
+        items: [{ id: cursor || 'first', currency: 'BRL', amountCents: 100, status: 'pending', createdAt: new Date().toISOString() }],
+        nextCursor: cursor ? null : 'next',
+      };
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(page) });
+    });
+  });
+
+  test('builds query with filters', async () => {
+    const { result } = renderHook(() =>
+      useAffiliateHistory({ statuses: ['pending'], currencies: ['BRL'], limit: 1 })
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect((global as any).fetch).toHaveBeenCalledWith('/api/affiliate/history?statuses=pending&currencies=BRL&limit=1');
+  });
+
+  test('loads more pages', async () => {
+    const { result } = renderHook(() => useAffiliateHistory());
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+  });
+});

--- a/src/hooks/useAffiliateHistory.ts
+++ b/src/hooks/useAffiliateHistory.ts
@@ -1,0 +1,77 @@
+import useSWRInfinite from 'swr/infinite';
+
+export type HistoryStatus = 'pending'|'available'|'paid'|'canceled'|'reversed';
+export type HistoryItem = {
+  id: string;
+  currency: string;        // 'BRL' | 'USD' | ...
+  amountCents: number;
+  status: HistoryStatus;
+  createdAt: string;       // ISO
+  availableAt?: string;    // ISO, se pending
+  invoiceId?: string;
+  subscriptionId?: string;
+  transferId?: string;     // se paid
+  reasonCode?: string;     // ver mapa abaixo
+  notes?: string | null;   // livre
+};
+
+export type HistoryQuery = {
+  statuses?: HistoryStatus[];
+  currencies?: string[];
+  dateFrom?: string;  // ISO
+  dateTo?: string;    // ISO
+  sortBy?: 'createdAt'|'amountCents';
+  sortDir?: 'asc'|'desc';
+  cursor?: string;    // paginação
+  limit?: number;     // default 20
+};
+
+export type HistoryResponse = {
+  items: HistoryItem[];
+  nextCursor?: string | null;
+};
+
+const fetcher = (url: string) => fetch(url).then(r => {
+  if (!r.ok) throw new Error('Network error');
+  return r.json();
+});
+
+function buildQuery(q: HistoryQuery & { cursor?: string }) {
+  const params = new URLSearchParams();
+  if (q.statuses) q.statuses.forEach(s => params.append('statuses', s));
+  if (q.currencies) q.currencies.forEach(c => params.append('currencies', c));
+  if (q.dateFrom) params.set('dateFrom', q.dateFrom);
+  if (q.dateTo) params.set('dateTo', q.dateTo);
+  if (q.sortBy) params.set('sortBy', q.sortBy);
+  if (q.sortDir) params.set('sortDir', q.sortDir);
+  if (q.cursor) params.set('cursor', q.cursor);
+  if (q.limit) params.set('limit', String(q.limit));
+  return params.toString();
+}
+
+export function useAffiliateHistory(query: HistoryQuery = {}) {
+  const getKey = (pageIndex: number, previousPageData: HistoryResponse | null) => {
+    if (previousPageData && !previousPageData.nextCursor) return null;
+    const cursor = pageIndex === 0 ? query.cursor : previousPageData?.nextCursor;
+    const q = { ...query, cursor } as HistoryQuery;
+    const qs = buildQuery(q);
+    return `/api/affiliate/history${qs ? `?${qs}` : ''}`;
+  };
+
+  const { data, error, size, setSize, isValidating, mutate } = useSWRInfinite<HistoryResponse>(getKey, fetcher);
+  const items = data ? data.flatMap(p => p.items) : [];
+  const loading = !data && !error;
+  const hasMore = !!data?.[data.length - 1]?.nextCursor;
+
+  const loadMore = () => setSize(size + 1);
+  const refresh = () => mutate();
+
+  return { items, loading, error, loadMore, hasMore, isValidating, refresh };
+}
+
+export function daysUntil(dateIso?: string) {
+  if (!dateIso) return 0;
+  const target = new Date(dateIso).getTime();
+  const now = Date.now();
+  return Math.ceil((target - now) / (1000 * 60 * 60 * 24));
+}


### PR DESCRIPTION
## Summary
- add affiliate history copy mapping and helper
- implement useAffiliateHistory hook with pagination
- add basic affiliate history components and mock API endpoint

## Testing
- `npm test src/copy/__tests__/affiliateHistory.test.ts src/hooks/__tests__/useAffiliateHistory.test.tsx`
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization and others)*
- `npm run lint` *(fails: prompt `How would you like to configure ESLint?`)*

------
https://chatgpt.com/codex/tasks/task_e_689d64072de4832eaa59480e11608dff