### PR TITLE
feat: add cron endpoint for affiliate maturation

### DIFF
--- a/src/app/api/cron/mature-affiliate-commissions/route.ts
+++ b/src/app/api/cron/mature-affiliate-commissions/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import matureAffiliateCommissions from '@/cron/matureAffiliateCommissions';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Cron job endpoint to mature pending affiliate commissions.
+ * Requires `x-cron-secret` header matching `CRON_SECRET` env var.
+ */
+export async function POST(req: NextRequest) {
+  if (req.headers.get('x-cron-secret') !== process.env.CRON_SECRET) {
+    return new NextResponse('forbidden', { status: 403 });
+  }
+
+  const result = await matureAffiliateCommissions();
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add protected cron endpoint to mature affiliate commissions

## Testing
- `npm test` *(fails: Test Suites: 112 failed, 40 passed, 152 total)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c06ef00832eb7d932b49c158a79