### PR TITLE
Use handleSignIn for landing CTA and mobile menu

### DIFF
--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -66,8 +66,10 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
             )}
             {/* Mantido o botão principal de "Começar Agora" */}
             <ButtonPrimary
-              href="/register"
-              onClick={() => track('cta_start_now_click')}
+              onClick={() => {
+                track('cta_start_now_click');
+                handleSignIn();
+              }}
               className="px-4 py-2 text-sm" // Ajustado para um tamanho menor
             >
               Começar Agora
@@ -115,16 +117,16 @@ export default function LandingHeader({ showLoginButton = false }: LandingHeader
                   >
                     Login
                   </Link>
-                  <Link
-                    href="/register"
+                  <button
                     onClick={() => {
                       track('cta_start_now_click');
                       setIsMenuOpen(false);
+                      handleSignIn();
                     }}
-                    className="px-4 py-2 text-sm font-bold text-brand-pink hover:bg-gray-100"
+                    className="px-4 py-2 text-sm font-bold text-brand-pink hover:bg-gray-100 text-left"
                   >
                     Começar Agora
-                  </Link>
+                  </button>
                 </>
               )}
             </nav>


### PR DESCRIPTION
## Summary
- Start login flow from desktop "Começar Agora" button using `handleSignIn`
- Trigger login flow from mobile menu CTA instead of linking to `/register`

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization; multiple failing test suites)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a79e278fb0832e9b91bf664ad94941