### PR TITLE
feat: add owner CTAs toggle

### DIFF
--- a/src/app/mediakit/[token]/MediaKitView.tsx
+++ b/src/app/mediakit/[token]/MediaKitView.tsx
@@ -707,6 +707,7 @@ export default function MediaKitView({
   kpis: initialKpis,
   demographics,
   showSharedBanner = false,
+  showOwnerCtas = false,
 }: MediaKitViewProps) {
   const cardVariants = {
     hidden: { opacity: 0, y: 20 },
@@ -821,7 +822,7 @@ export default function MediaKitView({
       <div className="bg-slate-50 min-h-screen font-sans">
         <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
 
-          {isOwner && (
+          {isOwner && showOwnerCtas && (
             <>
               <SubscribeCtaBanner isSubscribed={isSubscribed} />
 

--- a/src/types/mediakit.ts
+++ b/src/types/mediakit.ts
@@ -109,4 +109,5 @@ export interface MediaKitViewProps {
   demographics: DemographicsData | null;
   // Exibe o banner institucional apenas em contexto de compartilhamento público
   showSharedBanner?: boolean;
+  showOwnerCtas?: boolean;
 }


### PR DESCRIPTION
## Summary
- add optional `showOwnerCtas` flag to MediaKitView props
- gate owner-specific CTAs behind `isOwner && showOwnerCtas`

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'mockMetricAggregate' before initialization, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf950ab68c832eac7f9304ce4da3d4