### PR TITLE
feat: improve a11y and telemetry

### DIFF
--- a/src/app/components/ui/ToastA11yProvider.tsx
+++ b/src/app/components/ui/ToastA11yProvider.tsx
@@ -224,6 +224,7 @@ export function ToastA11yProvider({ children, maxVisible = 3 }: Props) {
     <ToastCtx.Provider value={value}>
       {/* Live region invisível */}
       <div
+        id="a11y-live-region"
         aria-live={srPoliteness}
         aria-atomic="true"
         aria-relevant="additions text"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,6 +56,11 @@
   display: block; /* Garante que o placeholder seja exibido */
 }
 
+:focus-visible {
+  outline: 2px solid hsl(220 90% 56%);
+  outline-offset: 2px;
+}
+
 /* Adicione aqui outros estilos globais realmente necessários */
 /* Exemplo: Estilos base para links, se não cobertos pelo Tailwind/Typography plugin */
 /*

--- a/src/app/landing/components/CallToAction.tsx
+++ b/src/app/landing/components/CallToAction.tsx
@@ -4,12 +4,11 @@ import { signIn } from 'next-auth/react';
 import { FaGoogle } from 'react-icons/fa';
 import ButtonPrimary from './ButtonPrimary';
 import Container from '../../components/Container';
+import { track } from '@/lib/track';
 
 export default function CallToAction() {
   const handleSignIn = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('event', 'sign_in_click');
-    }
+    track('sign_in_click');
     signIn('google', { callbackUrl: '/auth/complete-signup' });
   };
 
@@ -25,7 +24,7 @@ export default function CallToAction() {
           </p>
           <div className="mt-10">
             <ButtonPrimary onClick={handleSignIn}>
-              <FaGoogle /> Ativar meu estrategista agora ▸
+              <FaGoogle aria-hidden="true" /> Ativar meu estrategista agora ▸
             </ButtonPrimary>
           </div>
         </div>

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import ButtonPrimary from './ButtonPrimary';
 import Container from '../../components/Container';
+import { track } from '@/lib/track';
 
 interface LandingHeaderProps {
   showLoginButton?: boolean;
@@ -18,14 +19,8 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
 
-  const trackEvent = (eventName: string) => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('event', eventName);
-    }
-  };
-
   const handleSignIn = () => {
-    trackEvent('login_button_click');
+    track('login_button_click');
     signIn('google', { callbackUrl: '/auth/complete-signup' });
   };
 
@@ -72,7 +67,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
             {/* Mantido o botão principal de "Começar Agora" */}
             <ButtonPrimary
               href="/register"
-              onClick={() => trackEvent('cta_start_now_click')}
+              onClick={() => track('cta_start_now_click')}
               className="px-4 py-2 text-sm" // Ajustado para um tamanho menor
             >
               Começar Agora
@@ -87,7 +82,11 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
             aria-controls="mobile-menu"
             aria-expanded={isMenuOpen}
           >
-            {isMenuOpen ? <XMarkIcon className="w-6 h-6" /> : <Bars3Icon className="w-6 h-6" />}
+            {isMenuOpen ? (
+              <XMarkIcon className="w-6 h-6" aria-hidden="true" />
+            ) : (
+              <Bars3Icon className="w-6 h-6" aria-hidden="true" />
+            )}
           </button>
         </div>
         {isMenuOpen && (
@@ -107,7 +106,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
                   <Link
                     href="/login"
                     onClick={() => {
-                      trackEvent('login_link_click');
+                      track('login_link_click');
                       setIsMenuOpen(false);
                     }}
                     className="px-4 py-2 text-sm hover:bg-gray-100"
@@ -119,7 +118,7 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
                   <Link
                     href="/register"
                     onClick={() => {
-                      trackEvent('cta_start_now_click');
+                      track('cta_start_now_click');
                       setIsMenuOpen(false);
                     }}
                     className="px-4 py-2 text-sm font-bold text-brand-pink hover:bg-gray-100"

--- a/src/components/affiliate/AffiliateCard.tsx
+++ b/src/components/affiliate/AffiliateCard.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { v4 as uuidv4 } from 'uuid';
+import { track } from '@/lib/track';
 import {
   useAffiliateSummary,
   canRedeem,
@@ -45,12 +46,6 @@ export default function AffiliateCard() {
   const refresh = async () => { await Promise.all([refreshSummary(), refreshStatus()]); };
   const [redeemCur, setRedeemCur] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-
-  const track = (event: string, props?: Record<string, any>) => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('event', event, props);
-    }
-  };
 
   useEffect(() => {
     if (summary?.byCurrency) {

--- a/src/components/affiliate/RedeemModal.tsx
+++ b/src/components/affiliate/RedeemModal.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+import { useEscapeToClose, useFocusTrap, useReturnFocus } from '@/lib/a11y';
+
 interface Props {
   open: boolean;
   currency: string;
@@ -28,14 +31,38 @@ export default function RedeemModal({
   reason,
   onOpenCurrencyHelp,
 }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { remember, restore } = useReturnFocus();
+  useEscapeToClose(() => open && onClose());
+  useFocusTrap(ref);
+
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    if (open) {
+      remember();
+      ref.current?.querySelector<HTMLElement>('[data-autofocus]')?.focus();
+    } else {
+      restore();
+    }
+  }, [open, remember, restore]);
+
   if (!open) return null;
   const amount = fmt(amountCents, currency);
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" role="dialog" aria-modal="true">
-      <div className="bg-white rounded p-4 w-80 space-y-3">
-        <h4 className="font-medium text-sm">Resgatar {amount}</h4>
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/40" aria-hidden="true" onClick={onClose} />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="redeem-title"
+        className="relative w-full max-w-sm rounded-2xl bg-white p-4 shadow-lg focus:outline-none"
+      >
+        <h2 id="redeem-title" className="text-lg font-semibold" tabIndex={-1} data-autofocus>
+          Resgatar {amount}
+        </h2>
         {reason ? (
-          <p className="text-xs text-gray-600">
+          <p className="mt-2 text-xs text-gray-600">
             {reason}
             {onOpenCurrencyHelp && (
               <button onClick={onOpenCurrencyHelp} className="ml-1 underline">
@@ -44,19 +71,22 @@ export default function RedeemModal({
             )}
           </p>
         ) : (
-          <p className="text-xs text-gray-600">
+          <p className="mt-2 text-xs text-gray-600">
             Você vai transferir todo o saldo disponível em {currency.toUpperCase()} para sua conta Stripe Connect.
           </p>
         )}
-        <div className="flex gap-2 justify-end pt-2">
-          <button onClick={onClose} className="px-3 py-1 text-sm">
+        <div className="mt-4 flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="inline-flex items-center justify-center h-11 min-w-[44px] px-3 text-sm"
+          >
             Cancelar
           </button>
           {!reason && (
             <button
               disabled={loading}
               onClick={onConfirm}
-              className="px-3 py-1 rounded bg-brand-pink text-white text-sm disabled:opacity-50"
+              className="inline-flex items-center justify-center h-11 min-w-[44px] px-3 rounded bg-brand-pink text-white text-sm disabled:opacity-50"
             >
               {loading ? 'Enviando...' : 'Confirmar'}
             </button>

--- a/src/components/affiliate/history/AffiliateHistory.tsx
+++ b/src/components/affiliate/history/AffiliateHistory.tsx
@@ -6,99 +6,148 @@ import HistoryDrawer from './HistoryDrawer';
 import EmptyState from '@/components/ui/EmptyState';
 import SkeletonRow from '@/components/ui/SkeletonRow';
 import ErrorState from '@/components/ui/ErrorState';
+import { track } from '@/lib/track';
+import { useSession } from 'next-auth/react';
 
-  export default function AffiliateHistory() {
-    const [status, setStatus] = useState<string | undefined>();
-    const [currency, setCurrency] = useState<string | undefined>();
-    const [from, setFrom] = useState<string | undefined>();
-    const [to, setTo] = useState<string | undefined>();
+export default function AffiliateHistory() {
+  const { data: session } = useSession();
+  const userId = (session?.user as any)?.id;
+  const [status, setStatus] = useState<string | undefined>();
+  const [currency, setCurrency] = useState<string | undefined>();
+  const [from, setFrom] = useState<string | undefined>();
+  const [to, setTo] = useState<string | undefined>();
 
-    const { items, isLoading, error, loadMore, hasMore, setSize } = useAffiliateHistory({
-      status: status ? [status] : undefined,
-      currency,
-      from,
-      to,
+  const { items, isLoading, error, loadMore, hasMore, setSize } = useAffiliateHistory({
+    status: status ? [status] : undefined,
+    currency,
+    from,
+    to,
+  });
+  const [selected, setSelected] = useState<Item | null>(null);
+
+  if (error) return <ErrorState message="Erro ao carregar histórico." onRetry={() => location.reload()} />;
+  const resetAnd = (cb: () => void) => {
+    setSize(1);
+    cb();
+    setSelected(null);
+  };
+  const handleFilter = (next: { status?: string; currency?: string; from?: string; to?: string }) => {
+    track('affiliate_history_filter_change', {
+      userId,
+      status: next.status ?? status,
+      currency: next.currency ?? currency,
+      from: next.from ?? from,
+      to: next.to ?? to,
     });
-    const [selected, setSelected] = useState<Item | null>(null);
-
-    if (error) return <ErrorState message="Erro ao carregar histórico." onRetry={() => location.reload()} />;
-    const resetAnd = (cb: () => void) => {
-      setSize(1);
-      cb();
-      setSelected(null);
-    };
-    return (
-      <div>
-        <div className="mb-4 space-y-2">
-          <div className="flex flex-wrap gap-2">
-            {[
-              { label: 'Todos', value: undefined },
-              { label: 'Pendente', value: 'pending' },
-              { label: 'Disponível', value: 'available' },
-              { label: 'Pago', value: 'paid' },
-              { label: 'Cancelado', value: 'canceled' },
-              { label: 'Revertido', value: 'reversed' },
-            ].map(s => (
-              <button
-                key={s.label}
-                className={`px-3 py-1 rounded-full text-sm border ${
-                  status === s.value ? 'bg-blue-500 text-white' : 'bg-gray-100'
-                }`}
-                onClick={() =>
-                  resetAnd(() => setStatus(s.value as any))
-                }
-                aria-label={s.label}
-              >
-                {s.label}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            <select
-              value={currency || 'all'}
-              onChange={e =>
-                resetAnd(() => setCurrency(e.target.value === 'all' ? undefined : e.target.value))
+  };
+  const handleLoadMore = () => {
+    track('affiliate_history_load_more', { userId, status, currency, from, to });
+    loadMore();
+  };
+  const handleSelect = (it: Item) => {
+    track('affiliate_history_view_item', {
+      userId,
+      currency: it.currency,
+      amountCents: it.amountCents,
+      code: it.reasonCode,
+    });
+    setSelected(it);
+  };
+  return (
+    <div>
+      <div className="mb-4 space-y-2">
+        <div className="flex flex-wrap gap-2">
+          {[
+            { label: 'Todos', value: undefined },
+            { label: 'Pendente', value: 'pending' },
+            { label: 'Disponível', value: 'available' },
+            { label: 'Pago', value: 'paid' },
+            { label: 'Cancelado', value: 'canceled' },
+            { label: 'Revertido', value: 'reversed' },
+          ].map(s => (
+            <button
+              key={s.label}
+              className={`inline-flex items-center justify-center h-11 min-w-[44px] px-3 rounded-full text-sm border ${
+                status === s.value ? 'bg-blue-500 text-white' : 'bg-gray-100'
+              }`}
+              onClick={() =>
+                resetAnd(() => {
+                  setStatus(s.value as any);
+                  handleFilter({ status: s.value as any });
+                })
               }
-              className="border rounded p-1 text-sm"
-              aria-label="Filtrar por moeda"
+              aria-label={s.label}
             >
-              <option value="all">Todas as moedas</option>
-              <option value="BRL">BRL</option>
-              <option value="USD">USD</option>
-            </select>
-            <input
-              type="date"
-              value={from || ''}
-              onChange={e => resetAnd(() => setFrom(e.target.value || undefined))}
-              className="border rounded p-1 text-sm"
-              aria-label="Data inicial"
-            />
-            <input
-              type="date"
-              value={to || ''}
-              onChange={e => resetAnd(() => setTo(e.target.value || undefined))}
-              className="border rounded p-1 text-sm"
-              aria-label="Data final"
-            />
-          </div>
+              {s.label}
+            </button>
+          ))}
         </div>
-        {isLoading && (
-          <ul role="list" className="mb-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li key={i} className="p-3 border rounded mb-2" role="listitem">
-                <SkeletonRow />
-              </li>
-            ))}
-          </ul>
-        )}
-        {!isLoading && items.length === 0 && <EmptyState text="Nenhum registro no período selecionado." />}
+        <div className="flex items-center gap-2">
+          <select
+            value={currency || 'all'}
+            onChange={e =>
+              resetAnd(() => {
+                const value = e.target.value === 'all' ? undefined : e.target.value;
+                setCurrency(value);
+                handleFilter({ currency: value });
+              })
+            }
+            className="border rounded p-1 text-sm h-11"
+            aria-label="Filtrar por moeda"
+          >
+            <option value="all">Todas as moedas</option>
+            <option value="BRL">BRL</option>
+            <option value="USD">USD</option>
+          </select>
+          <input
+            type="date"
+            value={from || ''}
+            onChange={e =>
+              resetAnd(() => {
+                const v = e.target.value || undefined;
+                setFrom(v);
+                handleFilter({ from: v });
+              })
+            }
+            className="border rounded p-1 text-sm h-11"
+            aria-label="Data inicial"
+          />
+          <input
+            type="date"
+            value={to || ''}
+            onChange={e =>
+              resetAnd(() => {
+                const v = e.target.value || undefined;
+                setTo(v);
+                handleFilter({ to: v });
+              })
+            }
+            className="border rounded p-1 text-sm h-11"
+            aria-label="Data final"
+          />
+        </div>
+      </div>
+      {isLoading && (
+        <ul role="list" className="mb-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li key={i} className="p-3 border rounded mb-2" role="listitem">
+              <SkeletonRow />
+            </li>
+          ))}
+        </ul>
+      )}
+      {!isLoading && items.length === 0 && <EmptyState text="Nenhum registro no período selecionado." />}
       <ul role="list">
         {items.map(item => (
-          <HistoryItem key={item.id} item={item} onSelect={setSelected} />
+          <HistoryItem key={item.id} item={item} onSelect={handleSelect} />
         ))}
       </ul>
       {hasMore && (
-        <button className="mt-2 w-full border rounded p-2" onClick={loadMore} aria-label="Carregar mais">
+        <button
+          className="mt-2 w-full border rounded p-2 h-11"
+          onClick={handleLoadMore}
+          aria-label="Carregar mais"
+        >
           Carregar mais
         </button>
       )}

--- a/src/components/affiliate/history/HistoryDrawer.tsx
+++ b/src/components/affiliate/history/HistoryDrawer.tsx
@@ -4,6 +4,7 @@ import { HistoryItem } from '@/hooks/useAffiliateHistory';
 import StatusBadge from './StatusBadge';
 import { humanizeReason } from '@/copy/affiliateHistory';
 import { format } from 'date-fns';
+import { useEscapeToClose, useFocusTrap, useReturnFocus } from '@/lib/a11y';
 
 interface Props {
   item: HistoryItem | null;
@@ -12,28 +13,50 @@ interface Props {
 
 export default function HistoryDrawer({ item, onClose }: Props) {
   const ref = useRef<HTMLDivElement>(null);
+  const { remember, restore } = useReturnFocus();
+  const open = !!item;
+  useEscapeToClose(() => open && onClose());
+  useFocusTrap(ref);
+
   useEffect(() => {
-    if (item) ref.current?.focus();
-  }, [item]);
-    if (!item) return null;
-    const formatted = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: item.currency }).format(
-      item.amountCents / 100,
-    );
-    const sign = item.kind === 'redemption' && item.status === 'paid' ? '-' : '+';
+    if (open) {
+      remember();
+      ref.current?.querySelector<HTMLElement>('[data-autofocus]')?.focus();
+    } else {
+      restore();
+    }
+  }, [open, remember, restore]);
+
+  if (!item) return null;
+  const formatted = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: item.currency }).format(
+    item.amountCents / 100,
+  );
+  const sign = item.kind === 'redemption' && item.status === 'paid' ? '-' : '+';
   return (
-    <div className="fixed inset-0 bg-black/30 flex justify-end" onClick={onClose}>
+    <div className="fixed inset-0 z-50">
+      <div className="fixed inset-0 bg-black/30" aria-hidden="true" onClick={onClose} />
       <div
         ref={ref}
         role="dialog"
         aria-modal="true"
+        aria-labelledby="history-title"
         tabIndex={-1}
-        className="w-80 bg-white dark:bg-gray-800 h-full p-4 overflow-y-auto"
-        onClick={e => e.stopPropagation()}
+        className="fixed inset-0 sm:inset-y-0 sm:right-0 sm:w-[380px] w-full bg-white dark:bg-gray-800 h-full p-4 overflow-y-auto focus:outline-none"
       >
-        <button className="mb-4" onClick={onClose} aria-label="Fechar">✕</button>
-        <h2 className="text-lg font-bold mb-2">Detalhes</h2>
-          <div className="mb-2"><StatusBadge status={item.status} size="md" /></div>
-          <p className="mb-1">Valor: {sign}{formatted} ({item.currency})</p>
+        <button
+          className="mb-4 inline-flex items-center justify-center h-11 min-w-[44px] px-3"
+          onClick={onClose}
+          aria-label="Fechar"
+        >
+          ✕
+        </button>
+        <h2 id="history-title" className="text-lg font-bold mb-2" data-autofocus>
+          Detalhes
+        </h2>
+        <div className="mb-2">
+          <StatusBadge status={item.status} size="md" />
+        </div>
+        <p className="mb-1">Valor: {sign}{formatted} ({item.currency})</p>
         {item.availableAt && (
           <p className="mb-1">Libera em: {format(new Date(item.availableAt), 'dd/MM/yyyy')}</p>
         )}

--- a/src/components/affiliate/history/HistoryItem.tsx
+++ b/src/components/affiliate/history/HistoryItem.tsx
@@ -35,7 +35,7 @@ export default function HistoryItem({ item, onSelect }: Props) {
       </div>
       <div className="flex items-center space-x-2">
         <StatusBadge status={item.status} />
-        <InformationCircleIcon className="w-5 h-5 text-gray-500" />
+        <InformationCircleIcon className="w-5 h-5 text-gray-500" aria-hidden="true" />
       </div>
     </li>
   );

--- a/src/components/affiliate/history/StatusBadge.tsx
+++ b/src/components/affiliate/history/StatusBadge.tsx
@@ -34,7 +34,7 @@ export default function StatusBadge({ status, size = 'sm' }: StatusBadgeProps) {
       className={`inline-flex items-center rounded-full font-medium ${padding} ${textSize} ${color}`}
       aria-label={`Status: ${label}`}
     >
-      <Icon className={`${iconSize} mr-1`} />
+      <Icon className={`${iconSize} mr-1`} aria-hidden="true" />
       {label}
     </span>
   );

--- a/src/components/payments/CurrencyMismatchModal.tsx
+++ b/src/components/payments/CurrencyMismatchModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { CURRENCY_HELP } from '@/copy/stripe';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useEscapeToClose, useFocusTrap, useReturnFocus } from '@/lib/a11y';
 
 interface Props {
   open: boolean;
@@ -19,6 +20,21 @@ export default function CurrencyMismatchModal({
   onOnboard,
 }: Props) {
   const [loading, setLoading] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { remember, restore } = useReturnFocus();
+  useEscapeToClose(() => open && onClose());
+  useFocusTrap(ref);
+
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    if (open) {
+      remember();
+      ref.current?.querySelector<HTMLElement>('[data-autofocus]')?.focus();
+    } else {
+      restore();
+    }
+  }, [open, remember, restore]);
+
   if (!open) return null;
 
   const handleOnboard = async () => {
@@ -35,13 +51,20 @@ export default function CurrencyMismatchModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div className="bg-white rounded p-4 w-80 space-y-3">
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/40" aria-hidden="true" onClick={onClose} />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mismatch-title"
+        className="relative w-full max-w-sm rounded-2xl bg-white p-4 shadow-lg space-y-3 focus:outline-none"
+      >
         <div className="flex justify-between items-center">
-          <h4 className="font-medium text-sm">
+          <h2 id="mismatch-title" className="font-medium text-sm" tabIndex={-1} data-autofocus>
             {`Não consigo sacar ${balanceCurrency.toUpperCase()}`}
-          </h4>
-          <button onClick={onClose} aria-label="Fechar" className="text-sm">
+          </h2>
+          <button onClick={onClose} aria-label="Fechar" className="inline-flex items-center justify-center h-11 min-w-[44px] px-3 text-sm">
             ×
           </button>
         </div>

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+
+export function useEscapeToClose(onClose?: () => void) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose?.() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+}
+
+export function useReturnFocus<T extends HTMLElement>() {
+  const lastFocused = useRef<HTMLElement | null>(null)
+  function remember() { lastFocused.current = document.activeElement as HTMLElement }
+  function restore() { lastFocused.current?.focus?.() }
+  return { remember, restore }
+}
+
+/** Focus trap simples: move tab do fim para o início e vice-versa */
+export function useFocusTrap(containerRef: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const focusables = () => Array.from(el.querySelectorAll<HTMLElement>(
+      'a,button,input,select,textarea,[tabindex]:not([tabindex="-1"])'
+    )).filter(x => !x.hasAttribute('disabled') && !x.getAttribute('aria-hidden'))
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return
+      const nodes = focusables(); if (!nodes.length) return
+      const first = nodes[0], last = nodes[nodes.length - 1]
+      if (e.shiftKey && document.activeElement === first) { last.focus(); e.preventDefault() }
+      else if (!e.shiftKey && document.activeElement === last) { first.focus(); e.preventDefault() }
+    }
+    el.addEventListener('keydown', onKey as any)
+    return () => el.removeEventListener('keydown', onKey as any)
+  }, [containerRef])
+}

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,0 +1,12 @@
+type Props = Record<string, any>
+export function track(name: string, props?: Props) {
+  try {
+    if (typeof window !== 'undefined' && (window as any).gtag) {
+      (window as any).gtag('event', name, props || {})
+    } else {
+      if (process.env.NODE_ENV !== 'production') console.debug('[track]', name, props || {})
+    }
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable a11y hooks and tracking util
- make modals and drawer accessible and mobile friendly
- track affiliate history interactions and replace direct gtag usage

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_689e0f204b60832e8cfc58d1c14658d9