### PR TITLE
Centralize active plan status checks for WhatsApp routes

### DIFF
--- a/src/app/api/whatsapp/process-response/dailyTipHandler.ts
+++ b/src/app/api/whatsapp/process-response/dailyTipHandler.ts
@@ -8,7 +8,7 @@
 // - CORREÇÃO 2: Ajusta o tipo 'ProposalType'.
 // - CORREÇÃO: Adiciona validações de tipo (type guards) para garantir a segurança das atribuições.
 // - REMOÇÃO: Remove o uso de 'as any' para aumentar a segurança de tipos.
-// - NOVO: Bloqueia envios proativos quando plano for inativo; trata 'active' | 'non_renewing' | 'trial' como ativos.
+// - NOVO: Bloqueia envios proativos quando plano for inativo; trata 'active' | 'non_renewing' | 'trial' | 'trialing' como ativos.
 
 import { NextResponse } from 'next/server';
 import { logger } from '@/app/lib/logger';
@@ -23,7 +23,7 @@ import type { ICommunityInspiration } from '@/app/models/CommunityInspiration';
 import type { IMetric } from '@/app/models/Metric';
 import { IUser, IAlertHistoryEntry, AlertDetails } from '@/app/models/User'; 
 
-import { ProcessRequestBody, DetectedEvent, EnrichedAIContext } from './types'; 
+import { ProcessRequestBody, DetectedEvent, EnrichedAIContext } from './types';
 
 import ruleEngineInstance from '@/app/lib/ruleEngine';
 import {
@@ -41,11 +41,7 @@ import { callOpenAIForQuestion } from '@/app/lib/aiService';
 import { subDays, startOfDay } from 'date-fns';
 
 import * as fallbackInsightService from '@/app/lib/fallbackInsightService';
-
-// Helper: considera como “ativo” os estados active | non_renewing | trial
-function isActiveLike(s: unknown): s is 'active' | 'non_renewing' | 'trial' {
-  return s === 'active' || s === 'non_renewing' || s === 'trial';
-}
+import { isActiveLike } from '@/app/lib/isActiveLike';
 
 // ===================================================================================
 // INÍCIO: Definições de Tipos e Validadores (Type Guards) para Correção

--- a/src/app/api/whatsapp/process-response/route.ts
+++ b/src/app/api/whatsapp/process-response/route.ts
@@ -8,15 +8,11 @@ import { ProcessRequestBody } from './types';
 import { connectToDatabase } from '@/app/lib/mongoose';
 import User from '@/app/models/User';
 import { sendWhatsAppMessage } from '@/app/lib/whatsappService';
+import { isActiveLike } from '@/app/lib/isActiveLike';
 
 export const runtime = 'nodejs';
 
 const ROUTE_TAG = '[API Route /process-response]';
-
-// Helper: plano ativo-like
-function isActiveLike(s: unknown): s is 'active' | 'non_renewing' | 'trial' {
-  return s === 'active' || s === 'non_renewing' || s === 'trial';
-}
 
 // QStash Receiver
 const currentSigningKey = process.env.QSTASH_CURRENT_SIGNING_KEY;

--- a/src/app/api/whatsapp/process-response/userMessageHandler.ts
+++ b/src/app/api/whatsapp/process-response/userMessageHandler.ts
@@ -3,7 +3,7 @@
 // - ATUALIZADO: Captura e loga o WAMID retornado pelo whatsappService.
 // - ATUALIZADO: Melhorado o tratamento de erro para chamadas a sendWhatsAppMessage.
 // - CORRIGIDO: Adicionada chave de fechamento '}' ausente no final da função handleUserMessage (mantido).
-// - NOVO: Trata 'active' | 'non_renewing' | 'trial' como estados ativos.
+// - NOVO: Trata 'active' | 'non_renewing' | 'trial' | 'trialing' como estados ativos.
 // - Baseado em: vShortTermMemory_CtxExtract_13
 import { NextResponse } from 'next/server';
 import {
@@ -51,13 +51,9 @@ import {
     INSTIGATING_QUESTION_TEMP,
     INSTIGATING_QUESTION_MAX_TOKENS
 } from '@/app/lib/constants';
+import { isActiveLike } from '@/app/lib/isActiveLike';
 
 const HANDLER_TAG_BASE = '[UserMsgHandler vShortTermMemory_CtxExtract_13_FIXED_WamidHandling]'; // Tag atualizada
-
-// Helper local: considera como “ativo” os estados active | non_renewing | trial
-function isActiveLike(s: unknown): s is 'active' | 'non_renewing' | 'trial' {
-    return s === 'active' || s === 'non_renewing' || s === 'trial';
-}
 
 /**
  * Extrai o tópico principal e entidades chave da resposta de uma IA.

--- a/src/app/api/whatsapp/sendTips/route.ts
+++ b/src/app/api/whatsapp/sendTips/route.ts
@@ -9,6 +9,7 @@ import { DailyMetric, IDailyMetric }  from "@/app/models/DailyMetric";
 import { callOpenAIForTips }          from "@/app/lib/aiService";
 import { sendWhatsAppMessage }        from "@/app/lib/whatsappService";
 import { Model, Types }               from "mongoose";
+import { isActiveLike, type ActiveLikeStatus } from "@/app/lib/isActiveLike";
 
 /* ────────────────────────────────────────────────────────── *
  * Tipos auxiliares                                           *
@@ -55,7 +56,7 @@ function formatTipsMessage({ titulo = "💡 Dicas da Semana", dicas = [] }: Tips
 /* ==================================================================
    POST /api/whatsapp/sendTips
    Envia dicas semanais a todos os usuários com plano ativo-like
-   (active | non_renewing | trial) e WhatsApp verificado
+   (active | non_renewing | trial | trialing) e WhatsApp verificado
    ================================================================== */
 export async function POST(request: NextRequest) {
   const guardResponse = await guardPremiumRequest(request);
@@ -73,7 +74,12 @@ export async function POST(request: NextRequest) {
   await connectToDatabase();
 
   // ✅ Considera active-like e exige número verificado
-  const ACTIVE_LIKE = ["active", "non_renewing", "trial"];
+  const ACTIVE_LIKE: ActiveLikeStatus[] = [
+    "active",
+    "non_renewing",
+    "trial",
+    "trialing",
+  ].filter(isActiveLike);
   const users = await User.find({
     planStatus: { $in: ACTIVE_LIKE },
     whatsappPhone: { $exists: true, $ne: null },

--- a/src/app/api/whatsapp/verify/route.ts
+++ b/src/app/api/whatsapp/verify/route.ts
@@ -2,20 +2,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import User from "@/app/models/User";
+import { isActiveLike } from "@/app/lib/isActiveLike";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-function isActiveLike(s: unknown): s is "active" | "non_renewing" | "trial" {
-  return s === "active" || s === "non_renewing" || s === "trial";
-}
-
 /**
  * POST /api/whatsapp/verify
  * Body: { phoneNumber: string, code: string }
  * - Não depende de sessão/cookies (WhatsApp não envia cookies).
- * - Valida status do plano via DB (active | non_renewing | trial = OK).
+ * - Valida status do plano via DB (active | non_renewing | trial | trialing = OK).
  * - Vincula o telefone e marca whatsappVerified=true; invalida o código.
  */
 export async function POST(request: NextRequest) {

--- a/src/app/lib/isActiveLike.ts
+++ b/src/app/lib/isActiveLike.ts
@@ -1,0 +1,1 @@
+export { isActiveLike, type ActiveLikeStatus } from './planGuard';


### PR DESCRIPTION
## Summary
- re-export `isActiveLike` utility for shared plan status checks
- update WhatsApp routes to use centralized `isActiveLike` and include `trialing`

## Testing
- `npm test` *(fails: ReferenceError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a38578a7a4832ead7ab948eeda1e79