### PR TITLE
Rename subscription CTA to highlight free trial

### DIFF
--- a/src/app/assinar/page.tsx
+++ b/src/app/assinar/page.tsx
@@ -140,17 +140,16 @@ export default function PublicSubscribePage() {
             className="w-full bg-primary text-white py-3 px-4 rounded-xl text-lg font-semibold hover:bg-primary-dark transition-colors duration-300 shadow-md hover:shadow-lg"
             onClick={() => signIn(undefined, { callbackUrl: window.location.href })}
           >
-            Assinar agora
+            Iniciar teste gratuito
           </button>
         )}
 
         <div className="text-center mt-6">
           <p className="text-xs text-gray-500">
-            Pagamento seguro via Mercado Pago. Sem fidelidade.
+            Pagamento seguro via Mercado Pago. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
           </p>
           <p className="text-xs text-gray-500 mt-1">
-            Renovação automática.{' '}
-            <span className="font-semibold text-primary">Cancele quando quiser.</span>
+            Sem fidelidade — <span className="font-semibold text-primary">cancele quando quiser.</span>
           </p>
         </div>
 

--- a/src/app/dashboard/PaymentPanel.tsx
+++ b/src/app/dashboard/PaymentPanel.tsx
@@ -18,10 +18,10 @@ export default function PaymentPanel({ user: _user }: PaymentPanelProps) {
           href="/dashboard/billing/checkout"
           className="w-full inline-flex items-center justify-center gap-2 bg-black text-white py-3 rounded-xl font-semibold"
         >
-          Assinar agora
+          Iniciar teste gratuito
         </Link>
         <p className="mt-2 text-center text-xs text-gray-500">
-          Pagamento seguro via Stripe. Sem fidelidade — cancele quando quiser.
+          Pagamento seguro via Stripe. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
         </p>
       </div>
     </div>

--- a/src/app/dashboard/billing/BillingClientPage.tsx
+++ b/src/app/dashboard/billing/BillingClientPage.tsx
@@ -52,8 +52,11 @@ export default function BillingClientPage({ initialAffiliateCode = "" }: Props) 
           console.log("affiliateCode enviado:", code);
         }}
       >
-        Assinar agora
+        Iniciar teste gratuito
       </button>
+      <p className="mt-2 text-center text-xs text-gray-500">
+        Pagamento seguro via Stripe. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
+      </p>
     </div>
   );
 }

--- a/src/app/dashboard/billing/BillingPanel.tsx
+++ b/src/app/dashboard/billing/BillingPanel.tsx
@@ -131,7 +131,7 @@ export default function BillingPanel() {
       {isInactive && (
         <div className="text-sm">
           <a href="/pricing" className="inline-flex items-center px-3 py-2 rounded-lg bg-black text-white hover:opacity-90">
-            Assinar agora
+            Iniciar teste gratuito
           </a>
         </div>
       )}

--- a/src/app/dashboard/billing/PricingCard.tsx
+++ b/src/app/dashboard/billing/PricingCard.tsx
@@ -139,11 +139,11 @@ export default function PricingCard({ onSubscriptionCreated, affiliateCode }: Pr
         disabled={loading || !current}
         className="w-full rounded-xl bg-black px-4 py-3 text-white disabled:opacity-50"
       >
-        {loading ? "Iniciando…" : "Assinar agora"}
+        {loading ? "Iniciando…" : "Iniciar teste gratuito"}
       </button>
 
       <p className="mt-2 text-center text-xs text-gray-500">
-        Pagamento seguro via Stripe. Sem fidelidade — cancele quando quiser.
+        Pagamento seguro via Stripe. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
       </p>
     </div>
   );

--- a/src/app/dashboard/components/PlanTeaser.tsx
+++ b/src/app/dashboard/components/PlanTeaser.tsx
@@ -380,11 +380,11 @@ export default function PlanTeaser() {
         disabled={loading || (!current && !preview) || isPreviewLoading}
         className="w-full rounded-2xl bg-black px-4 py-3 text-white disabled:opacity-50"
       >
-        {loading ? 'Iniciando…' : 'Assinar agora'}
+        {loading ? 'Iniciando…' : 'Iniciar teste gratuito'}
       </button>
 
       <p className="mt-2 text-center text-xs text-gray-500">
-        Pagamento seguro via Stripe. Cancele quando quiser.
+        Pagamento seguro via Stripe. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
       </p>
     </div>
   );

--- a/src/components/billing/PlanCardPro.tsx
+++ b/src/components/billing/PlanCardPro.tsx
@@ -490,11 +490,11 @@ export default function PlanCardPro({ defaultCurrency = 'BRL', className, ...pro
                    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-pink
                    disabled:opacity-60 disabled:cursor-not-allowed disabled:shadow-none"
       >
-        {loading ? 'Iniciando…' : 'Assinar agora'}
+        {loading ? 'Iniciando…' : 'Iniciar teste gratuito'}
       </button>
 
       <p className="mt-4 text-center text-xs text-gray-500">
-        Pagamento seguro via Stripe. Sem fidelidade — cancele quando quiser.
+        Pagamento seguro via Stripe. Teste gratuito por 7 dias; a cobrança será automática após esse período, a menos que você cancele.
       </p>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- Rename subscription CTA buttons to "Iniciar teste gratuito"
- Update marketing copy to explain automatic billing after 7-day trial

## Testing
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization, Response is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dd95e898832e80a1b3f4fb6bc667