### PR TITLE
feat(billing): handle non-renewing subscription status

### DIFF
--- a/src/app/dashboard/billing/BillingPanel.tsx
+++ b/src/app/dashboard/billing/BillingPanel.tsx
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 import CancelRenewalCard from './CancelRenewalCard';
 
 export type BillingStatus = {
-  planStatus: 'active' | 'trialing' | 'canceled' | 'inactive' | 'pending';
+  planStatus: 'active' | 'trialing' | 'canceled' | 'inactive' | 'pending' | 'non_renewing';
   planInterval: 'month' | 'year' | null;
   planExpiresAt: string | null;
   cancelAt: string | null;
@@ -80,7 +80,7 @@ export default function BillingPanel() {
   if (loading || !s) return <div className="text-sm text-muted-foreground">Carregando informações do plano…</div>;
 
   const fmt = (d?: string | null) => (d ? format(new Date(d), 'dd/MM/yyyy') : '-');
-  const isCanceledAtEnd = s.planStatus === 'canceled';
+  const isCanceledAtEnd = s.planStatus === 'non_renewing';
   const isTrialing = s.planStatus === 'trialing';
   const isActive = s.planStatus === 'active' || s.planStatus === 'trialing';
   const isPending = s.planStatus === 'pending';

--- a/src/app/dashboard/billing/CancelRenewalCard.tsx
+++ b/src/app/dashboard/billing/CancelRenewalCard.tsx
@@ -18,7 +18,7 @@ export default function CancelRenewalCard({ planStatus, planExpiresAt }: Props) 
 
   const canCancel = planStatus === "active" || planStatus === "trialing";
   const isTrial = planStatus === "trialing";
-  const alreadyCancelled = planStatus === "canceled";
+  const alreadyCancelled = planStatus === "non_renewing" || planStatus === "canceled";
 
   // <<< INÍCIO DA CORREÇÃO >>>
   async function cancelRenewal() {
@@ -59,8 +59,9 @@ export default function CancelRenewalCard({ planStatus, planExpiresAt }: Props) 
     switch (status) {
       case "active":
         return "Ativo";
+      case "non_renewing":
       case "canceled":
-        return "Cancelado (não renovará)";
+        return "Cancelado ao fim do período";
       case "past_due":
         return "Pagamento pendente";
       case "trial":

--- a/tests/billing-panel.test.tsx
+++ b/tests/billing-panel.test.tsx
@@ -57,4 +57,24 @@ describe('BillingPanel', () => {
 
     expect(await screen.findByRole('button', { name: 'Cancelar pagamento' })).toBeInTheDocument();
   });
+
+  it('shows non renewing status and reactivate option', async () => {
+    const expires = '2030-02-20T00:00:00.000Z';
+    mockFetch({
+      planStatus: 'non_renewing',
+      planInterval: 'month',
+      planExpiresAt: expires,
+      cancelAt: expires,
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_123',
+      lastPaymentError: null,
+    });
+
+    render(<BillingPanel />);
+
+    const info = await screen.findByText(/Cancelado ao fim do período.*acesso até 20\/02\/2030/);
+    expect(info).toBeInTheDocument();
+
+    expect(await screen.findByRole('button', { name: 'Reativar' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- support `non_renewing` in billing panel
- allow reactivation when subscription is non-renewing
- show cancellation status and propagate to CancelRenewalCard

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*
- `npx jest tests/billing-panel.test.tsx --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68a9e4112e1c832e833e1bc7f5557bf8