### PR TITLE
Fix subscribe modal alignment and scrolling

### DIFF
--- a/src/app/dashboard/billing/BillingSubscribeModal.tsx
+++ b/src/app/dashboard/billing/BillingSubscribeModal.tsx
@@ -242,7 +242,7 @@ export default function BillingSubscribeModal({ open, onClose }: BillingSubscrib
   if (loading && !prices && !error) {
     return (
       <div
-        className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4"
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4 overflow-y-auto"
         role="dialog"
         aria-modal="true"
         aria-label="Carregando preços"
@@ -295,7 +295,7 @@ export default function BillingSubscribeModal({ open, onClose }: BillingSubscrib
   if (error && !prices) {
     return (
       <div
-        className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4"
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4 overflow-y-auto"
         role="dialog"
         aria-modal="true"
         aria-labelledby="billing-error-title"
@@ -348,7 +348,7 @@ export default function BillingSubscribeModal({ open, onClose }: BillingSubscrib
   if (prices) {
     return (
       <div
-        className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4"
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm px-3 sm:px-4 py-4 overflow-y-auto"
         role="dialog"
         aria-modal="true"
         aria-labelledby="subscribe-modal-title"


### PR DESCRIPTION
## Summary
- ensure BillingSubscribeModal overlay centers modal and allows scrolling

## Testing
- `npm test` *(fails: 114 failed, 41 passed)*
- `npm run lint` *(interactive prompt, not fully executed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9f262038832e9b61b5441bff4078