### PR TITLE
refactor: move premium guard to routes

### DIFF
--- a/docs/plan-guard.md
+++ b/docs/plan-guard.md
@@ -1,12 +1,12 @@
 # Guardião da Receita
 
-Middleware centralizado que protege rotas premium (IA, WhatsApp) verificando se o `planStatus` do usuário está **active**.
+Verificação centralizada que protege rotas premium (IA, WhatsApp) garantindo que o `planStatus` do usuário esteja **active**.
 
 ## Funcionamento
-- `guardPremiumRequest` é chamado pelo `middleware.ts` para rotas sensíveis.
+- Cada rota premium chama `guardPremiumRequest` no início do handler.
 - Quando o plano não está ativo, a requisição é bloqueada com status `403` e mensagem padrão.
-- Tentativas negadas são registradas com `logger.warn`.
 - Métricas de bloqueio são acumuladas em memória e podem ser consultadas em `/api/admin/plan-guard/metrics`.
 
 ## Métricas
 As métricas expõem o total de acessos bloqueados e o detalhamento por rota, permitindo monitoramento no dashboard de suporte.
+

--- a/src/app/api/ai-summary/route.ts
+++ b/src/app/api/ai-summary/route.ts
@@ -1,8 +1,13 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const guardResponse = await guardPremiumRequest(req);
+  if (guardResponse) {
+    return guardResponse;
+  }
   const data = {
     name: "AI Summary",
     description: "Summary of the application's AI capabilities.",

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import Metric, { IMetric } from "@/app/models/Metric";
 import { Model } from "mongoose";
 import { callOpenAIForQuestion } from "@/app/lib/aiService";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 
 // Garante que essa rota use Node.js em vez de Edge (importante para Mongoose).
 export const runtime = "nodejs";
@@ -12,7 +13,11 @@ export const runtime = "nodejs";
  * Body esperado: { userId, query }
  * Retorna uma resposta da IA baseada nas métricas do usuário.
  */
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
   try {
     // 1) Lê o body JSON
     const { userId, query } = (await request.json()) || {};

--- a/src/app/api/ai/dynamicCards/route.ts
+++ b/src/app/api/ai/dynamicCards/route.ts
@@ -1,8 +1,9 @@
 // @/src/app/api/ai/dynamicCards/route.ts – rev. OpenAI‑v4
 // Corrige import do SDK, simplifica instância e mantém restante da lógica.
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 
 /**
  * POST /api/ai/dynamicCards
@@ -12,7 +13,11 @@ import OpenAI from "openai";
  *   - filtros (opcional) -> array de strings
  * Retorna um JSON com "cards": [...]
  */
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
   try {
     /* --------------------------------------------------
        1. Leitura e validação do corpo

--- a/src/app/api/ai/planGuard.test.ts
+++ b/src/app/api/ai/planGuard.test.ts
@@ -1,26 +1,47 @@
+// @jest-environment node
 import { NextRequest } from 'next/server';
-import { middleware } from '../../../middleware';
+import { POST as chat } from './chat/route';
+import { POST as dynamicCards } from './dynamicCards/route';
+import { GET as insights } from './insights/route';
 import { getToken } from 'next-auth/jwt';
+import { connectToDatabase } from '@/app/lib/mongoose';
+import DbUser from '@/app/models/User';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+jest.mock('@/app/lib/mongoose', () => ({ connectToDatabase: jest.fn() }));
+jest.mock('@/app/models/User', () => ({ __esModule: true, default: { findById: jest.fn() } }));
 
 const mockGetToken = getToken as jest.Mock;
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindById = (DbUser as any).findById as jest.Mock;
 
-function makeRequest(path: string) {
-  return new NextRequest(`http://localhost${path}`);
+function makeRequest(url: string) {
+  return new NextRequest(url);
 }
 
 describe('plan guard for ai routes', () => {
   beforeEach(() => {
     mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
+    mockConnect.mockResolvedValue(null);
+    mockFindById.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ planStatus: 'inactive' }),
+      }),
+    });
   });
 
-  it.each([
-    '/api/ai/chat',
-    '/api/ai/dynamicCards',
-    '/api/ai/insights',
-  ])('blocks inactive plan for %s', async (path) => {
-    const res = await middleware(makeRequest(path));
+  it('blocks inactive plan for chat', async () => {
+    const res = await chat(makeRequest('http://localhost/api/ai/chat'));
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks inactive plan for dynamicCards', async () => {
+    const res = await dynamicCards(makeRequest('http://localhost/api/ai/dynamicCards'));
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks inactive plan for insights', async () => {
+    const res = await insights(makeRequest('http://localhost/api/ai/insights?userId=u1'));
     expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/whatsapp/generateCode/route.ts
+++ b/src/app/api/whatsapp/generateCode/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/whatsapp/generateCode/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 import { getToken } from "next-auth/jwt";
 import { jwtVerify } from "jose";
 import { connectToDatabase } from "@/app/lib/mongoose";
@@ -22,6 +23,11 @@ function generateVerificationCode(): string {
  * gera um código de verificação e zera o whatsappPhone para forçar re-verificação.
  */
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   console.log("[whatsapp/generateCode] Request received."); // Log inicial
 
   try {

--- a/src/app/api/whatsapp/planGuard.test.ts
+++ b/src/app/api/whatsapp/planGuard.test.ts
@@ -1,4 +1,9 @@
-import { middleware } from '../../../middleware';
+// @jest-environment node
+import { NextRequest } from 'next/server';
+import { POST as generateCode } from './generateCode/route';
+import { POST as sendTips } from './sendTips/route';
+import { POST as verify } from './verify/route';
+import { POST as weeklyReport } from './weeklyReport/route';
 import { getToken } from 'next-auth/jwt';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import DbUser from '@/app/models/User';
@@ -11,8 +16,8 @@ const mockGetToken = getToken as jest.Mock;
 const mockConnect = connectToDatabase as jest.Mock;
 const mockFindById = (DbUser as any).findById as jest.Mock;
 
-function makeRequest(path: string) {
-  return { nextUrl: { pathname: path } } as any;
+function makeRequest(url: string) {
+  return new NextRequest(url);
 }
 
 describe('plan guard for whatsapp routes', () => {
@@ -26,24 +31,24 @@ describe('plan guard for whatsapp routes', () => {
     });
   });
 
-  it.each([
-    '/api/whatsapp/generateCode',
-    '/api/whatsapp/sendTips',
-    '/api/whatsapp/verify',
-    '/api/whatsapp/weeklyReport',
-  ])('blocks inactive plan for %s', async (path) => {
-    const res = await middleware(makeRequest(path));
+  it('blocks inactive plan for generateCode', async () => {
+    const res = await generateCode(makeRequest('http://localhost/api/whatsapp/generateCode'));
     expect(res.status).toBe(403);
   });
 
-  it('allows when DB has active plan', async () => {
-    mockFindById.mockReturnValue({
-      select: jest.fn().mockReturnValue({
-        lean: jest.fn().mockResolvedValue({ planStatus: 'active' }),
-      }),
-    });
-    const res = await middleware(makeRequest('/api/whatsapp/generateCode'));
-    expect(res.status).toBe(200);
+  it('blocks inactive plan for sendTips', async () => {
+    const res = await sendTips(makeRequest('http://localhost/api/whatsapp/sendTips'));
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks inactive plan for verify', async () => {
+    const res = await verify(makeRequest('http://localhost/api/whatsapp/verify'));
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks inactive plan for weeklyReport', async () => {
+    const res = await weeklyReport(makeRequest('http://localhost/api/whatsapp/weeklyReport'));
+    expect(res.status).toBe(403);
   });
 });
 

--- a/src/app/api/whatsapp/sendTips/route.ts
+++ b/src/app/api/whatsapp/sendTips/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 import { getServerSession }          from "next-auth/next";
 import { authOptions }               from "@/app/api/auth/[...nextauth]/route";
 import { connectToDatabase }         from "@/app/lib/mongoose";
@@ -55,6 +56,11 @@ function formatTipsMessage({ titulo = "💡 Dicas da Semana", dicas = [] }: Tips
    Envia dicas semanais a todos os usuários com plano ativo
    ================================================================== */
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   const tag = "[whatsapp/sendTips]";
 
   /* 1. Autenticação (caso use sessão) ------------------------------ */

--- a/src/app/api/whatsapp/verify/route.ts
+++ b/src/app/api/whatsapp/verify/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/whatsapp/verify/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import mongoose from "mongoose";
 import User, { IUser } from "@/app/models/User";
@@ -16,6 +17,11 @@ export const runtime = "nodejs";
  * visto que mensagens do WhatsApp não trazem cookies de sessão.
  */
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   try {
     console.debug("[whatsapp/verify] Iniciando verificação de código (sem sessão).");
     

--- a/src/app/api/whatsapp/weeklyReport/route.ts
+++ b/src/app/api/whatsapp/weeklyReport/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/whatsapp/weeklyReport/route.ts - Correção v1.1
 
 import { NextRequest, NextResponse } from "next/server";
+import { guardPremiumRequest } from "@/app/lib/planGuard";
 import { getToken } from "next-auth/jwt";
 import { connectDB, safeSendWhatsAppMessage } from "@/app/lib/helpers"; // Verifique os caminhos
 import User, { IUser } from "@/app/models/User"; // Verifique o caminho
@@ -55,6 +56,11 @@ interface ReportResult {
  * Utiliza JWT para autenticação (getToken).
  */
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardPremiumRequest(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   const functionName = "[whatsapp/weeklyReport POST v1.1]"; // Atualiza tag da versão
   try {
     // Verifica se hoje é sexta-feira (dia 5)

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,12 +1,6 @@
 // @jest-environment node
 import { NextRequest } from 'next/server';
 import { middleware } from './middleware';
-import { resetPlanGuardMetrics } from '@/app/lib/planGuard';
-import { getToken } from 'next-auth/jwt';
-
-jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
-
-const mockGetToken = getToken as jest.Mock;
 
 function createRequest(path: string) {
   return new NextRequest(`http://localhost${path}`);
@@ -24,19 +18,3 @@ describe('affiliate code cookie', () => {
   });
 });
 
-describe('middleware plan guard', () => {
-  beforeEach(() => {
-    resetPlanGuardMetrics();
-  });
-  it('allows access when plan is active', async () => {
-    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'active' });
-    const res = await middleware(createRequest('/api/ai/chat'));
-    expect(res.status).toBe(200);
-  });
-
-  it('blocks access when plan is inactive', async () => {
-    mockGetToken.mockResolvedValue({ id: 'u1', planStatus: 'inactive' });
-    const res = await middleware(createRequest('/api/whatsapp/sendTips'));
-    expect(res.status).toBe(403);
-  });
-});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,10 @@
 // middleware.ts
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { guardPremiumRequest } from "@/app/lib/planGuard";
-
 const AFFILIATE_COOKIE_NAME = "d2c_ref";
 const AFFILIATE_CODE_REGEX = /^[A-Z0-9_-]{3,32}$/i;
 
 export async function middleware(req: NextRequest) {
-  // Cria a resposta base que permite a continuação da requisição
   const res = NextResponse.next();
 
   const rawRef =
@@ -17,54 +14,25 @@ export async function middleware(req: NextRequest) {
   const refCode =
     rawRef && AFFILIATE_CODE_REGEX.test(rawRef) ? rawRef.trim().toUpperCase() : "";
 
-  // Função auxiliar para configurar o cookie em uma dada resposta
-  const setAffiliateCookie = (response: NextResponse) => {
-    if (refCode) {
-      response.cookies.set(AFFILIATE_COOKIE_NAME, refCode, {
-        path: "/",
-        httpOnly: false, // permite leitura no client para autofill
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        maxAge:
-          Number(process.env.AFFILIATE_ATTRIBUTION_WINDOW_DAYS || 90) *
-          24 *
-          60 *
-          60, // 90 dias padrão
-      });
-    }
-    return response;
-  };
-
-  // Lógica para rotas protegidas
-  const guardPrefixes = [
-    "/api/whatsapp/generateCode",
-    "/api/whatsapp/sendTips",
-    "/api/whatsapp/verify",
-    "/api/whatsapp/weeklyReport",
-    "/api/ai",
-  ];
-
-  if (guardPrefixes.some((p) => req.nextUrl.pathname.startsWith(p))) {
-    const guardResponse = await guardPremiumRequest(req);
-    if (guardResponse) {
-      // Se a rota for protegida e bloqueada, retorna a resposta do guard com o cookie
-      return setAffiliateCookie(guardResponse);
-    }
+  if (refCode) {
+    res.cookies.set(AFFILIATE_COOKIE_NAME, refCode, {
+      path: "/",
+      httpOnly: false,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge:
+        Number(process.env.AFFILIATE_ATTRIBUTION_WINDOW_DAYS || 90) *
+        24 *
+        60 *
+        60,
+    });
   }
 
-  // Para todas as outras rotas, retorna a resposta principal com o cookie aplicado
-  return setAffiliateCookie(res);
+  return res;
 }
 
 export const config = {
   matcher: [
-    // Aplica o middleware a todas as rotas, exceto arquivos estáticos e de imagem.
     "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
-    // Aplica também explicitamente às rotas da API que podem ser acessadas diretamente
-    "/api/whatsapp/generateCode/:path*",
-    "/api/whatsapp/sendTips/:path*",
-    "/api/whatsapp/verify/:path*",
-    "/api/whatsapp/weeklyReport/:path*",
-    "/api/ai/:path*",
   ],
 };


### PR DESCRIPTION
## Summary
- remove plan verification from middleware and leave only affiliate cookie handling
- enforce `guardPremiumRequest` inside premium AI and WhatsApp API routes
- document new guard usage and update tests

## Testing
- `npm test` *(fails: 113 failed, 41 passed)*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b37620a0832ebaf0ad3cfc1c2565