### PR TITLE
feat: affiliate summary API and hook

### DIFF
--- a/src/app/api/affiliate/summary/route.ts
+++ b/src/app/api/affiliate/summary/route.ts
@@ -5,11 +5,21 @@ import { connectToDatabase } from '@/app/lib/mongoose';
 import User from '@/app/models/User';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
-function minForCurrency(cur: string) {
-  const upper = cur.toUpperCase();
-  const fromEnv = Number(process.env[`REDEEM_MIN_${upper}`] || 0);
-  return fromEnv > 0 ? Math.round(fromEnv) : 50 * 100;
+const MIN_BY_CUR: Record<string, number> = {
+  BRL: Number(process.env.AFFILIATE_MIN_REDEEM_BRL ?? 5000),
+  USD: Number(process.env.AFFILIATE_MIN_REDEEM_USD ?? 1000),
+};
+const minRedeemFor = (cur: string) =>
+  MIN_BY_CUR[cur] ?? Number(process.env.AFFILIATE_MIN_REDEEM_DEFAULT ?? 5000);
+
+function normalize(obj: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {};
+  Object.keys(obj || {}).forEach((k) => {
+    out[k.toUpperCase()] = obj[k];
+  });
+  return out;
 }
 
 export async function GET() {
@@ -17,19 +27,58 @@ export async function GET() {
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
   }
+
   await connectToDatabase();
-  const user = await User.findById(session.user.id);
+  const user = await User.findById(session.user.id).select(
+    'affiliateBalances commissionLog affiliateDebtByCurrency'
+  );
   if (!user) {
     return NextResponse.json({ error: 'Usuário não encontrado.' }, { status: 404 });
   }
 
-  const balances = Object.fromEntries(user.affiliateBalances || []);
-  const debt = Object.fromEntries(user.affiliateDebtByCurrency || []);
-  const min: Record<string, number> = {};
-  const currencies = new Set([...Object.keys(balances), ...Object.keys(debt)]);
-  currencies.forEach(cur => {
-    min[cur] = minForCurrency(cur);
+  const balances = normalize(Object.fromEntries(user.affiliateBalances || []));
+  const debt = normalize(Object.fromEntries(user.affiliateDebtByCurrency || []));
+  const commissions = user.commissionLog || [];
+
+  const currencies = new Set<string>([
+    ...Object.keys(balances),
+    ...commissions.map((c: any) => String(c.currency).toUpperCase()),
+    ...Object.keys(debt),
+  ]);
+
+  const now = Date.now();
+  const byCurrency: Record<string, any> = {};
+
+  currencies.forEach((cur) => {
+    const availableCents = balances[cur] ?? 0;
+    const pendingItems = commissions.filter(
+      (c: any) => String(c.currency).toUpperCase() === cur && c.status === 'pending'
+    );
+    const pendingCents = pendingItems.reduce(
+      (sum: number, i: any) => sum + (i.amountCents || 0),
+      0
+    );
+    const next = pendingItems
+      .map((i: any) => i.availableAt)
+      .filter((d: any) => d && new Date(d).getTime() > now)
+      .reduce<number | null>((acc, d: any) => {
+        const t = new Date(d).getTime();
+        return acc === null || t < acc ? t : acc;
+      }, null);
+    const nextMatureAt = next ? new Date(next).toISOString() : null;
+    const debtCents = debt[cur] ?? 0;
+
+    byCurrency[cur] = {
+      availableCents,
+      pendingCents,
+      debtCents,
+      nextMatureAt,
+      minRedeemCents: minRedeemFor(cur),
+    };
   });
 
-  return NextResponse.json({ balances, debt, min });
+  return NextResponse.json(
+    { byCurrency },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } }
+  );
 }

--- a/src/components/payments/StripeStatusPanel.tsx
+++ b/src/components/payments/StripeStatusPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { AffiliateStatus, AffiliateSummary } from '@/hooks/useAffiliateSummary';
+import { AffiliateStatus, AffiliateSummary } from '@/types/affiliate';
 import { STRIPE_DISABLED_REASON, STRIPE_STATUS, CURRENCY_HELP } from '@/copy/stripe';
 import CurrencyMismatchModal from './CurrencyMismatchModal';
 

--- a/src/hooks/useAffiliateSummary.test.ts
+++ b/src/hooks/useAffiliateSummary.test.ts
@@ -1,45 +1,40 @@
-import { canRedeem, AffiliateSummary, AffiliateStatus } from './useAffiliateSummary';
+import { canRedeem } from './useAffiliateSummary';
+import { AffiliateSummary, AffiliateStatus } from '@/types/affiliate';
 import { REDEEM_BLOCK_MESSAGES } from '@/copy/affiliates';
 
 describe('canRedeem', () => {
-  const status: AffiliateStatus = { payoutsEnabled: true, defaultCurrency: 'brl' } as any;
+  const status: AffiliateStatus = { payoutsEnabled: true, defaultCurrency: 'BRL' } as any;
   const summary: AffiliateSummary = {
-    balances: { brl: 10000, usd: 0 },
-    debt: { brl: 0 },
-    min: { brl: 5000 },
-    pending: {},
     byCurrency: {
-      brl: { availableCents: 10000, pendingCents: 0, debtCents: 0, minRedeemCents: 5000 },
-      usd: { availableCents: 0, pendingCents: 0, debtCents: 0 },
+      BRL: { availableCents: 10000, pendingCents: 0, debtCents: 0, nextMatureAt: null, minRedeemCents: 5000 },
+      USD: { availableCents: 0, pendingCents: 0, debtCents: 0, nextMatureAt: null, minRedeemCents: 0 },
     },
-  } as any;
+  };
 
   test('allows redeem when all conditions met', () => {
-    expect(canRedeem(status, summary, 'brl')).toBe(true);
+    expect(canRedeem(status, summary, 'BRL')).toBe(true);
   });
 
   test('blocks when payouts disabled', () => {
-    expect(canRedeem({ ...status, payoutsEnabled: false }, summary, 'brl')).toBe(false);
+    expect(canRedeem({ ...status, payoutsEnabled: false }, summary, 'BRL')).toBe(false);
   });
 
   test('blocks when debt exists', () => {
-    const s = {
-      ...summary,
-      byCurrency: { ...summary.byCurrency, brl: { ...summary.byCurrency.brl, debtCents: 100 } },
+    const s: AffiliateSummary = {
+      byCurrency: { ...summary.byCurrency, BRL: { ...summary.byCurrency.BRL, debtCents: 100 } },
     };
-    expect(canRedeem(status, s, 'brl')).toBe(false);
+    expect(canRedeem(status, s, 'BRL')).toBe(false);
   });
 
   test('blocks when below minimum', () => {
-    const s = {
-      ...summary,
-      byCurrency: { ...summary.byCurrency, brl: { ...summary.byCurrency.brl, availableCents: 1000 } },
+    const s: AffiliateSummary = {
+      byCurrency: { ...summary.byCurrency, BRL: { ...summary.byCurrency.BRL, availableCents: 1000 } },
     };
-    expect(canRedeem(status, s, 'brl')).toBe(false);
+    expect(canRedeem(status, s, 'BRL')).toBe(false);
   });
 
   test('blocks when currency mismatch', () => {
-    expect(canRedeem(status, summary, 'usd')).toBe(false);
+    expect(canRedeem(status, summary, 'USD')).toBe(false);
   });
 });
 

--- a/src/types/affiliate.ts
+++ b/src/types/affiliate.ts
@@ -1,0 +1,20 @@
+export type CurrencySummary = {
+  availableCents: number;
+  pendingCents: number;
+  debtCents: number;
+  nextMatureAt: string | null;
+  minRedeemCents: number;
+};
+
+export type AffiliateSummary = {
+  byCurrency: Record<string, CurrencySummary>;
+};
+
+export type AffiliateStatus = {
+  payoutsEnabled: boolean;
+  disabledReasonKey?: string;
+  defaultCurrency?: string;
+  needsOnboarding?: boolean;
+  accountCountry?: string;
+  isUnderReview?: boolean;
+};


### PR DESCRIPTION
## Summary
- add /api/affiliate/summary with per-currency balances, pending, debts and maturity info
- expose affiliate summary hook using SWR without stale cache
- centralize affiliate types and update consumers

## Testing
- `npm test src/hooks/useAffiliateSummary.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689df7b644c4832e9649d9ef2b4b03e9