### PR TITLE
Use top-level trial period in invoice preview

### DIFF
--- a/src/app/api/billing/preview/route.ts
+++ b/src/app/api/billing/preview/route.ts
@@ -164,8 +164,8 @@ export async function POST(req: NextRequest) {
       customer: customerId,
       subscription_details: {
         items: [{ price: priceId, quantity: 1 }],
-        trial_period_days: parseInt(process.env.TRIAL_DAYS ?? "7", 10),
       },
+      subscription_trial_period_days: parseInt(process.env.TRIAL_DAYS ?? "7", 10),
       discounts: affiliateCouponId ? [{ coupon: affiliateCouponId }] : [],
     });
 


### PR DESCRIPTION
## Summary
- set trial period via `subscription_trial_period_days` in billing preview

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'next')*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*
- `node -e "const Stripe=require('stripe'); ..."` *(fails: connection to Stripe retry error)*
- `npm test` *(fails: multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f316ded8832e90b72d0bb798ef43