### PR TITLE
feat: refresh inactive plan status from DB

### DIFF
--- a/src/app/api/whatsapp/planGuard.test.ts
+++ b/src/app/api/whatsapp/planGuard.test.ts
@@ -1,18 +1,29 @@
-import { NextRequest } from 'next/server';
 import { middleware } from '../../../middleware';
 import { getToken } from 'next-auth/jwt';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import DbUser from '@/app/models/User';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ __esModule: true, default: { findById: jest.fn() } }));
 
 const mockGetToken = getToken as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindById = (DbUser as any).findById as jest.Mock;
 
 function makeRequest(path: string) {
-  return new NextRequest(`http://localhost${path}`);
+  return { nextUrl: { pathname: path } } as any;
 }
 
 describe('plan guard for whatsapp routes', () => {
   beforeEach(() => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+    mockConnect.mockResolvedValue(null);
+    mockFindById.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ planStatus: 'inactive' }),
+      }),
+    });
   });
 
   it.each([
@@ -23,6 +34,16 @@ describe('plan guard for whatsapp routes', () => {
   ])('blocks inactive plan for %s', async (path) => {
     const res = await middleware(makeRequest(path));
     expect(res.status).toBe(403);
+  });
+
+  it('allows when DB has active plan', async () => {
+    mockFindById.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ planStatus: 'active' }),
+      }),
+    });
+    const res = await middleware(makeRequest('/api/whatsapp/generateCode'));
+    expect(res.status).toBe(200);
   });
 });
 

--- a/src/app/lib/planGuard.test.ts
+++ b/src/app/lib/planGuard.test.ts
@@ -1,22 +1,29 @@
-import { NextRequest } from 'next/server';
 import {
   guardPremiumRequest,
   getPlanGuardMetrics,
   resetPlanGuardMetrics,
 } from '@/app/lib/planGuard';
 import { getToken } from 'next-auth/jwt';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import DbUser from '@/app/models/User';
+
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ __esModule: true, default: { findById: jest.fn() } }));
 
 const mockGetToken = getToken as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindById = (DbUser as any).findById as jest.Mock;
 
 function createRequest(path: string) {
-  return new NextRequest(`http://localhost${path}`);
+  return { nextUrl: { pathname: path } } as any;
 }
 
 describe('guardPremiumRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetPlanGuardMetrics();
+    mockConnect.mockResolvedValue(null);
   });
 
   it('allows when plan is active', async () => {
@@ -33,12 +40,28 @@ describe('guardPremiumRequest', () => {
 
   it('blocks when plan is not active', async () => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+    mockFindById.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ planStatus: 'inactive' }),
+      }),
+    });
     const req = createRequest('/api/ai/chat');
     const res = await guardPremiumRequest(req);
     expect(res?.status).toBe(403);
     const metrics = getPlanGuardMetrics();
     expect(metrics.blocked).toBe(1);
     expect(metrics.byRoute['/api/ai/chat']).toBe(1);
+  });
+
+  it('allows if DB shows active plan despite inactive token', async () => {
+    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+    mockFindById.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ planStatus: 'active' }),
+      }),
+    });
+    const res = await guardPremiumRequest(createRequest('/api/ai/chat'));
+    expect(res).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- check database when token shows inactive plan
- add coverage around plan guard behavior

## Testing
- `npm test src/app/lib/planGuard.test.ts src/app/api/whatsapp/planGuard.test.ts` *(fails: ReferenceError: Response is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad2d5f7c832eb143d50cb26dfc5a