### PR TITLE
Remove userId from WhatsApp code request

### DIFF
--- a/src/app/dashboard/WhatsAppPanel.tsx
+++ b/src/app/dashboard/WhatsAppPanel.tsx
@@ -37,9 +37,7 @@ export default function WhatsAppPanel({
       try {
         const res = await fetch("/api/whatsapp/generateCode", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
           credentials: "include",
-          body: JSON.stringify({ userId }),
         });
 
         if (!res.ok) {


### PR DESCRIPTION
## Summary
- request WhatsApp code without sending userId and rely on session cookie

## Testing
- `npm test` *(fails: Test Suites: 113 failed, 41 passed)*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c3f1e93c832eba66cdcc4b21b8b2