### PR TITLE
fix: allow generic plan filter in creators API

### DIFF
--- a/src/app/api/admin/creators/route.ts
+++ b/src/app/api/admin/creators/route.ts
@@ -24,8 +24,8 @@ const querySchema = z.object({
   page: z.coerce.number().int().min(1).optional().default(1),
   limit: z.coerce.number().int().min(1).max(100).optional().default(10),
   search: z.string().optional(),
-  // CORREÇÃO: Adicionado o status "expired" para manter consistência com outras partes do código.
-  planStatus: z.enum(['active', 'pending', 'canceled', 'inactive', 'trial', 'expired', 'non_renewing']).optional(),
+  // Usamos string genérica para permitir diferentes identificadores de plano (ex.: "Free", "Pro").
+  planStatus: z.string().optional(),
   sortBy: z.string().optional().default('registrationDate'),
   sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
 });

--- a/src/types/admin/creators.ts
+++ b/src/types/admin/creators.ts
@@ -1,7 +1,5 @@
 // src/types/admin/creators.ts
 
-import type { PlanStatus } from '@/types/enums';
-
 // Define os possíveis status de um criador no contexto de admin
 export type AdminCreatorStatus = 'pending' | 'approved' | 'rejected' | 'active'; // 'active' pode ser um sinônimo de 'approved' ou um estado pós-aprovação.
 
@@ -10,7 +8,7 @@ export interface AdminCreatorListItem {
   _id: string; // Geralmente o ID do MongoDB como string
   name: string;
   email: string;
-  planStatus?: PlanStatus; // Status do plano - vindo do UserModel
+  planStatus?: string; // Identificador do plano (ex.: "Free", "Pro")
   inferredExpertiseLevel?: string; // Nível de expertise inferido - vindo do UserModel
   profilePictureUrl?: string; // URL da foto de perfil
   mediaKitSlug?: string; // Slug do mídia kit, se já gerado
@@ -32,7 +30,7 @@ export interface AdminCreatorListParams {
   limit?: number;
   search?: string; // Para buscar por nome, email, etc.
   status?: AdminCreatorStatus; // Para filtrar por status de admin
-  planStatus?: PlanStatus; // Para filtrar por status do plano
+  planStatus?: string | string[]; // Para filtrar por identificador do plano
   sortBy?: keyof AdminCreatorListItem | string; // Campo para ordenação
   sortOrder?: 'asc' | 'desc';
   // Adicionar startDate e endDate se a lista principal de gerenciamento de criadores for filtrável por data


### PR DESCRIPTION
## Summary
- allow any string for `planStatus` in admin creators API
- loosen admin creators types to accept arbitrary plan identifiers

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8f125928832e9246501b329857fc