### PR TITLE
Remover depoimento de Carla Souza da página inicial

### DIFF
--- a/src/app/landing/components/TestimonialsSection.tsx
+++ b/src/app/landing/components/TestimonialsSection.tsx
@@ -16,7 +16,7 @@ export default function TestimonialsSection() {
             Criadores como você já estão economizando tempo e crescendo com mais estratégia.
           </SectionSubtitle>
         </AnimatedSection>
-        <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-8">
           {testimonials.map((testimonial, index) => (
             <AnimatedSection delay={0.1 * (index + 1)} key={testimonial.name}>
               <TestimonialCard {...testimonial} />

--- a/src/data/testimonials.ts
+++ b/src/data/testimonials.ts
@@ -12,12 +12,6 @@ const testimonials: Testimonial[] = [
       handle: "@belli_rafa",
       quote: "Antes eu ficava meio perdido com os números, mas agora, com o acompanhamento pelo WhatsApp, é outra história. É como ter um parceiro super gente boa que te dá uns toques na hora certa. Os alertas chegam direto no meu WhatsApp e são super úteis. É um suporte personalizado que faz toda a diferença, me ajudando a entender tudo sem complicação e a crescer de verdade.",
       avatarUrl: "/images/Rafa Belli Foto D2C.png"
-    },
-    {
-      name: "Carla Souza",
-      handle: "@carladesign",
-      quote: "O programa de afiliados é genial! Já paguei minha assinatura só com as comissões, e meus amigos amaram o desconto e a ferramenta.",
-      avatarUrl: "/images/default-profile.png"
     }
 ];
 


### PR DESCRIPTION
## Summary
- removido depoimento de Carla Souza
- ajustado layout de depoimentos para duas colunas

## Testing
- `npm test` (falhou: Test Suites: 114 failed, 41 passed, 155 total)

------
https://chatgpt.com/codex/tasks/task_e_68a78c9dd40c832e89d6eccedecd44e4