### PR TITLE
feat: add stripe status panel and currency mismatch flow

### DIFF
--- a/src/app/api/affiliate/connect/status/route.test.ts
+++ b/src/app/api/affiliate/connect/status/route.test.ts
@@ -63,18 +63,19 @@ beforeEach(() => {
 });
 
 describe('GET /api/affiliate/connect/status', () => {
-  it('returns destCurrency from Stripe account', async () => {
+  it('returns default currency and status', async () => {
     mockGetServerSession.mockResolvedValue({ user: { id: 'user1' } });
     const mockUser = {
-      paymentInfo: { stripeAccountId: 'acct_123', stripeAccountStatus: 'pending' },
+      paymentInfo: { stripeAccountId: 'acct_123' },
       save: jest.fn().mockResolvedValue(undefined),
+      markModified: jest.fn(),
     } as any;
     mockFindById.mockResolvedValue(mockUser);
     mockRetrieve.mockResolvedValue({
-      details_submitted: true,
-      charges_enabled: true,
       payouts_enabled: true,
       default_currency: 'BRL',
+      country: 'BR',
+      requirements: { currently_due: [] },
     });
 
     const req = new NextRequest('http://localhost/api/affiliate/connect/status');
@@ -82,11 +83,10 @@ describe('GET /api/affiliate/connect/status', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.destCurrency).toBe('brl');
-    expect(body.stripeAccountId).toBe('acct_123');
-    expect(body.stripeAccountStatus).toBe('verified');
+    expect(body.defaultCurrency).toBe('BRL');
+    expect(body.payoutsEnabled).toBe(true);
     expect(body.needsOnboarding).toBe(false);
-    expect(mockUser.paymentInfo.stripeAccountDefaultCurrency).toBe('brl');
+    expect(mockUser.paymentInfo.stripeAccountDefaultCurrency).toBe('BRL');
     expect(mockUser.save).toHaveBeenCalled();
   });
 });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -69,27 +69,21 @@ export async function POST(req: NextRequest) {
         const user = await User.findOne({ "paymentInfo.stripeAccountId": acctId });
         if (user) {
           user.paymentInfo ||= {};
-          user.paymentInfo.stripeAccountStatus = info.stripeAccountStatus;
-          user.paymentInfo.stripeAccountDefaultCurrency = info.default_currency || undefined;
-          user.paymentInfo.stripeAccountPayoutsEnabled = info.payouts_enabled;
-          user.paymentInfo.stripeAccountChargesEnabled = info.charges_enabled;
-          user.paymentInfo.stripeAccountDisabledReason = info.disabled_reason || undefined;
-          // ← Correção: atribuir objeto em vez de Map
-          user.paymentInfo.stripeAccountCapabilities = {
-            card_payments: info.capabilities?.card_payments,
-            transfers: info.capabilities?.transfers,
-          };
+          user.paymentInfo.stripeAccountDefaultCurrency = info.defaultCurrency;
+          user.paymentInfo.stripeAccountPayoutsEnabled = info.payoutsEnabled;
+          user.paymentInfo.stripeAccountDisabledReason = info.disabledReasonKey;
           user.paymentInfo.stripeAccountNeedsOnboarding = info.needsOnboarding;
+          user.paymentInfo.stripeAccountCountry = info.accountCountry;
           user.markModified("paymentInfo");
           await user.save();
         }
 
         logger.info("[connect:account.updated]", {
           accountId: acctId,
-          payouts_enabled: info.payouts_enabled,
-          default_currency: info.default_currency,
+          payouts_enabled: info.payoutsEnabled,
+          default_currency: info.defaultCurrency,
           needsOnboarding: info.needsOnboarding,
-          disabled_reason: info.disabled_reason,
+          disabled_reason: info.disabledReasonKey,
         });
         break;
       }

--- a/src/app/dashboard/PaymentSettings.tsx
+++ b/src/app/dashboard/PaymentSettings.tsx
@@ -6,9 +6,8 @@ import useSWR from "swr";
 
 type ConnectStatus =
   | {
-      stripeAccountId: string | null;
-      stripeAccountStatus: "verified" | "pending" | "disabled" | null;
-      destCurrency: string | null; // em minúsculas (ex.: 'brl' | 'usd')
+      payoutsEnabled: boolean;
+      defaultCurrency?: string;
       needsOnboarding: boolean;
     }
   | undefined;
@@ -47,7 +46,7 @@ export default function PaymentSettings() {
   const balances: Record<string, number> =
     (session?.user as any)?.affiliateBalances || {};
 
-  const destCurrency = connectStatus?.destCurrency || null;
+  const destCurrency = connectStatus?.defaultCurrency?.toLowerCase() || null;
 
   const balanceCents = useMemo(() => {
     if (!destCurrency) return 0;
@@ -111,9 +110,8 @@ export default function PaymentSettings() {
     }
   }, [updateSession, mutate]);
 
-  const isVerified = connectStatus?.stripeAccountStatus === "verified";
   const canRedeem =
-    !!destCurrency && balanceCents > 0 && isVerified && !isRedeeming;
+    !!destCurrency && balanceCents > 0 && connectStatus?.payoutsEnabled && !isRedeeming;
 
   return (
     <div className="space-y-4">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -100,7 +100,7 @@ const AffiliateCardContent: React.FC<{
   const { data: session } = useSession();
   const fetcher = (url: string) => fetch(url).then(r => r.json());
   const { data: connectStatus } = useSWR('/api/affiliate/connect/status', fetcher, { revalidateOnFocus: false });
-  const destCurrency = connectStatus?.destCurrency?.toLowerCase();
+  const destCurrency = connectStatus?.defaultCurrency?.toLowerCase();
   const balances: Record<string, number> = (session as any)?.user?.affiliateBalances || {};
   const entries = Object.entries(balances).sort(([a],[b]) => a.localeCompare(b));
   return (

--- a/src/app/services/stripe/mapAccountInfo.ts
+++ b/src/app/services/stripe/mapAccountInfo.ts
@@ -1,68 +1,39 @@
 // src/app/services/stripe/mapAccountInfo.ts
 import type Stripe from 'stripe';
 
-// Alias local — o SDK não exporta CapabilityStatus
-type CapabilityStatus = 'active' | 'inactive' | 'pending';
-
-export interface StripeAccountInfo {
-  payouts_enabled: boolean;
-  charges_enabled: boolean;
-  default_currency: string | null;
-  disabled_reason: string | null;
-  capabilities: {
-    card_payments: CapabilityStatus;
-    transfers: CapabilityStatus;
-  };
-  requirements: {
-    currently_due: string[];
-    past_due: string[];
-    current_deadline: string | null;
-  };
+export interface StripeUiStatus {
+  payoutsEnabled: boolean;
   needsOnboarding: boolean;
-  stripeAccountStatus: 'verified' | 'pending' | 'disabled';
+  disabledReasonKey?: string;
+  defaultCurrency?: string;
+  accountCountry?: string;
+  isUnderReview?: boolean;
 }
 
-export function mapStripeAccountInfo(account: Stripe.Account): StripeAccountInfo {
-  const payouts_enabled = !!account.payouts_enabled;
-  const charges_enabled = !!account.charges_enabled;
-  const default_currency = account.default_currency
-    ? String(account.default_currency).toLowerCase()
-    : null;
-
-  const disabled_reason =
+export function mapStripeAccountInfo(account: Stripe.Account): StripeUiStatus {
+  const payoutsEnabled = !!account.payouts_enabled;
+  const defaultCurrency = account.default_currency
+    ? String(account.default_currency).toUpperCase()
+    : undefined;
+  const accountCountry = account.country
+    ? String(account.country).toUpperCase()
+    : undefined;
+  const disabledReasonKey =
     (account.requirements as any)?.disabled_reason ||
     (account as any).disabled_reason ||
-    null;
-
-  // Normaliza capabilities com fallback seguro
-  const card_payments = (account.capabilities?.card_payments ?? 'inactive') as CapabilityStatus;
-  const transfers = (account.capabilities?.transfers ?? 'inactive') as CapabilityStatus;
-
-  const requirements = {
-    currently_due: (account.requirements?.currently_due ?? []) as string[],
-    past_due: (account.requirements?.past_due ?? []) as string[],
-    current_deadline: account.requirements?.current_deadline
-      ? new Date(account.requirements.current_deadline * 1000).toISOString()
-      : null,
-  };
-
-  const needsOnboarding = requirements.currently_due.length > 0 || !payouts_enabled;
-
-  let stripeAccountStatus: 'verified' | 'pending' | 'disabled' = 'pending';
-  if (disabled_reason) {
-    stripeAccountStatus = 'disabled';
-  } else if (payouts_enabled && charges_enabled) {
-    stripeAccountStatus = 'verified';
-  }
+    undefined;
+  const needsOnboarding =
+    !payoutsEnabled || (account.requirements?.currently_due?.length ?? 0) > 0;
+  const isUnderReview =
+    disabledReasonKey === 'under_review' ||
+    (disabledReasonKey?.startsWith('rejected.') ?? false);
 
   return {
-    payouts_enabled,
-    charges_enabled,
-    default_currency,
-    disabled_reason,
-    capabilities: { card_payments, transfers },
-    requirements,
+    payoutsEnabled,
     needsOnboarding,
-    stripeAccountStatus,
+    disabledReasonKey,
+    defaultCurrency,
+    accountCountry,
+    isUnderReview,
   };
 }

--- a/src/components/affiliate/RedeemModal.tsx
+++ b/src/components/affiliate/RedeemModal.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+interface Props {
+  open: boolean;
+  currency: string;
+  amountCents: number;
+  onConfirm: () => void;
+  onClose: () => void;
+  loading?: boolean;
+  reason?: string | null;
+  onOpenCurrencyHelp?: () => void;
+}
+
+function fmt(amountCents: number, cur: string) {
+  const n = amountCents / 100;
+  const currency = cur.toUpperCase();
+  const locale = currency === 'BRL' ? 'pt-BR' : 'en-US';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(n);
+}
+
+export default function RedeemModal({
+  open,
+  currency,
+  amountCents,
+  onConfirm,
+  onClose,
+  loading,
+  reason,
+  onOpenCurrencyHelp,
+}: Props) {
+  if (!open) return null;
+  const amount = fmt(amountCents, currency);
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" role="dialog" aria-modal="true">
+      <div className="bg-white rounded p-4 w-80 space-y-3">
+        <h4 className="font-medium text-sm">Resgatar {amount}</h4>
+        {reason ? (
+          <p className="text-xs text-gray-600">
+            {reason}
+            {onOpenCurrencyHelp && (
+              <button onClick={onOpenCurrencyHelp} className="ml-1 underline">
+                Entenda como sacar {currency.toUpperCase()}
+              </button>
+            )}
+          </p>
+        ) : (
+          <p className="text-xs text-gray-600">
+            Você vai transferir todo o saldo disponível em {currency.toUpperCase()} para sua conta Stripe Connect.
+          </p>
+        )}
+        <div className="flex gap-2 justify-end pt-2">
+          <button onClick={onClose} className="px-3 py-1 text-sm">
+            Cancelar
+          </button>
+          {!reason && (
+            <button
+              disabled={loading}
+              onClick={onConfirm}
+              className="px-3 py-1 rounded bg-brand-pink text-white text-sm disabled:opacity-50"
+            >
+              {loading ? 'Enviando...' : 'Confirmar'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/payments/CurrencyMismatchModal.tsx
+++ b/src/components/payments/CurrencyMismatchModal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { CURRENCY_HELP } from '@/copy/stripe';
+import { useState } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  balanceCurrency: string;
+  destinationCurrency: string;
+}
+
+export default function CurrencyMismatchModal({
+  open,
+  onClose,
+  balanceCurrency,
+  destinationCurrency,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  if (!open) return null;
+
+  const connectNew = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/affiliate/connect/link', { method: 'POST' });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openPortal = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/affiliate/connect/portal');
+      const data = await res.json();
+      if (data.url) window.open(data.url, '_blank');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const contactSupport = () => {
+    window.location.href = 'mailto:support@example.com';
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+      <div className="bg-white rounded p-4 w-80 space-y-3">
+        <div className="flex justify-between items-center">
+          <h4 className="font-medium text-sm">
+            {`Não consigo sacar ${balanceCurrency.toUpperCase()}`}
+          </h4>
+          <button onClick={onClose} aria-label="Fechar" className="text-sm">×</button>
+        </div>
+        <p className="text-xs text-gray-600">
+          {CURRENCY_HELP.mismatch_reason(balanceCurrency.toUpperCase(), destinationCurrency.toUpperCase())}
+        </p>
+        <div className="space-y-2">
+          <button
+            onClick={connectNew}
+            disabled={loading}
+            className="w-full rounded border p-2 text-xs text-left"
+          >
+            Conectar outra conta que receba em {balanceCurrency.toUpperCase()}
+          </button>
+          <button
+            onClick={openPortal}
+            disabled={loading}
+            className="w-full rounded border p-2 text-xs text-left"
+          >
+            Ver se minha conta aceita {balanceCurrency.toUpperCase()}
+          </button>
+          <button
+            onClick={contactSupport}
+            disabled={loading}
+            className="w-full rounded border p-2 text-xs text-left"
+          >
+            Falar com suporte
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/payments/StripeStatusPanel.tsx
+++ b/src/components/payments/StripeStatusPanel.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import { AffiliateStatus, AffiliateSummary } from '@/hooks/useAffiliateSummary';
+import { STRIPE_DISABLED_REASON, STRIPE_STATUS, CURRENCY_HELP } from '@/copy/stripe';
+import CurrencyMismatchModal from './CurrencyMismatchModal';
+
+interface Props {
+  status: AffiliateStatus;
+  summary?: AffiliateSummary;
+  onRefresh?: () => void;
+  onOnboard?: () => void;
+}
+
+function fmt(amountCents: number, cur: string) {
+  const n = amountCents / 100;
+  const currency = cur.toUpperCase();
+  const locale = currency === 'BRL' ? 'pt-BR' : 'en-US';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(n);
+}
+
+export default function StripeStatusPanel({ status, summary, onRefresh, onOnboard }: Props) {
+  const [mismatchOpen, setMismatchOpen] = useState(false);
+
+  const dstCur = status.defaultCurrency?.toUpperCase();
+  let mismatchCur: string | undefined;
+  let mismatchAmount = 0;
+  if (summary && dstCur) {
+    for (const cur of Object.keys(summary.byCurrency)) {
+      if (cur.toUpperCase() !== dstCur && summary.byCurrency[cur].availableCents > 0) {
+        mismatchCur = cur.toUpperCase();
+        mismatchAmount = summary.byCurrency[cur].availableCents;
+        break;
+      }
+    }
+  }
+
+  const reason = status.disabledReasonKey
+    ? STRIPE_DISABLED_REASON[status.disabledReasonKey] || STRIPE_DISABLED_REASON.default
+    : undefined;
+
+  let badge = STRIPE_STATUS.action_needed;
+  if (status.payoutsEnabled) badge = STRIPE_STATUS.verified;
+  else if (status.isUnderReview) badge = STRIPE_STATUS.under_review;
+
+  return (
+    <div className="rounded-xl bg-gray-50 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-600">Status Stripe</span>
+        <span className="text-xs font-semibold">{badge}</span>
+      </div>
+      {dstCur && (
+        <div className="text-xs text-gray-600">Moeda de recebimento: {dstCur}</div>
+      )}
+      {mismatchCur && dstCur && (
+        <div className="bg-amber-100 text-xs p-2 rounded space-y-1">
+          <p>
+            Você tem {fmt(mismatchAmount, mismatchCur)}. {CURRENCY_HELP.mismatch_banner(mismatchCur, dstCur)}
+          </p>
+          <button
+            className="underline"
+            onClick={() => setMismatchOpen(true)}
+          >
+            Entenda como sacar {mismatchCur}
+          </button>
+        </div>
+      )}
+      {!status.payoutsEnabled && reason && (
+        <div className="text-xs text-gray-700 space-y-1">
+          <p className="font-medium">{reason.title}</p>
+          <p>{reason.body}</p>
+          {reason.cta === 'onboarding' && (
+            <button onClick={onOnboard} className="underline">Configurar Stripe</button>
+          )}
+          {reason.cta === 'contact' && (
+            <button onClick={onOnboard} className="underline">Abrir conta no Stripe</button>
+          )}
+        </div>
+      )}
+      <button
+        onClick={onRefresh}
+        className="w-full rounded border px-3 py-1.5 text-xs font-medium"
+      >
+        Atualizar status
+      </button>
+      {mismatchCur && dstCur && (
+        <CurrencyMismatchModal
+          open={mismatchOpen}
+          onClose={() => setMismatchOpen(false)}
+          balanceCurrency={mismatchCur}
+          destinationCurrency={dstCur}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/copy/__tests__/__snapshots__/stripe.test.ts.snap
+++ b/src/copy/__tests__/__snapshots__/stripe.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`stripe copy matches snapshot 1`] = `
+{
+  "CURRENCY_HELP": {
+    "mismatch_banner": [Function],
+    "mismatch_reason": [Function],
+    "options": [
+      "Usar outra conta Stripe que receba na mesma moeda.",
+      "Ajustar sua conta junto ao Stripe para aceitar a moeda (quando o país permitir).",
+      "Solicitar ajuda ao suporte para alternativas.",
+    ],
+    "options_title": [Function],
+  },
+  "STRIPE_DISABLED_REASON": {
+    "default": {
+      "body": "Há uma pendência na sua conta Stripe. Revise seu cadastro para liberar os saques.",
+      "cta": "onboarding",
+      "title": "Ação necessária no Stripe",
+    },
+    "rejected.fraud": {
+      "body": "Sua conta foi rejeitada por suspeita de fraude. Entre em contato com o suporte do Stripe.",
+      "cta": "contact",
+      "title": "Conta rejeitada",
+    },
+    "rejected.terms_of_service": {
+      "body": "Houve um problema com os Termos do Stripe. Fale com o suporte do Stripe para detalhes.",
+      "cta": "contact",
+      "title": "Conta rejeitada",
+    },
+    "requirements.past_due": {
+      "body": "Faltam documentos obrigatórios no Stripe. Envie-os para liberar seus saques.",
+      "cta": "onboarding",
+      "title": "Informações pendentes",
+    },
+    "requirements.pending_verification": {
+      "body": "O Stripe está verificando seus documentos. Isso pode levar algum tempo.",
+      "cta": "wait",
+      "title": "Verificação em andamento",
+    },
+    "under_review": {
+      "body": "Sua conta está passando por uma revisão interna do Stripe.",
+      "cta": "wait",
+      "title": "Conta em revisão",
+    },
+  },
+  "STRIPE_STATUS": {
+    "action_needed": "Ação necessária",
+    "under_review": "Em revisão",
+    "verified": "Verificado",
+  },
+}
+`;

--- a/src/copy/__tests__/stripe.test.ts
+++ b/src/copy/__tests__/stripe.test.ts
@@ -1,0 +1,7 @@
+import { STRIPE_STATUS, STRIPE_DISABLED_REASON, CURRENCY_HELP } from '../stripe';
+
+describe('stripe copy', () => {
+  it('matches snapshot', () => {
+    expect({ STRIPE_STATUS, STRIPE_DISABLED_REASON, CURRENCY_HELP }).toMatchSnapshot();
+  });
+});

--- a/src/copy/stripe.ts
+++ b/src/copy/stripe.ts
@@ -1,0 +1,53 @@
+export const STRIPE_STATUS = {
+  verified: 'Verificado',
+  action_needed: 'Ação necessária',
+  under_review: 'Em revisão',
+} as const;
+
+export const STRIPE_DISABLED_REASON: Record<string, {title: string, body: string, cta?: 'onboarding'|'contact'|'wait'}> = {
+  'requirements.past_due': {
+    title: 'Informações pendentes',
+    body: 'Faltam documentos obrigatórios no Stripe. Envie-os para liberar seus saques.',
+    cta: 'onboarding',
+  },
+  'requirements.pending_verification': {
+    title: 'Verificação em andamento',
+    body: 'O Stripe está verificando seus documentos. Isso pode levar algum tempo.',
+    cta: 'wait',
+  },
+  'rejected.fraud': {
+    title: 'Conta rejeitada',
+    body: 'Sua conta foi rejeitada por suspeita de fraude. Entre em contato com o suporte do Stripe.',
+    cta: 'contact',
+  },
+  'rejected.terms_of_service': {
+    title: 'Conta rejeitada',
+    body: 'Houve um problema com os Termos do Stripe. Fale com o suporte do Stripe para detalhes.',
+    cta: 'contact',
+  },
+  'under_review': {
+    title: 'Conta em revisão',
+    body: 'Sua conta está passando por uma revisão interna do Stripe.',
+    cta: 'wait',
+  },
+  // fallback genérico
+  default: {
+    title: 'Ação necessária no Stripe',
+    body: 'Há uma pendência na sua conta Stripe. Revise seu cadastro para liberar os saques.',
+    cta: 'onboarding',
+  },
+};
+
+export const CURRENCY_HELP = {
+  mismatch_banner: (balCur: string, dstCur: string) =>
+    `Você tem saldo em ${balCur}. Sua conta Stripe recebe em ${dstCur}.`,
+  mismatch_reason: (balCur: string, dstCur: string) =>
+    `Sua conta Stripe recebe em ${dstCur}; este saldo está em ${balCur}.`,
+  options_title: (balCur: string) => `Como sacar ${balCur}?`,
+  options: [
+    'Usar outra conta Stripe que receba na mesma moeda.',
+    'Ajustar sua conta junto ao Stripe para aceitar a moeda (quando o país permitir).',
+    'Solicitar ajuda ao suporte para alternativas.',
+  ],
+} as const;
+

--- a/src/hooks/useAffiliateSummary.test.ts
+++ b/src/hooks/useAffiliateSummary.test.ts
@@ -2,7 +2,7 @@ import { canRedeem, AffiliateSummary, AffiliateStatus } from './useAffiliateSumm
 import { REDEEM_BLOCK_MESSAGES } from '@/copy/affiliates';
 
 describe('canRedeem', () => {
-  const status: AffiliateStatus = { payouts_enabled: true, default_currency: 'brl' } as any;
+  const status: AffiliateStatus = { payoutsEnabled: true, defaultCurrency: 'brl' } as any;
   const summary: AffiliateSummary = {
     balances: { brl: 10000, usd: 0 },
     debt: { brl: 0 },
@@ -19,7 +19,7 @@ describe('canRedeem', () => {
   });
 
   test('blocks when payouts disabled', () => {
-    expect(canRedeem({ ...status, payouts_enabled: false }, summary, 'brl')).toBe(false);
+    expect(canRedeem({ ...status, payoutsEnabled: false }, summary, 'brl')).toBe(false);
   });
 
   test('blocks when debt exists', () => {

--- a/src/hooks/useAffiliateSummary.ts
+++ b/src/hooks/useAffiliateSummary.ts
@@ -21,10 +21,12 @@ export interface AffiliateSummary {
 }
 
 export interface AffiliateStatus {
-  payouts_enabled: boolean;
-  disabled_reason?: string;
-  default_currency: string;
+  payoutsEnabled: boolean;
+  disabledReasonKey?: string;
+  defaultCurrency?: string;
   needsOnboarding?: boolean;
+  accountCountry?: string;
+  isUnderReview?: boolean;
 }
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
@@ -67,9 +69,9 @@ export function canRedeem(
   summary: AffiliateSummary | undefined,
   cur: string,
 ) {
-  if (!status?.payouts_enabled) return false;
+  if (!status?.payoutsEnabled) return false;
   if (!summary) return false;
-  if (cur !== status.default_currency) return false;
+  if (cur !== status.defaultCurrency) return false;
   const curSummary = summary.byCurrency?.[cur];
   if (!curSummary) return false;
   const min = curSummary.minRedeemCents ?? 0;
@@ -89,11 +91,11 @@ export function getRedeemBlockReason(
   cur: string,
 ): RedeemBlockReason | null {
   if (!status) return null;
-  if (!status.payouts_enabled) {
+  if (!status.payoutsEnabled) {
     return status.needsOnboarding ? 'needsOnboarding' : 'payouts_disabled';
   }
   if (!summary) return null;
-  if (cur !== status.default_currency) return 'currency_mismatch';
+  if (cur !== status.defaultCurrency) return 'currency_mismatch';
   const curSummary = summary.byCurrency?.[cur];
   if (!curSummary) return null;
   if (curSummary.debtCents > 0) return 'has_debt';

--- a/tests/mapStripeAccountInfo.test.ts
+++ b/tests/mapStripeAccountInfo.test.ts
@@ -5,27 +5,25 @@ describe('mapStripeAccountInfo', () => {
     const account: any = {
       id: 'acct_1',
       payouts_enabled: true,
-      charges_enabled: true,
       default_currency: 'BRL',
+      country: 'BR',
       requirements: { currently_due: [], past_due: [], disabled_reason: null },
-      capabilities: { card_payments: 'active', transfers: 'active' },
     };
     const info = mapStripeAccountInfo(account);
-    expect(info.stripeAccountStatus).toBe('verified');
+    expect(info.payoutsEnabled).toBe(true);
     expect(info.needsOnboarding).toBe(false);
+    expect(info.defaultCurrency).toBe('BRL');
   });
 
   it('maps pending account when requirements due', () => {
     const account: any = {
       id: 'acct_2',
       payouts_enabled: false,
-      charges_enabled: true,
       default_currency: 'BRL',
       requirements: { currently_due: ['external_account'], past_due: [] },
-      capabilities: { card_payments: 'pending', transfers: 'inactive' },
     };
     const info = mapStripeAccountInfo(account);
-    expect(info.stripeAccountStatus).toBe('pending');
+    expect(info.payoutsEnabled).toBe(false);
     expect(info.needsOnboarding).toBe(true);
   });
 
@@ -33,13 +31,11 @@ describe('mapStripeAccountInfo', () => {
     const account: any = {
       id: 'acct_3',
       payouts_enabled: true,
-      charges_enabled: true,
       default_currency: 'BRL',
       requirements: { currently_due: [], past_due: [], disabled_reason: 'requirements.past_due' },
-      capabilities: { card_payments: 'active', transfers: 'active' },
     };
     const info = mapStripeAccountInfo(account);
-    expect(info.stripeAccountStatus).toBe('disabled');
-    expect(info.disabled_reason).toBe('requirements.past_due');
+    expect(info.disabledReasonKey).toBe('requirements.past_due');
+    expect(info.isUnderReview).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add human-readable Stripe status and disabled reason copies
- implement StripeStatusPanel and CurrencyMismatchModal for account status and currency mismatch guidance
- map Stripe account info to UI-friendly structure and expose via API

## Testing
- `npx jest tests/mapStripeAccountInfo.test.ts src/copy/__tests__/stripe.test.ts src/hooks/useAffiliateSummary.test.ts src/app/api/affiliate/connect/status/route.test.ts`
- `npx eslint src/components/payments/StripeStatusPanel.tsx src/components/payments/CurrencyMismatchModal.tsx src/app/services/stripe/mapAccountInfo.ts src/app/api/affiliate/connect/status/route.ts src/components/affiliate/AffiliateCard.tsx src/hooks/useAffiliateSummary.ts src/components/affiliate/RedeemModal.tsx src/app/api/stripe/webhook/route.ts src/app/dashboard/PaymentSettings.tsx src/app/dashboard/page.tsx` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d669d15d8832e947d5af0454828ab