### PR TITLE
P0 – Maturação de comissão (HOLD → AVAILABLE) + cron interno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ STRIPE_CONNECT_RETURN_URL=https://example.com/affiliate/connect/return
 STRIPE_CONNECT_REFRESH_URL=https://example.com/affiliate/connect/refresh
 AFFILIATE_COMMISSION_PERCENT=10
 AFFILIATE_ATTRIBUTION_WINDOW_DAYS=90
+INTERNAL_CRON_SECRET=changeme
 
 # Minimum redeem amounts per currency (in cents)
 REDEEM_MIN_BRL=1000

--- a/src/app/api/internal/affiliate/mature/route.ts
+++ b/src/app/api/internal/affiliate/mature/route.ts
@@ -1,30 +1,112 @@
-import { User } from "@/server/db/models/User";
-import { adjustBalance } from "@/server/affiliate/balance";
+import os from 'node:os';
+import { connectMongo } from '@/server/db/connect';
+import { User } from '@/server/db/models/User';
+import { adjustBalance } from '@/server/affiliate/balance';
+import { CronLock } from '@/server/db/models/CronLock';
 
-export async function POST(req: Request) {
-  const token = req.headers.get("x-internal-secret");
-  if (token !== process.env.INTERNAL_CRON_SECRET) {
-    return new Response("Unauthorized", { status: 401 });
+export const runtime = 'nodejs';
+
+async function safeJson(req: Request) {
+  try {
+    return await req.json();
+  } catch {
+    return {};
   }
+}
+
+async function acquireLock(name = 'affiliate-mature', ttlSec = 240) {
+  const now = new Date();
+  const expires = new Date(now.getTime() + ttlSec * 1000);
+  const owner = os.hostname();
+
+  const res = await CronLock.findOneAndUpdate(
+    {
+      _id: name,
+      $or: [{ expiresAt: { $lte: now } }, { lockedAt: null }],
+    },
+    { $set: { lockedAt: now, expiresAt: expires, owner } },
+    { upsert: true, new: true }
+  );
+
+  const has =
+    !!res && res.owner === owner && res.expiresAt && res.expiresAt.getTime() === expires.getTime();
+  return { has, owner };
+}
+
+/**
+ * POST /api/internal/affiliate/mature
+ * Headers:
+ *   x-internal-secret: <INTERNAL_CRON_SECRET>
+ * Body (opcional JSON):
+ *   {
+ *     "limit": number, // default 100 usuários por execução
+ *     "maxItemsPerUser": number, // default 20 items por user
+ *     "dryRun": boolean // se true, NÃO persiste
+ *   }
+ */
+export async function POST(req: Request) {
+  const token = req.headers.get('x-internal-secret');
+  if (token !== process.env.INTERNAL_CRON_SECRET) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  await connectMongo();
+
+  const { has } = await acquireLock('affiliate-mature', 240);
+  if (!has) return new Response(JSON.stringify({ ok: false, reason: 'locked' }), { status: 409 });
+
+  const { limit = 100, maxItemsPerUser = 20, dryRun = false } = await safeJson(req);
 
   const now = new Date();
-  const batch = await User.find({
-    commissionLog: { $elemMatch: { status: "pending", availableAt: { $lte: now } } }
-  }).limit(100);
+  const users = await User.find({
+    commissionLog: {
+      $elemMatch: { type: 'commission', status: 'pending', availableAt: { $lte: now } },
+    },
+  })
+    .select({ commissionLog: 1, affiliateBalances: 1 })
+    .limit(Math.max(1, Math.min(500, Number(limit))))
+    .lean(false);
 
-  let matured = 0;
-  for (const u of batch) {
-    let dirty = false;
-    for (const e of (u as any).commissionLog) {
-      if (e.type === "commission" && e.status === "pending" && e.availableAt && e.availableAt <= now) {
-        await adjustBalance(u, e.currency, e.amountCents);
-        e.status = "available";
-        e.maturedAt = new Date();
-        dirty = true; matured++;
+  let maturedUsers = 0;
+  let maturedEntries = 0;
+
+  for (const u of users) {
+    let changed = false;
+    let countThisUser = 0;
+
+    for (const e of u.commissionLog ?? []) {
+      if (countThisUser >= maxItemsPerUser) break;
+
+      if (
+        e?.type === 'commission' &&
+        e.status === 'pending' &&
+        e.availableAt &&
+        e.availableAt <= now &&
+        typeof e.amountCents === 'number' &&
+        e.amountCents > 0
+      ) {
+        if (!dryRun) {
+          await adjustBalance(u as any, e.currency, e.amountCents);
+          e.status = 'available';
+          e.maturedAt = new Date();
+        }
+        changed = true;
+        maturedEntries++;
+        countThisUser++;
       }
     }
-    if (dirty) await u.save();
+
+    if (changed && !dryRun) {
+      await u.save();
+      maturedUsers++;
+    }
   }
 
-  return Response.json({ matured, processedUsers: batch.length });
+  return Response.json({
+    ok: true,
+    dryRun,
+    processedUsers: users.length,
+    maturedUsers,
+    maturedEntries,
+  });
 }

--- a/src/server/affiliate/balance.ts
+++ b/src/server/affiliate/balance.ts
@@ -1,7 +1,27 @@
-export function adjustBalance(user: any, currency: string, deltaCents: number) {
-  const cur = String(currency || '').toLowerCase();
-  user.affiliateBalances ||= new Map();
-  const prev = user.affiliateBalances.get(cur) ?? 0;
-  user.affiliateBalances.set(cur, prev + deltaCents);
+import type { HydratedDocument } from 'mongoose';
+
+function normCurrency(cur: string) {
+  return String(cur || 'brl').toLowerCase();
+}
+
+/** Incrementa/decrementa saldo do afiliado, em CENTAVOS (pode ser negativo). */
+export async function adjustBalance(
+  user: HydratedDocument<any>,
+  currency: string,
+  deltaCents: number
+) {
+  const cur = normCurrency(currency);
+  const map = (user as any).affiliateBalances || new Map<string, number>();
+  const current = typeof map.get === 'function' ? map.get(cur) ?? 0 : Number((map as any)[cur] || 0);
+  const next = current + Math.trunc(deltaCents);
+
+  let newMap: Map<string, number>;
+  if (map instanceof Map) {
+    newMap = map;
+  } else {
+    newMap = new Map(Object.entries(map || {}));
+  }
+  newMap.set(cur, next < 0 ? 0 : next);
+  (user as any).affiliateBalances = newMap;
   if (typeof user.markModified === 'function') user.markModified('affiliateBalances');
 }

--- a/src/server/db/connect.ts
+++ b/src/server/db/connect.ts
@@ -1,0 +1,5 @@
+import { connectToDatabase } from '@/app/lib/mongoose';
+
+export async function connectMongo() {
+  return connectToDatabase();
+}

--- a/src/server/db/models/CronLock.ts
+++ b/src/server/db/models/CronLock.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models } from 'mongoose';
+
+const CronLockSchema = new Schema(
+  {
+    _id: { type: String, required: true },
+    lockedAt: { type: Date, default: null },
+    owner: { type: String, default: null },
+    expiresAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+export const CronLock = models.CronLock || model('CronLock', CronLockSchema);

--- a/tests/affiliateMatureEndpoint.test.ts
+++ b/tests/affiliateMatureEndpoint.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment node */
+import { POST } from '@/app/api/internal/affiliate/mature/route';
+
+jest.mock('@/server/db/connect', () => ({ connectMongo: jest.fn() }));
+jest.mock('@/server/db/models/User', () => ({ User: { find: jest.fn() } }));
+jest.mock('@/server/db/models/CronLock', () => ({ CronLock: { findOneAndUpdate: jest.fn() } }));
+
+const { User } = require('@/server/db/models/User');
+const { CronLock } = require('@/server/db/models/CronLock');
+
+function mockRequest(body: any = {}, headers: Record<string, string> = {}) {
+  return new Request('http://localhost/api/internal/affiliate/mature', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/internal/affiliate/mature', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.INTERNAL_CRON_SECRET = 's3cr3t';
+    (CronLock.findOneAndUpdate as jest.Mock).mockImplementation((_f: any, update: any) => ({
+      owner: update.$set.owner,
+      expiresAt: update.$set.expiresAt,
+    }));
+  });
+
+  it('rejects unauthorized', async () => {
+    const res = await POST(mockRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('matures entries respecting limits', async () => {
+    const user = {
+      commissionLog: [
+        { type: 'commission', status: 'pending', availableAt: new Date(Date.now() - 1000), currency: 'brl', amountCents: 100 },
+        { type: 'commission', status: 'pending', availableAt: new Date(Date.now() - 1000), currency: 'brl', amountCents: 200 },
+      ],
+      affiliateBalances: new Map<string, number>(),
+      save: jest.fn(),
+    };
+    const chain = {
+      select: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([user]),
+    };
+    (User.find as jest.Mock).mockReturnValue(chain);
+
+    const res = await POST(
+      mockRequest({ limit: 10, maxItemsPerUser: 1 }, { 'x-internal-secret': 's3cr3t' })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.maturedEntries).toBe(1);
+    expect(body.maturedUsers).toBe(1);
+    expect(user.commissionLog[0].status).toBe('available');
+    expect(user.commissionLog[1].status).toBe('pending');
+    expect(user.affiliateBalances.get('brl')).toBe(100);
+    expect(user.save).toHaveBeenCalled();
+  });
+
+  it('supports dry run without persisting', async () => {
+    const user = {
+      commissionLog: [
+        { type: 'commission', status: 'pending', availableAt: new Date(Date.now() - 1000), currency: 'brl', amountCents: 100 },
+      ],
+      affiliateBalances: new Map<string, number>(),
+      save: jest.fn(),
+    };
+    const chain = {
+      select: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([user]),
+    };
+    (User.find as jest.Mock).mockReturnValue(chain);
+
+    const res = await POST(
+      mockRequest({ dryRun: true }, { 'x-internal-secret': 's3cr3t' })
+    );
+    const body = await res.json();
+    expect(body.dryRun).toBe(true);
+    expect(body.maturedEntries).toBe(1);
+    expect(body.maturedUsers).toBe(0);
+    expect(user.save).not.toHaveBeenCalled();
+    expect(user.commissionLog[0].status).toBe('pending');
+    expect(user.affiliateBalances.get('brl')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Resumo
- adiciona endpoint protegido POST /api/internal/affiliate/mature com batch, dry-run e limites
- implementa helper de saldo adjustBalance centralizado
- inclui lock distribuído via CronLock e variáveis de ambiente correspondentes

## Testes
- `npm test` *(falhou: Test Suites: 112 failed, 41 passed, 153 total)*

------
https://chatgpt.com/codex/tasks/task_e_689e64dc752c832e85c7d65b7249bff2