### PR TITLE
Add trial period to billing preview

### DIFF
--- a/src/app/api/billing/preview/route.ts
+++ b/src/app/api/billing/preview/route.ts
@@ -164,6 +164,7 @@ export async function POST(req: NextRequest) {
       customer: customerId,
       subscription_details: {
         items: [{ price: priceId, quantity: 1 }],
+        trial_period_days: parseInt(process.env.TRIAL_DAYS ?? "7", 10),
       },
       discounts: affiliateCouponId ? [{ coupon: affiliateCouponId }] : [],
     });


### PR DESCRIPTION
## Summary
- include configurable `trial_period_days` when generating Stripe invoice previews

## Testing
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e2ec00f8832e9e5b5713d72b20bb