### PR TITLE
feat: add socket IP fallback for client IP detection

### DIFF
--- a/src/app/mediakit/[token]/page.test.ts
+++ b/src/app/mediakit/[token]/page.test.ts
@@ -28,4 +28,21 @@ describe('MediaKitPage logging', () => {
     await MediaKitPage({ params: { token: 'tok' } } as Params);
     expect(mockLogAccess).toHaveBeenCalledWith('u1', '1.1.1.1', undefined);
   });
+
+  it('falls back to socket.remoteAddress when headers lack IP', async () => {
+    mockHeaders.mockReturnValue(new Headers());
+    const req = { socket: { remoteAddress: '2.2.2.2' } } as any;
+    await MediaKitPage({ params: { token: 'tok' } } as Params, req);
+    expect(mockLogAccess).toHaveBeenCalledWith('u1', '2.2.2.2', undefined);
+  });
+
+  it('does not use socket.remoteAddress in production', async () => {
+    mockHeaders.mockReturnValue(new Headers());
+    const req = { socket: { remoteAddress: '3.3.3.3' } } as any;
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    await MediaKitPage({ params: { token: 'tok' } } as Params, req);
+    expect(mockLogAccess).toHaveBeenCalledWith('u1', 'unknown', undefined);
+    process.env.NODE_ENV = prev;
+  });
 });

--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -130,7 +130,10 @@ async function fetchDemographics(baseUrl: string, userId: string): Promise<Demog
 
 // --- COMPONENTE DE PÁGINA (SERVER COMPONENT) ---
 
-export default async function MediaKitPage({ params }: { params: { token: string } }) {
+export default async function MediaKitPage(
+  { params }: { params: { token: string } },
+  req?: Request,
+) {
   await connectToDatabase();
 
   const user = await UserModel.findOne({ mediaKitSlug: params.token }).lean();
@@ -141,7 +144,7 @@ export default async function MediaKitPage({ params }: { params: { token: string
   const reqHeaders = headers();
 
   // Usa o helper robusto (lida com cf-connecting-ip, x-forwarded-for, forwarded, etc.)
-  const ip = getClientIpFromHeaders(reqHeaders);
+  const ip = getClientIpFromHeaders(reqHeaders, req);
   const referer = reqHeaders.get('referer') || undefined;
 
   // Registra o acesso (o util já normaliza e evita IP vazio)


### PR DESCRIPTION
## Summary
- extend `getClientIpFromHeaders` to accept optional request and fall back to `socket.remoteAddress` in non-production envs
- pass request to `getClientIpFromHeaders` when available
- expand MediaKit page tests to cover socket fallback

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization and other environment-related errors)*
- `npx jest --runTestsByPath src/app/mediakit/\[token\]/page.test.ts` *(fails: NEXT_RSC_ERR_CLIENT_IMPORT: next/headers)*

------
https://chatgpt.com/codex/tasks/task_e_68abaa1d4034832eadc4ad69381fe3be