### PR TITLE
Handle comma-separated values in chat tables

### DIFF
--- a/src/app/dashboard/ChatPanel.tsx
+++ b/src/app/dashboard/ChatPanel.tsx
@@ -159,6 +159,22 @@ function renderFormatted(text: string) {
               {rows.map((row, rIdx) => (
                 <tr key={rIdx}>
                   {row.map((cell, cIdx) => {
+                    if (cell.includes(',')) {
+                      const parts = cell.split(',').map((p) => p.trim()).filter(Boolean);
+                      return (
+                        <td key={cIdx} className="px-2 py-1 border-b text-gray-700">
+                          {parts.map((part, pIdx) => {
+                            const htmlPart = applyInlineMarkup(escapeHtml(part));
+                            return (
+                              <div
+                                key={pIdx}
+                                dangerouslySetInnerHTML={{ __html: htmlPart }}
+                              />
+                            );
+                          })}
+                        </td>
+                      );
+                    }
                     const html = applyInlineMarkup(escapeHtml(cell));
                     return (
                       <td


### PR DESCRIPTION
## Summary
- Split comma-separated table cells and render each segment with inline markup to allow stacked links

## Testing
- `npm test` *(fails: ReferenceError, component and environment issues)*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e2294988832eb03a04c6020aae7a