### PR TITLE
feat: extend WhatsApp code expiration to 60 minutes

### DIFF
--- a/src/app/api/whatsapp/generateCode/route.ts
+++ b/src/app/api/whatsapp/generateCode/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 // === Config ===
 // Janela de validade do código (em ms). Mesmo que o schema ainda não tenha o campo
 // de expiresAt, manter aqui torna o endpoint idempotente e pronto para o ciclo 2 (schema).
-const CODE_TTL_MS = 15 * 60 * 1000; // 15 minutos
+const CODE_TTL_MS = 60 * 60 * 1000; // 60 minutos
 
 /** Gera um código de verificação aleatório com 6 caracteres maiúsculos. */
 function generateVerificationCode(): string {

--- a/tests/whatsapp-generateCode.test.ts
+++ b/tests/whatsapp-generateCode.test.ts
@@ -30,7 +30,8 @@ describe("POST /api/whatsapp/generateCode", () => {
       whatsappVerified: false,
       save: mockSave,
     };
-    (User.findById as jest.Mock).mockResolvedValue(user);
+    const mockSelect = jest.fn().mockResolvedValue(user);
+    (User.findById as jest.Mock).mockReturnValue({ select: mockSelect });
 
     const request = new NextRequest("http://localhost/api/whatsapp/generateCode", { method: "POST" });
     const response = await POST(request);
@@ -38,6 +39,9 @@ describe("POST /api/whatsapp/generateCode", () => {
 
     expect(response.status).toBe(200);
     expect(data.code).toHaveLength(6);
+    const diffMs = new Date(data.expiresAt).getTime() - Date.now();
+    expect(diffMs).toBeGreaterThanOrEqual(59 * 60 * 1000);
+    expect(diffMs).toBeLessThanOrEqual(60 * 60 * 1000);
     expect(user.whatsappVerificationCode).toBeTruthy();
     expect(mockSave).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- extend WhatsApp verification code TTL to 60 minutes
- update WhatsApp code generation test to validate new expiration window

## Testing
- `npm test -- tests/whatsapp-generateCode.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ace1573074832e826d73b41ebca6a5