### PR TITLE
feat: disable caching for platform summary

### DIFF
--- a/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
+++ b/src/app/admin/creator-dashboard/components/kpis/PlatformSummaryKpis.tsx
@@ -48,8 +48,8 @@ const PlatformSummaryKpis: React.FC<PlatformSummaryKpisProps> = ({ apiPrefix = '
         });
 
         const [response, prevResponse] = await Promise.all([
-          fetch(`${apiPrefix}/dashboard/platform-summary?${params.toString()}`),
-          fetch(`${apiPrefix}/dashboard/platform-summary?${prevParams.toString()}`),
+          fetch(`${apiPrefix}/dashboard/platform-summary?${params.toString()}`, { cache: 'no-store' }),
+          fetch(`${apiPrefix}/dashboard/platform-summary?${prevParams.toString()}`, { cache: 'no-store' }),
         ]);
 
         if (!response.ok) {

--- a/src/app/api/admin/dashboard/platform-summary/route.test.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.test.ts
@@ -32,6 +32,7 @@ describe('GET /api/admin/dashboard/platform-summary', () => {
     mockGetServerSession.mockResolvedValue(null);
     const res = await GET(makeRequest());
     expect(res.status).toBe(401);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 
   it('returns summary data when authenticated as admin', async () => {
@@ -43,6 +44,7 @@ describe('GET /api/admin/dashboard/platform-summary', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
     expect(body).toEqual(data);
     expect(fetchPlatformSummary).toHaveBeenCalledWith({ dateRange: {
       startDate: new Date('2024-01-01T00:00:00.000Z'),

--- a/src/app/api/admin/dashboard/platform-summary/route.ts
+++ b/src/app/api/admin/dashboard/platform-summary/route.ts
@@ -5,6 +5,7 @@ import { fetchPlatformSummary } from '@/app/lib/dataService/marketAnalysis/dashb
 import { DatabaseError } from '@/app/lib/errors';
 import { getAdminSession } from '@/lib/getAdminSession';
 export const dynamic = 'force-dynamic';
+const noStore = { 'Cache-Control': 'no-store' };
 
 
 const TAG = '/api/admin/dashboard/platform-summary';
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
   const session = await getAdminSession(req);
   if (!session || !session.user) {
     logger.warn(`${TAG} Unauthorized access attempt.`);
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: noStore });
   }
 
 
@@ -46,7 +47,10 @@ export async function GET(req: NextRequest) {
   const validationResult = querySchema.safeParse(definedQueryParams);
   if (!validationResult.success) {
     logger.warn(`${TAG} Invalid query parameters:`, validationResult.error.flatten());
-    return NextResponse.json({ error: 'Invalid query parameters', details: validationResult.error.flatten() }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: validationResult.error.flatten() },
+      { status: 400, headers: noStore }
+    );
   }
 
   let dateRange;
@@ -58,12 +62,12 @@ export async function GET(req: NextRequest) {
 
   try {
     const summaryData = await fetchPlatformSummary({ dateRange });
-    return NextResponse.json(summaryData, { status: 200 });
+    return NextResponse.json(summaryData, { status: 200, headers: noStore });
   } catch (error: any) {
     logger.error(`${TAG} Error in request handler:`, { message: error.message, stack: error.stack });
     if (error instanceof DatabaseError) {
-      return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500 });
+      return NextResponse.json({ error: 'Database error', details: error.message }, { status: 500, headers: noStore });
     }
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500, headers: noStore });
   }
 }


### PR DESCRIPTION
## Summary
- avoid CDN/proxy caching by disabling fetch cache in PlatformSummaryKpis
- return `Cache-Control: no-store` for admin and agency platform summary endpoints
- assert `no-store` header in platform summary API tests

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68ab392bc5f8832e8e353e09d5e8bbe0