### PR TITLE
Add cookie consent banner and GA consent handling

### DIFF
--- a/src/app/components/CookieConsent.tsx
+++ b/src/app/components/CookieConsent.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+
+const CookieConsent: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem("cookie_consent");
+    if (!consent) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem("cookie_consent", "granted");
+    (window as any).gtag?.("consent", "update", {
+      ad_storage: "granted",
+      analytics_storage: "granted",
+    });
+    setIsVisible(false);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-brand-dark text-brand-light p-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <span>
+        Utilizamos cookies para melhorar sua experiência. Aceita o uso de cookies?
+      </span>
+      <button
+        onClick={acceptCookies}
+        className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded"
+      >
+        Aceitar
+      </button>
+    </div>
+  );
+};
+
+export default CookieConsent;
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import ClientHooksWrapper from "./components/ClientHooksWrapper";
 import MainContentWrapper from "./components/MainContentWrapper"; // ✅ IMPORTADO O NOVO COMPONENTE
 import { ToastA11yProvider } from "@/app/components/ui/ToastA11yProvider";
 import GoogleAnalytics from "./GoogleAnalytics";
+import CookieConsent from "./components/CookieConsent";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -55,6 +56,7 @@ export default async function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
+            gtag('consent', 'default', { ad_storage: 'denied', analytics_storage: 'denied' });
             gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
           `}
         </Script>
@@ -84,6 +86,7 @@ export default async function RootLayout({
 
               <Footer />
             </AuthRedirectHandler>
+            <CookieConsent />
           </Providers>
         </ToastA11yProvider>
       </body>


### PR DESCRIPTION
## Summary
- initialize Google Analytics with denied ad and analytics storage
- add cookie consent banner prompting users for cookie usage
- update consent to granted when user accepts cookies

## Testing
- `npm test` (fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization, ...)
- `npm run lint` (fails: prompt `How would you like to configure ESLint?`)


------
https://chatgpt.com/codex/tasks/task_e_68a8dc458420832e97494a75abe68dae