### PR TITLE
feat: integrate Google Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 # Public base URL of the application
 NEXT_PUBLIC_APP_URL=https://example.com
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
 # Base URL for NextAuth (fallback for NEXT_PUBLIC_APP_URL)
 NEXTAUTH_URL=https://example.com

--- a/src/app/GoogleAnalytics.tsx
+++ b/src/app/GoogleAnalytics.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { pageview } from '@/lib/gtag';
+
+export default function GoogleAnalytics() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    pageview(pathname);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 // Imports do NextAuth para buscar a sessão no servidor
@@ -15,6 +16,7 @@ import AuthRedirectHandler from "./components/auth/AuthRedirectHandler";
 import ClientHooksWrapper from "./components/ClientHooksWrapper";
 import MainContentWrapper from "./components/MainContentWrapper"; // ✅ IMPORTADO O NOVO COMPONENTE
 import { ToastA11yProvider } from "@/app/components/ui/ToastA11yProvider";
+import GoogleAnalytics from "./GoogleAnalytics";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -44,6 +46,18 @@ export default async function RootLayout({
         <link rel="preconnect" href="https://www.youtube.com" />
         <link rel="preconnect" href="https://www.google.com" />
         <link rel="preconnect" href="https://img.youtube.com" />
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="ga-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
+          `}
+        </Script>
       </head>
       <body
         className={`
@@ -58,6 +72,7 @@ export default async function RootLayout({
       >
         <ToastA11yProvider maxVisible={3}>
           <Providers session={serializableSession}>
+            <GoogleAnalytics />
             <ClientHooksWrapper />
             <AuthRedirectHandler>
               <Header />

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,0 +1,14 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID ?? '';
+
+export const pageview = (url: string) => {
+  (window as any).gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+export const event = (
+  action: string,
+  params: Record<string, any>
+) => {
+  (window as any).gtag('event', action, params);
+};


### PR DESCRIPTION
## Summary
- load Google Analytics scripts and tracking component in app layout
- track page views through new gtag helper
- document GA measurement ID in example env file

## Testing
- `npm test` *(fails: invariant expected app router to be mounted and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d43e7e64832e85afaa511f2c4ede