### PR TITLE
Hide media kit banners for non-owners

### DIFF
--- a/__mocks__/lucide-react.js
+++ b/__mocks__/lucide-react.js
@@ -1,0 +1,2 @@
+const React = require('react');
+module.exports = { __esModule: true, default: () => React.createElement('svg') };

--- a/src/app/mediakit/[token]/MediaKitView.test.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import MediaKitView from './MediaKitView';
+import { useSession } from 'next-auth/react';
+
+jest.mock('next-auth/react', () => ({ useSession: jest.fn() }));
+
+jest.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    motion: new Proxy({}, {
+      get: (_, prop) => (props: any) => React.createElement(prop as any, props, props.children),
+    }),
+  };
+});
+
+jest.mock('@/app/admin/creator-dashboard/components/filters/GlobalTimePeriodContext', () => {
+  const React = require('react');
+  return {
+    GlobalTimePeriodProvider: ({ children }: any) => <div>{children}</div>,
+    useGlobalTimePeriod: () => ({ timePeriod: 'last_90_days', setTimePeriod: jest.fn() }),
+  };
+});
+
+jest.mock('@/hooks/usePlannerData', () => ({ usePlannerData: () => ({ slots: null, heatmap: null, loading: false }) }));
+
+jest.mock('@/app/admin/creator-dashboard/components/VideosTable', () => ({ __esModule: true, default: () => <div data-testid="VideosTable" /> }));
+jest.mock('@/app/dashboard/components/AverageMetricRow', () => ({ __esModule: true, default: () => <div data-testid="AverageMetricRow" /> }));
+jest.mock('@/app/admin/creator-dashboard/PostDetailModal', () => ({ __esModule: true, default: () => <div data-testid="PostDetailModal" /> }));
+jest.mock('@/app/mediakit/components/PlannerSlotModal', () => ({ __esModule: true, default: () => <div data-testid="PlannerSlotModal" /> }));
+jest.mock('@/app/components/UserAvatar', () => ({ UserAvatar: ({ name }: any) => <div data-testid="UserAvatar">{name}</div> }));
+
+jest.mock('@/components/affiliate/AffiliateCard', () => ({ __esModule: true, default: () => <div data-testid="affiliate-card">AffiliateCard</div> }));
+jest.mock('@/app/mediakit/components/SubscribeCtaBanner', () => ({ __esModule: true, default: () => <div data-testid="subscribe-banner">SubscribeCtaBanner</div> }));
+
+describe('MediaKitView ownership visibility', () => {
+  const baseProps = {
+    user: { _id: 'user1', name: 'Owner', profile_picture_url: '', email: 'owner@example.com' },
+    summary: null,
+    videos: [],
+    kpis: null,
+    demographics: null,
+  } as any;
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('hides cards for visitors', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: null });
+    render(<MediaKitView {...baseProps} />);
+    expect(screen.queryByTestId('subscribe-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('affiliate-card')).not.toBeInTheDocument();
+  });
+
+  it('hides cards for non-owners', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { _id: 'other' } } });
+    render(<MediaKitView {...baseProps} />);
+    expect(screen.queryByTestId('subscribe-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('affiliate-card')).not.toBeInTheDocument();
+  });
+
+  it('shows cards for owner', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { _id: 'user1' } } });
+    render(<MediaKitView {...baseProps} />);
+    expect(screen.getByTestId('subscribe-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('affiliate-card')).toBeInTheDocument();
+  });
+});

--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -821,14 +821,16 @@ export default function MediaKitView({
       <div className="bg-slate-50 min-h-screen font-sans">
         <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
 
-          <SubscribeCtaBanner isSubscribed={isSubscribed} />
-
           {isOwner && (
-            <motion.div variants={cardVariants} initial="hidden" animate="visible" custom={0.15}>
-              <div className="mb-6 sm:mb-8">
-                <AffiliateCard variant="mediakit" />
-              </div>
-            </motion.div>
+            <>
+              <SubscribeCtaBanner isSubscribed={isSubscribed} />
+
+              <motion.div variants={cardVariants} initial="hidden" animate="visible" custom={0.15}>
+                <div className="mb-6 sm:mb-8">
+                  <AffiliateCard variant="mediakit" />
+                </div>
+              </motion.div>
+            </>
           )}
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-10">


### PR DESCRIPTION
## Summary
- Show SubscribeCtaBanner and AffiliateCard only when viewing own media kit
- Add tests ensuring non-owners or visitors cannot see subscription or affiliate banners
- Mock lucide-react icons for Jest

## Testing
- `npm test` *(fails: ReferenceError and other failing suites)*
- `npx jest --runTestsByPath src/app/mediakit/\[token\]/MediaKitView.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf90ae4714832eabd2d2b32e2c0b32