### PR TITLE
feat: affiliate history endpoint and ui

### DIFF
--- a/src/app/api/affiliate/history/route.ts
+++ b/src/app/api/affiliate/history/route.ts
@@ -1,20 +1,145 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import User from '@/app/models/User';
+import Redemption from '@/app/models/Redemption';
+import { Types } from 'mongoose';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function clamp(num: number, min: number, max: number) {
+  return Math.min(Math.max(num, min), max);
+}
 
 export async function GET(req: NextRequest) {
-  // For now this is a mocked endpoint used for tests and development.
-  const { searchParams } = new URL(req.url);
-  const cursor = searchParams.get('cursor');
-  const items = [
-    {
-      id: cursor ? 'second' : 'first',
-      currency: 'BRL',
-      amountCents: 1000,
-      status: 'pending',
-      createdAt: new Date().toISOString(),
-      availableAt: new Date(Date.now() + 7 * 86400000).toISOString(),
-      invoiceId: 'in_123',
-    },
-  ];
-  const nextCursor = cursor ? null : 'next';
-  return NextResponse.json({ items, nextCursor });
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: 'unauthorized' },
+      { status: 401, headers: { 'Cache-Control': 'no-store, max-age=0' } }
+    );
+  }
+
+  const searchParams = req.nextUrl.searchParams;
+  const take = clamp(Number(searchParams.get('take')) || 20, 10, 50);
+  const currency = searchParams.get('currency')?.toUpperCase() || null;
+  const statusFilter = (searchParams.get('status') || '')
+    .split(',')
+    .filter(Boolean);
+  const from = searchParams.get('from') ? new Date(searchParams.get('from')!) : null;
+  const to = searchParams.get('to') ? new Date(searchParams.get('to')!) : null;
+
+  let curDate: Date | null = null;
+  let curId: Types.ObjectId | null = null;
+  const cursorParam = searchParams.get('cursor');
+  if (cursorParam) {
+    try {
+      const c = JSON.parse(Buffer.from(cursorParam, 'base64').toString('utf8'));
+      if (c.createdAt) curDate = new Date(c.createdAt);
+      if (c.id) curId = new Types.ObjectId(c.id);
+    } catch {
+      // ignore invalid cursor
+    }
+  }
+
+  await connectToDatabase();
+  const userId = new Types.ObjectId(session.user.id);
+
+  // commissions stored in User.commissionLog
+  const user = await User.findById(userId, 'commissionLog').lean();
+  const commissionsRaw: any[] = user?.commissionLog || [];
+  let commissionItems = commissionsRaw.map((c) => ({
+    id: c._id.toString(),
+    kind: 'commission',
+    currency: (c.currency || '').toUpperCase(),
+    amountCents: c.amountCents,
+    status: c.status,
+    createdAt: c.createdAt,
+    availableAt: c.availableAt ?? null,
+    invoiceId: c.invoiceId ?? null,
+    subscriptionId: c.subscriptionId ?? null,
+    transferId: null,
+    reasonCode: c.reasonCode ?? null,
+    notes: c.note ?? null,
+  }));
+
+  // redemptions
+  const match: any = { userId };
+  if (currency) match.currency = currency.toLowerCase();
+  if (from || to) {
+    match.createdAt = {};
+    if (from) match.createdAt.$gte = from;
+    if (to) match.createdAt.$lte = to;
+  }
+  const redemptions = await Redemption.find(match).lean();
+  const redemptionItems = redemptions
+    .map((r: any) => {
+      if (r.status === 'processing') return null; // ignore
+      let status = r.status === 'paid' ? 'paid' : 'reversed';
+      let reasonCode = r.reasonCode || null;
+      if (r.status === 'rejected') {
+        status = 'reversed';
+        reasonCode = r.reasonCode || 'payout_rejected';
+      }
+      return {
+        id: r._id.toString(),
+        kind: 'redemption',
+        currency: (r.currency || '').toUpperCase(),
+        amountCents: r.amountCents,
+        status,
+        createdAt: r.createdAt,
+        availableAt: null,
+        invoiceId: null,
+        subscriptionId: null,
+        transferId: r.transferId ?? null,
+        reasonCode,
+        notes: r.notes ?? null,
+      };
+    })
+    .filter(Boolean) as any[];
+
+  let items = [...commissionItems, ...redemptionItems];
+
+  if (currency) {
+    items = items.filter((i) => i.currency === currency);
+  }
+  if (from) {
+    items = items.filter((i) => new Date(i.createdAt) >= from!);
+  }
+  if (to) {
+    items = items.filter((i) => new Date(i.createdAt) <= to!);
+  }
+  if (statusFilter.length) {
+    items = items.filter((i) => statusFilter.includes(i.status));
+  }
+
+  items.sort((a, b) => {
+    const da = new Date(a.createdAt).getTime();
+    const db = new Date(b.createdAt).getTime();
+    if (db !== da) return db - da;
+    return b.id.localeCompare(a.id);
+  });
+
+  if (curDate && curId) {
+    items = items.filter((i) => {
+      const d = new Date(i.createdAt).getTime();
+      if (d < curDate!.getTime()) return true;
+      if (d > curDate!.getTime()) return false;
+      return i.id < curId!.toString();
+    });
+  }
+
+  const hasMore = items.length > take;
+  const page = hasMore ? items.slice(0, take) : items;
+  const last = page[page.length - 1];
+  const nextCursor = hasMore
+    ? Buffer.from(JSON.stringify({ createdAt: last.createdAt, id: last.id })).toString('base64')
+    : null;
+
+  return NextResponse.json(
+    { items: page, nextCursor },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } }
+  );
 }

--- a/src/components/affiliate/history/AffiliateHistory.tsx
+++ b/src/components/affiliate/history/AffiliateHistory.tsx
@@ -7,23 +7,91 @@ import EmptyState from '@/components/ui/EmptyState';
 import SkeletonRow from '@/components/ui/SkeletonRow';
 import ErrorState from '@/components/ui/ErrorState';
 
-export default function AffiliateHistory() {
-  const { items, loading, error, loadMore, hasMore } = useAffiliateHistory();
-  const [selected, setSelected] = useState<Item | null>(null);
+  export default function AffiliateHistory() {
+    const [status, setStatus] = useState<string | undefined>();
+    const [currency, setCurrency] = useState<string | undefined>();
+    const [from, setFrom] = useState<string | undefined>();
+    const [to, setTo] = useState<string | undefined>();
 
-  if (error) return <ErrorState message="Erro ao carregar histórico." onRetry={() => location.reload()} />;
-  return (
-    <div>
-      {loading && (
-        <ul role="list" className="mb-2">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <li key={i} className="p-3 border rounded mb-2" role="listitem">
-              <SkeletonRow />
-            </li>
-          ))}
-        </ul>
-      )}
-      {!loading && items.length === 0 && <EmptyState text="Nenhum registro no período selecionado." />}
+    const { items, isLoading, error, loadMore, hasMore, setSize } = useAffiliateHistory({
+      status: status ? [status] : undefined,
+      currency,
+      from,
+      to,
+    });
+    const [selected, setSelected] = useState<Item | null>(null);
+
+    if (error) return <ErrorState message="Erro ao carregar histórico." onRetry={() => location.reload()} />;
+    const resetAnd = (cb: () => void) => {
+      setSize(1);
+      cb();
+      setSelected(null);
+    };
+    return (
+      <div>
+        <div className="mb-4 space-y-2">
+          <div className="flex flex-wrap gap-2">
+            {[
+              { label: 'Todos', value: undefined },
+              { label: 'Pendente', value: 'pending' },
+              { label: 'Disponível', value: 'available' },
+              { label: 'Pago', value: 'paid' },
+              { label: 'Cancelado', value: 'canceled' },
+              { label: 'Revertido', value: 'reversed' },
+            ].map(s => (
+              <button
+                key={s.label}
+                className={`px-3 py-1 rounded-full text-sm border ${
+                  status === s.value ? 'bg-blue-500 text-white' : 'bg-gray-100'
+                }`}
+                onClick={() =>
+                  resetAnd(() => setStatus(s.value as any))
+                }
+                aria-label={s.label}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <select
+              value={currency || 'all'}
+              onChange={e =>
+                resetAnd(() => setCurrency(e.target.value === 'all' ? undefined : e.target.value))
+              }
+              className="border rounded p-1 text-sm"
+              aria-label="Filtrar por moeda"
+            >
+              <option value="all">Todas as moedas</option>
+              <option value="BRL">BRL</option>
+              <option value="USD">USD</option>
+            </select>
+            <input
+              type="date"
+              value={from || ''}
+              onChange={e => resetAnd(() => setFrom(e.target.value || undefined))}
+              className="border rounded p-1 text-sm"
+              aria-label="Data inicial"
+            />
+            <input
+              type="date"
+              value={to || ''}
+              onChange={e => resetAnd(() => setTo(e.target.value || undefined))}
+              className="border rounded p-1 text-sm"
+              aria-label="Data final"
+            />
+          </div>
+        </div>
+        {isLoading && (
+          <ul role="list" className="mb-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <li key={i} className="p-3 border rounded mb-2" role="listitem">
+                <SkeletonRow />
+              </li>
+            ))}
+          </ul>
+        )}
+        {!isLoading && items.length === 0 && <EmptyState text="Nenhum registro no período selecionado." />}
       <ul role="list">
         {items.map(item => (
           <HistoryItem key={item.id} item={item} onSelect={setSelected} />

--- a/src/components/affiliate/history/HistoryDrawer.tsx
+++ b/src/components/affiliate/history/HistoryDrawer.tsx
@@ -15,10 +15,11 @@ export default function HistoryDrawer({ item, onClose }: Props) {
   useEffect(() => {
     if (item) ref.current?.focus();
   }, [item]);
-  if (!item) return null;
-  const amount = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: item.currency }).format(
-    item.amountCents / 100,
-  );
+    if (!item) return null;
+    const formatted = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: item.currency }).format(
+      item.amountCents / 100,
+    );
+    const sign = item.kind === 'redemption' && item.status === 'paid' ? '-' : '+';
   return (
     <div className="fixed inset-0 bg-black/30 flex justify-end" onClick={onClose}>
       <div
@@ -31,8 +32,8 @@ export default function HistoryDrawer({ item, onClose }: Props) {
       >
         <button className="mb-4" onClick={onClose} aria-label="Fechar">✕</button>
         <h2 className="text-lg font-bold mb-2">Detalhes</h2>
-        <div className="mb-2"><StatusBadge status={item.status} size="md" /></div>
-        <p className="mb-1">Valor: {amount} ({item.currency})</p>
+          <div className="mb-2"><StatusBadge status={item.status} size="md" /></div>
+          <p className="mb-1">Valor: {sign}{formatted} ({item.currency})</p>
         {item.availableAt && (
           <p className="mb-1">Libera em: {format(new Date(item.availableAt), 'dd/MM/yyyy')}</p>
         )}

--- a/src/components/affiliate/history/HistoryItem.tsx
+++ b/src/components/affiliate/history/HistoryItem.tsx
@@ -10,12 +10,14 @@ interface Props {
   onSelect: (item: Item) => void;
 }
 
-function formatAmount(item: Item) {
-  return new Intl.NumberFormat('pt-BR', {
-    style: 'currency',
-    currency: item.currency,
-  }).format(item.amountCents / 100);
-}
+  function formatAmount(item: Item) {
+    const amount = new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: item.currency,
+    }).format(item.amountCents / 100);
+    const sign = item.kind === 'redemption' && item.status === 'paid' ? '-' : '+';
+    return `${sign}${amount}`;
+  }
 
 export default function HistoryItem({ item, onSelect }: Props) {
   const pendingDays = item.status === 'pending' ? daysUntil(item.availableAt) : 0;
@@ -24,8 +26,8 @@ export default function HistoryItem({ item, onSelect }: Props) {
     <li
       className="flex justify-between items-center border rounded p-3 mb-2 cursor-pointer" role="listitem" onClick={() => onSelect(item)}
     >
-      <div className="flex flex-col">
-        <span className="font-semibold">{formatAmount(item)} ({item.currency})</span>
+        <div className="flex flex-col">
+          <span className="font-semibold">{formatAmount(item)}</span>
         <span className="text-xs text-gray-500">
           {format(new Date(item.createdAt), 'dd/MM/yyyy')}
           {liberaEm && <span className="ml-2 inline-block bg-gray-100 text-gray-600 px-1 rounded">{liberaEm}</span>}

--- a/src/copy/__tests__/__snapshots__/affiliateHistory.test.ts.snap
+++ b/src/copy/__tests__/__snapshots__/affiliateHistory.test.ts.snap
@@ -2,16 +2,13 @@
 
 exports[`affiliateHistory copy maps reason labels snapshot 1`] = `
 {
-  "adjustment_after_redeem": "Ajuste pós-resgate.",
-  "admin_manual_correction": "Correção manual pela equipe.",
-  "chargeback": "Estorno por contestação do pagamento.",
-  "coupon_100": "Pagamento com 100% de desconto não gera comissão.",
-  "currency_mismatch": "Moeda incompatível para saque.",
-  "duplicate_prevented": "Entrada duplicada ignorada.",
-  "refund_after_payout": "Reembolso após liberação (ajuste aplicado).",
-  "refund_within_hold": "Reembolso dentro do período de 7 dias.",
-  "self_referral_blocked": "Autoindicação não é elegível a comissão.",
-  "trial_no_commission": "Período de teste gratuito não gera comissão.",
+  "duplicates_blocked": "Pagamento duplicado — comissão ignorada.",
+  "payout_rejected": "Saque rejeitado — valor recreditado ao saldo.",
+  "race_condition": "Concorrência detectada — operação não concluída.",
+  "refund_after_release": "Reembolso após liberação — ajuste aplicado.",
+  "refund_within_hold": "Reembolso dentro do período de retenção — comissão cancelada.",
+  "self_referral_blocked": "Autoindicação não gera comissão.",
+  "transfer_reversed": "Transferência revertida pelo Stripe — valor recreditado.",
 }
 `;
 

--- a/src/copy/__tests__/affiliateHistory.test.ts
+++ b/src/copy/__tests__/affiliateHistory.test.ts
@@ -9,8 +9,8 @@ describe('affiliateHistory copy maps', () => {
     expect(REASON_LABEL).toMatchSnapshot();
   });
 
-  test('humanizeReason fallback', () => {
-    expect(humanizeReason('unknown')).toBe('Ajuste no registro.');
-    expect(humanizeReason()).toBe('Ajuste no registro.');
-  });
+    test('humanizeReason fallback', () => {
+      expect(humanizeReason('unknown')).toBe('Ajuste administrativo.');
+      expect(humanizeReason()).toBe('Ajuste administrativo.');
+    });
 });

--- a/src/copy/affiliateHistory.ts
+++ b/src/copy/affiliateHistory.ts
@@ -7,19 +7,16 @@ export const STATUS_LABEL: Record<string, string> = {
 };
 
 export const REASON_LABEL: Record<string, string> = {
-  refund_within_hold: 'Reembolso dentro do período de 7 dias.',
-  refund_after_payout: 'Reembolso após liberação (ajuste aplicado).',
-  chargeback: 'Estorno por contestação do pagamento.',
-  adjustment_after_redeem: 'Ajuste pós-resgate.',
-  self_referral_blocked: 'Autoindicação não é elegível a comissão.',
-  coupon_100: 'Pagamento com 100% de desconto não gera comissão.',
-  trial_no_commission: 'Período de teste gratuito não gera comissão.',
-  currency_mismatch: 'Moeda incompatível para saque.',
-  duplicate_prevented: 'Entrada duplicada ignorada.',
-  admin_manual_correction: 'Correção manual pela equipe.',
+  refund_within_hold: 'Reembolso dentro do período de retenção — comissão cancelada.',
+  refund_after_release: 'Reembolso após liberação — ajuste aplicado.',
+  self_referral_blocked: 'Autoindicação não gera comissão.',
+  duplicates_blocked: 'Pagamento duplicado — comissão ignorada.',
+  payout_rejected: 'Saque rejeitado — valor recreditado ao saldo.',
+  transfer_reversed: 'Transferência revertida pelo Stripe — valor recreditado.',
+  race_condition: 'Concorrência detectada — operação não concluída.',
 };
 
 export function humanizeReason(code?: string | null): string {
-  if (!code) return 'Ajuste no registro.';
-  return REASON_LABEL[code] ?? 'Ajuste no registro.';
+  if (!code) return 'Ajuste administrativo.';
+  return REASON_LABEL[code] ?? 'Ajuste administrativo.';
 }

--- a/src/hooks/__tests__/useAffiliateHistory.test.tsx
+++ b/src/hooks/__tests__/useAffiliateHistory.test.tsx
@@ -7,7 +7,16 @@ describe('useAffiliateHistory', () => {
       const u = new URL(url, 'http://localhost');
       const cursor = u.searchParams.get('cursor');
       const page: HistoryResponse = {
-        items: [{ id: cursor || 'first', currency: 'BRL', amountCents: 100, status: 'pending', createdAt: new Date().toISOString() }],
+        items: [
+          {
+            id: cursor ? 'second' : 'first',
+            kind: 'commission',
+            currency: 'BRL',
+            amountCents: 100,
+            status: 'pending',
+            createdAt: new Date().toISOString(),
+          },
+        ],
         nextCursor: cursor ? null : 'next',
       };
       return Promise.resolve({ ok: true, json: () => Promise.resolve(page) });
@@ -15,11 +24,12 @@ describe('useAffiliateHistory', () => {
   });
 
   test('builds query with filters', async () => {
-    const { result } = renderHook(() =>
-      useAffiliateHistory({ statuses: ['pending'], currencies: ['BRL'], limit: 1 })
-    );
+    const { result } = renderHook(() => useAffiliateHistory({ status: ['pending'], currency: 'BRL' }));
     await waitFor(() => expect(result.current.items).toHaveLength(1));
-    expect((global as any).fetch).toHaveBeenCalledWith('/api/affiliate/history?statuses=pending&currencies=BRL&limit=1');
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      '/api/affiliate/history?take=20&currency=BRL&status=pending',
+      { cache: 'no-store' }
+    );
   });
 
   test('loads more pages', async () => {


### PR DESCRIPTION
## Summary
- add affiliate history API combining commissions and redemptions with cursor pagination and filters
- expose SWR hook with filters
- implement history list with filters, drawer and sign handling
- map affiliate reason codes to human text

## Testing
- `npm test src/hooks/__tests__/useAffiliateHistory.test.tsx src/copy/__tests__/affiliateHistory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e05525dd8832e9947cf6c77d3d3be