### PR TITLE
Ocultar próxima cobrança quando cancelamento programado

### DIFF
--- a/src/components/billing/SubscriptionCard.tsx
+++ b/src/components/billing/SubscriptionCard.tsx
@@ -86,9 +86,11 @@ export default function SubscriptionCard() {
         <ReactivateBanner onClick={reactivate} disabled={reactivating}/>
       )}
       <div className="mb-2 text-sm text-gray-700">Status: {subscription.status}</div>
-      <div className="mb-2 text-sm text-gray-700">
-        Próxima cobrança: {amount} em {nextDate}
-      </div>
+      {!subscription.cancelAtPeriodEnd && (
+        <div className="mb-2 text-sm text-gray-700">
+          Próxima cobrança: {amount} em {nextDate}
+        </div>
+      )}
       <div className="mb-4 text-sm text-gray-700">
         Método de pagamento: {subscription.defaultPaymentMethodBrand ?? ''} {card}
       </div>

--- a/tests/subscription-card.test.tsx
+++ b/tests/subscription-card.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SubscriptionCard from '@/components/billing/SubscriptionCard';
+
+const mockUseSubscription = jest.fn();
+jest.mock('@/hooks/billing/useSubscription', () => ({
+  useSubscription: () => mockUseSubscription(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ update: jest.fn() }),
+}));
+
+jest.mock('@/components/billing/CancelSubscriptionModal', () => () => <div />);
+jest.mock('@/components/billing/ReactivateBanner', () => () => <div />);
+
+describe('SubscriptionCard', () => {
+  const baseSubscription = {
+    planName: 'Pro',
+    cancelAtPeriodEnd: false,
+    nextInvoiceDate: new Date().toISOString(),
+    nextInvoiceAmountCents: 5000,
+    currency: 'BRL',
+    paymentMethodLast4: '1234',
+    defaultPaymentMethodBrand: 'Visa',
+    status: 'active',
+    currentPeriodEnd: new Date().toISOString(),
+  };
+
+  it('does not show next charge when subscription is set to cancel', () => {
+    mockUseSubscription.mockReturnValue({
+      subscription: { ...baseSubscription, cancelAtPeriodEnd: true },
+      error: null,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+    render(<SubscriptionCard />);
+    expect(screen.queryByText(/Próxima cobrança/)).not.toBeInTheDocument();
+  });
+
+  it('shows next charge when subscription is active', () => {
+    mockUseSubscription.mockReturnValue({
+      subscription: { ...baseSubscription, cancelAtPeriodEnd: false },
+      error: null,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+    render(<SubscriptionCard />);
+    expect(screen.getByText(/Próxima cobrança/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- exibir próxima cobrança apenas se assinatura estiver ativa sem cancelamento
- testar componente SubscriptionCard para verificar condicional de próxima cobrança

## Testing
- `npm test 2>&1 | tail -n 20`
- `npx jest --runTestsByPath tests/subscription-card.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a2af0caafc832e94369edb890a6abf