### PR TITLE
Enable Stripe account capabilities for card payments and transfers

### DIFF
--- a/src/app/api/affiliate/connect/onboard/route.ts
+++ b/src/app/api/affiliate/connect/onboard/route.ts
@@ -26,7 +26,11 @@ export async function POST() {
     const acct = await stripe.accounts.create({
       type: 'express',
       email: user.email ?? undefined,
-      capabilities: { transfers: { requested: true } },
+      country: 'BR',
+      capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+      },
       metadata: { userId: String(user._id) },
     });
     accountId = acct.id;


### PR DESCRIPTION
## Summary
- request card payment and transfer capabilities when creating Stripe Express accounts for affiliates

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c477693c832ebc8c11235c637e7d