### PR TITLE
feat: track interaction events on buttons

### DIFF
--- a/src/app/components/ScrollToTopButton.tsx
+++ b/src/app/components/ScrollToTopButton.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { ChevronUpIcon } from "@heroicons/react/24/outline";
+import { event } from "@/lib/gtag";
 
 export default function ScrollToTopButton() {
   const [isVisible, setIsVisible] = useState(false);
@@ -25,7 +26,13 @@ export default function ScrollToTopButton() {
   return (
     <button
       aria-label="Voltar ao topo"
-      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      onClick={() => {
+        event("select_content", {
+          content_type: "button",
+          item_id: "scroll_to_top",
+        });
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }}
       className="fixed bottom-6 right-6 p-2 rounded-full bg-indigo-600 text-white shadow-md hover:bg-indigo-700"
     >
       <ChevronUpIcon className="w-5 h-5" />

--- a/src/app/dashboard/billing/AbortPendingButton.tsx
+++ b/src/app/dashboard/billing/AbortPendingButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { event } from "@/lib/gtag";
 
 export default function AbortPendingButton() {
   const { data: session, update } = useSession();
@@ -12,6 +13,10 @@ export default function AbortPendingButton() {
   if (session?.user?.planStatus !== "pending") return null;
 
   async function handleAbortPending() {
+    event("select_content", {
+      content_type: "button",
+      item_id: "abort_pending",
+    });
     try {
       setSubmitting(true);
       await fetch("/api/billing/abort", {

--- a/src/app/landing/components/ButtonPrimary.tsx
+++ b/src/app/landing/components/ButtonPrimary.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import React from "react";
+import { event } from "@/lib/gtag";
 
 // Define as props que o componente aceita
 interface ButtonPrimaryProps {
@@ -32,10 +33,18 @@ export default function ButtonPrimary({
     ${className}
   `;
 
+  const handleClick = () => {
+    event("select_content", {
+      content_type: "button",
+      item_id: "button_primary",
+    });
+    onClick?.();
+  };
+
   // Se a prop 'href' for fornecida, renderiza um componente Link do Next.js
   if (href) {
     return (
-      <Link href={href} className={commonClasses} rel={rel}>
+      <Link href={href} className={commonClasses} rel={rel} onClick={handleClick}>
         {children}
       </Link>
     );
@@ -43,7 +52,7 @@ export default function ButtonPrimary({
 
   // Caso contrário, renderiza um botão padrão
   return (
-    <button onClick={onClick} className={commonClasses}>
+    <button onClick={handleClick} className={commonClasses}>
       {children}
     </button>
   );


### PR DESCRIPTION
## Summary
- track interactions for primary button
- track scroll-to-top button clicks
- track abort-pending action

## Testing
- `npm test` *(failed: ReferenceError, TypeError and other test failures)*
- `npm run lint` *(failed: prompted for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a8de58949c832eb3215bf575e830e1