### PR TITLE
feat: add safe area padding to chat header

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -50,6 +50,7 @@ function ChatHeader({ user }: { user?: SessionUser }) {
   return (
     <header
       ref={headerRef}
+      style={{ paddingTop: "var(--sat)" }}
       className="absolute top-0 left-0 right-0 z-20 p-2 sm:p-4 bg-white/80 backdrop-blur-sm border-b border-gray-200/80"
       aria-label="Barra superior do chat"
     >


### PR DESCRIPTION
## Summary
- add CSS safe-area-top padding to chat header

## Testing
- `npm test` *(fails: 113 failed, 41 passed)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b31a3815c0832eb3ae9062f44dc915