### PR TITLE
fix: use svh for layout height

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -85,7 +85,7 @@ export default async function RootLayout({
           antialiased
           flex
           flex-col
-          min-h-screen
+          min-h-svh
           bg-brand-light
           text-brand-dark
         `}


### PR DESCRIPTION
## Summary
- use 100svh min height on root layout

## Testing
- `npm test` *(fails: Test Suites: 113 failed, 41 passed, 154 total)*
- `npm run build` *(fails: Error: Failed to fetch font Inter)*

------
https://chatgpt.com/codex/tasks/task_e_68b37b4524bc832ebd49efa85c460f83