### PR TITLE
feat: add locale and trial period to stripe checkout fallback

### DIFF
--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -312,6 +312,7 @@ export async function POST(req: NextRequest) {
         : { allow_promotion_codes: true }
       ),
       subscription_data: {
+        trial_period_days: parseInt(process.env.TRIAL_DAYS ?? "7", 10),
         metadata: {
           userId: String(user._id),
           plan,
@@ -321,6 +322,7 @@ export async function POST(req: NextRequest) {
           ...(source ? { attribution_source: String(source) } : {}),
         },
       },
+      locale: "auto",
       success_url: successUrl,
       cancel_url: cancelUrl,
       client_reference_id: String(user._id),


### PR DESCRIPTION
## Summary
- localize Stripe Checkout session to auto-detect locale
- add configurable trial period to subscription_data

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*
- `npm run lint` *(fails: command prompts for ESLint configuration)*
- `node -e "const Stripe=require('stripe');..."` *(fails: StripeConnectionError: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fc8ec7d8832e8728e2e543ecb115