### PR TITLE
feat: open subscribe modal from header

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -66,7 +66,9 @@ function ChatHeader({ user }: { user?: SessionUser }) {
         <div className="flex flex-col items-center">
           <h2 className="font-semibold text-gray-800 select-none">data2content</h2>
           <button
-            onClick={() => router.push("/dashboard/billing?subscribe=pro")}
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent("open-subscribe-modal"))
+            }
             className="text-xs font-semibold text-white bg-gray-900 px-3 py-1 rounded-full hover:bg-gray-800 transition-colors shadow-sm"
             aria-label="Assine o plano Pro"
           >

--- a/src/app/dashboard/chat/page.tsx
+++ b/src/app/dashboard/chat/page.tsx
@@ -28,6 +28,12 @@ export default function ChatHomePage() {
   const closeBillingModal = () => setShowBillingModal(false);
   const openedAfterIgRef = useRef(false);
 
+  useEffect(() => {
+    const handler = () => setShowBillingModal(true);
+    window.addEventListener("open-subscribe-modal" as any, handler);
+    return () => window.removeEventListener("open-subscribe-modal" as any, handler);
+  }, []);
+
   // Limpa o parâmetro ?instagramLinked=true do URL após a primeira renderização
   useEffect(() => {
     const params = new URLSearchParams(sp.toString());


### PR DESCRIPTION
## Summary
- trigger subscribe modal from chat header button
- listen for header event to open billing modal in chat page

## Testing
- `npm test` *(fails: 113 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b29cf675e8832ea8a6e2178aff0738