### PR TITLE
Use flex-1 for chat panel container

### DIFF
--- a/src/app/dashboard/chat/page.tsx
+++ b/src/app/dashboard/chat/page.tsx
@@ -63,7 +63,7 @@ export default function ChatHomePage() {
       </div>
 
       {/* Chat ocupa todo o restante */}
-      <div className="flex-grow w-full">
+      <div className="flex-1 w-full">
         <ChatPanel onUpsellClick={openBillingModal} />
       </div>
 


### PR DESCRIPTION
## Summary
- ensure chat panel grows to fill page by replacing flex-grow with flex-1

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: 113 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b29cb7f564832e8d2d91aa0f8123cc