### PR TITLE
feat: add comparison period to KPI fetch

### DIFF
--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -93,11 +93,20 @@ async function fetchTopVideos(baseUrl: string, userId: string): Promise<VideoLis
 }
 
 /**
- * Busca os dados de KPI para o período padrão (inicial).
+ * Busca os dados de KPI para o período comparativo informado.
+ *
+ * @param comparisonPeriod Período de comparação desejado (padrão: último 30 dias vs anteriores).
  */
-async function fetchKpis(baseUrl: string, userId: string): Promise<KpiComparison | null> {
+async function fetchKpis(
+  baseUrl: string,
+  userId: string,
+  comparisonPeriod = 'last_30d_vs_previous_30d'
+): Promise<KpiComparison | null> {
   try {
-    const res = await fetch(`${baseUrl}/api/v1/users/${userId}/kpis/periodic-comparison`, { cache: 'no-store' });
+    const res = await fetch(
+      `${baseUrl}/api/v1/users/${userId}/kpis/periodic-comparison?comparisonPeriod=${comparisonPeriod}`,
+      { cache: 'no-store' }
+    );
     if (!res.ok) {
       console.error(`[MediaKitPage] Falha ao buscar kpis: ${res.status}`);
       return null;


### PR DESCRIPTION
## Summary
- ensure KPI requests use default comparison period and allow future customization

## Testing
- `npm test` *(fails: 114 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab75eca6c4832e8e649d67ce14b7ac