### PR TITLE
Use plan status dropdown in creators management

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ STRIPE_COUPON_AFFILIATE10_ONCE_USD=coupon_...
 Na dashboard administrativa, utilize o componente **CreatorsScatterPlot** para comparar métricas de diferentes criadores em um gráfico de dispersão.
 Selecione múltiplos criadores e defina as métricas dos eixos X e Y para gerar o gráfico.
 
+### Filtros de Criadores
+
+Na página `/admin/creators-management`, é possível filtrar a listagem por **Status do Plano**. As opções do seletor são carregadas de `PLAN_STATUSES` (pending, active, inactive, canceled, trial, trialing, expired, past_due, incomplete, incomplete_expired, unpaid e non_renewing) e os valores enviados permanecem em minúsculas.
+
 ### User Monthly Comparison Chart
 
 O componente **UserMonthlyComparisonChart** exibe a evolução de uma métrica entre os três últimos meses para um criador específico.

--- a/src/app/admin/creators-management/page.tsx
+++ b/src/app/admin/creators-management/page.tsx
@@ -8,6 +8,7 @@ import {
   AdminCreatorListParams,
   AdminCreatorStatus,
 } from '@/types/admin/creators'; // Ajuste o caminho se necessário
+import { PLAN_STATUSES, type PlanStatus } from '@/types/enums';
 import { 
     MagnifyingGlassIcon, 
     ChevronDownIcon, 
@@ -44,7 +45,7 @@ export default function CreatorsManagementPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<AdminCreatorStatus | ''>('');
-  const [planFilter, setPlanFilter] = useState<string>('');
+  const [planFilter, setPlanFilter] = useState<PlanStatus | ''>('');
 
   const [sortConfig, setSortConfig] = useState<SortConfig>({ sortBy: 'registrationDate', sortOrder: 'desc' });
 
@@ -76,7 +77,7 @@ export default function CreatorsManagementPage() {
 
     if (debouncedSearchTerm) params.append('search', debouncedSearchTerm);
     if (statusFilter) params.append('status', statusFilter);
-    if (planFilter) params.append('planStatus', planFilter);
+    if (planFilter) params.append('planStatus', planFilter.toLowerCase());
 
     try {
       const response = await fetch(`/api/admin/creators?${params.toString()}`);
@@ -262,16 +263,24 @@ export default function CreatorsManagementPage() {
             </select>
           </div>
           <div>
-            <label htmlFor="planFilter" className="block text-sm font-medium text-gray-700">Plano</label>
-             <input
-              type="text"
+            <label htmlFor="planFilter" className="block text-sm font-medium text-gray-700">Status do Plano</label>
+            <select
               id="planFilter"
               name="planFilter"
               className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
-              placeholder="Ex: Free, Pro"
               value={planFilter}
-              onChange={(e) => {setPlanFilter(e.target.value); setCurrentPage(1);}}
-            />
+              onChange={(e) => { setPlanFilter(e.target.value.toLowerCase() as PlanStatus | ''); setCurrentPage(1); }}
+            >
+              <option value="">Todos os Status de Plano</option>
+              {PLAN_STATUSES.map(status => (
+                <option key={status} value={status}>
+                  {status
+                    .split('_')
+                    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join(' ')}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace free-text plan filter with dropdown sourced from `PLAN_STATUSES`
- send lowercase plan statuses matching allowed values
- document plan status filter for creators management

## Testing
- `npm test src/app/api/agency/accept-invite/route.test.ts` *(fails: Request is not defined)*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68acbb9db594832eb0d9686f92f5d1b5