### PR TITLE
feat: disable fetch caching for metrics

### DIFF
--- a/src/hooks/useMetrics.ts
+++ b/src/hooks/useMetrics.ts
@@ -59,6 +59,7 @@ export function useMetrics(): UseMetricsReturn {
     try {
       const res = await fetch(`/api/metrics?userId=${session.user.id}`, {
         credentials: "include", // Envia cookie de sessão
+        cache: "no-store",
       });
       const data: MetricsResponse = await res.json();
 
@@ -83,6 +84,7 @@ export function useMetrics(): UseMetricsReturn {
         headers: { "Content-Type": "application/json" },
         credentials: "include", // Envia cookie de sessão
         body: JSON.stringify(payload),
+        cache: "no-store",
       });
       const data: CreateMetricResponse = await res.json();
 


### PR DESCRIPTION
## Summary
- avoid fetch caching in metric hooks by setting `cache: "no-store"`

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*
- `npm run lint` *(fails: prompts for ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68ab4e7cfc00832ebe57d22be3b8a30e