### PR TITLE
feat(affiliates): enable new UI under flag and add /debug/ui smoke test

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -23,6 +23,9 @@ import VideoCarousel from './VideoCarousel';
 import InstagramConnectCard from './InstagramConnectCard';
 import StepIndicator from './StepIndicator';
 import PlanCardPro from '@/components/billing/PlanCardPro';
+import AffiliateCard from '@/components/affiliate/AffiliateCard';
+import AffiliateHistory from '@/components/affiliate/history/AffiliateHistory';
+import SubscriptionCard from '@/components/billing/SubscriptionCard';
 
 // --- FIM IMPORTS ---
 
@@ -298,6 +301,7 @@ export default function MainDashboard() {
   const userId = user?.id ?? "";
 
   useEffect(() => {
+    if (process.env.NEXT_PUBLIC_AFFILIATES_V2 === 'on') return;
     if (typeof window !== 'undefined' && affiliateCode) {
       const origin = window.location.origin;
       setFullAffiliateLink(`${origin}/?ref=${affiliateCode}`);
@@ -307,6 +311,7 @@ export default function MainDashboard() {
   }, [affiliateCode]);
 
   useEffect(() => {
+    if (process.env.NEXT_PUBLIC_AFFILIATES_V2 === 'on') return;
     if (status === "authenticated" && userId) {
       const fetchLog = async () => {
         setIsLoadingCommissionLog(true);
@@ -668,11 +673,18 @@ export default function MainDashboard() {
                 </div>
               </motion.section>
 
-              {/* Card de Afiliados para MOBILE */}
+              {/* Card de Afiliados / Subscription (Mobile) */}
               <div className="lg:hidden">
-                <motion.section variants={cardVariants} initial="hidden" animate="visible" custom={0.8}>
-                  <AffiliateCardContent {...affiliateCardProps} />
-                </motion.section>
+                {process.env.NEXT_PUBLIC_AFFILIATES_V2 === 'on' ? (
+                  <div className="space-y-4">
+                    <AffiliateCard />
+                    <SubscriptionCard />
+                  </div>
+                ) : (
+                  <motion.section variants={cardVariants} initial="hidden" animate="visible" custom={0.8}>
+                    <AffiliateCardContent {...affiliateCardProps} />
+                  </motion.section>
+                )}
               </div>
 
               {/* Suas Métricas (UploadMetrics) */}
@@ -701,14 +713,27 @@ export default function MainDashboard() {
                   />
                 </div>
               </motion.section>
+
+              {process.env.NEXT_PUBLIC_AFFILIATES_V2 === 'on' && (
+                <section className="mt-6">
+                  <AffiliateHistory />
+                </section>
+              )}
             </div>
 
             {/* --- COLUNA DA DIREITA (SIDEBAR) */}
             <div className="hidden lg:block lg:col-span-1 space-y-8">
-              {/* Card de Afiliados para DESKTOP */}
-              <motion.section variants={cardVariants} initial="hidden" animate="visible" custom={0.5}>
-                <AffiliateCardContent {...affiliateCardProps} />
-              </motion.section>
+              {/* Affiliate & Subscription (Desktop) */}
+              {process.env.NEXT_PUBLIC_AFFILIATES_V2 === 'on' ? (
+                <section className="space-y-4">
+                  <AffiliateCard />
+                  <SubscriptionCard />
+                </section>
+              ) : (
+                <motion.section variants={cardVariants} initial="hidden" animate="visible" custom={0.5}>
+                  <AffiliateCardContent {...affiliateCardProps} />
+                </motion.section>
+              )}
 
               {/* Seção "Precisa de Ajuda?" */}
               <motion.section variants={cardVariants} initial="hidden" animate="visible" custom={3}>

--- a/src/app/debug/ui/page.tsx
+++ b/src/app/debug/ui/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import React from 'react'
+import StripeStatusPanel from '@/components/payments/StripeStatusPanel'
+
+/**
+ * NOTA:
+ * - Este debug injeta dados "fake" diretamente no StripeStatusPanel.
+ * - O AffiliateCard normalmente busca dados via hooks. Como debug rápido,
+ *   foque no StripeStatusPanel (status + moeda + banner de mismatch).
+ * - Remova ou proteja esta rota antes do deploy (ex.: checar NODE_ENV).
+ */
+
+const fakeSummary = {
+  byCurrency: {
+    BRL: { availableCents: 123400, pendingCents: 5600, debtCents: 0, minRedeemCents: 5000, nextMatureAt: new Date(Date.now()+5*864e5).toISOString() },
+    USD: { availableCents: 0, pendingCents: 2500, debtCents: 1500, minRedeemCents: 1000, nextMatureAt: new Date(Date.now()+2*864e5).toISOString() }
+  }
+}
+
+const fakeStatus = {
+  payoutsEnabled: false,        // force "Ação necessária"
+  needsOnboarding: true,
+  defaultCurrency: 'BRL',
+  disabledReasonKey: 'requirements.past_due',
+  isUnderReview: false,
+}
+
+export default function Page() {
+  return (
+    <div className="p-6 space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Debug UI — Pagamentos & Afiliados</h1>
+
+      {/* Painel de status + mismatch banner */}
+      <StripeStatusPanel
+        status={fakeStatus as any}
+        summary={fakeSummary as any}
+        onRefresh={() => console.log('refresh status')}
+        onOnboard={() => console.log('open onboarding')}
+      />
+
+      <div className="text-sm text-gray-600">
+        <p>Este mock deve exibir:</p>
+        <ul className="list-disc pl-5">
+          <li>Badge <strong>Ação necessária</strong> (payouts desabilitado + needsOnboarding).</li>
+          <li>Linha <strong>Moeda de recebimento: BRL</strong>.</li>
+          <li><strong>Banner de mismatch</strong> (saldo em USD com conta BRL) com CTA “Entenda como sacar USD”.</li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- enable affiliate & subscription components in dashboard under NEXT_PUBLIC_AFFILIATES_V2
- add /debug/ui page to visually test StripeStatusPanel without backend
- isolate legacy affiliate card implementation behind flag

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689df4cbd568832ea79996496ffcb69c