### PR TITLE
Verify whatsapp code persistence after saving

### DIFF
--- a/src/app/api/whatsapp/generateCode/route.ts
+++ b/src/app/api/whatsapp/generateCode/route.ts
@@ -139,7 +139,18 @@ export async function POST(request: NextRequest) {
     user.whatsappPhone = null;
     user.whatsappVerified = false;
     await user.save();
-    console.log(`[whatsapp/generateCode] Código salvo e whatsappPhone/whatsappVerified resetados para usuário ${user._id}.`);
+    if (!user.whatsappVerificationCode) {
+      console.error(
+        `[whatsapp/generateCode] Erro: whatsappVerificationCode não foi persistido para usuário ${user._id}.`
+      );
+    } else {
+      console.log(
+        `[whatsapp/generateCode] whatsappVerificationCode confirmado para usuário ${user._id}: ${user.whatsappVerificationCode}`
+      );
+    }
+    console.log(
+      `[whatsapp/generateCode] Código salvo e whatsappPhone/whatsappVerified resetados para usuário ${user._id}.`
+    );
 
     // Retorna apenas o código gerado
     return NextResponse.json({ code: verificationCode }, { status: 200 });

--- a/tests/whatsapp-generateCode.test.ts
+++ b/tests/whatsapp-generateCode.test.ts
@@ -1,0 +1,44 @@
+/* @jest-environment node */
+import { NextRequest } from "next/server";
+import mongoose from "mongoose";
+
+jest.mock("@/app/lib/planGuard", () => ({ guardPremiumRequest: jest.fn().mockResolvedValue(null) }));
+jest.mock("next-auth/jwt", () => ({ getToken: jest.fn().mockResolvedValue({ sub: "507f1f77bcf86cd799439011" }) }));
+jest.mock("@/app/lib/mongoose", () => ({ connectToDatabase: jest.fn().mockResolvedValue(null) }));
+jest.mock("jose", () => ({ jwtVerify: jest.fn().mockResolvedValue({ payload: {} }) }));
+
+const mockSave = jest.fn().mockResolvedValue(null);
+jest.mock("@/app/models/User", () => ({
+  __esModule: true,
+  default: { findById: jest.fn() },
+}));
+
+import User from "@/app/models/User";
+import { POST } from "@/app/api/whatsapp/generateCode/route";
+
+// Ensure the NEXTAUTH_SECRET is set for jwtVerify path
+beforeAll(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret";
+});
+
+describe("POST /api/whatsapp/generateCode", () => {
+  it("salva e retorna um código de verificação", async () => {
+    const user = {
+      _id: new mongoose.Types.ObjectId("507f1f77bcf86cd799439011"),
+      whatsappPhone: null,
+      whatsappVerificationCode: null as string | null,
+      whatsappVerified: false,
+      save: mockSave,
+    };
+    (User.findById as jest.Mock).mockResolvedValue(user);
+
+    const request = new NextRequest("http://localhost/api/whatsapp/generateCode", { method: "POST" });
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.code).toHaveLength(6);
+    expect(user.whatsappVerificationCode).toBeTruthy();
+    expect(mockSave).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- log a post-save check confirming `whatsappVerificationCode` persists
- add unit test simulating successful WhatsApp verification code generation

## Testing
- `npm test` *(fails: ReferenceError: Request is not defined, setImmediate is not defined, and others)*
- `npx jest tests/whatsapp-generateCode.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2c500bf08832ea5798eb490231785