### PR TITLE
P0 – UX assinatura: return_url com polling + 422 para código inválido

### DIFF
--- a/src/components/billing/PaymentStep.tsx
+++ b/src/components/billing/PaymentStep.tsx
@@ -16,9 +16,12 @@ function InnerPayment({ clientSecret, onClose }: { clientSecret: string; onClose
   async function handleConfirm() {
     if (!stripe || !elements) return;
     setLoading(true); setError(null);
+    // sempre voltar para a página com polling
+    const returnUrl = `${window.location.origin}/dashboard/billing/success`;
+
     const { error } = await stripe.confirmPayment({
       elements,
-      confirmParams: { return_url: window.location.origin + '/billing/success' }
+      confirmParams: { return_url: returnUrl },
     });
     if (error) setError(error.message || 'Não foi possível confirmar o pagamento.');
     setLoading(false);


### PR DESCRIPTION
## Summary
- always redirect payment confirmation to `/dashboard/billing/success` to enable status polling
- show input error when `/api/billing/subscribe` returns 422 for invalid codes
- backend prioritizes affiliate codes over manual coupons and responds 422 for invalid code; avoids sending empty discounts

## Testing
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization, invariant expected app router to be mounted, setImmediate is not defined, etc.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689e5b94a9f0832eb6c520ac337736ad