### PR TITLE
fix: show next cycle price during trial

### DIFF
--- a/src/components/billing/PlanCardPro.tsx
+++ b/src/components/billing/PlanCardPro.tsx
@@ -240,8 +240,8 @@ export default function PlanCardPro({ defaultCurrency = 'BRL', className, ...pro
           const nm = normalizePreview(m.data, currency);
           const na = normalizePreview(a.data, currency);
           setBaseline({
-            monthly: nm?.total ?? undefined,
-            annual: na?.total ?? undefined,
+            monthly: nm?.nextCycleAmount ?? undefined,
+            annual: na?.nextCycleAmount ?? undefined,
           });
         }
       } catch {
@@ -337,7 +337,11 @@ export default function PlanCardPro({ defaultCurrency = 'BRL', className, ...pro
 
   const hasDiscount = (preview?.discountsTotal ?? 0) > 0;
   const displayCurrency = (preview?.currency ?? currency) as string;
-  const displayTotal = preview?.total ?? null;
+  const displayTotal = preview
+    ? preview.total === 0 && preview.nextCycleAmount
+      ? preview.nextCycleAmount
+      : preview.total ?? null
+    : null;
   const displaySubtotal = preview?.subtotal ?? null;
 
   return (

--- a/tests/plan-card-pro.test.tsx
+++ b/tests/plan-card-pro.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import PlanCardPro from '@/components/billing/PlanCardPro';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+describe('PlanCardPro', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('shows next cycle amount when total is zero', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ total: 0, nextCycleAmount: 4990, currency: 'BRL' }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ total: 0, nextCycleAmount: 4990 }),
+      });
+
+    render(<PlanCardPro defaultCurrency="BRL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/R\$\s*49,90/)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure PlanCardPro shows upcoming price when current total is zero
- compute baseline savings using nextCycleAmount
- test price display during trial

## Testing
- `npm test` *(fails: 115 failed, 42 passed, 157 total)*
- `npm test tests/plan-card-pro.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aa002215a8832e907b5df0b5064bca