### PR TITLE
feat: apply discounts during trial in checkout

### DIFF
--- a/docs/stripe-trial-discount.md
+++ b/docs/stripe-trial-discount.md
@@ -1,0 +1,15 @@
+# Stripe: Trial + Discount simultâneo
+
+Para garantir que o Stripe exiba o texto **"Após X dias: R$ xx com desconto"** no Checkout hospedado, a criação da assinatura deve informar **trial** e **desconto** ao mesmo tempo.
+
+## Implementação
+- `stripe.subscriptions.create` recebe `trial_period_days` e `discounts` juntos.
+- `stripe.checkout.sessions.create` envia `discounts` na raiz e em `subscription_data.discounts`, além de `subscription_data.trial_period_days`.
+
+## QA rápido
+1. Definir `TRIAL_DAYS=7` e cupom de afiliado (`STRIPE_COUPON_AFFILIATE10_ONCE_BRL`).
+2. Iniciar subscribe com código afiliado válido.
+3. Caso o fluxo caia no Checkout hospedado, a página deve mostrar:
+   > "Após 7 dias: R$ xx com desconto".
+
+Se algum dos parâmetros estiver ausente, o Stripe oculta o texto do trial ou ignora o desconto.

--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -319,7 +319,10 @@ export async function POST(req: NextRequest) {
         : { allow_promotion_codes: true }
       ),
       subscription_data: {
+        // Informar trial e desconto aqui garante que o Checkout hospedado mostre
+        // "Após X dias: R$ yy com desconto" de forma consistente.
         ...(trialDays > 0 ? { trial_period_days: trialDays } : {}),
+        ...(discounts && discounts.length > 0 ? { discounts } : {}),
         metadata: {
           userId: String(user._id),
           plan,


### PR DESCRIPTION
## Summary
- ensure hosted checkout shows trial + discount by passing subscription_data.discounts
- document Stripe trial+discount interaction and QA steps

## Testing
- `npm test` *(fails: Cannot access 'mockMetricAggregate' before initialization, Next app router not mounted, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c55daa0832e9be977b677b6faac