### PR TITLE
Fix chat layout with fixed input

### DIFF
--- a/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
+++ b/src/app/admin/creator-dashboard/StandaloneChatInterface.tsx
@@ -370,7 +370,7 @@ const StandaloneChatInterface: React.FC<StandaloneChatInterfaceProps> = ({ initi
   };
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-800">
+    <div className="flex flex-col h-full overflow-hidden bg-gray-50 dark:bg-gray-800">
       {/* Chat Messages Area */}
       <main className="flex-1 overflow-y-auto p-4 md:p-6 space-y-2">
         {messages.length === 0 && !isLoading && (

--- a/src/app/dashboard/ChatPanel.tsx
+++ b/src/app/dashboard/ChatPanel.tsx
@@ -355,7 +355,7 @@ export default function ChatPanel({ onUpsellClick }: { onUpsellClick?: () => voi
 
   return (
     <div
-      className="relative flex flex-col h-full w-full bg-white overflow-x-hidden"
+      className="relative flex flex-col h-full w-full bg-white overflow-hidden"
       style={{ minHeight: 'calc(100svh - var(--header-h, 4rem))' }}
     >
       {/* timeline */}


### PR DESCRIPTION
## Summary
- prevent ChatPanel container from scrolling so only messages scroll
- keep admin standalone chat input fixed at bottom

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e86ebc3c832e9426a75dcff6531e