### PR TITLE
fix: wrap long messages in chat panel

### DIFF
--- a/src/app/dashboard/ChatPanel.tsx
+++ b/src/app/dashboard/ChatPanel.tsx
@@ -48,7 +48,7 @@ function renderFormatted(text: string) {
     blocks.push(
       <p
         key={`p-${i}`}
-        className="leading-relaxed"
+        className="leading-relaxed break-words"
         dangerouslySetInnerHTML={{ __html: line.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') }}
       />
     );


### PR DESCRIPTION
## Summary
- ensure chat messages break mid-word to avoid overflow

## Testing
- `npm test` *(fails: invariant expected app router to be mounted and more)*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b290b216b0832e9e86a3775ac0cba2