### PR TITLE
feat(chatpanel): render markdown tables

### DIFF
--- a/docs/qa-ranking-table.md
+++ b/docs/qa-ranking-table.md
@@ -1,0 +1,28 @@
+# QA - Tabela de Rankings no ChatPanel
+
+## Cenário: Exibir ranking em tabela
+1. Abrir `/dashboard/chat`.
+2. Enviar a mensagem abaixo no campo de texto:
+
+```
+| Rank | Criador | Pontos |
+| --- | --- | --- |
+| 1 | Alice | 98 |
+| 2 | Bob | 87 |
+| 3 | Carol | 75 |
+```
+
+3. Verificar que a resposta renderiza uma tabela com rolagem horizontal (`overflow-x-auto`).
+4. Confirmar que o texto das colunas utiliza a classe `text-xs` e está legível em telas móveis.
+
+## Cenário: Tabela com muitas colunas
+1. Enviar a mensagem:
+
+```
+| Rank | Criador | Pontos | Seguidores | Engajamento |
+| --- | --- | --- | --- | --- |
+| 1 | Alice | 98 | 120k | 5% |
+| 2 | Bob | 87 | 90k | 4% |
+```
+
+2. Validar que é possível rolar horizontalmente e todas as colunas são exibidas corretamente.

--- a/src/app/dashboard/ChatPanel.tsx
+++ b/src/app/dashboard/ChatPanel.tsx
@@ -116,8 +116,58 @@ function renderFormatted(text: string) {
       return;
     }
 
-    // Listas
+    // Listas / Tabelas
     const lines = trimmed.split(/\n/).map(l => l.trim()).filter(Boolean);
+
+    // Tabela simples (markdown pipes com linha de separação ---)
+    const isTable =
+      lines.length >= 2 &&
+      lines[0].includes("|") &&
+      lines[1].includes("|") &&
+      /---/.test(lines[1]);
+
+    if (isTable) {
+      const headers = lines[0].split("|").map(c => c.trim()).filter(Boolean);
+      const rows = lines.slice(2).map(row => row.split("|").map(c => c.trim()).filter(Boolean));
+      elements.push(
+        <div key={`tbl-${idx}`} className="overflow-x-auto my-2">
+          <table className="min-w-full text-left text-xs">
+            <thead>
+              <tr>
+                {headers.map((h, i) => {
+                  const html = applyInlineMarkup(escapeHtml(h));
+                  return (
+                    <th
+                      key={i}
+                      className="px-2 py-1 border-b font-semibold text-gray-800"
+                      dangerouslySetInnerHTML={{ __html: html }}
+                    />
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, rIdx) => (
+                <tr key={rIdx}>
+                  {row.map((cell, cIdx) => {
+                    const html = applyInlineMarkup(escapeHtml(cell));
+                    return (
+                      <td
+                        key={cIdx}
+                        className="px-2 py-1 border-b text-gray-700"
+                        dangerouslySetInnerHTML={{ __html: html }}
+                      />
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+      return;
+    }
+
     const isBulleted = lines.length > 0 && lines.every(l => /^[-*]\s+/.test(l));
     const isNumbered = lines.length > 0 && lines.every(l => /^\d+\.\s+/.test(l));
 


### PR DESCRIPTION
## Summary
- support markdown table blocks in chat messages
- document manual ranking table QA scenarios

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d9bb6ed4832e8d8072bee1102923