### PR TITLE
Ensure JWT subject and map token id from sub

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -253,6 +253,7 @@ async function customEncode({ token, secret, maxAge }: JWTEncodeParams): Promise
   }
 
   return new SignJWT(cleanToken)
+    .setSubject(cleanToken.id)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime(expirationTime)

--- a/src/app/api/whatsapp/generateCode/route.ts
+++ b/src/app/api/whatsapp/generateCode/route.ts
@@ -19,9 +19,12 @@ async function getUserIdFromRequest(request: NextRequest): Promise<string | null
   // 1) next-auth
   try {
     const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
-    const uid = (token as any)?.id ?? (token as any)?.sub;
+    if (token && !(token as any).id && (token as any).sub) {
+      (token as any).id = String((token as any).sub);
+    }
+    const uid = (token as any)?.id;
     if (uid) return String(uid);
-    console.log("[whatsapp/generateCode] getToken() -> OK mas sem id/sub");
+    console.log("[whatsapp/generateCode] getToken() -> OK mas sem id");
   } catch (e) {
     console.error("[whatsapp/generateCode] getToken() error:", e);
   }

--- a/src/app/api/whatsapp/status/route.ts
+++ b/src/app/api/whatsapp/status/route.ts
@@ -15,7 +15,10 @@ async function getUserIdFromRequest(request: NextRequest): Promise<string | null
   // 1) Tenta via next-auth
   try {
     const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
-    const uid = (token as any)?.id ?? (token as any)?.sub;
+    if (token && !(token as any).id && (token as any).sub) {
+      (token as any).id = String((token as any).sub);
+    }
+    const uid = (token as any)?.id;
     if (uid) return String(uid);
   } catch (e) {
     console.error("[whatsapp/status] getToken() error:", e);

--- a/src/app/lib/planGuard.ts
+++ b/src/app/lib/planGuard.ts
@@ -76,9 +76,12 @@ async function getAuthTokenFromRequest(
 ): Promise<Record<string, any> | null> {
   try {
     const t = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
-    const hasId = (t as any)?.id || (t as any)?.sub || (t as any)?.email;
+    if (t && !(t as any).id && (t as any).sub) {
+      (t as any).id = String((t as any).sub);
+    }
+    const hasId = (t as any)?.id || (t as any)?.email;
     if (t && hasId) return t as any;
-    if (t) console.warn('[planGuard] getToken() -> token sem id/sub/email, tentando fallback');
+    if (t) console.warn('[planGuard] getToken() -> token sem id/email, tentando fallback');
   } catch (e) {
     console.error('[planGuard] getToken() error:', e);
   }


### PR DESCRIPTION
## Summary
- add `setSubject(cleanToken.id)` when encoding JWTs
- map `sub` to `id` for tokens obtained via `getToken`

## Testing
- `npm test` *(fails: ReferenceError and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a381fa3568832e9781eb90656b40e2