### PR TITLE
feat: toggle owner ctas

### DIFF
--- a/src/app/dashboard/media-kit/page.tsx
+++ b/src/app/dashboard/media-kit/page.tsx
@@ -97,14 +97,15 @@ function SelfMediaKitContent({ userId, fallbackName, fallbackEmail, fallbackImag
   return (
     <div className="bg-slate-50">
       <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
-        <MediaKitView
-          user={user}
-          summary={summary}
-          videos={videos}
-          kpis={kpis}
-          demographics={demographics}
-          showSharedBanner={false}
-        />
+          <MediaKitView
+            user={user}
+            summary={summary}
+            videos={videos}
+            kpis={kpis}
+            demographics={demographics}
+            showSharedBanner={false}
+            showOwnerCtas={true}
+          />
       </div>
     </div>
   );

--- a/src/app/mediakit/[token]/page.tsx
+++ b/src/app/mediakit/[token]/page.tsx
@@ -221,13 +221,14 @@ export default async function MediaKitPage(
   const plainUser = JSON.parse(JSON.stringify(user));
 
   return (
-    <MediaKitView
-      user={plainUser}
-      summary={summary}
-      videos={compatibleVideos}
-      kpis={kpis}
-      demographics={demographics}
-      showSharedBanner={!isOwner}
-    />
+        <MediaKitView
+          user={plainUser}
+          summary={summary}
+          videos={compatibleVideos}
+          kpis={kpis}
+          demographics={demographics}
+          showSharedBanner={!isOwner}
+          showOwnerCtas={false}
+        />
   );
 }


### PR DESCRIPTION
## Summary
- show owner CTAs on dashboard media kit
- explicitly hide owner CTAs on public media kit page

## Testing
- `npm test` *(fails: expected environment issues)*
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bf969fe534832e9192c439a258f86b