### PR TITLE
feat: rebuild adaptive board v2 and narrative source foundations

### DIFF
--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_MANUAL_QA.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_MANUAL_QA.md
@@ -1,0 +1,132 @@
+# Board Adaptativo V2 - Checklist de QA Manual
+
+Este checklist orienta a validação visual/manual do harness interno antes de qualquer integração da V2 no BoardShell.
+
+## Pré-requisitos
+
+- Estar na branch `feat/adaptive-post-creation-board-v2`.
+- Rodar o app localmente.
+- Usar `NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED=1`.
+- Acessar `/dashboard/boards/adaptive-v2-preview`.
+
+## Cenários para Revisar
+
+| Cenário | URL relativa |
+| --- | --- |
+| `validate-pauta` | `/dashboard/boards/adaptive-v2-preview?scenario=validate-pauta` |
+| `format-guidance` | `/dashboard/boards/adaptive-v2-preview?scenario=format-guidance` |
+| `discover-pauta` | `/dashboard/boards/adaptive-v2-preview?scenario=discover-pauta` |
+| `brand-match` | `/dashboard/boards/adaptive-v2-preview?scenario=brand-match` |
+| `collab-match` | `/dashboard/boards/adaptive-v2-preview?scenario=collab-match` |
+| `comment-to-post` | `/dashboard/boards/adaptive-v2-preview?scenario=comment-to-post` |
+
+## Checklist Visual por Cenário
+
+Aplicar este checklist em todos os cenários:
+
+- O título `Preview interno — Board Adaptativo V2` aparece.
+- O cenário ativo está correto.
+- O input controlado está correto.
+- O modo detectado está correto.
+- O bloco `Leitura inicial` aparece.
+- O bloco `Caminhos de decisão` aparece.
+- O bloco `Leitura da rodada` aparece.
+- O bloco `Plano estratégico` aparece.
+- As perguntas estão legíveis.
+- Opções longas não quebram o layout.
+- A indicação `Sugestão estratégica` não parece gabarito.
+- Não aparece score, nota, percentual ou pontuação.
+- Não aparece linguagem de jogo/prova.
+- Próximos passos parecem úteis e não prometem performance.
+
+## Checklist Específico por Cenário
+
+### validate-pauta
+
+- Não deve mostrar bloco de collab automaticamente.
+- Deve parecer validação de ideia, não plano comercial forçado.
+
+### format-guidance
+
+- Deve começar pela força/narrativa da pauta antes do formato.
+- Formato deve aparecer como conclusão da leitura.
+
+### discover-pauta
+
+- Deve parecer desbloqueio criativo.
+- Deve começar por território/narrativa.
+
+### brand-match
+
+- Deve mostrar `Encaixe com marca`.
+- Não deve mostrar `Encaixe com collab` sem motivo.
+
+### collab-match
+
+- Deve mostrar `Encaixe com collab`.
+- Deve sugerir dinâmica de parceria sem parecer campanha obrigatória.
+
+### comment-to-post
+
+- Deve aproveitar o comentário como origem da pauta.
+- Deve parecer resposta à audiência.
+
+## Checklist de Linguagem Proibida
+
+Procurar visualmente pelos termos abaixo. Nenhum deles deve aparecer na experiência renderizada:
+
+- `score`
+- `nota`
+- `pontuação`
+- `acerto`
+- `erro`
+- `errado`
+- `resposta correta`
+- `gabarito`
+- `venceu`
+- `perdeu`
+- `garantido`
+- `certeza`
+- `comprovado`
+- `viralizar garantido`
+
+## Checklist Mobile e Responsivo
+
+Testar no DevTools em largura mobile:
+
+- Cards de opção.
+- Blocos 5W2H.
+- Cenas sugeridas.
+- Próximos passos.
+- Links de cenário.
+- Scroll geral da página.
+- Quebra de textos longos em labels, helpers e razões.
+- Espaçamento entre blocos e legibilidade em telas estreitas.
+
+## Critérios de Aprovação Visual
+
+Considerar a QA visual aprovada apenas se:
+
+- Nenhum termo proibido for encontrado.
+- Nenhum layout estiver quebrado.
+- Nenhum cenário renderizar bloco errado de marca/collab.
+- A navegação por cenários funcionar.
+- A página bloqueada aparecer corretamente com a flag off.
+- A experiência parecer mentoria estratégica, não quiz de acerto.
+
+## Achados
+
+Preencher durante a revisão manual:
+
+| Cenário | Problema encontrado | Severidade | Sugestão de ajuste | Status |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+
+## Próxima Decisão
+
+Depois desta QA manual, escolher uma das próximas direções:
+
+- Avançar para V2M: proteção por sessão admin/dev.
+- Fazer ajuste visual de UI caso a QA encontre problema.
+
+Não avançar para integração no BoardShell antes de resolver achados visuais relevantes.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -7,10 +7,10 @@ Este documento descreve a estratégia de reintrodução do Board Adaptativo em e
 - Implementação da lógica de Feature Flag isolada (`postCreationAdaptiveFeatureFlag.ts`).
 - Testes unitários para a Feature Flag.
 
-## Fase V2B: Roteamento de Intenção & Lógica (Próxima)
-- Reintroduzir o roteador adaptativo para detecção de intenção.
-- Implementar a lógica de decisão (DecisionViewModel) sem UI.
-- Validar via testes unitários.
+## Fase V2B: Roteamento de Intenção & Lógica (Concluída)
+- Reintroduzir o roteador adaptativo para detecção de intenção (`postCreationAdaptiveRouter.ts`).
+- Validar prioridades de intenção via testes unitários.
+- Manter a lógica isolada, sem UI, BoardShell, endpoints ou OpenAI.
 
 ## Fase V2C: Quiz Builder & Gerenciamento de Estado
 - Reintroduzir a construção de perguntas baseada na intenção.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -12,11 +12,16 @@ Este documento descreve a estratégia de reintrodução do Board Adaptativo em e
 - Validar prioridades de intenção via testes unitários.
 - Manter a lógica isolada, sem UI, BoardShell, endpoints ou OpenAI.
 
-## Fase V2C: Quiz Builder & Gerenciamento de Estado
-- Reintroduzir a construção de perguntas baseada na intenção.
-- Implementar o AnswerKey para mapeamento de respostas estratégicas.
+## Fase V2C: Quiz Builder Isolado (Concluída)
+- Reintroduzir a construção de perguntas baseada na intenção (`postCreationAdaptiveQuizBuilder.ts`).
+- Validar estrutura, mapKeys e linguagem consultiva via testes unitários.
+- Manter a fase sem AnswerKey, score, UI, BoardShell, endpoints ou OpenAI.
 
-## Fase V2D: Componentes de UI & Handoff
+## Fase V2D: AnswerKey & Recomendações Estratégicas
+- Implementar o mapeamento de respostas estratégicas.
+- Validar recomendações sem UI e sem score visual.
+
+## Fase V2E: Componentes de UI & Handoff
 - Reintroduzir o NativeFlow e ScoreCard de forma modular.
 - Integrar com o BoardShell através da feature flag.
 - Garantir handoff seguro para o fluxo legado.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -22,7 +22,12 @@ Este documento descreve a estratégia de reintrodução do Board Adaptativo em e
 - Validar recomendações e linguagem consultiva via testes unitários.
 - Manter a fase sem UI e sem score visual.
 
-## Fase V2E: Componentes de UI & Handoff
+## Fase V2E: Strategic Plan Builder puro (Concluída)
+- Criar a camada de construção do plano estratégico (`postCreationAdaptivePlanBuilder.ts`).
+- Gerar cenas, 5W2H e próximas ações de forma determinística.
+- Validar linguagem consultiva e integridade do plano via testes unitários.
+
+## Fase V2F: Componentes de UI & Handoff
 - Reintroduzir o NativeFlow e ScoreCard de forma modular.
 - Integrar com o BoardShell através da feature flag.
 - Garantir handoff seguro para o fluxo legado.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -1,33 +1,119 @@
-# Plano de Implementação: Board Adaptativo V2
+# Board Adaptativo V2 - Status do Rollout
 
-Este documento descreve a estratégia de reintrodução do Board Adaptativo em etapas modulares, garantindo segurança e estabilidade.
+Este documento registra o estado atual da reconstrução do Board Adaptativo V2 após o revert do PR #784.
 
-## Fase V2A: Fundação & Feature Flag (Concluída)
-- Reintrodução dos tipos base (`postCreationAdaptiveTypes.ts`).
-- Implementação da lógica de Feature Flag isolada (`postCreationAdaptiveFeatureFlag.ts`).
-- Testes unitários para a Feature Flag.
+A V2 foi reintroduzida em camadas pequenas e verificáveis: primeiro lógica pura, depois QA do pipeline, depois uma UI preview isolada e, por fim, um harness interno protegido por flag. Até este momento, nada foi conectado ao fluxo real do produto.
 
-## Fase V2B: Roteamento de Intenção & Lógica (Concluída)
-- Reintroduzir o roteador adaptativo para detecção de intenção (`postCreationAdaptiveRouter.ts`).
-- Validar prioridades de intenção via testes unitários.
-- Manter a lógica isolada, sem UI, BoardShell, endpoints ou OpenAI.
+## Resumo da V2
 
-## Fase V2C: Quiz Builder Isolado (Concluída)
-- Reintroduzir a construção de perguntas baseada na intenção (`postCreationAdaptiveQuizBuilder.ts`).
-- Validar estrutura, mapKeys e linguagem consultiva via testes unitários.
-- Manter a fase sem AnswerKey, score, UI, BoardShell, endpoints ou OpenAI.
+A implementação atual cobre:
 
-## Fase V2D: AnswerKey & Recomendações Estratégicas (Concluída)
-- Implementar o mapeamento de respostas estratégicas (`postCreationAdaptiveAnswerKey.ts`).
-- Validar recomendações e linguagem consultiva via testes unitários.
-- Manter a fase sem UI e sem score visual.
+- Lógica pura de detecção, perguntas, leitura estratégica e plano.
+- QA de pipeline completo: Router -> QuizBuilder -> AnswerKey -> PlanBuilder.
+- UI preview isolada, renderizada apenas por props.
+- Harness interno em rota própria, protegido por env flag.
+- Cenários controlados do pipeline para visualização interna.
 
-## Fase V2E: Strategic Plan Builder puro (Concluída)
-- Criar a camada de construção do plano estratégico (`postCreationAdaptivePlanBuilder.ts`).
-- Gerar cenas, 5W2H e próximas ações de forma determinística.
-- Validar linguagem consultiva e integridade do plano via testes unitários.
+A implementação atual não cobre:
 
-## Fase V2F: Componentes de UI & Handoff
-- Reintroduzir o NativeFlow e ScoreCard de forma modular.
-- Integrar com o BoardShell através da feature flag.
-- Garantir handoff seguro para o fluxo legado.
+- Integração com `PostCreationFunnelBoardShell`.
+- Exibição no produto real.
+- Persistência de pauta.
+- Uso de usuário real.
+- Banco de dados.
+- OpenAI.
+- Input livre.
+- Handoff para Planner, Media Kit, marcas, collabs reais ou DNA Narrativo.
+
+## Mapa das Fases
+
+| Fase | Status | Arquivos principais | O que faz |
+| --- | --- | --- | --- |
+| V2A - Fundação tipada e feature flag isolada | Concluída | `postCreationAdaptiveTypes.ts`, `postCreationAdaptiveFeatureFlag.ts`, `postCreationAdaptiveFeatureFlag.test.ts` | Reintroduz tipos base e controle isolado por flag. |
+| V2B - Roteador heurístico de intenção isolado | Concluída | `postCreationAdaptiveRouter.ts`, `postCreationAdaptiveRouter.test.ts` | Detecta intenções como validar pauta, descobrir pauta, formato, marca, collab e comentário para post. |
+| V2C - Quiz Builder isolado | Concluída | `postCreationAdaptiveQuizBuilder.ts`, `postCreationAdaptiveQuizBuilder.test.ts` | Gera perguntas determinísticas por modo, com linguagem consultiva e sem UI. |
+| V2D - AnswerKey & Recomendações Estratégicas | Concluída | `postCreationAdaptiveAnswerKey.ts`, `postCreationAdaptiveAnswerKey.test.ts` | Avalia respostas e gera leitura consultiva sem score visual. |
+| V2E - Strategic Plan Builder puro | Concluída | `postCreationAdaptivePlanBuilder.ts`, `postCreationAdaptivePlanBuilder.test.ts` | Monta plano estratégico, 5W2H, cenas, próximas ações e blocos opcionais de marca/collab. |
+| V2F - QA do pipeline invisível | Concluída | `postCreationAdaptivePipeline.test.ts` | Valida o pipeline completo com jornadas obrigatórias e guarda de linguagem. |
+| V2G - Evitar collabMatch automático em validate_pauta | Concluída | `postCreationAdaptivePlanBuilder.ts`, `postCreationAdaptivePlanBuilder.test.ts`, `postCreationAdaptivePipeline.test.ts` | Impede que `validate_pauta` gere collab automaticamente apenas por mapKey `collab`. |
+| V2H - UI Preview isolada | Concluída | `components/adaptiveV2/AdaptiveV2Preview.tsx`, `AdaptiveV2IntentPreview.tsx`, `AdaptiveV2QuestionPreview.tsx`, `AdaptiveV2AnswerKeyPreview.tsx`, `AdaptiveV2PlanPreview.tsx`, `AdaptiveV2Preview.test.tsx` | Renderiza a experiência adaptativa por props, sem chamar pipeline, fetch, OpenAI, browser APIs ou BoardShell. |
+| V2I - Preview Harness isolado com fixture estática | Concluída | `adaptive-v2-preview/page.tsx`, `adaptive-v2-preview/page.test.tsx`, `components/adaptiveV2/adaptiveV2PreviewFixture.ts` | Cria rota interna protegida por flag usando dados fixture. |
+| V2J - Preview Harness com cenários controlados do pipeline | Concluída | `components/adaptiveV2/buildAdaptiveV2PreviewScenario.ts`, `adaptive-v2-preview/page.tsx`, `adaptive-v2-preview/page.test.tsx` | Permite visualizar cenários fixos que rodam o pipeline local, sem input livre e sem fluxo real. |
+
+## Harness Interno
+
+Rota:
+
+```text
+/dashboard/boards/adaptive-v2-preview
+```
+
+Flag necessária:
+
+```text
+NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED=1
+```
+
+Com a flag desligada, a rota renderiza um estado bloqueado e não monta a preview.
+
+### Cenários disponíveis
+
+```text
+/dashboard/boards/adaptive-v2-preview?scenario=validate-pauta
+/dashboard/boards/adaptive-v2-preview?scenario=format-guidance
+/dashboard/boards/adaptive-v2-preview?scenario=discover-pauta
+/dashboard/boards/adaptive-v2-preview?scenario=brand-match
+/dashboard/boards/adaptive-v2-preview?scenario=collab-match
+/dashboard/boards/adaptive-v2-preview?scenario=comment-to-post
+```
+
+Se `scenario` estiver ausente ou inválido, o harness usa `validate-pauta` como padrão.
+
+## Limites Atuais
+
+- A V2 não está conectada ao BoardShell.
+- A V2 não aparece no produto real.
+- A V2 não salva pauta.
+- A V2 não usa usuário real.
+- A V2 não acessa banco.
+- A V2 não usa OpenAI.
+- A V2 não tem input livre.
+- A V2 usa cenários controlados no harness.
+- A proteção atual é por env flag, não por sessão admin/dev.
+- O harness não adiciona link em menu ou navegação principal.
+
+## Critérios Antes de Conectar no BoardShell
+
+Antes de qualquer integração experimental com o BoardShell:
+
+- Validar visualmente o harness em browser real.
+- Revisar linguagem e tom com foco em mentoria consultiva.
+- Decidir explicitamente se haverá score visual ou se a V2 seguirá sem score.
+- Se necessário, proteger acesso por sessão admin/dev além da env flag.
+- Definir handoff para fluxo real sem quebrar o legado.
+- Definir se e como haverá salvar pauta.
+- Criar plano de rollback.
+- Manter a feature flag desligada em produção até aprovação.
+- Revalidar que não há promessa de performance, linguagem de prova ou termos de jogo.
+
+## Comandos de QA Recomendados
+
+```bash
+npm test -- --runInBand src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
+npm test -- --runInBand src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts
+npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts
+npm run typecheck
+```
+
+## Próximas Fases Sugeridas
+
+- V2L: QA visual manual no harness.
+- V2M: Proteção por sessão admin/dev.
+- V2N: Integração experimental no BoardShell atrás da flag.
+- V2O: Handoff para plano real ou salvar pauta.
+- V2P: Decisão sobre liberar para beta interno.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -17,9 +17,10 @@ Este documento descreve a estratégia de reintrodução do Board Adaptativo em e
 - Validar estrutura, mapKeys e linguagem consultiva via testes unitários.
 - Manter a fase sem AnswerKey, score, UI, BoardShell, endpoints ou OpenAI.
 
-## Fase V2D: AnswerKey & Recomendações Estratégicas
-- Implementar o mapeamento de respostas estratégicas.
-- Validar recomendações sem UI e sem score visual.
+## Fase V2D: AnswerKey & Recomendações Estratégicas (Concluída)
+- Implementar o mapeamento de respostas estratégicas (`postCreationAdaptiveAnswerKey.ts`).
+- Validar recomendações e linguagem consultiva via testes unitários.
+- Manter a fase sem UI e sem score visual.
 
 ## Fase V2E: Componentes de UI & Handoff
 - Reintroduzir o NativeFlow e ScoreCard de forma modular.

--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -1,0 +1,22 @@
+# Plano de Implementação: Board Adaptativo V2
+
+Este documento descreve a estratégia de reintrodução do Board Adaptativo em etapas modulares, garantindo segurança e estabilidade.
+
+## Fase V2A: Fundação & Feature Flag (Concluída)
+- Reintrodução dos tipos base (`postCreationAdaptiveTypes.ts`).
+- Implementação da lógica de Feature Flag isolada (`postCreationAdaptiveFeatureFlag.ts`).
+- Testes unitários para a Feature Flag.
+
+## Fase V2B: Roteamento de Intenção & Lógica (Próxima)
+- Reintroduzir o roteador adaptativo para detecção de intenção.
+- Implementar a lógica de decisão (DecisionViewModel) sem UI.
+- Validar via testes unitários.
+
+## Fase V2C: Quiz Builder & Gerenciamento de Estado
+- Reintroduzir a construção de perguntas baseada na intenção.
+- Implementar o AnswerKey para mapeamento de respostas estratégicas.
+
+## Fase V2D: Componentes de UI & Handoff
+- Reintroduzir o NativeFlow e ScoreCard de forma modular.
+- Integrar com o BoardShell através da feature flag.
+- Garantir handoff seguro para o fluxo legado.

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
@@ -15,7 +15,17 @@ afterEach(() => {
 });
 
 describe("AdaptiveV2PreviewPage", () => {
-  it("renders the internal preview when enabled", () => {
+  it("renders a blocked state when the internal flag is off", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "0";
+
+    render(<AdaptiveV2PreviewPage />);
+
+    expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
+    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.queryByText("Leitura inicial")).not.toBeInTheDocument();
+  });
+
+  it("renders the default validate-pauta scenario when enabled without scenario", () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
     render(<AdaptiveV2PreviewPage />);
@@ -25,6 +35,49 @@ describe("AdaptiveV2PreviewPage", () => {
     expect(screen.getByText("Caminhos de decisão")).toBeInTheDocument();
     expect(screen.getByText("Leitura da rodada")).toBeInTheDocument();
     expect(screen.getByText("Plano estratégico")).toBeInTheDocument();
+    expect(screen.getAllByText("Validar pauta").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
+  });
+
+  it("renders the brand match scenario from search params", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "brand-match" }} />);
+
+    expect(screen.getAllByText("Match com marca").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("brand_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com marca")).toBeInTheDocument();
+    expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
+  });
+
+  it("renders the collab match scenario from search params", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "collab-match" }} />);
+
+    expect(screen.getAllByText("Match com collab").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("collab_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
+  });
+
+  it("falls back to the default scenario when search params are invalid", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+
+    expect(screen.getAllByText("Validar pauta").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
+  });
+
+  it("continues without proof or visual score language", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    const { container } = render(<AdaptiveV2PreviewPage searchParams={{ scenario: "brand-match" }} />);
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of ["score", "nota", "pontuação", "acerto", "erro", "gabarito", "resposta correta"]) {
+      expect(text).not.toContain(forbidden);
+    }
   });
 
   it("does not import BoardShell or real product flow dependencies", () => {
@@ -38,26 +91,5 @@ describe("AdaptiveV2PreviewPage", () => {
     expect(source).not.toMatch(/openai/);
     expect(source).not.toMatch(/prisma/);
     expect(source).not.toMatch(/route handler/i);
-  });
-
-  it("continues without proof or visual score language", () => {
-    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
-
-    const { container } = render(<AdaptiveV2PreviewPage />);
-    const text = container.textContent?.toLowerCase() || "";
-
-    for (const forbidden of ["score", "nota", "pontuação", "acerto", "erro", "gabarito", "resposta correta"]) {
-      expect(text).not.toContain(forbidden);
-    }
-  });
-
-  it("renders a blocked state when the internal flag is off", () => {
-    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "0";
-
-    render(<AdaptiveV2PreviewPage />);
-
-    expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
-    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
-    expect(screen.queryByText("Leitura inicial")).not.toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
@@ -1,0 +1,63 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import AdaptiveV2PreviewPage from "./page";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = originalEnvValue;
+});
+
+describe("AdaptiveV2PreviewPage", () => {
+  it("renders the internal preview when enabled", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    render(<AdaptiveV2PreviewPage />);
+
+    expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
+    expect(screen.getByText("Leitura inicial")).toBeInTheDocument();
+    expect(screen.getByText("Caminhos de decisão")).toBeInTheDocument();
+    expect(screen.getByText("Leitura da rodada")).toBeInTheDocument();
+    expect(screen.getByText("Plano estratégico")).toBeInTheDocument();
+  });
+
+  it("does not import BoardShell or real product flow dependencies", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).not.toMatch(/PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/BoardShell/);
+    expect(source).not.toMatch(/usePostCreation/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/OpenAI/);
+    expect(source).not.toMatch(/openai/);
+    expect(source).not.toMatch(/prisma/);
+    expect(source).not.toMatch(/route handler/i);
+  });
+
+  it("continues without proof or visual score language", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    const { container } = render(<AdaptiveV2PreviewPage />);
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of ["score", "nota", "pontuação", "acerto", "erro", "gabarito", "resposta correta"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("renders a blocked state when the internal flag is off", () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "0";
+
+    render(<AdaptiveV2PreviewPage />);
+
+    expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
+    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.queryByText("Leitura inicial")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
@@ -1,14 +1,17 @@
 import { AdaptiveV2Preview } from "../components/adaptiveV2";
 import {
-  adaptiveV2PreviewAnswerKeyFixture,
-  adaptiveV2PreviewAnswersFixture,
-  adaptiveV2PreviewDetectionFixture,
-  adaptiveV2PreviewPlanFixture,
-  adaptiveV2PreviewQuestionsFixture,
-} from "../components/adaptiveV2/adaptiveV2PreviewFixture";
+  ADAPTIVE_V2_PREVIEW_SCENARIOS,
+  buildAdaptiveV2PreviewScenario,
+} from "../components/adaptiveV2/buildAdaptiveV2PreviewScenario";
 import { isPostCreationAdaptiveEnvEnabled } from "../postCreationAdaptiveFeatureFlag";
 
-export default function AdaptiveV2PreviewPage() {
+type AdaptiveV2PreviewPageProps = {
+  searchParams?: {
+    scenario?: string | string[];
+  };
+};
+
+export default function AdaptiveV2PreviewPage({ searchParams }: AdaptiveV2PreviewPageProps = {}) {
   const isEnabled = isPostCreationAdaptiveEnvEnabled();
 
   if (!isEnabled) {
@@ -18,13 +21,15 @@ export default function AdaptiveV2PreviewPage() {
           <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
           <h1 className="mt-2 text-2xl font-semibold">Preview interno — Board Adaptativo V2</h1>
           <p className="mt-3 text-sm leading-6 text-zinc-700">
-            Esta tela usa dados fixture e permanece bloqueada enquanto a flag interna da experiência adaptativa estiver
-            desligada.
+            Esta tela usa cenários controlados e permanece bloqueada enquanto a flag interna da experiência adaptativa
+            estiver desligada.
           </p>
         </section>
       </main>
     );
   }
+
+  const preview = buildAdaptiveV2PreviewScenario(searchParams?.scenario);
 
   return (
     <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
@@ -33,16 +38,53 @@ export default function AdaptiveV2PreviewPage() {
           <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna</p>
           <h1 className="mt-2 text-2xl font-semibold">Preview interno — Board Adaptativo V2</h1>
           <p className="mt-3 text-sm leading-6 text-zinc-700">
-            Esta tela usa dados fixture e não está conectada ao fluxo real.
+            Esta tela usa cenários controlados e não está conectada ao fluxo real.
           </p>
         </header>
 
+        <section className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap gap-2">
+            {ADAPTIVE_V2_PREVIEW_SCENARIOS.map((scenario) => {
+              const isActive = scenario.id === preview.scenario.id;
+
+              return (
+                <a
+                  key={scenario.id}
+                  href={`/dashboard/boards/adaptive-v2-preview?scenario=${scenario.id}`}
+                  className={
+                    isActive
+                      ? "rounded-full bg-zinc-950 px-3 py-1.5 text-sm font-semibold text-white"
+                      : "rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700"
+                  }
+                >
+                  {scenario.label}
+                </a>
+              );
+            })}
+          </div>
+
+          <dl className="mt-4 grid gap-3 text-sm md:grid-cols-3">
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Cenário ativo</dt>
+              <dd className="mt-1 text-zinc-900">{preview.scenario.label}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3 md:col-span-1">
+              <dt className="font-semibold text-zinc-500">Input controlado</dt>
+              <dd className="mt-1 text-zinc-900">{preview.scenario.input}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Modo detectado</dt>
+              <dd className="mt-1 text-zinc-900">{preview.detection.mode}</dd>
+            </div>
+          </dl>
+        </section>
+
         <AdaptiveV2Preview
-          detection={adaptiveV2PreviewDetectionFixture}
-          questions={adaptiveV2PreviewQuestionsFixture}
-          answers={adaptiveV2PreviewAnswersFixture}
-          answerKey={adaptiveV2PreviewAnswerKeyFixture}
-          plan={adaptiveV2PreviewPlanFixture}
+          detection={preview.detection}
+          questions={preview.questions}
+          answers={preview.answers}
+          answerKey={preview.answerKey}
+          plan={preview.plan}
         />
       </div>
     </main>

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
@@ -1,0 +1,50 @@
+import { AdaptiveV2Preview } from "../components/adaptiveV2";
+import {
+  adaptiveV2PreviewAnswerKeyFixture,
+  adaptiveV2PreviewAnswersFixture,
+  adaptiveV2PreviewDetectionFixture,
+  adaptiveV2PreviewPlanFixture,
+  adaptiveV2PreviewQuestionsFixture,
+} from "../components/adaptiveV2/adaptiveV2PreviewFixture";
+import { isPostCreationAdaptiveEnvEnabled } from "../postCreationAdaptiveFeatureFlag";
+
+export default function AdaptiveV2PreviewPage() {
+  const isEnabled = isPostCreationAdaptiveEnvEnabled();
+
+  if (!isEnabled) {
+    return (
+      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Board Adaptativo V2</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa dados fixture e permanece bloqueada enquanto a flag interna da experiência adaptativa estiver
+            desligada.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Board Adaptativo V2</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa dados fixture e não está conectada ao fluxo real.
+          </p>
+        </header>
+
+        <AdaptiveV2Preview
+          detection={adaptiveV2PreviewDetectionFixture}
+          questions={adaptiveV2PreviewQuestionsFixture}
+          answers={adaptiveV2PreviewAnswersFixture}
+          answerKey={adaptiveV2PreviewAnswerKeyFixture}
+          plan={adaptiveV2PreviewPlanFixture}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2AnswerKeyPreview.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2AnswerKeyPreview.tsx
@@ -1,0 +1,58 @@
+import type { PostCreationAdaptiveAnswerKeyResult } from "../../postCreationAdaptiveTypes";
+
+type AdaptiveV2AnswerKeyPreviewProps = {
+  answerKey: PostCreationAdaptiveAnswerKeyResult;
+};
+
+export function AdaptiveV2AnswerKeyPreview({ answerKey }: AdaptiveV2AnswerKeyPreviewProps) {
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Leitura da rodada</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Recomendação consultiva</h2>
+      </div>
+
+      <p className="mt-4 rounded-lg bg-zinc-50 p-3 text-sm leading-6 text-zinc-800">{answerKey.summary}</p>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-950">Pontos fortes</h3>
+          <ul className="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+            {answerKey.strengths.length > 0 ? (
+              answerKey.strengths.map((strength) => <li key={strength}>{strength}</li>)
+            ) : (
+              <li>Há espaço para consolidar pontos fortes depois das próximas escolhas.</li>
+            )}
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-950">Ajustes recomendados</h3>
+          <ul className="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+            {answerKey.adjustments.length > 0 ? (
+              answerKey.adjustments.map((adjustment) => <li key={adjustment}>{adjustment}</li>)
+            ) : (
+              <li>O caminho escolhido já está coerente para transformar em plano.</li>
+            )}
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-zinc-950">Leitura por pergunta</h3>
+        <div className="mt-2 grid gap-2">
+          {answerKey.evaluations.map((evaluation) => (
+            <article key={evaluation.questionId} className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+              <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-zinc-500">
+                <span>{evaluation.key}</span>
+                {evaluation.selectedLabel ? <span>Escolha: {evaluation.selectedLabel}</span> : null}
+                {evaluation.recommendedLabel ? <span>Referência: {evaluation.recommendedLabel}</span> : null}
+              </div>
+              <p className="mt-1.5 text-sm leading-6 text-zinc-700">{evaluation.reason}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2IntentPreview.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2IntentPreview.tsx
@@ -1,0 +1,50 @@
+import type { PostCreationAdaptiveIntentDetection } from "../../postCreationAdaptiveTypes";
+
+type AdaptiveV2IntentPreviewProps = {
+  detection: PostCreationAdaptiveIntentDetection;
+};
+
+function compactText(value: string, maxLength = 120) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+export function AdaptiveV2IntentPreview({ detection }: AdaptiveV2IntentPreviewProps) {
+  const signals = detection.signals.slice(0, 4);
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase text-zinc-500">Leitura inicial</p>
+          <h2 className="mt-1 text-lg font-semibold text-zinc-950">Direção detectada</h2>
+        </div>
+        <span className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-xs font-semibold text-zinc-700">
+          {detection.mode}
+        </span>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <dt className="font-semibold text-zinc-500">Relato original</dt>
+          <dd className="mt-1 leading-6 text-zinc-800">{compactText(detection.originalInput || "Sem relato informado.")}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-zinc-500">Sinais principais</dt>
+          <dd className="mt-1 flex flex-wrap gap-2">
+            {signals.length > 0 ? (
+              signals.map((signal) => (
+                <span key={signal} className="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-800">
+                  {signal}
+                </span>
+              ))
+            ) : (
+              <span className="text-zinc-600">Sem sinais específicos nesta leitura.</span>
+            )}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2PlanPreview.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2PlanPreview.tsx
@@ -1,0 +1,114 @@
+import type { PostCreationStrategicPlan } from "../../postCreationAdaptiveTypes";
+
+type AdaptiveV2PlanPreviewProps = {
+  plan: PostCreationStrategicPlan;
+};
+
+function Detail({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-800">{value}</dd>
+    </div>
+  );
+}
+
+export function AdaptiveV2PlanPreview({ plan }: AdaptiveV2PlanPreviewProps) {
+  const fiveW2HItems = [
+    ["Quem", plan.fiveW2H.who],
+    ["O que", plan.fiveW2H.what],
+    ["Onde", plan.fiveW2H.where],
+    ["Quando", plan.fiveW2H.when],
+    ["Por que", plan.fiveW2H.why],
+    ["Como", plan.fiveW2H.how],
+    ["Esforço", plan.fiveW2H.howMuch],
+  ] as const;
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Plano estratégico</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Roteiro de decisão</h2>
+      </div>
+
+      <dl className="mt-4 grid gap-3 md:grid-cols-2">
+        <Detail label="Pauta" value={plan.pauta} />
+        <Detail label="Objetivo" value={plan.objective} />
+        <Detail label="Narrativa" value={plan.narrative} />
+        <Detail label="Formato" value={plan.format} />
+        <Detail label="Gancho" value={plan.hook} />
+        <Detail label="Convite" value={plan.cta} />
+      </dl>
+
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-zinc-950">5W2H resumido</h3>
+        <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {fiveW2HItems.map(([label, value]) =>
+            value ? (
+              <div key={label} className="rounded-lg bg-zinc-50 p-3">
+                <dt className="text-xs font-semibold text-zinc-500">{label}</dt>
+                <dd className="mt-1 text-sm leading-6 text-zinc-700">{value}</dd>
+              </div>
+            ) : null
+          )}
+        </dl>
+      </div>
+
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-zinc-950">Cenas sugeridas</h3>
+        <div className="mt-2 grid gap-2">
+          {plan.scenes.map((scene) => (
+            <article key={scene.id} className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+              <h4 className="text-sm font-semibold text-zinc-950">{scene.title}</h4>
+              <p className="mt-1 text-sm leading-6 text-zinc-700">{scene.visual}</p>
+              <p className="mt-1 text-sm leading-6 text-zinc-700">{scene.message}</p>
+              {scene.direction ? <p className="mt-1 text-sm leading-6 text-zinc-600">{scene.direction}</p> : null}
+            </article>
+          ))}
+        </div>
+      </div>
+
+      {plan.brandMatch ? (
+        <div className="mt-4 rounded-lg border border-emerald-100 bg-emerald-50 p-3">
+          <h3 className="text-sm font-semibold text-emerald-950">Encaixe com marca</h3>
+          {plan.brandMatch.category ? (
+            <p className="mt-1 text-sm leading-6 text-emerald-900">Categoria: {plan.brandMatch.category}</p>
+          ) : null}
+          {plan.brandMatch.angle ? (
+            <p className="mt-1 text-sm leading-6 text-emerald-900">Direção: {plan.brandMatch.angle}</p>
+          ) : null}
+          {plan.brandMatch.desiredBrandSignals?.length ? (
+            <p className="mt-1 text-sm leading-6 text-emerald-900">
+              Sinais: {plan.brandMatch.desiredBrandSignals.join(", ")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {plan.collabMatch ? (
+        <div className="mt-4 rounded-lg border border-indigo-100 bg-indigo-50 p-3">
+          <h3 className="text-sm font-semibold text-indigo-950">Encaixe com collab</h3>
+          {plan.collabMatch.creatorProfile ? (
+            <p className="mt-1 text-sm leading-6 text-indigo-900">Perfil: {plan.collabMatch.creatorProfile}</p>
+          ) : null}
+          {plan.collabMatch.collaborationAngle ? (
+            <p className="mt-1 text-sm leading-6 text-indigo-900">
+              Direção: {plan.collabMatch.collaborationAngle}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-zinc-950">Próximos passos</h3>
+        <ol className="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+          {plan.nextActions.map((action) => (
+            <li key={action}>{action}</li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx
@@ -1,0 +1,274 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import { AdaptiveV2Preview } from "./AdaptiveV2Preview";
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveAnswerKeyResult,
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationStrategicPlan,
+} from "../../postCreationAdaptiveTypes";
+
+const detection: PostCreationAdaptiveIntentDetection = {
+  mode: "validate_pauta",
+  confidence: 0.85,
+  normalizedInput: "quero gravar um pov sobre rotina",
+  originalInput: "Quero gravar um POV sobre rotina",
+  detectedPauta: "rotina",
+  objective: null,
+  brandCategory: null,
+  sourceComment: null,
+  signals: ["quero gravar"],
+  suggestedStage: "quiz",
+};
+
+const questions: PostCreationAdaptiveQuestion[] = [
+  {
+    id: "question-objective",
+    mapKey: "objective",
+    type: "strategic_choice",
+    title: "Que reação essa pauta deveria puxar?",
+    helper: "A intenção orienta a execução.",
+    required: true,
+    options: [
+      {
+        id: "comments",
+        label: "Abrir conversa",
+        reason: "Combina com identificação e pergunta simples.",
+        recommended: true,
+      },
+      {
+        id: "saves",
+        label: "Gerar consulta depois",
+        reason: "Combina com conteúdo prático.",
+      },
+    ],
+  },
+  {
+    id: "question-format",
+    mapKey: "format",
+    type: "preference",
+    title: "Qual formato cabe melhor agora?",
+    helper: "O formato precisa caber na energia disponível.",
+    required: true,
+    options: [
+      {
+        id: "reels",
+        label: "Reels simples",
+        reason: "Bom quando a cena carrega a ideia.",
+        recommended: true,
+      },
+      {
+        id: "carousel",
+        label: "Carrossel curto",
+        reason: "Bom quando a ideia precisa de ordem.",
+      },
+    ],
+  },
+];
+
+const answers: PostCreationAdaptiveAnswer[] = [
+  {
+    questionId: "question-objective",
+    key: "objective",
+    optionId: "comments",
+    value: null,
+  },
+  {
+    questionId: "question-format",
+    key: "format",
+    optionId: "reels",
+    value: null,
+  },
+];
+
+const answerKey: PostCreationAdaptiveAnswerKeyResult = {
+  mode: "validate_pauta",
+  totalQuestions: 2,
+  answeredQuestions: 2,
+  recommendedMatches: 2,
+  evaluations: [
+    {
+      questionId: "question-objective",
+      key: "objective",
+      selectedOptionId: "comments",
+      selectedLabel: "Abrir conversa",
+      recommendedOptionId: "comments",
+      recommendedLabel: "Abrir conversa",
+      isRecommendedChoice: true,
+      reason: "Essa escolha mantém a pauta consultiva e clara.",
+    },
+    {
+      questionId: "question-format",
+      key: "format",
+      selectedOptionId: "reels",
+      selectedLabel: "Reels simples",
+      recommendedOptionId: "reels",
+      recommendedLabel: "Reels simples",
+      isRecommendedChoice: true,
+      reason: "Esse formato ajuda a transformar a cena em narrativa.",
+    },
+  ],
+  strengths: ["Ponto forte: Abrir conversa.", "Ponto forte: Reels simples."],
+  adjustments: [],
+  summary: "A leitura aponta uma direção clara para transformar a rotina em pauta.",
+};
+
+const planWithoutMatches: PostCreationStrategicPlan = {
+  pauta: "rotina",
+  objective: "Abrir conversa",
+  narrative: "Cena cotidiana com ponto de vista",
+  format: "Reels simples",
+  hook: "POV que entra direto na rotina",
+  cta: "Perguntar quem também vive isso",
+  fiveW2H: {
+    who: "Audiência do Instagram",
+    what: "rotina",
+    where: "Instagram",
+    when: "Próxima janela de publicação",
+    why: "A pauta aproxima a audiência de uma cena reconhecível.",
+    how: "Reels simples com narrativa cotidiana.",
+    howMuch: "Baixo esforço",
+  },
+  scenes: [
+    {
+      id: "scene-1",
+      title: "Gancho visual",
+      visual: "Começar no meio da rotina.",
+      message: "Mostrar a tensão principal sem explicar demais.",
+    },
+    {
+      id: "scene-2",
+      title: "Fechamento",
+      visual: "Encerrar com olhar direto para a câmera.",
+      message: "Abrir conversa com uma pergunta natural.",
+    },
+  ],
+  brandMatch: null,
+  collabMatch: null,
+  nextActions: ["Revisar o roteiro.", "Separar elementos visuais.", "Observar a resposta da audiência."],
+};
+
+function renderPreview(plan: PostCreationStrategicPlan = planWithoutMatches) {
+  return render(
+    <AdaptiveV2Preview
+      detection={detection}
+      questions={questions}
+      answers={answers}
+      answerKey={answerKey}
+      plan={plan}
+    />
+  );
+}
+
+describe("AdaptiveV2Preview", () => {
+  it("renders the complete isolated preview", () => {
+    renderPreview();
+
+    expect(screen.getByText("Leitura inicial")).toBeInTheDocument();
+    expect(screen.getByText("Caminhos de decisão")).toBeInTheDocument();
+    expect(screen.getByText("Leitura da rodada")).toBeInTheDocument();
+    expect(screen.getByText("Plano estratégico")).toBeInTheDocument();
+  });
+
+  it("does not render proof or game language", () => {
+    const { container } = renderPreview();
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "acerto",
+      "acertou",
+      "erro",
+      "errou",
+      "errado",
+      "nota",
+      "pontuação",
+      "venceu",
+      "perdeu",
+      "resposta correta",
+      "gabarito",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not render visual score language", () => {
+    const { container } = renderPreview();
+    const text = container.textContent?.toLowerCase() || "";
+
+    expect(text).not.toContain("%");
+    expect(text).not.toContain("score");
+    expect(text).not.toContain("nota");
+    expect(text).not.toContain("pontuação");
+  });
+
+  it("renders brand match only when present", () => {
+    const { rerender } = renderPreview();
+
+    expect(screen.queryByText("Encaixe com marca")).not.toBeInTheDocument();
+
+    rerender(
+      <AdaptiveV2Preview
+        detection={detection}
+        questions={questions}
+        answers={answers}
+        answerKey={answerKey}
+        plan={{
+          ...planWithoutMatches,
+          brandMatch: {
+            enabled: true,
+            category: "skincare",
+            angle: "Rotina real com produto em contexto.",
+            desiredBrandSignals: ["uso natural"],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Encaixe com marca")).toBeInTheDocument();
+    expect(screen.getByText(/skincare/i)).toBeInTheDocument();
+  });
+
+  it("renders collab match only when present", () => {
+    const { rerender } = renderPreview();
+
+    expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
+
+    rerender(
+      <AdaptiveV2Preview
+        detection={detection}
+        questions={questions}
+        answers={answers}
+        answerKey={answerKey}
+        plan={{
+          ...planWithoutMatches,
+          collabMatch: {
+            enabled: true,
+            creatorProfile: "Creator do mesmo nicho",
+            collaborationAngle: "Contraste de rotina",
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
+    expect(screen.getByText(/Creator do mesmo nicho/i)).toBeInTheDocument();
+  });
+
+  it("keeps preview components isolated from product flow dependencies", () => {
+    const previewDir = __dirname;
+    const source = fs
+      .readdirSync(previewDir)
+      .filter((file) => file.endsWith(".tsx") && !file.endsWith(".test.tsx"))
+      .map((file) => fs.readFileSync(path.join(previewDir, file), "utf8"))
+      .join("\n");
+
+    expect(source).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/postCreationAdaptiveRouter|postCreationAdaptiveQuizBuilder/);
+    expect(source).not.toMatch(/postCreationAdaptiveAnswerKey|postCreationAdaptivePlanBuilder/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/OpenAI|openai/i);
+    expect(source).not.toMatch(/\bwindow\b|localStorage/);
+  });
+});

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.tsx
@@ -1,0 +1,36 @@
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveAnswerKeyResult,
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationStrategicPlan,
+} from "../../postCreationAdaptiveTypes";
+import { AdaptiveV2AnswerKeyPreview } from "./AdaptiveV2AnswerKeyPreview";
+import { AdaptiveV2IntentPreview } from "./AdaptiveV2IntentPreview";
+import { AdaptiveV2PlanPreview } from "./AdaptiveV2PlanPreview";
+import { AdaptiveV2QuestionPreview } from "./AdaptiveV2QuestionPreview";
+
+export type AdaptiveV2PreviewProps = {
+  detection: PostCreationAdaptiveIntentDetection;
+  questions: PostCreationAdaptiveQuestion[];
+  answers: PostCreationAdaptiveAnswer[];
+  answerKey: PostCreationAdaptiveAnswerKeyResult;
+  plan: PostCreationStrategicPlan;
+};
+
+export function AdaptiveV2Preview({
+  detection,
+  questions,
+  answers,
+  answerKey,
+  plan,
+}: AdaptiveV2PreviewProps) {
+  return (
+    <div className="space-y-4 rounded-lg bg-zinc-100 p-4 text-zinc-950">
+      <AdaptiveV2IntentPreview detection={detection} />
+      <AdaptiveV2QuestionPreview questions={questions} answers={answers} />
+      <AdaptiveV2AnswerKeyPreview answerKey={answerKey} />
+      <AdaptiveV2PlanPreview plan={plan} />
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2QuestionPreview.tsx
+++ b/src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2QuestionPreview.tsx
@@ -1,0 +1,73 @@
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveQuestion,
+} from "../../postCreationAdaptiveTypes";
+
+type AdaptiveV2QuestionPreviewProps = {
+  questions: PostCreationAdaptiveQuestion[];
+  answers: PostCreationAdaptiveAnswer[];
+};
+
+export function AdaptiveV2QuestionPreview({ questions, answers }: AdaptiveV2QuestionPreviewProps) {
+  const answerByQuestionId = new Map(answers.map((answer) => [answer.questionId, answer]));
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Caminhos de decisão</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Perguntas da rodada</h2>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {questions.map((question, index) => {
+          const selectedOptionId = answerByQuestionId.get(question.id)?.optionId || null;
+
+          return (
+            <article key={question.id} className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs font-semibold text-zinc-500">Decisão {index + 1}</p>
+                  <h3 className="mt-1 text-sm font-semibold leading-6 text-zinc-950">{question.title}</h3>
+                </div>
+                <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-zinc-600 ring-1 ring-zinc-200">
+                  {question.mapKey}
+                </span>
+              </div>
+
+              {question.helper ? <p className="mt-2 text-sm leading-6 text-zinc-600">{question.helper}</p> : null}
+
+              <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+                {question.options.map((option) => {
+                  const isSelected = option.id === selectedOptionId;
+                  const isRecommended = option.recommended === true;
+
+                  return (
+                    <li
+                      key={option.id}
+                      className="rounded-lg border border-zinc-200 bg-white p-3 text-sm text-zinc-800"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold">{option.label}</span>
+                        {isSelected ? (
+                          <span className="rounded-full bg-zinc-900 px-2 py-0.5 text-[11px] font-semibold text-white">
+                            Escolha selecionada
+                          </span>
+                        ) : null}
+                        {isRecommended ? (
+                          <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
+                            Sugestão estratégica
+                          </span>
+                        ) : null}
+                      </div>
+                      {option.reason ? <p className="mt-1.5 leading-5 text-zinc-600">{option.reason}</p> : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/adaptiveV2PreviewFixture.ts
+++ b/src/app/dashboard/boards/components/adaptiveV2/adaptiveV2PreviewFixture.ts
@@ -1,0 +1,213 @@
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveAnswerKeyResult,
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationStrategicPlan,
+} from "../../postCreationAdaptiveTypes";
+
+export const adaptiveV2PreviewDetectionFixture: PostCreationAdaptiveIntentDetection = {
+  mode: "validate_pauta",
+  confidence: 0.85,
+  normalizedInput: "quero gravar um pov sobre rotina",
+  originalInput: "Quero gravar um POV sobre rotina",
+  detectedPauta: "rotina",
+  objective: null,
+  brandCategory: null,
+  sourceComment: null,
+  signals: ["quero gravar"],
+  suggestedStage: "quiz",
+};
+
+export const adaptiveV2PreviewQuestionsFixture: PostCreationAdaptiveQuestion[] = [
+  {
+    id: "preview-objective",
+    mapKey: "objective",
+    type: "strategic_choice",
+    title: "Que reação essa pauta deveria puxar?",
+    helper: "A intenção orienta a execução sem transformar a rodada em avaliação.",
+    required: true,
+    options: [
+      {
+        id: "comments",
+        label: "Abrir conversa",
+        reason: "Combina com identificação e pergunta simples.",
+        recommended: true,
+      },
+      {
+        id: "saves",
+        label: "Gerar consulta depois",
+        reason: "Combina com conteúdo prático e estrutura clara.",
+      },
+      {
+        id: "reach",
+        label: "Ampliar descoberta",
+        reason: "Combina com cena reconhecível e abertura direta.",
+      },
+    ],
+  },
+  {
+    id: "preview-format",
+    mapKey: "format",
+    type: "preference",
+    title: "Qual formato cabe melhor agora?",
+    helper: "O formato precisa caber na energia disponível e no tipo de narrativa.",
+    required: true,
+    options: [
+      {
+        id: "reels",
+        label: "Reels simples",
+        reason: "Bom quando a cena carrega a ideia com rapidez.",
+        recommended: true,
+      },
+      {
+        id: "carousel",
+        label: "Carrossel curto",
+        reason: "Bom quando a ideia precisa de ordem e consulta.",
+      },
+      {
+        id: "stories",
+        label: "Stories em conversa",
+        reason: "Bom para testar reação antes de transformar em pauta maior.",
+      },
+    ],
+  },
+  {
+    id: "preview-cta",
+    mapKey: "cta",
+    type: "strategic_choice",
+    title: "Qual convite parece continuação natural da cena?",
+    helper: "O próximo passo deve soar como conversa, não como comando solto.",
+    required: true,
+    options: [
+      {
+        id: "question",
+        label: "Perguntar quem também vive isso",
+        reason: "Mantém a audiência dentro da situação apresentada.",
+        recommended: true,
+      },
+      {
+        id: "save",
+        label: "Salvar para rever depois",
+        reason: "Funciona melhor quando a entrega tem passo prático.",
+      },
+      {
+        id: "share",
+        label: "Enviar para alguém",
+        reason: "Funciona melhor quando a situação tem reconhecimento imediato.",
+      },
+    ],
+  },
+];
+
+export const adaptiveV2PreviewAnswersFixture: PostCreationAdaptiveAnswer[] = [
+  {
+    questionId: "preview-objective",
+    key: "objective",
+    optionId: "comments",
+    value: null,
+  },
+  {
+    questionId: "preview-format",
+    key: "format",
+    optionId: "reels",
+    value: null,
+  },
+  {
+    questionId: "preview-cta",
+    key: "cta",
+    optionId: "question",
+    value: null,
+  },
+];
+
+export const adaptiveV2PreviewAnswerKeyFixture: PostCreationAdaptiveAnswerKeyResult = {
+  mode: "validate_pauta",
+  totalQuestions: 3,
+  answeredQuestions: 3,
+  recommendedMatches: 3,
+  evaluations: [
+    {
+      questionId: "preview-objective",
+      key: "objective",
+      selectedOptionId: "comments",
+      selectedLabel: "Abrir conversa",
+      recommendedOptionId: "comments",
+      recommendedLabel: "Abrir conversa",
+      isRecommendedChoice: true,
+      reason: "Essa escolha mantém a pauta próxima da audiência.",
+    },
+    {
+      questionId: "preview-format",
+      key: "format",
+      selectedOptionId: "reels",
+      selectedLabel: "Reels simples",
+      recommendedOptionId: "reels",
+      recommendedLabel: "Reels simples",
+      isRecommendedChoice: true,
+      reason: "Esse formato ajuda a transformar a rotina em cena rápida.",
+    },
+    {
+      questionId: "preview-cta",
+      key: "cta",
+      selectedOptionId: "question",
+      selectedLabel: "Perguntar quem também vive isso",
+      recommendedOptionId: "question",
+      recommendedLabel: "Perguntar quem também vive isso",
+      isRecommendedChoice: true,
+      reason: "Esse convite continua a conversa criada pela cena.",
+    },
+  ],
+  strengths: [
+    "Ponto forte: Abrir conversa.",
+    "Ponto forte: Reels simples.",
+    "Ponto forte: Perguntar quem também vive isso.",
+  ],
+  adjustments: [],
+  summary: "A leitura aponta uma direção clara para transformar rotina em uma pauta de conversa.",
+};
+
+export const adaptiveV2PreviewPlanFixture: PostCreationStrategicPlan = {
+  pauta: "rotina",
+  objective: "Abrir conversa",
+  narrative: "Cena cotidiana com ponto de vista",
+  format: "Reels simples",
+  hook: "POV que entra direto na rotina",
+  cta: "Perguntar quem também vive isso",
+  fiveW2H: {
+    who: "Audiência do Instagram",
+    what: "rotina",
+    where: "Instagram",
+    when: "Próxima janela de publicação",
+    why: "A pauta aproxima a audiência de uma cena reconhecível.",
+    how: "Reels simples com narrativa cotidiana.",
+    howMuch: "Baixo esforço",
+  },
+  scenes: [
+    {
+      id: "preview-scene-1",
+      title: "Gancho visual",
+      visual: "Começar no meio de uma situação real da rotina.",
+      message: "Mostrar a tensão principal sem explicar demais.",
+    },
+    {
+      id: "preview-scene-2",
+      title: "Virada da cena",
+      visual: "Cortar para a reação ou frase que resume o incômodo.",
+      message: "Transformar o detalhe cotidiano em identificação.",
+    },
+    {
+      id: "preview-scene-3",
+      title: "Fechamento e convite",
+      visual: "Encerrar olhando para a câmera ou para o elemento da cena.",
+      message: "Abrir conversa com uma pergunta natural.",
+    },
+  ],
+  brandMatch: null,
+  collabMatch: null,
+  nextActions: [
+    "Revisar o roteiro com base nas cenas sugeridas.",
+    "Separar um elemento visual que deixe a rotina reconhecível.",
+    "Observar a resposta da audiência para calibrar a próxima pauta.",
+  ],
+};

--- a/src/app/dashboard/boards/components/adaptiveV2/buildAdaptiveV2PreviewScenario.ts
+++ b/src/app/dashboard/boards/components/adaptiveV2/buildAdaptiveV2PreviewScenario.ts
@@ -1,0 +1,82 @@
+import { buildPostCreationAdaptiveAnswerKey } from "../../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../../postCreationAdaptiveTypes";
+
+export type AdaptiveV2PreviewScenario = {
+  id: string;
+  label: string;
+  input: string;
+};
+
+export const ADAPTIVE_V2_PREVIEW_SCENARIOS: AdaptiveV2PreviewScenario[] = [
+  {
+    id: "validate-pauta",
+    label: "Validar pauta",
+    input: "Quero gravar um POV sobre rotina",
+  },
+  {
+    id: "format-guidance",
+    label: "Escolher formato",
+    input: "Qual formato usar para uma publi de skincare?",
+  },
+  {
+    id: "discover-pauta",
+    label: "Descobrir pauta",
+    input: "Não sei o que postar amanhã",
+  },
+  {
+    id: "brand-match",
+    label: "Match com marca",
+    input: "Quero atrair marcas de skincare",
+  },
+  {
+    id: "collab-match",
+    label: "Match com collab",
+    input: "Quero fazer uma collab para gerar comentários",
+  },
+  {
+    id: "comment-to-post",
+    label: "Comentário vira post",
+    input: "Comentaram isso aqui: como você organiza sua rotina?",
+  },
+];
+
+export const DEFAULT_ADAPTIVE_V2_PREVIEW_SCENARIO_ID = "validate-pauta";
+
+function normalizeScenarioId(value?: string | string[] | null) {
+  if (Array.isArray(value)) return value[0] || DEFAULT_ADAPTIVE_V2_PREVIEW_SCENARIO_ID;
+  return value || DEFAULT_ADAPTIVE_V2_PREVIEW_SCENARIO_ID;
+}
+
+export function getAdaptiveV2PreviewScenario(value?: string | string[] | null) {
+  const scenarioId = normalizeScenarioId(value);
+  return (
+    ADAPTIVE_V2_PREVIEW_SCENARIOS.find((scenario) => scenario.id === scenarioId) ||
+    ADAPTIVE_V2_PREVIEW_SCENARIOS[0]!
+  );
+}
+
+export function buildAdaptiveV2PreviewScenario(value?: string | string[] | null) {
+  const scenario = getAdaptiveV2PreviewScenario(value);
+  const detection = detectPostCreationAdaptiveIntent(scenario.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => ({
+    questionId: question.id,
+    key: question.mapKey,
+    optionId: question.options.find((option) => option.recommended)?.id || question.options[0]!.id,
+    value: null,
+  }));
+  const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+  const plan = buildPostCreationAdaptiveStrategicPlan({ detection, questions, answers, answerKey });
+
+  return {
+    scenario,
+    detection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}

--- a/src/app/dashboard/boards/components/adaptiveV2/index.ts
+++ b/src/app/dashboard/boards/components/adaptiveV2/index.ts
@@ -1,0 +1,6 @@
+export { AdaptiveV2Preview } from "./AdaptiveV2Preview";
+export type { AdaptiveV2PreviewProps } from "./AdaptiveV2Preview";
+export { AdaptiveV2IntentPreview } from "./AdaptiveV2IntentPreview";
+export { AdaptiveV2QuestionPreview } from "./AdaptiveV2QuestionPreview";
+export { AdaptiveV2AnswerKeyPreview } from "./AdaptiveV2AnswerKeyPreview";
+export { AdaptiveV2PlanPreview } from "./AdaptiveV2PlanPreview";

--- a/src/app/dashboard/boards/components/narrativeSource/CreatorSignalsPreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/CreatorSignalsPreview.tsx
@@ -1,0 +1,39 @@
+import type { CreatorNarrativeSignal } from "../../narrativeSource/narrativeSourceTypes";
+
+type CreatorSignalsPreviewProps = {
+  profileSignals: CreatorNarrativeSignal[];
+};
+
+export function CreatorSignalsPreview({ profileSignals }: CreatorSignalsPreviewProps) {
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Sinais para entender a conta</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Pistas de perfil narrativo</h2>
+      </div>
+
+      {profileSignals.length ? (
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {profileSignals.map((signal) => (
+            <article key={signal.id} className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-sm font-semibold text-zinc-950">{signal.signalType}</h3>
+                {signal.shouldPersistLater ? (
+                  <span className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-900">
+                    pode enriquecer o perfil depois
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-2 text-sm leading-6 text-zinc-800">{signal.value}</p>
+              {signal.evidence ? <p className="mt-1 text-sm leading-6 text-zinc-600">{signal.evidence}</p> : null}
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 rounded-lg bg-zinc-50 p-3 text-sm leading-6 text-zinc-700">
+          Nenhum sinal de perfil foi separado nesta prévia.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeAdaptiveBridgePreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeAdaptiveBridgePreview.tsx
@@ -1,0 +1,76 @@
+import type {
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+} from "../../postCreationAdaptiveTypes";
+import type { NarrativeSourceAdaptiveInput } from "../../narrativeSource/narrativeSourceAdaptiveAdapter";
+
+type NarrativeAdaptiveBridgePreviewProps = {
+  adaptiveInput: NarrativeSourceAdaptiveInput;
+  adaptiveDetection?: PostCreationAdaptiveIntentDetection | null;
+  questions?: PostCreationAdaptiveQuestion[];
+  answerKey?: { summary: string } | null;
+};
+
+export function NarrativeAdaptiveBridgePreview({
+  adaptiveInput,
+  adaptiveDetection = null,
+  questions = [],
+  answerKey = null,
+}: NarrativeAdaptiveBridgePreviewProps) {
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Entrada estratégica para o Adaptive V2</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Ponte narrativa para o board</h2>
+      </div>
+
+      <div className="mt-4 rounded-lg bg-zinc-50 p-3">
+        <p className="text-sm font-medium text-zinc-950">{adaptiveInput.input}</p>
+        <p className="mt-2 text-sm leading-6 text-zinc-700">{adaptiveInput.sourceSummary}</p>
+      </div>
+
+      <dl className="mt-4 grid gap-3 md:grid-cols-3">
+        <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+          <dt className="text-xs font-semibold uppercase text-zinc-500">Modo sugerido</dt>
+          <dd className="mt-1 text-sm leading-6 text-zinc-800">{adaptiveInput.modeHint || "sem sugestão"}</dd>
+        </div>
+        {adaptiveDetection ? (
+          <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+            <dt className="text-xs font-semibold uppercase text-zinc-500">Modo detectado</dt>
+            <dd className="mt-1 text-sm leading-6 text-zinc-800">{adaptiveDetection.mode}</dd>
+          </div>
+        ) : null}
+        {answerKey ? (
+          <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+            <dt className="text-xs font-semibold uppercase text-zinc-500">Leitura da rodada</dt>
+            <dd className="mt-1 text-sm leading-6 text-zinc-800">{answerKey.summary}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {adaptiveInput.signals.length ? (
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold text-zinc-950">Sinais enviados</h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {adaptiveInput.signals.map((signal) => (
+              <span key={signal} className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700">
+                {signal}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {questions.length ? (
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold text-zinc-950">Perguntas disponíveis</h3>
+          <ul className="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+            {questions.map((question) => (
+              <li key={question.id}>{question.title}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeAssetsPreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeAssetsPreview.tsx
@@ -1,0 +1,48 @@
+import type { NarrativeAsset } from "../../narrativeSource/narrativeSourceTypes";
+
+type NarrativeAssetsPreviewProps = {
+  assets: NarrativeAsset[];
+  summary: string;
+  suggestedNextStep: string;
+};
+
+function groupAssetsByType(assets: NarrativeAsset[]) {
+  return assets.reduce<Record<string, NarrativeAsset[]>>((groups, asset) => {
+    groups[asset.type] = [...(groups[asset.type] || []), asset];
+    return groups;
+  }, {});
+}
+
+export function NarrativeAssetsPreview({ assets, summary, suggestedNextStep }: NarrativeAssetsPreviewProps) {
+  const groupedAssets = groupAssetsByType(assets);
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Assets narrativos</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Material extraído da fonte</h2>
+      </div>
+
+      <div className="mt-4 rounded-lg bg-zinc-50 p-3">
+        <p className="text-sm leading-6 text-zinc-800">{summary}</p>
+        <p className="mt-2 text-sm leading-6 text-zinc-700">{suggestedNextStep}</p>
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        {Object.entries(groupedAssets).map(([type, typeAssets]) => (
+          <article key={type} className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+            <h3 className="text-sm font-semibold text-zinc-950">{type}</h3>
+            <ul className="mt-2 space-y-2">
+              {typeAssets.map((asset) => (
+                <li key={asset.id} className="text-sm leading-6 text-zinc-700">
+                  <span className="font-medium text-zinc-900">{asset.value}</span>
+                  {asset.evidence ? <span className="block text-zinc-600">{asset.evidence}</span> : null}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeSourceIntentPreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeSourceIntentPreview.tsx
@@ -1,0 +1,46 @@
+import type { NarrativeSourceIntentDetection } from "../../narrativeSource/narrativeSourceTypes";
+
+type NarrativeSourceIntentPreviewProps = {
+  sourceIntent: NarrativeSourceIntentDetection;
+};
+
+function confidenceLabel(confidence: number): string {
+  if (confidence >= 0.8) return "alta";
+  if (confidence >= 0.5) return "média";
+  return "inicial";
+}
+
+export function NarrativeSourceIntentPreview({ sourceIntent }: NarrativeSourceIntentPreviewProps) {
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Intenção da fonte</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Leitura estratégica inicial</h2>
+      </div>
+
+      <dl className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+          <dt className="text-xs font-semibold uppercase text-zinc-500">Intenção</dt>
+          <dd className="mt-1 text-sm leading-6 text-zinc-800">{sourceIntent.intent}</dd>
+        </div>
+        <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+          <dt className="text-xs font-semibold uppercase text-zinc-500">Confiança da leitura</dt>
+          <dd className="mt-1 text-sm leading-6 text-zinc-800">{confidenceLabel(sourceIntent.confidence)}</dd>
+        </div>
+      </dl>
+
+      {sourceIntent.signals.length ? (
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold text-zinc-950">Sinais encontrados</h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {sourceIntent.signals.map((signal) => (
+              <span key={signal} className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700">
+                {signal}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePlanPreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePlanPreview.tsx
@@ -1,0 +1,80 @@
+import type { PostCreationStrategicPlan } from "../../postCreationAdaptiveTypes";
+
+type NarrativeSourcePlanPreviewProps = {
+  plan?: PostCreationStrategicPlan | null;
+};
+
+function Detail({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-800">{value}</dd>
+    </div>
+  );
+}
+
+export function NarrativeSourcePlanPreview({ plan = null }: NarrativeSourcePlanPreviewProps) {
+  if (!plan) {
+    return (
+      <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Plano gerado</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Plano ainda não gerado nesta prévia.</h2>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Plano gerado</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Leitura adaptativa final</h2>
+      </div>
+
+      <dl className="mt-4 grid gap-3 md:grid-cols-2">
+        <Detail label="Pauta" value={plan.pauta} />
+        <Detail label="Objetivo" value={plan.objective} />
+        <Detail label="Narrativa" value={plan.narrative} />
+        <Detail label="Formato" value={plan.format} />
+        <Detail label="Gancho" value={plan.hook} />
+        <Detail label="Convite" value={plan.cta} />
+      </dl>
+
+      {plan.brandMatch ? (
+        <div className="mt-4 rounded-lg border border-emerald-100 bg-emerald-50 p-3">
+          <h3 className="text-sm font-semibold text-emerald-950">Encaixe com marca</h3>
+          {plan.brandMatch.category ? (
+            <p className="mt-1 text-sm leading-6 text-emerald-900">Categoria: {plan.brandMatch.category}</p>
+          ) : null}
+          {plan.brandMatch.angle ? (
+            <p className="mt-1 text-sm leading-6 text-emerald-900">Direção: {plan.brandMatch.angle}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {plan.collabMatch ? (
+        <div className="mt-4 rounded-lg border border-indigo-100 bg-indigo-50 p-3">
+          <h3 className="text-sm font-semibold text-indigo-950">Encaixe com collab</h3>
+          {plan.collabMatch.creatorProfile ? (
+            <p className="mt-1 text-sm leading-6 text-indigo-900">Perfil: {plan.collabMatch.creatorProfile}</p>
+          ) : null}
+          {plan.collabMatch.collaborationAngle ? (
+            <p className="mt-1 text-sm leading-6 text-indigo-900">
+              Direção: {plan.collabMatch.collaborationAngle}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-zinc-950">Próximos passos</h3>
+        <ol className="mt-2 space-y-2 text-sm leading-6 text-zinc-700">
+          {plan.nextActions.map((action) => (
+            <li key={action}>{action}</li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
@@ -106,6 +106,7 @@ describe("NarrativeSourcePreview", () => {
     const source = fs
       .readdirSync(previewDir)
       .filter((file) => /\.(tsx|ts)$/.test(file) && !file.endsWith(".test.tsx"))
+      .filter((file) => file !== "buildNarrativeSourcePreviewScenario.ts")
       .map((file) => fs.readFileSync(path.join(previewDir, file), "utf8"))
       .join("\n");
 

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
@@ -1,0 +1,126 @@
+import fs from "fs";
+import path from "path";
+import type { ComponentProps } from "react";
+import { render, screen } from "@testing-library/react";
+import { NarrativeSourcePreview } from "./NarrativeSourcePreview";
+import { narrativeSourcePreviewFixture } from "./narrativeSourcePreviewFixture";
+
+function renderPreview(props: Partial<ComponentProps<typeof NarrativeSourcePreview>> = {}) {
+  return render(<NarrativeSourcePreview {...narrativeSourcePreviewFixture} {...props} />);
+}
+
+describe("NarrativeSourcePreview", () => {
+  it("renders the complete narrative source preview", () => {
+    renderPreview();
+
+    expect(screen.getByText("Fonte narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Intenção da fonte")).toBeInTheDocument();
+    expect(screen.getByText("Assets narrativos")).toBeInTheDocument();
+    expect(screen.getByText("Sinais para entender a conta")).toBeInTheDocument();
+    expect(screen.getByText("Entrada estratégica para o Adaptive V2")).toBeInTheDocument();
+    expect(screen.getByText("Plano gerado")).toBeInTheDocument();
+  });
+
+  it("renders the state without a generated plan", () => {
+    renderPreview({ plan: null });
+
+    expect(screen.getByText("Plano ainda não gerado nesta prévia.")).toBeInTheDocument();
+  });
+
+  it("renders brand match only when it exists in the plan", () => {
+    const { rerender } = renderPreview({
+      plan: {
+        ...narrativeSourcePreviewFixture.plan,
+        brandMatch: null,
+      },
+    });
+
+    expect(screen.queryByText("Encaixe com marca")).not.toBeInTheDocument();
+
+    rerender(<NarrativeSourcePreview {...narrativeSourcePreviewFixture} />);
+
+    expect(screen.getByText("Encaixe com marca")).toBeInTheDocument();
+    expect(screen.getAllByText(/autocuidado/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders collab match only when it exists in the plan", () => {
+    const { rerender } = renderPreview();
+
+    expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
+
+    rerender(
+      <NarrativeSourcePreview
+        {...narrativeSourcePreviewFixture}
+        plan={{
+          ...narrativeSourcePreviewFixture.plan,
+          brandMatch: null,
+          collabMatch: {
+            enabled: true,
+            creatorProfile: "Creator de rotina complementar",
+            collaborationAngle: "Contraste entre duas formas de autocuidado",
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
+    expect(screen.getByText(/Creator de rotina complementar/i)).toBeInTheDocument();
+  });
+
+  it("does not claim profile persistence", () => {
+    const { container } = renderPreview();
+    const text = container.textContent?.toLowerCase() || "";
+
+    expect(text).toContain("pode enriquecer o perfil depois");
+    expect(text).not.toContain("salvo");
+    expect(text).not.toContain("treinado");
+    expect(text).not.toContain("definitivo");
+    expect(text).not.toContain("aprendido permanentemente");
+  });
+
+  it("does not render forbidden or game language", () => {
+    const { container } = renderPreview();
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps narrative source preview files isolated from product flow dependencies", () => {
+    const previewDir = __dirname;
+    const source = fs
+      .readdirSync(previewDir)
+      .filter((file) => /\.(tsx|ts)$/.test(file) && !file.endsWith(".test.tsx"))
+      .map((file) => fs.readFileSync(path.join(previewDir, file), "utf8"))
+      .join("\n");
+
+    expect(source).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/Prisma|prisma|banco/);
+    expect(source).not.toMatch(/endpoint|route handler/i);
+    expect(source).not.toMatch(/usePostCreation|useAdaptive|useNarrative/);
+    expect(source).not.toMatch(/detectNarrativeSourceIntent/);
+    expect(source).not.toMatch(/extractNarrativeAssets/);
+    expect(source).not.toMatch(/buildAdaptiveInputFromNarrativeSource/);
+    expect(source).not.toMatch(/detectPostCreationAdaptiveIntent/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveQuiz/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveAnswerKey|AnswerKey/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveStrategicPlan|PlanBuilder/);
+  });
+});

--- a/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.tsx
+++ b/src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.tsx
@@ -1,0 +1,137 @@
+import type {
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationStrategicPlan,
+} from "../../postCreationAdaptiveTypes";
+import type { NarrativeSourceAdaptiveInput } from "../../narrativeSource/narrativeSourceAdaptiveAdapter";
+import type {
+  CreatorNarrativeSignal,
+  NarrativeAsset,
+  NarrativeSource,
+  NarrativeSourceIntentDetection,
+} from "../../narrativeSource/narrativeSourceTypes";
+import { CreatorSignalsPreview } from "./CreatorSignalsPreview";
+import { NarrativeAdaptiveBridgePreview } from "./NarrativeAdaptiveBridgePreview";
+import { NarrativeAssetsPreview } from "./NarrativeAssetsPreview";
+import { NarrativeSourceIntentPreview } from "./NarrativeSourceIntentPreview";
+import { NarrativeSourcePlanPreview } from "./NarrativeSourcePlanPreview";
+
+export type NarrativeSourceExtractionPreview = {
+  assets: NarrativeAsset[];
+  profileSignals: CreatorNarrativeSignal[];
+  summary: string;
+  suggestedNextStep: string;
+};
+
+export type NarrativeSourcePreviewProps = {
+  source: NarrativeSource;
+  sourceIntent: NarrativeSourceIntentDetection;
+  extraction: NarrativeSourceExtractionPreview;
+  adaptiveInput: NarrativeSourceAdaptiveInput;
+  adaptiveDetection?: PostCreationAdaptiveIntentDetection | null;
+  questions?: PostCreationAdaptiveQuestion[];
+  answerKey?: { summary: string } | null;
+  plan?: PostCreationStrategicPlan | null;
+};
+
+function sanitizePreviewText(value: string): string {
+  return value
+    .replace(/\bgarantido\b/gi, "prometido")
+    .replace(/\bcerteza\b/gi, "clareza")
+    .replace(/\bcomprovado\b/gi, "observado")
+    .replace(/\bviralizar\b/gi, "ampliar alcance")
+    .replace(/\bscore\b/gi, "leitura")
+    .replace(/\bnota\b/gi, "leitura")
+    .replace(/\bpontuação\b/gi, "leitura")
+    .replace(/\bacerto\b/gi, "sinal")
+    .replace(/\berro\b/gi, "ajuste")
+    .replace(/\bgabarito\b/gi, "referência")
+    .replace(/\bresposta correta\b/gi, "referência");
+}
+
+function compactPreviewText(value?: string | null, maxLength = 160): string | null {
+  const compacted = sanitizePreviewText(value || "").replace(/\s+/g, " ").trim();
+  if (!compacted) return null;
+  return compacted.length > maxLength ? `${compacted.slice(0, maxLength - 3).trim()}...` : compacted;
+}
+
+function SourceDetail({ label, value }: { label: string; value?: string | null }) {
+  const displayValue = compactPreviewText(value);
+  if (!displayValue) return null;
+
+  return (
+    <div className="rounded-lg border border-zinc-100 bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-800">{displayValue}</dd>
+    </div>
+  );
+}
+
+function NarrativeSourceContent({ source }: { source: NarrativeSource }) {
+  const metadataItems = [
+    source.metadata.title ? `Título: ${source.metadata.title}` : null,
+    source.metadata.platform ? `Plataforma: ${source.metadata.platform}` : null,
+    source.metadata.format ? `Formato: ${source.metadata.format}` : null,
+    source.metadata.campaignContext ? `Contexto: ${source.metadata.campaignContext}` : null,
+    typeof source.metadata.durationSeconds === "number" ? `Duração: ${source.metadata.durationSeconds}s` : null,
+  ].filter((item): item is string => Boolean(item));
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div>
+        <p className="text-xs font-semibold uppercase text-zinc-500">Fonte narrativa</p>
+        <h2 className="mt-1 text-lg font-semibold text-zinc-950">Material analisado</h2>
+      </div>
+
+      <dl className="mt-4 grid gap-3 md:grid-cols-2">
+        <SourceDetail label="Tipo" value={source.sourceType} />
+        <SourceDetail label="Pergunta do criador" value={source.creatorQuestion} />
+        <SourceDetail label="Texto bruto" value={source.rawText} />
+        <SourceDetail label="Transcrição" value={source.transcript} />
+        <SourceDetail label="Descrição visual" value={source.visualDescription} />
+      </dl>
+
+      {metadataItems.length ? (
+        <div className="mt-4 rounded-lg bg-zinc-50 p-3">
+          <h3 className="text-sm font-semibold text-zinc-950">Metadados</h3>
+          <ul className="mt-2 space-y-1 text-sm leading-6 text-zinc-700">
+            {metadataItems.map((item) => (
+              <li key={item}>{sanitizePreviewText(item)}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function NarrativeSourcePreview({
+  source,
+  sourceIntent,
+  extraction,
+  adaptiveInput,
+  adaptiveDetection = null,
+  questions = [],
+  answerKey = null,
+  plan = null,
+}: NarrativeSourcePreviewProps) {
+  return (
+    <div className="space-y-4 rounded-lg bg-zinc-100 p-4 text-zinc-950">
+      <NarrativeSourceContent source={source} />
+      <NarrativeSourceIntentPreview sourceIntent={sourceIntent} />
+      <NarrativeAssetsPreview
+        assets={extraction.assets}
+        summary={extraction.summary}
+        suggestedNextStep={extraction.suggestedNextStep}
+      />
+      <CreatorSignalsPreview profileSignals={extraction.profileSignals} />
+      <NarrativeAdaptiveBridgePreview
+        adaptiveInput={adaptiveInput}
+        adaptiveDetection={adaptiveDetection}
+        questions={questions}
+        answerKey={answerKey}
+      />
+      <NarrativeSourcePlanPreview plan={plan} />
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/narrativeSource/buildNarrativeSourcePreviewScenario.ts
+++ b/src/app/dashboard/boards/components/narrativeSource/buildNarrativeSourcePreviewScenario.ts
@@ -1,0 +1,190 @@
+import { buildPostCreationAdaptiveAnswerKey } from "../../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../../postCreationAdaptiveTypes";
+import { extractNarrativeAssets } from "../../narrativeSource/narrativeAssetExtractor";
+import { buildAdaptiveInputFromNarrativeSource } from "../../narrativeSource/narrativeSourceAdaptiveAdapter";
+import { detectNarrativeSourceIntent } from "../../narrativeSource/narrativeSourceIntentRouter";
+import { createEmptyNarrativeSource, type NarrativeSource } from "../../narrativeSource/narrativeSourceTypes";
+
+export type NarrativeSourcePreviewScenario = {
+  id: string;
+  label: string;
+  source: NarrativeSource;
+};
+
+function source(params: Partial<NarrativeSource> & Pick<NarrativeSource, "sourceType">): NarrativeSource {
+  return {
+    ...createEmptyNarrativeSource({
+      id: params.id || `nse-preview-${params.sourceType}`,
+      sourceType: params.sourceType,
+    }),
+    ...params,
+    metadata: params.metadata || {},
+  };
+}
+
+export const NARRATIVE_SOURCE_PREVIEW_SCENARIOS: NarrativeSourcePreviewScenario[] = [
+  {
+    id: "video-validate",
+    label: "Vídeo: validar antes de postar",
+    source: source({
+      id: "nse-preview-video-validate",
+      sourceType: "video_simulated",
+      creatorQuestion: "Gravei esse vídeo e quero saber se vale postar",
+      transcript: "Mostro minha rotina de skincare pela manhã com cuidado e autocuidado.",
+      visualDescription: "Pessoa organizando produtos de skincare na bancada.",
+      metadata: {
+        title: "Rotina de skincare da manhã",
+        format: "reel",
+        platform: "instagram",
+      },
+    }),
+  },
+  {
+    id: "video-brand-potential",
+    label: "Vídeo: potencial de marca",
+    source: source({
+      id: "nse-preview-video-brand-potential",
+      sourceType: "video_simulated",
+      creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+      transcript: "Mostro minha rotina de skincare e autocuidado pela manhã.",
+      visualDescription: "Bancada com produtos de cuidado pessoal em uso real.",
+      metadata: {
+        title: "Rotina real com skincare",
+        format: "reel",
+        platform: "instagram",
+        campaignContext: "autocuidado",
+      },
+    }),
+  },
+  {
+    id: "video-discover-narrative",
+    label: "Vídeo: descobrir narrativa",
+    source: source({
+      id: "nse-preview-video-discover-narrative",
+      sourceType: "video_simulated",
+      creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+      transcript: "Bastidor do processo de produção e organização do trabalho.",
+      visualDescription: "Mesa com roteiro, gravação e cenas de bastidor.",
+      metadata: {
+        title: "Bastidor de produção",
+        format: "short_video",
+        platform: "instagram",
+      },
+    }),
+  },
+  {
+    id: "video-improve-content",
+    label: "Vídeo: melhorar gancho",
+    source: source({
+      id: "nse-preview-video-improve-content",
+      sourceType: "video_simulated",
+      creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+      rawText: "Bastidor de trabalho mostrando processo e gravação.",
+      transcript: "Mostro uma reunião e o processo de produção do conteúdo.",
+      metadata: {
+        title: "Processo criativo em bastidor",
+        format: "reel",
+        platform: "instagram",
+      },
+    }),
+  },
+  {
+    id: "video-collab",
+    label: "Vídeo: collab",
+    source: source({
+      id: "nse-preview-video-collab",
+      sourceType: "video_simulated",
+      creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+      rawText: "Bastidor de trabalho com processo de produção e decisões criativas.",
+      metadata: {
+        title: "Bastidor para collab",
+        format: "reel",
+        platform: "instagram",
+      },
+    }),
+  },
+  {
+    id: "comment-to-post",
+    label: "Comentário vira post",
+    source: source({
+      id: "nse-preview-comment-to-post",
+      sourceType: "comment",
+      rawText: "Comentaram isso aqui: como você organiza sua rotina? Me perguntaram no direct.",
+      metadata: {
+        platform: "instagram",
+      },
+    }),
+  },
+  {
+    id: "script-to-plan",
+    label: "Roteiro vira plano",
+    source: source({
+      id: "nse-preview-script-to-plan",
+      sourceType: "script",
+      creatorQuestion: "Quero saber se vale postar esse roteiro",
+      rawText: "Roteiro sobre bastidor de reunião, trabalho e processo de produção.",
+      metadata: {
+        title: "Roteiro de bastidor",
+        format: "reel",
+        platform: "instagram",
+      },
+    }),
+  },
+];
+
+export const DEFAULT_NARRATIVE_SOURCE_PREVIEW_SCENARIO_ID = "video-validate";
+
+function normalizeScenarioId(value?: string | string[] | null) {
+  if (Array.isArray(value)) return value[0] || DEFAULT_NARRATIVE_SOURCE_PREVIEW_SCENARIO_ID;
+  return value || DEFAULT_NARRATIVE_SOURCE_PREVIEW_SCENARIO_ID;
+}
+
+export function getNarrativeSourcePreviewScenario(value?: string | string[] | null) {
+  const scenarioId = normalizeScenarioId(value);
+  return (
+    NARRATIVE_SOURCE_PREVIEW_SCENARIOS.find((scenario) => scenario.id === scenarioId) ||
+    NARRATIVE_SOURCE_PREVIEW_SCENARIOS[0]!
+  );
+}
+
+export function buildNarrativeSourcePreviewScenario(value?: string | string[] | null) {
+  const scenario = getNarrativeSourcePreviewScenario(value);
+  const sourceIntent = detectNarrativeSourceIntent(scenario.source);
+  const extraction = extractNarrativeAssets({ source: scenario.source, intentDetection: sourceIntent });
+  const adaptiveInput = buildAdaptiveInputFromNarrativeSource({
+    source: scenario.source,
+    intentDetection: sourceIntent,
+    extraction,
+  });
+  const adaptiveDetection = detectPostCreationAdaptiveIntent(adaptiveInput.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection: adaptiveDetection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => ({
+    questionId: question.id,
+    key: question.mapKey,
+    optionId: question.options.find((option) => option.recommended)?.id || question.options[0]!.id,
+    value: null,
+  }));
+  const answerKey = buildPostCreationAdaptiveAnswerKey({ detection: adaptiveDetection, questions, answers });
+  const plan = buildPostCreationAdaptiveStrategicPlan({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+  });
+
+  return {
+    scenario,
+    source: scenario.source,
+    sourceIntent,
+    extraction,
+    adaptiveInput,
+    adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}

--- a/src/app/dashboard/boards/components/narrativeSource/index.ts
+++ b/src/app/dashboard/boards/components/narrativeSource/index.ts
@@ -1,0 +1,10 @@
+export { CreatorSignalsPreview } from "./CreatorSignalsPreview";
+export { NarrativeAdaptiveBridgePreview } from "./NarrativeAdaptiveBridgePreview";
+export { NarrativeAssetsPreview } from "./NarrativeAssetsPreview";
+export { NarrativeSourceIntentPreview } from "./NarrativeSourceIntentPreview";
+export { NarrativeSourcePlanPreview } from "./NarrativeSourcePlanPreview";
+export { NarrativeSourcePreview } from "./NarrativeSourcePreview";
+export type {
+  NarrativeSourceExtractionPreview,
+  NarrativeSourcePreviewProps,
+} from "./NarrativeSourcePreview";

--- a/src/app/dashboard/boards/components/narrativeSource/narrativeSourcePreviewFixture.ts
+++ b/src/app/dashboard/boards/components/narrativeSource/narrativeSourcePreviewFixture.ts
@@ -1,0 +1,200 @@
+import type {
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationStrategicPlan,
+} from "../../postCreationAdaptiveTypes";
+import type { NarrativeSourceAdaptiveInput } from "../../narrativeSource/narrativeSourceAdaptiveAdapter";
+import type {
+  CreatorNarrativeSignal,
+  NarrativeAsset,
+  NarrativeSource,
+  NarrativeSourceIntentDetection,
+} from "../../narrativeSource/narrativeSourceTypes";
+
+export const narrativeSourcePreviewSourceFixture: NarrativeSource = {
+  id: "narrative-source-preview",
+  sourceType: "video_simulated",
+  rawText: null,
+  creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+  transcript: "Mostro minha rotina de skincare pela manhã com cuidado e autocuidado.",
+  visualDescription: "Pessoa organizando produtos de skincare na bancada.",
+  metadata: {
+    title: "Rotina de skincare da manhã",
+    platform: "instagram",
+    format: "reel",
+    campaignContext: "autocuidado",
+  },
+  createdAt: null,
+};
+
+export const narrativeSourcePreviewIntentFixture: NarrativeSourceIntentDetection = {
+  intent: "brand_potential",
+  confidence: 0.85,
+  sourceType: "video_simulated",
+  originalQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+  normalizedQuestion: "quero saber se esse video tem potencial para atrair marcas",
+  signals: ["potencial para atrair marcas"],
+};
+
+export const narrativeSourcePreviewAssetsFixture: NarrativeAsset[] = [
+  {
+    id: "asset-central-theme-routine",
+    type: "central_theme",
+    value: "rotina de autocuidado",
+    confidence: 0.82,
+    evidence: "Sinais de rotina, skincare, cuidado ou autocuidado.",
+  },
+  {
+    id: "asset-brand-territory-self-care",
+    type: "brand_territory",
+    value: "autocuidado",
+    confidence: 0.78,
+    evidence: "Território compatível com hábitos pessoais e cuidado.",
+  },
+  {
+    id: "asset-content-proposal-organic-brand-fit",
+    type: "content_proposal",
+    value: "organic_brand_fit",
+    confidence: 0.8,
+    evidence: "Proposta de conteúdo com marca integrada ao contexto.",
+  },
+];
+
+export const narrativeSourcePreviewSignalsFixture: CreatorNarrativeSignal[] = [
+  {
+    id: "signal-recurring-theme-routine",
+    signalType: "recurring_theme",
+    value: "rotina",
+    confidence: 0.76,
+    sourceType: "video_simulated",
+    shouldPersistLater: true,
+    evidence: "Tema recorrente possível: rotina.",
+  },
+  {
+    id: "signal-brand-territory-self-care",
+    signalType: "brand_territory",
+    value: "autocuidado",
+    confidence: 0.76,
+    sourceType: "video_simulated",
+    shouldPersistLater: true,
+    evidence: "Território de marca possível: autocuidado.",
+  },
+];
+
+export const narrativeSourcePreviewExtractionFixture = {
+  assets: narrativeSourcePreviewAssetsFixture,
+  profileSignals: narrativeSourcePreviewSignalsFixture,
+  summary: "A fonte apresenta sinais narrativos úteis para orientar a próxima leitura estratégica.",
+  suggestedNextStep: "Revisar os assets extraídos e escolher qual direção merece aprofundamento.",
+};
+
+export const narrativeSourcePreviewAdaptiveInputFixture: NarrativeSourceAdaptiveInput = {
+  input: "Quero atrair marcas de autocuidado com uma narrativa sobre rotina de autocuidado.",
+  modeHint: "brand_match",
+  sourceSummary:
+    "Fonte video_simulated com intenção brand_potential, tema rotina de autocuidado, 3 assets e 2 sinais de perfil.",
+  signals: ["potencial para atrair marcas", "rotina de autocuidado", "autocuidado", "organic_brand_fit", "rotina"],
+};
+
+export const narrativeSourcePreviewAdaptiveDetectionFixture: PostCreationAdaptiveIntentDetection = {
+  mode: "brand_match",
+  confidence: 0.85,
+  normalizedInput: "quero atrair marcas de autocuidado com uma narrativa sobre rotina de autocuidado.",
+  originalInput: "Quero atrair marcas de autocuidado com uma narrativa sobre rotina de autocuidado.",
+  detectedPauta: null,
+  objective: null,
+  brandCategory: "autocuidado com uma narrativa sobre rotina de autocuidado",
+  sourceComment: null,
+  signals: ["marcas", "atrair marcas", "marcas de autocuidado com uma narrativa sobre rotina de autocuidado"],
+  suggestedStage: "quiz",
+};
+
+export const narrativeSourcePreviewQuestionsFixture: PostCreationAdaptiveQuestion[] = [
+  {
+    id: "brand-question",
+    type: "strategic_choice",
+    title: "Qual ponte com marca parece mais natural?",
+    helper: "A ponte precisa nascer da narrativa, não da vitrine.",
+    mapKey: "brand",
+    required: true,
+    options: [
+      {
+        id: "routine",
+        label: "Produto dentro da rotina",
+        reason: "A marca aparece como parte do contexto.",
+        recommended: true,
+      },
+    ],
+  },
+];
+
+export const narrativeSourcePreviewRoundReadingFixture = {
+  mode: "brand_match",
+  totalQuestions: 1,
+  answeredQuestions: 1,
+  recommendedMatches: 1,
+  evaluations: [
+    {
+      questionId: "brand-question",
+      key: "brand",
+      selectedOptionId: "routine",
+      selectedLabel: "Produto dentro da rotina",
+      recommendedOptionId: "routine",
+      recommendedLabel: "Produto dentro da rotina",
+      isRecommendedChoice: true,
+      reason: "Essa escolha mantém a marca dentro da narrativa.",
+    },
+  ],
+  strengths: ["Ponto forte: Produto dentro da rotina."],
+  adjustments: [],
+  summary: "A leitura aponta uma direção clara para aproximar marca e rotina.",
+};
+
+export const narrativeSourcePreviewPlanFixture: PostCreationStrategicPlan = {
+  pauta: "rotina de autocuidado",
+  objective: "Abrir conversa",
+  narrative: "Rotina real com ponto de vista",
+  format: "Reels simples",
+  hook: "Começar pela bancada antes da rotina estar pronta",
+  cta: "Perguntar quem também organiza a rotina desse jeito",
+  fiveW2H: {
+    who: "Audiência do Instagram",
+    what: "rotina de autocuidado",
+    where: "Instagram",
+    when: "Próxima janela de publicação",
+    why: "A pauta aproxima rotina e identificação.",
+    how: "Reels simples com narrativa cotidiana.",
+    howMuch: "Baixo esforço",
+  },
+  scenes: [
+    {
+      id: "scene-1",
+      title: "Bancada real",
+      visual: "Produtos organizados antes do começo da rotina.",
+      message: "Mostrar contexto antes de explicar.",
+    },
+  ],
+  brandMatch: {
+    enabled: true,
+    category: "autocuidado",
+    angle: "Produto aparece como parte da rotina real.",
+    desiredBrandSignals: ["uso natural"],
+  },
+  collabMatch: null,
+  nextActions: [
+    "Revisar a abertura do roteiro.",
+    "Separar elementos visuais da rotina.",
+    "Observar a resposta da audiência.",
+  ],
+};
+
+export const narrativeSourcePreviewFixture = {
+  source: narrativeSourcePreviewSourceFixture,
+  sourceIntent: narrativeSourcePreviewIntentFixture,
+  extraction: narrativeSourcePreviewExtractionFixture,
+  adaptiveInput: narrativeSourcePreviewAdaptiveInputFixture,
+  adaptiveDetection: narrativeSourcePreviewAdaptiveDetectionFixture,
+  questions: narrativeSourcePreviewQuestionsFixture,
+  answerKey: narrativeSourcePreviewRoundReadingFixture,
+  plan: narrativeSourcePreviewPlanFixture,
+};

--- a/src/app/dashboard/boards/narrative-source-preview/page.test.tsx
+++ b/src/app/dashboard/boards/narrative-source-preview/page.test.tsx
@@ -1,0 +1,126 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import NarrativeSourcePreviewPage from "./page";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = originalEnvValue;
+});
+
+describe("NarrativeSourcePreviewPage", () => {
+  it("renders a blocked state when the internal flag is off", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "0";
+
+    render(<NarrativeSourcePreviewPage />);
+
+    expect(screen.getByText("Preview interno — Narrative Source Engine")).toBeInTheDocument();
+    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
+  });
+
+  it("renders the default video validation scenario when enabled without scenario", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(<NarrativeSourcePreviewPage />);
+
+    expect(screen.getByText("Preview interno — Narrative Source Engine")).toBeInTheDocument();
+    expect(screen.getByText("Fonte narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Intenção da fonte")).toBeInTheDocument();
+    expect(screen.getByText("Assets narrativos")).toBeInTheDocument();
+    expect(screen.getByText("Entrada estratégica para o Adaptive V2")).toBeInTheDocument();
+    expect(screen.getAllByText("Vídeo: validar antes de postar").length).toBeGreaterThan(0);
+  });
+
+  it("renders the brand potential scenario from search params", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-brand-potential" }} />);
+
+    expect(screen.getAllByText("Vídeo: potencial de marca").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("brand_potential").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("brand_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com marca")).toBeInTheDocument();
+    expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
+  });
+
+  it("renders the collab scenario from search params", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-collab" }} />);
+
+    expect(screen.getAllByText("collab_potential").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("collab_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
+  });
+
+  it("renders the comment-to-post scenario from search params", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "comment-to-post" }} />);
+
+    expect(screen.getAllByText("comment").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("comment_to_post").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/rotina/i).length).toBeGreaterThan(0);
+  });
+
+  it("falls back to the default scenario when search params are invalid", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+
+    expect(screen.getAllByText("Vídeo: validar antes de postar").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validate_before_posting").length).toBeGreaterThan(0);
+  });
+
+  it("continues without forbidden or game language", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    const { container } = render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-brand-potential" }} />);
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import BoardShell or real product flow dependencies", () => {
+    const pageSource = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+    const scenarioSource = fs.readFileSync(
+      path.join(__dirname, "../components/narrativeSource/buildNarrativeSourcePreviewScenario.ts"),
+      "utf8"
+    );
+    const source = `${pageSource}\n${scenarioSource}`;
+
+    expect(source).not.toMatch(/PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/BoardShell/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/OpenAI/);
+    expect(source).not.toMatch(/openai/);
+    expect(source).not.toMatch(/prisma/);
+    expect(source).not.toMatch(/route handlers?/i);
+    expect(source).not.toMatch(/usePostCreation/);
+    expect(source).not.toMatch(/upload/i);
+    expect(source).not.toMatch(/storage/i);
+  });
+});

--- a/src/app/dashboard/boards/narrative-source-preview/page.tsx
+++ b/src/app/dashboard/boards/narrative-source-preview/page.tsx
@@ -1,0 +1,105 @@
+import { NarrativeSourcePreview } from "../components/narrativeSource";
+import {
+  buildNarrativeSourcePreviewScenario,
+  NARRATIVE_SOURCE_PREVIEW_SCENARIOS,
+} from "../components/narrativeSource/buildNarrativeSourcePreviewScenario";
+import { isNarrativeSourceEngineEnabled } from "../narrativeSource/narrativeSourceFeatureFlag";
+
+type NarrativeSourcePreviewPageProps = {
+  searchParams?: {
+    scenario?: string | string[];
+  };
+};
+
+export default function NarrativeSourcePreviewPage({ searchParams }: NarrativeSourcePreviewPageProps = {}) {
+  const isEnabled = isNarrativeSourceEngineEnabled();
+
+  if (!isEnabled) {
+    return (
+      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Narrative Source Engine</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa cenários controlados e permanece bloqueada enquanto a flag interna do Narrative Source
+            Engine estiver desligada.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const preview = buildNarrativeSourcePreviewScenario(searchParams?.scenario);
+  const sourcePrompt =
+    preview.source.creatorQuestion || preview.source.rawText || preview.source.transcript || preview.source.visualDescription;
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Narrative Source Engine</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa cenários controlados e não está conectada ao fluxo real.
+          </p>
+        </header>
+
+        <section className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap gap-2">
+            {NARRATIVE_SOURCE_PREVIEW_SCENARIOS.map((scenario) => {
+              const isActive = scenario.id === preview.scenario.id;
+
+              return (
+                <a
+                  key={scenario.id}
+                  href={`/dashboard/boards/narrative-source-preview?scenario=${scenario.id}`}
+                  className={
+                    isActive
+                      ? "rounded-full bg-zinc-950 px-3 py-1.5 text-sm font-semibold text-white"
+                      : "rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700"
+                  }
+                >
+                  {scenario.label}
+                </a>
+              );
+            })}
+          </div>
+
+          <dl className="mt-4 grid gap-3 text-sm md:grid-cols-5">
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Cenário ativo</dt>
+              <dd className="mt-1 text-zinc-900">{preview.scenario.label}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Tipo de fonte</dt>
+              <dd className="mt-1 text-zinc-900">{preview.source.sourceType}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3 md:col-span-1">
+              <dt className="font-semibold text-zinc-500">Input controlado</dt>
+              <dd className="mt-1 text-zinc-900">{sourcePrompt}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Intent detectada</dt>
+              <dd className="mt-1 text-zinc-900">{preview.sourceIntent.intent}</dd>
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <dt className="font-semibold text-zinc-500">Adaptive mode</dt>
+              <dd className="mt-1 text-zinc-900">{preview.adaptiveDetection.mode}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <NarrativeSourcePreview
+          source={preview.source}
+          sourceIntent={preview.sourceIntent}
+          extraction={preview.extraction}
+          adaptiveInput={preview.adaptiveInput}
+          adaptiveDetection={preview.adaptiveDetection}
+          questions={preview.questions}
+          answerKey={preview.answerKey}
+          plan={preview.plan}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/narrativeSource/NARRATIVE_SOURCE_ENGINE_QA.md
+++ b/src/app/dashboard/boards/narrativeSource/NARRATIVE_SOURCE_ENGINE_QA.md
@@ -1,0 +1,131 @@
+# Narrative Source Engine Manual QA
+
+Checklist manual para validar a NSE no browser antes de qualquer conexão com o fluxo real.
+
+## Pré-requisitos
+
+- Estar na branch `feat/adaptive-post-creation-board-v2`.
+- Rodar o app localmente.
+- Usar `NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1`.
+- Acessar `/dashboard/boards/narrative-source-preview`.
+- Manter o PR em draft.
+
+## URLs dos cenários
+
+- `/dashboard/boards/narrative-source-preview?scenario=video-validate`
+- `/dashboard/boards/narrative-source-preview?scenario=video-brand-potential`
+- `/dashboard/boards/narrative-source-preview?scenario=video-discover-narrative`
+- `/dashboard/boards/narrative-source-preview?scenario=video-improve-content`
+- `/dashboard/boards/narrative-source-preview?scenario=video-collab`
+- `/dashboard/boards/narrative-source-preview?scenario=comment-to-post`
+- `/dashboard/boards/narrative-source-preview?scenario=script-to-plan`
+
+## Checklist geral
+
+- A página mostra `Preview interno — Narrative Source Engine`.
+- A página informa que usa cenários controlados.
+- A lista de cenários aparece sem quebrar layout.
+- O cenário ativo está correto.
+- `sourceType` está correto.
+- `creatorQuestion`, `rawText`, `transcript` ou `visualDescription` aparecem compactados.
+- Bloco `Fonte narrativa` aparece.
+- Bloco `Intenção da fonte` aparece.
+- Bloco `Assets narrativos` aparece.
+- Bloco `Sinais para entender a conta` aparece.
+- Bloco `Entrada estratégica para o Adaptive V2` aparece.
+- Bloco `Plano gerado` aparece quando há plano.
+- Nenhum campo sugere que algo foi salvo, treinado ou persistido definitivamente.
+- Com a flag desligada, a página mostra estado bloqueado e não renderiza a preview.
+
+## Checklist de linguagem
+
+Procurar visualmente e reprovar se aparecer:
+
+- garantido
+- certeza
+- comprovado
+- viralizar
+- score
+- nota
+- pontuação
+- acerto
+- erro
+- gabarito
+- resposta correta
+- venceu
+- perdeu
+- salvo
+- treinado
+- definitivo
+- aprendido permanentemente
+
+## Checklist mobile
+
+Testar em largura mobile no DevTools:
+
+- links de cenário quebram linha sem sobrepor conteúdo;
+- cards de fonte ficam legíveis;
+- listas de assets não estouram a tela;
+- sinais de perfil continuam legíveis;
+- entrada Adaptive V2 não cria overflow horizontal;
+- plano e próximos passos ficam escaneáveis;
+- página mantém scroll natural.
+
+## Checklist por cenário
+
+### video-validate
+
+- Intent deve ser `validate_before_posting`.
+- Adaptive mode deve ser `validate_pauta`.
+- Plano deve parecer validação de pauta, não oferta comercial forçada.
+
+### video-brand-potential
+
+- Intent deve ser `brand_potential`.
+- Adaptive mode deve ser `brand_match`.
+- Deve mostrar `Encaixe com marca`.
+- Não deve mostrar `Encaixe com collab` sem motivo.
+
+### video-discover-narrative
+
+- Intent deve ser `discover_narrative`.
+- Adaptive mode deve ser `discover_pauta`.
+- A leitura deve parecer descoberta de narrativa.
+
+### video-improve-content
+
+- Intent deve ser `improve_content`.
+- Assets devem incluir fraqueza de gancho ou sinal de abertura.
+- Plano deve sugerir ajuste de gancho sem tom de correção escolar.
+
+### video-collab
+
+- Intent deve ser `collab_potential`.
+- Adaptive mode deve ser `collab_match`.
+- Deve mostrar `Encaixe com collab`.
+
+### comment-to-post
+
+- `sourceType` deve ser `comment`.
+- Assets devem incluir `comment_to_post`.
+- Plano deve preservar a origem do comentário.
+
+### script-to-plan
+
+- `sourceType` deve ser `script`.
+- A leitura deve tratar o roteiro como ponto de partida.
+- Plano deve ser gerado sem sugerir upload ou automação inexistente.
+
+## Achados
+
+| Cenário | Problema encontrado | Severidade | Sugestão de ajuste | Status |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Próxima decisão
+
+Depois dessa QA manual, decidir entre:
+
+- NSE10: proteção por sessão admin/dev;
+- ajustes visuais no harness;
+- adiar integração até resolver linguagem, persistência ou escopo de upload.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -29,3 +29,7 @@ Esta fase adiciona `buildAdaptiveInputFromNarrativeSource(...)`, um adapter puro
 ## NSE5
 
 Esta fase adiciona `narrativeSourcePipeline.test.ts`, uma suíte de QA que valida o fluxo completo em ambiente de teste: `NarrativeSource` → roteador NSE → extractor → adapter → pipeline Adaptive V2. A fase não cria lógica nova de produção e continua sem UI, endpoint, banco, upload, OpenAI ou conexão com o BoardShell.
+
+## NSE6
+
+Esta fase adiciona uma preview visual isolada em `components/narrativeSource/`. Os componentes recebem dados prontos por props e mostram fonte, intenção, assets, sinais de perfil, ponte para Adaptive V2 e plano recebido. Eles não rodam pipeline, não criam rota, não chamam UI real, endpoint, banco, upload, OpenAI ou BoardShell.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -1,0 +1,15 @@
+# Narrative Source Engine
+
+NSE representa fontes criativas como contratos narrativos puros. Nesta primeira fase, vídeo é apenas uma possível `NarrativeSource`, sem upload real, endpoint, banco, OpenAI ou UI.
+
+## NSE1
+
+Esta fase define:
+
+- Tipos de fonte narrativa.
+- Intenções possíveis por trás da fonte.
+- Assets narrativos extraídos futuramente.
+- Sinais que podem enriquecer o perfil narrativo depois.
+- Diagnóstico narrativo básico.
+
+Os contratos vivem em `narrativeSourceTypes.ts`. A fase não implementa extração, roteamento, adapters para Adaptive V2 ou persistência.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -17,3 +17,7 @@ Os contratos vivem em `narrativeSourceTypes.ts`. A fase não implementa extraç�
 ## NSE2
 
 Esta fase adiciona `detectNarrativeSourceIntent(source)`, um roteador heurístico e determinístico para identificar a intenção estratégica da fonte narrativa. Ele usa apenas texto local da `NarrativeSource` e continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.
+
+## NSE3
+
+Esta fase adiciona `extractNarrativeAssets({ source, intentDetection })`, um extractor simulado e determinístico que transforma a fonte em assets narrativos e sinais de perfil por heurísticas simples. Ele continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -1,39 +1,140 @@
 # Narrative Source Engine
 
-NSE representa fontes criativas como contratos narrativos puros. Nesta primeira fase, vídeo é apenas uma possível `NarrativeSource`, sem upload real, endpoint, banco, OpenAI ou UI.
+O Narrative Source Engine (NSE) é uma camada pura para transformar fontes criativas em leitura estratégica. A proposta não é criar uma ferramenta isolada de "análise de vídeo", mas representar qualquer fonte criativa como uma `NarrativeSource` capaz de revelar:
 
-## NSE1
+- intenção estratégica;
+- assets narrativos;
+- sinais de perfil;
+- entrada para o Adaptive V2;
+- plano adaptativo em ambiente controlado.
 
-Esta fase define:
+Vídeo é uma fonte futura e rica, mas a NSE ainda não faz upload, transcrição, extração de frames ou análise multimodal real. Nesta etapa, vídeo aparece apenas como `video_simulated`, alimentado por texto, transcrição ou descrição visual mockada/controlada.
 
-- Tipos de fonte narrativa.
-- Intenções possíveis por trás da fonte.
-- Assets narrativos extraídos futuramente.
-- Sinais que podem enriquecer o perfil narrativo depois.
-- Diagnóstico narrativo básico.
+## Mapa das fases
 
-Os contratos vivem em `narrativeSourceTypes.ts`. A fase não implementa extração, roteamento, adapters para Adaptive V2 ou persistência.
+| Fase | Status | Arquivos principais | Faz | Não faz |
+| --- | --- | --- | --- | --- |
+| NSE1 | Concluída | `narrativeSourceTypes.ts`, `narrativeSourceTypes.test.ts` | Define contratos puros para fontes, intents, assets, sinais e diagnóstico. | Não extrai assets, não roteia, não persiste e não integra com UI. |
+| NSE2 | Concluída | `narrativeSourceIntentRouter.ts`, `narrativeSourceIntentRouter.test.ts` | Detecta intenção estratégica da fonte por heurísticas determinísticas. | Não usa IA, fetch, banco, upload ou UI. |
+| NSE3 | Concluída | `narrativeAssetExtractor.ts`, `narrativeAssetExtractor.test.ts` | Extrai assets narrativos e sinais de perfil simulados por regras simples. | Não usa OpenAI, análise multimodal ou persistência. |
+| NSE4 | Concluída | `narrativeSourceAdaptiveAdapter.ts`, `narrativeSourceAdaptiveAdapter.test.ts` | Transforma a fonte analisada em input textual para o Adaptive V2. | Não roda Router, QuizBuilder, AnswerKey ou PlanBuilder dentro do adapter. |
+| NSE5 | Concluída | `narrativeSourcePipeline.test.ts` | Valida em teste o pipeline NSE -> Adaptive V2 completo. | Não cria lógica nova de produção e não conecta o fluxo real. |
+| NSE6 | Concluída | `components/narrativeSource/*` | Renderiza preview visual isolada por props. | Não roda pipeline internamente, não cria rota e não chama serviços. |
+| NSE7 | Concluída | `narrative-source-preview/page.tsx`, `buildNarrativeSourcePreviewScenario.ts`, `narrativeSourceFeatureFlag.ts` | Cria harness interno com cenários controlados e flag própria. | Não adiciona navegação/menu, input livre, upload, endpoint ou BoardShell. |
 
-## NSE2
+## Arquitetura atual
 
-Esta fase adiciona `detectNarrativeSourceIntent(source)`, um roteador heurístico e determinístico para identificar a intenção estratégica da fonte narrativa. Ele usa apenas texto local da `NarrativeSource` e continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.
+Fluxo conceitual validado:
 
-## NSE3
+```text
+NarrativeSource
+  ↓
+detectNarrativeSourceIntent
+  ↓
+extractNarrativeAssets
+  ↓
+buildAdaptiveInputFromNarrativeSource
+  ↓
+Adaptive V2 Router
+  ↓
+QuizBuilder
+  ↓
+AnswerKey
+  ↓
+PlanBuilder
+  ↓
+NarrativeSourcePreview
+```
 
-Esta fase adiciona `extractNarrativeAssets({ source, intentDetection })`, um extractor simulado e determinístico que transforma a fonte em assets narrativos e sinais de perfil por heurísticas simples. Ele continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.
+O adapter existe para aproximar a linguagem da fonte narrativa da linguagem que o Adaptive V2 já entende. A preview recebe dados prontos por props. Apenas o harness interno controlado roda o pipeline para montar cenários de desenvolvimento.
 
-## NSE4
+## Rota interna de preview
 
-Esta fase adiciona `buildAdaptiveInputFromNarrativeSource(...)`, um adapter puro que transforma uma fonte narrativa analisada em uma entrada textual estratégica para o Adaptive V2. Ele apenas monta `input`, `modeHint`, `sourceSummary` e `signals`; não chama Router, QuizBuilder, AnswerKey, PlanBuilder, UI, endpoint, banco, upload ou OpenAI.
+Rota:
 
-## NSE5
+```text
+/dashboard/boards/narrative-source-preview
+```
 
-Esta fase adiciona `narrativeSourcePipeline.test.ts`, uma suíte de QA que valida o fluxo completo em ambiente de teste: `NarrativeSource` → roteador NSE → extractor → adapter → pipeline Adaptive V2. A fase não cria lógica nova de produção e continua sem UI, endpoint, banco, upload, OpenAI ou conexão com o BoardShell.
+Flag necessária:
 
-## NSE6
+```text
+NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1
+```
 
-Esta fase adiciona uma preview visual isolada em `components/narrativeSource/`. Os componentes recebem dados prontos por props e mostram fonte, intenção, assets, sinais de perfil, ponte para Adaptive V2 e plano recebido. Eles não rodam pipeline, não criam rota, não chamam UI real, endpoint, banco, upload, OpenAI ou BoardShell.
+Cenários disponíveis:
 
-## NSE7
+- `/dashboard/boards/narrative-source-preview?scenario=video-validate`
+- `/dashboard/boards/narrative-source-preview?scenario=video-brand-potential`
+- `/dashboard/boards/narrative-source-preview?scenario=video-discover-narrative`
+- `/dashboard/boards/narrative-source-preview?scenario=video-improve-content`
+- `/dashboard/boards/narrative-source-preview?scenario=video-collab`
+- `/dashboard/boards/narrative-source-preview?scenario=comment-to-post`
+- `/dashboard/boards/narrative-source-preview?scenario=script-to-plan`
 
-Esta fase adiciona a rota interna `/dashboard/boards/narrative-source-preview`, protegida por `NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1`. O harness usa apenas cenários controlados, não aceita input livre, não faz upload e não aparece em navegação/menu.
+Se `scenario` estiver ausente ou inválido, o harness usa `video-validate`.
+
+## Limites atuais
+
+A NSE ainda não possui:
+
+- upload real;
+- análise multimodal real;
+- transcrição automática;
+- extração de frames;
+- OpenAI;
+- banco ou persistência;
+- treino real da conta;
+- input livre do usuário;
+- exposição no produto real;
+- conexão com BoardShell;
+- link em navegação/menu;
+- integração com Planner, Media Kit, marcas, collabs reais ou DNA Narrativo.
+
+O estado atual usa apenas cenários controlados, contratos tipados e heurísticas determinísticas.
+
+## Conexão com a promessa da D2C
+
+A NSE reforça a promessa da D2C de ajudar o criador a descobrir, manter e evoluir uma narrativa consistente. Fontes criativas como comentários, roteiros, legendas, briefings e vídeos podem revelar temas recorrentes, territórios de marca, inseguranças, forças de conteúdo e oportunidades de posicionamento.
+
+Esses assets e sinais podem, futuramente, enriquecer o perfil narrativo do criador. O vídeo entra como uma fonte mais rica dentro do mesmo modelo, não como o centro do produto.
+
+## Critérios antes de avançar para upload real
+
+Antes de qualquer upload real ou análise de vídeo, validar:
+
+- harness visual em browser real;
+- linguagem dos relatórios e blocos de leitura;
+- política de persistência dos sinais de perfil;
+- consentimento do usuário para uso e persistência de sinais;
+- limites de vídeo: duração, tamanho, formato e quantidade;
+- estratégia de storage temporário;
+- estratégia de transcrição;
+- estratégia de extração de frames;
+- custo por análise;
+- plano de rollback;
+- feature flag desligada em produção até aprovação explícita.
+
+## QA recomendado
+
+```bash
+npm test -- --runInBand src/app/dashboard/boards/narrative-source-preview/page.test.tsx
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts
+npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts
+npm run typecheck
+```
+
+## Próximas fases sugeridas
+
+- NSE9: QA manual visual do harness.
+- NSE10: proteção por sessão admin/dev.
+- NSE11: integração experimental com BoardShell atrás de flag.
+- VU1: fundação de upload de vídeo, em PR separado.
+- VU2: transcrição e frames.
+- VU3: análise multimodal com IA.
+- NP1: persistência de perfil narrativo, em PR separado.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -21,3 +21,7 @@ Esta fase adiciona `detectNarrativeSourceIntent(source)`, um roteador heurístic
 ## NSE3
 
 Esta fase adiciona `extractNarrativeAssets({ source, intentDetection })`, um extractor simulado e determinístico que transforma a fonte em assets narrativos e sinais de perfil por heurísticas simples. Ele continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.
+
+## NSE4
+
+Esta fase adiciona `buildAdaptiveInputFromNarrativeSource(...)`, um adapter puro que transforma uma fonte narrativa analisada em uma entrada textual estratégica para o Adaptive V2. Ele apenas monta `input`, `modeHint`, `sourceSummary` e `signals`; não chama Router, QuizBuilder, AnswerKey, PlanBuilder, UI, endpoint, banco, upload ou OpenAI.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -13,3 +13,7 @@ Esta fase define:
 - Diagnóstico narrativo básico.
 
 Os contratos vivem em `narrativeSourceTypes.ts`. A fase não implementa extração, roteamento, adapters para Adaptive V2 ou persistência.
+
+## NSE2
+
+Esta fase adiciona `detectNarrativeSourceIntent(source)`, um roteador heurístico e determinístico para identificar a intenção estratégica da fonte narrativa. Ele usa apenas texto local da `NarrativeSource` e continua sem UI, endpoint, banco, upload, OpenAI ou integração com o fluxo real.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -33,3 +33,7 @@ Esta fase adiciona `narrativeSourcePipeline.test.ts`, uma suíte de QA que valid
 ## NSE6
 
 Esta fase adiciona uma preview visual isolada em `components/narrativeSource/`. Os componentes recebem dados prontos por props e mostram fonte, intenção, assets, sinais de perfil, ponte para Adaptive V2 e plano recebido. Eles não rodam pipeline, não criam rota, não chamam UI real, endpoint, banco, upload, OpenAI ou BoardShell.
+
+## NSE7
+
+Esta fase adiciona a rota interna `/dashboard/boards/narrative-source-preview`, protegida por `NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1`. O harness usa apenas cenários controlados, não aceita input livre, não faz upload e não aparece em navegação/menu.

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -25,3 +25,7 @@ Esta fase adiciona `extractNarrativeAssets({ source, intentDetection })`, um ext
 ## NSE4
 
 Esta fase adiciona `buildAdaptiveInputFromNarrativeSource(...)`, um adapter puro que transforma uma fonte narrativa analisada em uma entrada textual estratégica para o Adaptive V2. Ele apenas monta `input`, `modeHint`, `sourceSummary` e `signals`; não chama Router, QuizBuilder, AnswerKey, PlanBuilder, UI, endpoint, banco, upload ou OpenAI.
+
+## NSE5
+
+Esta fase adiciona `narrativeSourcePipeline.test.ts`, uma suíte de QA que valida o fluxo completo em ambiente de teste: `NarrativeSource` → roteador NSE → extractor → adapter → pipeline Adaptive V2. A fase não cria lógica nova de produção e continua sem UI, endpoint, banco, upload, OpenAI ou conexão com o BoardShell.

--- a/src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts
@@ -1,0 +1,185 @@
+import fs from "fs";
+import path from "path";
+import { extractNarrativeAssets } from "./narrativeAssetExtractor";
+import { detectNarrativeSourceIntent } from "./narrativeSourceIntentRouter";
+import { createEmptyNarrativeSource, type NarrativeSource } from "./narrativeSourceTypes";
+
+function makeSource(params: Partial<NarrativeSource> = {}): NarrativeSource {
+  return {
+    ...createEmptyNarrativeSource({
+      id: params.id || "source-test",
+      sourceType: params.sourceType || "video_simulated",
+    }),
+    ...params,
+    metadata: params.metadata || {},
+  };
+}
+
+function extractFromSource(source: NarrativeSource) {
+  return extractNarrativeAssets({
+    source,
+    intentDetection: detectNarrativeSourceIntent(source),
+  });
+}
+
+function assetValues(result: ReturnType<typeof extractFromSource>, type: string) {
+  return result.assets.filter((asset) => asset.type === type).map((asset) => asset.value);
+}
+
+function signalValues(result: ReturnType<typeof extractFromSource>, signalType: string) {
+  return result.profileSignals
+    .filter((signal) => signal.signalType === signalType)
+    .map((signal) => signal.value);
+}
+
+describe("extractNarrativeAssets", () => {
+  it("extracts routine, skincare, and self-care narrative signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+        transcript: "Mostro minha rotina de skincare pela manhã com cuidado e autocuidado.",
+        visualDescription: "Pessoa organizando produtos de skincare na bancada.",
+      })
+    );
+
+    expect(assetValues(result, "central_theme")).toContain("rotina de autocuidado");
+    expect(assetValues(result, "brand_territory")).toContain("autocuidado");
+    expect(signalValues(result, "recurring_theme")).toContain("rotina");
+  });
+
+  it("extracts behind-the-scenes work and process signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        sourceType: "script",
+        rawText: "Roteiro sobre bastidor de reunião, trabalho e processo de produção.",
+      })
+    );
+
+    expect(assetValues(result, "content_proposal")).toContain("behind_the_scenes");
+    expect(assetValues(result, "narrative_pattern")).toContain("bastidor real");
+    expect(signalValues(result, "content_strength")).toContain("bastidor");
+  });
+
+  it("extracts hook weakness when the opening needs improvement", () => {
+    const result = extractFromSource(
+      makeSource({
+        creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+      })
+    );
+
+    expect(assetValues(result, "weakness")).toContain("gancho precisa ficar mais claro");
+    expect(assetValues(result, "hook_signal")).toContain("abrir com tensão mais cedo");
+    expect(signalValues(result, "recurring_insecurity")).toContain("força do gancho");
+  });
+
+  it("extracts brand potential signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+      })
+    );
+
+    expect(assetValues(result, "brand_territory")).toContain("marca em contexto orgânico");
+    expect(assetValues(result, "content_proposal")).toContain("organic_brand_fit");
+    expect(signalValues(result, "brand_territory")).toContain("marca em contexto orgânico");
+  });
+
+  it("extracts collab opportunity signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+      })
+    );
+
+    expect(assetValues(result, "collab_opportunity")).toContain("criador complementar");
+    expect(assetValues(result, "content_proposal")).toContain("collab_narrativa");
+  });
+
+  it("extracts positioning and authority signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        creatorQuestion: "Quero saber se esse vídeo combina com meu posicionamento e autoridade",
+      })
+    );
+
+    expect(assetValues(result, "creator_role")).toContain("autoridade em construção");
+    expect(signalValues(result, "positioning_signal")).toContain("autoridade");
+  });
+
+  it("extracts comment-to-post signals", () => {
+    const result = extractFromSource(
+      makeSource({
+        sourceType: "comment",
+        rawText: "Comentaram isso aqui: como você organiza sua rotina? Me perguntaram no direct.",
+      })
+    );
+
+    expect(assetValues(result, "content_proposal")).toContain("comment_to_post");
+    expect(assetValues(result, "audience_reaction")).toContain("resposta à dúvida da audiência");
+  });
+
+  it("returns a safe fallback when there is not enough useful text", () => {
+    const result = extractFromSource(makeSource());
+
+    expect(result.assets.length).toBeGreaterThanOrEqual(1);
+    expect(assetValues(result, "central_theme")).toContain("tema ainda pouco definido");
+    expect(result.summary).toBe("A fonte ainda precisa de mais contexto para revelar uma narrativa clara.");
+    expect(result.suggestedNextStep).toBe("Adicionar mais contexto sobre objetivo, público ou intenção do conteúdo.");
+  });
+
+  it("deduplicates assets and profile signals by type and value", () => {
+    const result = extractFromSource(
+      makeSource({
+        rawText: "rotina rotina rotina skincare skincare rotina skincare",
+      })
+    );
+    const assetKeys = result.assets.map((asset) => `${asset.type}:${asset.value}`);
+    const signalKeys = result.profileSignals.map((signal) => `${signal.signalType}:${signal.value}`);
+
+    expect(new Set(assetKeys).size).toBe(assetKeys.length);
+    expect(new Set(signalKeys).size).toBe(signalKeys.length);
+  });
+
+  it("keeps language safe across summaries, assets, and profile signals", () => {
+    const cases = [
+      extractFromSource(
+        makeSource({
+          creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+        })
+      ),
+      extractFromSource(
+        makeSource({
+          creatorQuestion: "Quero transformar esse vídeo em uma publi para uma marca de skincare",
+        })
+      ),
+      extractFromSource(makeSource()),
+    ];
+    const text = JSON.stringify(cases).toLowerCase();
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps the extractor isolated from UI and external dependencies", () => {
+    const source = fs.readFileSync(path.join(__dirname, "narrativeAssetExtractor.ts"), "utf8");
+
+    expect(source).not.toMatch(/React|from ["']react["']/);
+    expect(source).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/Prisma|prisma|banco/);
+    expect(source).not.toMatch(/components?\//);
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.ts
@@ -1,0 +1,446 @@
+import type {
+  CreatorNarrativeSignal,
+  CreatorNarrativeSignalType,
+  NarrativeAsset,
+  NarrativeAssetType,
+  NarrativeSource,
+  NarrativeSourceIntentDetection,
+} from "./narrativeSourceTypes";
+
+type ExtractionResult = {
+  assets: NarrativeAsset[];
+  profileSignals: CreatorNarrativeSignal[];
+  summary: string;
+  suggestedNextStep: string;
+};
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[“”"']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function createId(prefix: string, value: string): string {
+  const slug = normalizeText(value)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${prefix}-${slug || "generic"}`;
+}
+
+function hasAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term));
+}
+
+function buildAnalysisText(source: NarrativeSource, intentDetection: NarrativeSourceIntentDetection): string {
+  return normalizeText(
+    [
+      source.creatorQuestion,
+      source.rawText,
+      source.transcript,
+      source.visualDescription,
+      source.metadata.title,
+      source.metadata.campaignContext,
+      intentDetection.normalizedQuestion,
+      intentDetection.signals.join(" "),
+    ]
+      .filter(Boolean)
+      .join(" ")
+  );
+}
+
+function addAsset(
+  assets: NarrativeAsset[],
+  params: {
+    type: NarrativeAssetType;
+    value: string;
+    confidence: number;
+    evidence?: string | null;
+  }
+) {
+  const exists = assets.some((asset) => asset.type === params.type && asset.value === params.value);
+  if (exists) return;
+
+  assets.push({
+    id: createId(`asset-${params.type.replace(/_/g, "-")}`, params.value),
+    type: params.type,
+    value: params.value,
+    confidence: params.confidence,
+    evidence: params.evidence ?? null,
+  });
+}
+
+function addSignal(
+  profileSignals: CreatorNarrativeSignal[],
+  source: NarrativeSource,
+  params: {
+    signalType: CreatorNarrativeSignalType;
+    value: string;
+    confidence: number;
+    shouldPersistLater?: boolean;
+    evidence?: string | null;
+  }
+) {
+  const exists = profileSignals.some(
+    (signal) => signal.signalType === params.signalType && signal.value === params.value
+  );
+  if (exists) return;
+
+  profileSignals.push({
+    id: createId(`signal-${params.signalType.replace(/_/g, "-")}`, params.value),
+    signalType: params.signalType,
+    value: params.value,
+    confidence: params.confidence,
+    sourceType: source.sourceType,
+    shouldPersistLater: params.shouldPersistLater ?? false,
+    evidence: params.evidence ?? null,
+  });
+}
+
+function addRoutineSignals(assets: NarrativeAsset[], profileSignals: CreatorNarrativeSignal[], source: NarrativeSource) {
+  addAsset(assets, {
+    type: "central_theme",
+    value: "rotina de autocuidado",
+    confidence: 0.82,
+    evidence: "Sinais de rotina, skincare, cuidado ou autocuidado.",
+  });
+  addAsset(assets, {
+    type: "brand_territory",
+    value: "autocuidado",
+    confidence: 0.78,
+    evidence: "Território compatível com hábitos pessoais e cuidado.",
+  });
+  addAsset(assets, {
+    type: "category",
+    value: source.metadata.format === "reel" ? "lifestyle" : "beauty_personal_care",
+    confidence: 0.7,
+    evidence: "Categoria inferida por rotina/skincare/autocuidado.",
+  });
+  addAsset(assets, {
+    type: "narrative_pattern",
+    value: "rotina real",
+    confidence: 0.76,
+    evidence: "A fonte aponta para uma narrativa de hábito cotidiano.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "recurring_theme",
+    value: "rotina",
+    confidence: 0.76,
+    shouldPersistLater: true,
+    evidence: "Tema recorrente possível: rotina.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "brand_territory",
+    value: "autocuidado",
+    confidence: 0.76,
+    shouldPersistLater: true,
+    evidence: "Território de marca possível: autocuidado.",
+  });
+}
+
+function addWorkBehindScenesSignals(
+  assets: NarrativeAsset[],
+  profileSignals: CreatorNarrativeSignal[],
+  source: NarrativeSource
+) {
+  addAsset(assets, {
+    type: "central_theme",
+    value: "bastidor de trabalho",
+    confidence: 0.78,
+    evidence: "Sinais de bastidor, trabalho, processo ou produção.",
+  });
+  addAsset(assets, {
+    type: "content_proposal",
+    value: "behind_the_scenes",
+    confidence: 0.8,
+    evidence: "A fonte sugere bastidor como proposta de conteúdo.",
+  });
+  addAsset(assets, {
+    type: "narrative_pattern",
+    value: "bastidor real",
+    confidence: 0.78,
+    evidence: "A narrativa pode se apoiar no processo acontecendo.",
+  });
+  addAsset(assets, {
+    type: "creator_role",
+    value: "estrategista",
+    confidence: 0.68,
+    evidence: "O criador aparece conduzindo processo ou decisão.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "content_strength",
+    value: "bastidor",
+    confidence: 0.74,
+    shouldPersistLater: true,
+    evidence: "Bastidor aparece como força de conteúdo.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "creator_role",
+    value: "estrategista",
+    confidence: 0.66,
+    shouldPersistLater: true,
+    evidence: "Papel narrativo possível: estrategista.",
+  });
+}
+
+function addHookWeaknessSignals(
+  assets: NarrativeAsset[],
+  profileSignals: CreatorNarrativeSignal[],
+  source: NarrativeSource
+) {
+  addAsset(assets, {
+    type: "weakness",
+    value: "gancho precisa ficar mais claro",
+    confidence: 0.84,
+    evidence: "A fonte menciona começo fraco, gancho ou primeiros segundos.",
+  });
+  addAsset(assets, {
+    type: "hook_signal",
+    value: "abrir com tensão mais cedo",
+    confidence: 0.82,
+    evidence: "O ajuste principal está na abertura do conteúdo.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "recurring_insecurity",
+    value: "força do gancho",
+    confidence: 0.74,
+    shouldPersistLater: true,
+    evidence: "A insegurança aparece ligada ao começo do conteúdo.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "content_weakness",
+    value: "abertura",
+    confidence: 0.76,
+    shouldPersistLater: true,
+    evidence: "Abertura aparece como ponto de ajuste.",
+  });
+}
+
+function addBrandSignals(assets: NarrativeAsset[], profileSignals: CreatorNarrativeSignal[], source: NarrativeSource) {
+  addAsset(assets, {
+    type: "brand_territory",
+    value: "marca em contexto orgânico",
+    confidence: 0.82,
+    evidence: "A fonte menciona marca, publi, campanha ou potencial comercial.",
+  });
+  addAsset(assets, {
+    type: "audience_reaction",
+    value: "confiança/identificação",
+    confidence: 0.72,
+    evidence: "O encaixe de marca depende de parecer natural para a audiência.",
+  });
+  addAsset(assets, {
+    type: "content_proposal",
+    value: "organic_brand_fit",
+    confidence: 0.8,
+    evidence: "Proposta de conteúdo com marca integrada ao contexto.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "brand_territory",
+    value: "marca em contexto orgânico",
+    confidence: 0.78,
+    shouldPersistLater: true,
+    evidence: "Território comercial possível sem tirar o contexto narrativo.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "audience_goal",
+    value: "confiança",
+    confidence: 0.7,
+    shouldPersistLater: true,
+    evidence: "A reação desejada envolve confiança no encaixe.",
+  });
+}
+
+function addCollabSignals(assets: NarrativeAsset[], profileSignals: CreatorNarrativeSignal[], source: NarrativeSource) {
+  addAsset(assets, {
+    type: "collab_opportunity",
+    value: "criador complementar",
+    confidence: 0.82,
+    evidence: "A fonte menciona collab, parceria, dupla ou outro creator.",
+  });
+  addAsset(assets, {
+    type: "content_proposal",
+    value: "collab_narrativa",
+    confidence: 0.8,
+    evidence: "A proposta depende da troca entre creators.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "audience_goal",
+    value: "conversa entre comunidades",
+    confidence: 0.74,
+    shouldPersistLater: true,
+    evidence: "A collab pode aproximar audiências complementares.",
+  });
+}
+
+function addPositioningSignals(
+  assets: NarrativeAsset[],
+  profileSignals: CreatorNarrativeSignal[],
+  source: NarrativeSource
+) {
+  addAsset(assets, {
+    type: "creator_role",
+    value: "autoridade em construção",
+    confidence: 0.8,
+    evidence: "A fonte menciona posicionamento, autoridade, imagem ou identidade.",
+  });
+  addAsset(assets, {
+    type: "narrative_pattern",
+    value: "posicionamento",
+    confidence: 0.78,
+    evidence: "O foco é coerência com a identidade do criador.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "positioning_signal",
+    value: "autoridade",
+    confidence: 0.76,
+    shouldPersistLater: true,
+    evidence: "Sinal de posicionamento ligado a autoridade.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "creator_role",
+    value: "autoridade em construção",
+    confidence: 0.74,
+    shouldPersistLater: true,
+    evidence: "Papel narrativo possível: autoridade em construção.",
+  });
+}
+
+function addCommentSignals(assets: NarrativeAsset[], profileSignals: CreatorNarrativeSignal[], source: NarrativeSource) {
+  addAsset(assets, {
+    type: "content_proposal",
+    value: "comment_to_post",
+    confidence: 0.82,
+    evidence: "A fonte nasce de comentário ou dúvida da audiência.",
+  });
+  addAsset(assets, {
+    type: "audience_reaction",
+    value: "resposta à dúvida da audiência",
+    confidence: 0.8,
+    evidence: "A narrativa pode responder diretamente a uma pergunta recebida.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "audience_goal",
+    value: "conversa",
+    confidence: 0.76,
+    shouldPersistLater: true,
+    evidence: "A fonte aponta para conversa com a audiência.",
+  });
+}
+
+function addScriptCaptionSignals(
+  assets: NarrativeAsset[],
+  profileSignals: CreatorNarrativeSignal[],
+  source: NarrativeSource,
+  text: string
+) {
+  const preferredFormat = source.sourceType === "caption" ? "legenda" : "roteiro";
+
+  addAsset(assets, {
+    type: "format_fit",
+    value: "roteiro/legenda como ponto de partida",
+    confidence: 0.7,
+    evidence: "A fonte usa roteiro, legenda ou formato textual estruturado.",
+  });
+  addSignal(profileSignals, source, {
+    signalType: "preferred_format",
+    value: preferredFormat,
+    confidence: 0.68,
+    shouldPersistLater: true,
+    evidence: `Fonte textual indica preferência por ${preferredFormat}.`,
+  });
+
+  if (hasAny(text, ["duvida", "nao sei", "fraco", "melhorar"])) {
+    addAsset(assets, {
+      type: "hook_signal",
+      value: "clarear a intenção antes de produzir",
+      confidence: 0.6,
+      evidence: "A fonte textual traz sinal de dúvida ou ajuste.",
+    });
+  }
+}
+
+function fallbackResult(assets: NarrativeAsset[], profileSignals: CreatorNarrativeSignal[]): ExtractionResult {
+  addAsset(assets, {
+    type: "central_theme",
+    value: "tema ainda pouco definido",
+    confidence: 0.35,
+    evidence: "A fonte não trouxe contexto suficiente para uma leitura específica.",
+  });
+
+  return {
+    assets,
+    profileSignals,
+    summary: "A fonte ainda precisa de mais contexto para revelar uma narrativa clara.",
+    suggestedNextStep: "Adicionar mais contexto sobre objetivo, público ou intenção do conteúdo.",
+  };
+}
+
+export function extractNarrativeAssets(params: {
+  source: NarrativeSource;
+  intentDetection: NarrativeSourceIntentDetection;
+}): ExtractionResult {
+  const { source, intentDetection } = params;
+  const text = buildAnalysisText(source, intentDetection);
+  const assets: NarrativeAsset[] = [];
+  const profileSignals: CreatorNarrativeSignal[] = [];
+
+  if (hasAny(text, ["rotina", "skincare", "autocuidado", "manha", "cuidado"])) {
+    addRoutineSignals(assets, profileSignals, source);
+  }
+
+  if (hasAny(text, ["bastidor", "trabalho", "processo", "reuniao", "gravacao", "producao"])) {
+    addWorkBehindScenesSignals(assets, profileSignals, source);
+  }
+
+  if (
+    intentDetection.intent === "improve_content" ||
+    hasAny(text, ["comeco fraco", "gancho", "prender atencao", "primeiros segundos"])
+  ) {
+    addHookWeaknessSignals(assets, profileSignals, source);
+  }
+
+  if (
+    intentDetection.intent === "brand_potential" ||
+    intentDetection.intent === "adapt_to_ad" ||
+    hasAny(text, ["marca", "publi", "campanha", "patrocinado"])
+  ) {
+    addBrandSignals(assets, profileSignals, source);
+  }
+
+  if (
+    intentDetection.intent === "collab_potential" ||
+    hasAny(text, ["collab", "parceria", "outro creator", "dupla"])
+  ) {
+    addCollabSignals(assets, profileSignals, source);
+  }
+
+  if (
+    intentDetection.intent === "positioning_fit" ||
+    hasAny(text, ["posicionamento", "autoridade", "minha imagem", "identidade"])
+  ) {
+    addPositioningSignals(assets, profileSignals, source);
+  }
+
+  if (source.sourceType === "comment" || hasAny(text, ["comentaram", "comentario", "me perguntaram"])) {
+    addCommentSignals(assets, profileSignals, source);
+  }
+
+  if (source.sourceType === "script" || source.sourceType === "caption" || hasAny(text, ["roteiro", "legenda"])) {
+    addScriptCaptionSignals(assets, profileSignals, source, text);
+  }
+
+  if (assets.length === 0) {
+    return fallbackResult(assets, profileSignals);
+  }
+
+  return {
+    assets,
+    profileSignals,
+    summary: "A fonte já apresenta sinais narrativos úteis para orientar a próxima leitura estratégica.",
+    suggestedNextStep: "Revisar os assets extraídos e escolher qual direção merece aprofundamento.",
+  };
+}

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts
@@ -1,0 +1,260 @@
+import fs from "fs";
+import path from "path";
+import { buildAdaptiveInputFromNarrativeSource } from "./narrativeSourceAdaptiveAdapter";
+import { createEmptyNarrativeSource, type NarrativeAsset, type NarrativeSource } from "./narrativeSourceTypes";
+import type {
+  CreatorNarrativeSignal,
+  NarrativeSourceIntent,
+  NarrativeSourceIntentDetection,
+} from "./narrativeSourceTypes";
+
+function makeSource(params: Partial<NarrativeSource> = {}): NarrativeSource {
+  return {
+    ...createEmptyNarrativeSource({
+      id: params.id || "source-adapter-test",
+      sourceType: params.sourceType || "video_simulated",
+    }),
+    ...params,
+    metadata: params.metadata || {},
+  };
+}
+
+function makeIntentDetection(
+  intent: NarrativeSourceIntent,
+  source: NarrativeSource,
+  signals: string[] = []
+): NarrativeSourceIntentDetection {
+  const originalQuestion = source.creatorQuestion || source.rawText || source.transcript || source.visualDescription || "";
+
+  return {
+    intent,
+    confidence: intent === "unknown" ? 0.2 : 0.85,
+    sourceType: source.sourceType,
+    originalQuestion,
+    normalizedQuestion: originalQuestion.toLowerCase().replace(/\s+/g, " ").trim(),
+    signals,
+  };
+}
+
+function makeAsset(type: NarrativeAsset["type"], value: string): NarrativeAsset {
+  return {
+    id: `asset-${type}-${value}`,
+    type,
+    value,
+    confidence: 0.8,
+    evidence: "Sinal de teste.",
+  };
+}
+
+function makeSignal(signalType: CreatorNarrativeSignal["signalType"], value: string): CreatorNarrativeSignal {
+  return {
+    id: `signal-${signalType}-${value}`,
+    signalType,
+    value,
+    confidence: 0.8,
+    sourceType: "video_simulated",
+    shouldPersistLater: true,
+    evidence: "Sinal de perfil de teste.",
+  };
+}
+
+function adapt(params: {
+  source: NarrativeSource;
+  intent: NarrativeSourceIntent;
+  assets?: NarrativeAsset[];
+  profileSignals?: CreatorNarrativeSignal[];
+  signals?: string[];
+  summary?: string;
+}) {
+  return buildAdaptiveInputFromNarrativeSource({
+    source: params.source,
+    intentDetection: makeIntentDetection(params.intent, params.source, params.signals),
+    extraction: {
+      assets: params.assets || [],
+      profileSignals: params.profileSignals || [],
+      summary: params.summary || "A fonte apresenta sinais narrativos úteis.",
+      suggestedNextStep: "Explorar a direção mais clara.",
+    },
+  });
+}
+
+describe("buildAdaptiveInputFromNarrativeSource", () => {
+  it("maps validate_before_posting to validate_pauta", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Gravei esse vídeo e quero saber se vale postar",
+      }),
+      intent: "validate_before_posting",
+      assets: [makeAsset("central_theme", "rotina de autocuidado")],
+    });
+
+    expect(result.modeHint).toBe("validate_pauta");
+    expect(result.input).toContain("validar");
+    expect(result.input).toContain("rotina de autocuidado");
+  });
+
+  it("maps improve_content to validate_pauta with hook context", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+      }),
+      intent: "improve_content",
+      assets: [makeAsset("central_theme", "bastidor de trabalho")],
+    });
+
+    expect(result.modeHint).toBe("validate_pauta");
+    expect(result.input).toContain("melhorar");
+    expect(result.input).toContain("gancho");
+    expect(result.input).toContain("bastidor de trabalho");
+  });
+
+  it("maps discover_narrative to discover_pauta", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+      }),
+      intent: "discover_narrative",
+      assets: [makeAsset("narrative_pattern", "bastidor real")],
+    });
+
+    expect(result.modeHint).toBe("discover_pauta");
+    expect(result.input).toContain("narrativa");
+    expect(result.input).toContain("bastidor real");
+  });
+
+  it("maps brand_potential to brand_match", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+      }),
+      intent: "brand_potential",
+      assets: [makeAsset("central_theme", "rotina de autocuidado"), makeAsset("brand_territory", "autocuidado")],
+    });
+
+    expect(result.modeHint).toBe("brand_match");
+    expect(result.input).toContain("atrair marcas");
+    expect(result.input).toContain("autocuidado");
+  });
+
+  it("maps adapt_to_ad to brand_match with ad context", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Quero transformar esse vídeo em uma publi para uma marca de skincare",
+      }),
+      intent: "adapt_to_ad",
+      assets: [makeAsset("central_theme", "rotina de autocuidado"), makeAsset("brand_territory", "autocuidado")],
+    });
+
+    expect(result.modeHint).toBe("brand_match");
+    expect(result.input).toContain("publi");
+    expect(result.input).toMatch(/sem parecer forçado|sem parecer forcado/);
+  });
+
+  it("maps collab_potential to collab_match", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+      }),
+      intent: "collab_potential",
+      assets: [makeAsset("central_theme", "bastidor de trabalho")],
+    });
+
+    expect(result.modeHint).toBe("collab_match");
+    expect(result.input).toContain("collab");
+    expect(result.input).toContain("bastidor de trabalho");
+  });
+
+  it("maps positioning_fit to validate_pauta", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Quero saber se esse vídeo combina com meu posicionamento",
+      }),
+      intent: "positioning_fit",
+      assets: [makeAsset("creator_role", "autoridade em construção")],
+    });
+
+    expect(result.modeHint).toBe("validate_pauta");
+    expect(result.input).toContain("posicionamento");
+    expect(result.input).toContain("tema ainda pouco definido");
+  });
+
+  it("returns a safe fallback for unknown intent and sparse assets", () => {
+    const result = adapt({
+      source: makeSource({
+        rawText: "Preciso de uma direção para esse conteúdo",
+      }),
+      intent: "unknown",
+      assets: [],
+      profileSignals: [],
+    });
+
+    expect(result.modeHint).toBe("unknown");
+    expect(result.input).toBeTruthy();
+    expect(result.sourceSummary).toContain("Fonte video_simulated");
+  });
+
+  it("deduplicates and limits adapter signals", () => {
+    const repeatedAssets = [
+      makeAsset("central_theme", "rotina"),
+      makeAsset("central_theme", "rotina"),
+      makeAsset("brand_territory", "autocuidado"),
+      makeAsset("brand_territory", "autocuidado"),
+      ...Array.from({ length: 16 }, (_, index) => makeAsset("content_proposal", `sinal ${index}`)),
+    ];
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+      }),
+      intent: "brand_potential",
+      signals: ["rotina", "rotina", "marca"],
+      assets: repeatedAssets,
+      profileSignals: [makeSignal("brand_territory", "autocuidado"), makeSignal("brand_territory", "autocuidado")],
+    });
+
+    expect(result.signals.length).toBeLessThanOrEqual(12);
+    expect(new Set(result.signals.map((signal) => signal.toLowerCase())).size).toBe(result.signals.length);
+  });
+
+  it("keeps generated language safe", () => {
+    const result = adapt({
+      source: makeSource({
+        creatorQuestion: "Quero viralizar garantido com esse conteúdo",
+      }),
+      intent: "general_question",
+      signals: ["garantido", "score", "nota", "viralizar"],
+      assets: [makeAsset("central_theme", "pontuação comprovado")],
+      profileSignals: [makeSignal("audience_goal", "certeza")],
+    });
+    const text = JSON.stringify([result.input, result.sourceSummary, result.signals]).toLowerCase();
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps the adapter isolated from UI, external dependencies, and Adaptive V2 pipeline calls", () => {
+    const source = fs.readFileSync(path.join(__dirname, "narrativeSourceAdaptiveAdapter.ts"), "utf8");
+
+    expect(source).not.toMatch(/React|from ["']react["']/);
+    expect(source).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/Prisma|prisma|banco/);
+    expect(source).not.toMatch(/components?\//);
+    expect(source).not.toMatch(/detectPostCreationAdaptiveIntent/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveQuiz/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveAnswerKey|AnswerKey/);
+    expect(source).not.toMatch(/buildPostCreationAdaptiveStrategicPlan|PlanBuilder/);
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.ts
@@ -145,11 +145,11 @@ function buildInput(params: {
     case "improve_content":
       return `Quero melhorar uma pauta sobre ${params.theme}, principalmente o gancho e a clareza.`;
     case "discover_narrative":
-      return `Não sei qual narrativa explorar em um conteúdo sobre ${params.theme}.`;
+      return `Não sei o que postar para explorar a narrativa sobre ${params.theme}.`;
     case "brand_potential":
       return `Quero atrair marcas de ${params.territory} com uma narrativa sobre ${params.theme}.`;
     case "adapt_to_ad":
-      return `Quero adaptar uma pauta sobre ${params.theme} para uma publi de ${params.territory} sem parecer forçado.`;
+      return `Quero adaptar uma pauta sobre ${params.theme} para uma campanha/publi de ${params.territory} sem parecer forçado.`;
     case "collab_potential":
       return `Quero fazer uma collab em uma narrativa sobre ${params.theme}.`;
     case "positioning_fit":

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.ts
@@ -1,0 +1,194 @@
+import type { PostCreationAdaptiveMode } from "../postCreationAdaptiveTypes";
+import type {
+  CreatorNarrativeSignal,
+  NarrativeAsset,
+  NarrativeSource,
+  NarrativeSourceIntent,
+  NarrativeSourceIntentDetection,
+} from "./narrativeSourceTypes";
+
+type NarrativeSourceExtraction = {
+  assets: NarrativeAsset[];
+  profileSignals: CreatorNarrativeSignal[];
+  summary: string;
+  suggestedNextStep: string;
+};
+
+export type NarrativeSourceAdaptiveInput = {
+  input: string;
+  modeHint: PostCreationAdaptiveMode | null;
+  sourceSummary: string;
+  signals: string[];
+};
+
+const MODE_BY_INTENT: Record<NarrativeSourceIntent, PostCreationAdaptiveMode> = {
+  validate_before_posting: "validate_pauta",
+  improve_content: "validate_pauta",
+  discover_narrative: "discover_pauta",
+  brand_potential: "brand_match",
+  adapt_to_ad: "brand_match",
+  collab_potential: "collab_match",
+  positioning_fit: "validate_pauta",
+  general_question: "unknown",
+  unknown: "unknown",
+};
+
+const BLOCKED_LANGUAGE_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/\bgarantido\b/gi, "prometido"],
+  [/\bcerteza\b/gi, "clareza"],
+  [/\bcomprovado\b/gi, "observado"],
+  [/\bviralizar\b/gi, "ampliar alcance"],
+  [/\bscore\b/gi, "leitura"],
+  [/\bnota\b/gi, "leitura"],
+  [/\bpontuação\b/gi, "leitura"],
+  [/\bacerto\b/gi, "sinal"],
+  [/\berro\b/gi, "ajuste"],
+  [/\bgabarito\b/gi, "referência"],
+];
+
+function normalizeText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compactText(value: string | null | undefined, fallback: string): string {
+  const compacted = sanitizeGeneratedText((value || "").replace(/\s+/g, " ").trim());
+  if (!compacted) return fallback;
+  return compacted.length > 90 ? `${compacted.slice(0, 87).trim()}...` : compacted;
+}
+
+function sanitizeGeneratedText(value: string): string {
+  return BLOCKED_LANGUAGE_REPLACEMENTS.reduce(
+    (currentValue, [pattern, replacement]) => currentValue.replace(pattern, replacement),
+    value
+  );
+}
+
+function firstAssetValue(assets: NarrativeAsset[], type: NarrativeAsset["type"]): string | null {
+  return assets.find((asset) => asset.type === type && asset.value.trim())?.value.trim() || null;
+}
+
+function firstSignalValue(
+  profileSignals: CreatorNarrativeSignal[],
+  signalType: CreatorNarrativeSignal["signalType"]
+): string | null {
+  return profileSignals.find((signal) => signal.signalType === signalType && signal.value.trim())?.value.trim() || null;
+}
+
+function chooseTheme(source: NarrativeSource, assets: NarrativeAsset[]): string {
+  return sanitizeGeneratedText(
+    firstAssetValue(assets, "central_theme") ||
+      firstAssetValue(assets, "narrative_pattern") ||
+      compactText(source.metadata.title, "") ||
+      compactText(source.rawText, "") ||
+      compactText(source.transcript, "") ||
+      "tema ainda pouco definido"
+  );
+}
+
+function chooseBrandTerritory(
+  source: NarrativeSource,
+  assets: NarrativeAsset[],
+  profileSignals: CreatorNarrativeSignal[]
+): string {
+  return sanitizeGeneratedText(
+    firstAssetValue(assets, "brand_territory") ||
+      firstSignalValue(profileSignals, "brand_territory") ||
+      compactText(source.metadata.campaignContext, "") ||
+      "marca em contexto orgânico"
+  );
+}
+
+function buildSignals(params: {
+  intentDetection: NarrativeSourceIntentDetection;
+  assets: NarrativeAsset[];
+  profileSignals: CreatorNarrativeSignal[];
+}): string[] {
+  const seen = new Set<string>();
+  const signals: string[] = [];
+
+  for (const value of [
+    ...params.intentDetection.signals,
+    ...params.assets.map((asset) => asset.value),
+    ...params.profileSignals.map((signal) => signal.value),
+  ]) {
+    const safeValue = sanitizeGeneratedText(value).trim();
+    const key = normalizeText(safeValue).toLowerCase();
+    if (!safeValue || seen.has(key)) continue;
+
+    seen.add(key);
+    signals.push(safeValue);
+    if (signals.length >= 12) break;
+  }
+
+  return signals;
+}
+
+function buildInput(params: {
+  intent: NarrativeSourceIntent;
+  source: NarrativeSource;
+  extraction: NarrativeSourceExtraction;
+  theme: string;
+  territory: string;
+}): string {
+  const fallback = compactText(
+    params.source.creatorQuestion || params.source.rawText || params.extraction.summary,
+    "Quero explorar uma pauta com mais contexto narrativo."
+  );
+
+  switch (params.intent) {
+    case "validate_before_posting":
+      return `Quero validar uma pauta sobre ${params.theme} antes de postar.`;
+    case "improve_content":
+      return `Quero melhorar uma pauta sobre ${params.theme}, principalmente o gancho e a clareza.`;
+    case "discover_narrative":
+      return `Não sei qual narrativa explorar em um conteúdo sobre ${params.theme}.`;
+    case "brand_potential":
+      return `Quero atrair marcas de ${params.territory} com uma narrativa sobre ${params.theme}.`;
+    case "adapt_to_ad":
+      return `Quero adaptar uma pauta sobre ${params.theme} para uma publi de ${params.territory} sem parecer forçado.`;
+    case "collab_potential":
+      return `Quero fazer uma collab em uma narrativa sobre ${params.theme}.`;
+    case "positioning_fit":
+      return `Quero validar se uma pauta sobre ${params.theme} combina com meu posicionamento.`;
+    default:
+      return fallback;
+  }
+}
+
+export function buildAdaptiveInputFromNarrativeSource(params: {
+  source: NarrativeSource;
+  intentDetection: NarrativeSourceIntentDetection;
+  extraction: NarrativeSourceExtraction;
+}): NarrativeSourceAdaptiveInput {
+  const { source, intentDetection, extraction } = params;
+  const modeHint = MODE_BY_INTENT[intentDetection.intent] ?? null;
+  const theme = chooseTheme(source, extraction.assets);
+  const territory = chooseBrandTerritory(source, extraction.assets, extraction.profileSignals);
+  const input = sanitizeGeneratedText(
+    buildInput({
+      intent: intentDetection.intent,
+      source,
+      extraction,
+      theme,
+      territory,
+    })
+  );
+  const signals = buildSignals({
+    intentDetection,
+    assets: extraction.assets,
+    profileSignals: extraction.profileSignals,
+  });
+
+  return {
+    input,
+    modeHint,
+    sourceSummary: sanitizeGeneratedText(
+      `Fonte ${source.sourceType} com intenção ${intentDetection.intent}, tema ${theme}, ${extraction.assets.length} assets e ${extraction.profileSignals.length} sinais de perfil.`
+    ),
+    signals,
+  };
+}

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.test.ts
@@ -1,0 +1,28 @@
+import { isNarrativeSourceEngineEnabled } from "./narrativeSourceFeatureFlag";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = originalEnvValue;
+});
+
+describe("narrativeSourceFeatureFlag", () => {
+  it("enables NSE when env flag is 1", () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    expect(isNarrativeSourceEngineEnabled()).toBe(true);
+  });
+
+  it("keeps NSE disabled when env flag is absent or off", () => {
+    delete process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+    expect(isNarrativeSourceEngineEnabled()).toBe(false);
+
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "0";
+    expect(isNarrativeSourceEngineEnabled()).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.ts
@@ -1,0 +1,5 @@
+const NARRATIVE_SOURCE_ENV_FLAG = "NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED";
+
+export function isNarrativeSourceEngineEnabled(): boolean {
+  return process.env[NARRATIVE_SOURCE_ENV_FLAG] === "1";
+}

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+import path from "path";
+import { createEmptyNarrativeSource, type NarrativeSource } from "./narrativeSourceTypes";
+import { detectNarrativeSourceIntent } from "./narrativeSourceIntentRouter";
+
+function makeSource(params: Partial<NarrativeSource> = {}): NarrativeSource {
+  return {
+    ...createEmptyNarrativeSource({
+      id: params.id || "source-test",
+      sourceType: params.sourceType || "video_simulated",
+    }),
+    ...params,
+    metadata: params.metadata || {},
+  };
+}
+
+describe("detectNarrativeSourceIntent", () => {
+  it("detects validate_before_posting", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Gravei esse vídeo e quero saber se vale postar" })
+    );
+
+    expect(result.intent).toBe("validate_before_posting");
+    expect(result.signals).toEqual(expect.arrayContaining(["vale postar"]));
+  });
+
+  it("detects improve_content", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho" })
+    );
+
+    expect(result.intent).toBe("improve_content");
+  });
+
+  it("detects discover_narrative", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Não sei qual narrativa esse vídeo comunica" })
+    );
+
+    expect(result.intent).toBe("discover_narrative");
+  });
+
+  it("detects brand_potential", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas" })
+    );
+
+    expect(result.intent).toBe("brand_potential");
+  });
+
+  it("detects adapt_to_ad over brand_potential", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Quero transformar esse vídeo em uma publi para uma marca de skincare" })
+    );
+
+    expect(result.intent).toBe("adapt_to_ad");
+  });
+
+  it("detects collab_potential over brand_potential", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator para atrair marcas?" })
+    );
+
+    expect(result.intent).toBe("collab_potential");
+  });
+
+  it("detects positioning_fit", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Quero saber se esse vídeo combina com meu posicionamento" })
+    );
+
+    expect(result.intent).toBe("positioning_fit");
+  });
+
+  it("prefers improve_content over brand_potential when the primary pain is content adjustment", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Quero melhorar o começo desse vídeo para ele atrair marcas" })
+    );
+
+    expect(result.intent).toBe("improve_content");
+  });
+
+  it("prefers brand_potential over validate_before_posting when the goal is brand attraction", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Quero saber se vale postar esse vídeo para atrair marcas" })
+    );
+
+    expect(result.intent).toBe("brand_potential");
+  });
+
+  it("falls back to rawText when creatorQuestion is empty", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({
+        creatorQuestion: "",
+        rawText: "Quero saber se esse roteiro tem potencial para atrair marcas",
+      })
+    );
+
+    expect(result.intent).toBe("brand_potential");
+    expect(result.originalQuestion).toBe("Quero saber se esse roteiro tem potencial para atrair marcas");
+  });
+
+  it("falls back to transcript when creatorQuestion and rawText are empty", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({
+        creatorQuestion: "",
+        rawText: "",
+        transcript: "Eu queria entender minha narrativa antes de publicar",
+      })
+    );
+
+    expect(result.intent).toBe("discover_narrative");
+    expect(result.originalQuestion).toBe("Eu queria entender minha narrativa antes de publicar");
+  });
+
+  it("returns unknown when there is not enough text", () => {
+    const result = detectNarrativeSourceIntent(makeSource());
+
+    expect(result.intent).toBe("unknown");
+    expect(result.confidence).toBe(0.2);
+    expect(result.signals).toEqual([]);
+  });
+
+  it("returns general_question when there is a generic question", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "Você pode me ajudar com esse conteúdo?" })
+    );
+
+    expect(result.intent).toBe("general_question");
+    expect(result.confidence).toBe(0.45);
+  });
+
+  it("normalizes question casing, accents, quotes, and spacing", () => {
+    const result = detectNarrativeSourceIntent(
+      makeSource({ creatorQuestion: "  NÃO   sei   qual   narrativa   esse   vídeo   comunica  " })
+    );
+
+    expect(result.normalizedQuestion).toBe("nao sei qual narrativa esse video comunica");
+  });
+
+  it("keeps the router isolated from UI and external dependencies", () => {
+    const source = fs.readFileSync(path.join(__dirname, "narrativeSourceIntentRouter.ts"), "utf8");
+
+    expect(source).not.toMatch(/React|from ["']react["']/);
+    expect(source).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/Prisma|prisma/);
+    expect(source).not.toMatch(/components?\//);
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.ts
@@ -1,0 +1,290 @@
+import type {
+  NarrativeSource,
+  NarrativeSourceIntent,
+  NarrativeSourceIntentDetection,
+} from "./narrativeSourceTypes";
+
+type IntentRule = {
+  intent: NarrativeSourceIntent;
+  confidence: number;
+  patterns: RegExp[];
+};
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[“”"']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function pickOriginalQuestion(source: NarrativeSource): string {
+  return (
+    source.creatorQuestion?.trim() ||
+    source.rawText?.trim() ||
+    source.transcript?.trim() ||
+    source.visualDescription?.trim() ||
+    ""
+  );
+}
+
+function collectSignals(text: string, patterns: RegExp[]): string[] {
+  return patterns
+    .map((pattern) => text.match(pattern)?.[0] || null)
+    .filter((signal): signal is string => Boolean(signal));
+}
+
+const adaptToAdRule: IntentRule = {
+  intent: "adapt_to_ad",
+  confidence: 0.85,
+  patterns: [
+    /\bpubli\b/,
+    /\bpublicidade\b/,
+    /\bcampanha\b/,
+    /\badaptar para marca\b/,
+    /\btransformar (?:isso|esse video|essa ideia|esse conteudo) em publi\b/,
+    /\bbriefing\b/,
+    /\bpatrocinad[oa]\b/,
+    /\bskincare\b.*\b(publi|campanha|publicidade|marca)\b/,
+    /\b(publi|campanha|publicidade|marca)\b.*\bskincare\b/,
+  ],
+};
+
+const collabRule: IntentRule = {
+  intent: "collab_potential",
+  confidence: 0.85,
+  patterns: [
+    /\bcollab\b/,
+    /\bcolaboracao\b/,
+    /\bconteudo junto\b/,
+    /\boutro creator\b/,
+    /\bcriador parceiro\b/,
+    /\bparceiro\b/,
+    /\bdupla\b/,
+    /\bconvidad[oa]\b/,
+  ],
+};
+
+const improveRule: IntentRule = {
+  intent: "improve_content",
+  confidence: 0.85,
+  patterns: [
+    /\bmelhorar\b/,
+    /\bcomeco fraco\b/,
+    /\bgancho fraco\b/,
+    /\bcortar\b/,
+    /\bregravar\b/,
+    /\beditar\b/,
+    /\benquadramento\b/,
+    /\britmo\b/,
+    /\blegenda\b/,
+    /\bcapa\b/,
+    /\bcta\b/,
+  ],
+};
+
+const brandRule: IntentRule = {
+  intent: "brand_potential",
+  confidence: 0.85,
+  patterns: [
+    /\batrair marcas\b/,
+    /\bmatch com marca\b/,
+    /\bpotencial para marca\b/,
+    /\bpotencial para atrair marcas\b/,
+    /\bmonetizar\b/,
+    /\bmarca combinaria\b/,
+    /\bque marcas\b/,
+    /\bcomercial\b/,
+  ],
+};
+
+const positioningRule: IntentRule = {
+  intent: "positioning_fit",
+  confidence: 0.85,
+  patterns: [
+    /\bposicionamento\b/,
+    /\bcombina comigo\b/,
+    /\bcombina com minha conta\b/,
+    /\bminha imagem\b/,
+    /\bcoerencia com meu perfil\b/,
+    /\bautoridade\b/,
+    /\bidentidade\b/,
+  ],
+};
+
+const discoverNarrativeRule: IntentRule = {
+  intent: "discover_narrative",
+  confidence: 0.85,
+  patterns: [
+    /\bqual narrativa\b/,
+    /\bnarrativa (?:esse video )?comunica\b/,
+    /\bque historia\b/,
+    /\bo que isso diz\b/,
+    /\bnao sei que narrativa\b/,
+    /\bentender minha narrativa\b/,
+  ],
+};
+
+const validateRule: IntentRule = {
+  intent: "validate_before_posting",
+  confidence: 0.85,
+  patterns: [
+    /\bvale postar\b/,
+    /\besta bom\b/,
+    /\bdevo postar\b/,
+    /\bpostar ou nao\b/,
+    /\binsegur[oa]\b/,
+    /\bduvida se publico\b/,
+  ],
+};
+
+function buildDetection(params: {
+  source: NarrativeSource;
+  intent: NarrativeSourceIntent;
+  confidence: number;
+  originalQuestion: string;
+  normalizedQuestion: string;
+  signals: string[];
+}): NarrativeSourceIntentDetection {
+  return {
+    intent: params.intent,
+    confidence: params.confidence,
+    sourceType: params.source.sourceType,
+    originalQuestion: params.originalQuestion,
+    normalizedQuestion: params.normalizedQuestion,
+    signals: params.signals,
+  };
+}
+
+function matchRule(rule: IntentRule, text: string) {
+  const signals = collectSignals(text, rule.patterns);
+  return signals.length > 0 ? signals : null;
+}
+
+function hasGenericQuestion(text: string) {
+  return /\?/.test(text) || /\b(voce pode|me ajuda|me ajudar|como|qual|o que|sera que)\b/.test(text);
+}
+
+export function detectNarrativeSourceIntent(source: NarrativeSource): NarrativeSourceIntentDetection {
+  const originalQuestion = pickOriginalQuestion(source);
+  const normalizedQuestion = normalizeText(originalQuestion);
+  const campaignContext = normalizeText(source.metadata.campaignContext || "");
+  const analysisText = [normalizedQuestion, campaignContext].filter(Boolean).join(" ");
+
+  if (analysisText.length < 3) {
+    return buildDetection({
+      source,
+      intent: "unknown",
+      confidence: 0.2,
+      originalQuestion,
+      normalizedQuestion,
+      signals: [],
+    });
+  }
+
+  const adaptSignals = matchRule(adaptToAdRule, analysisText);
+  if (adaptSignals) {
+    return buildDetection({
+      source,
+      intent: adaptToAdRule.intent,
+      confidence: adaptToAdRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: adaptSignals,
+    });
+  }
+
+  const collabSignals = matchRule(collabRule, analysisText);
+  if (collabSignals) {
+    return buildDetection({
+      source,
+      intent: collabRule.intent,
+      confidence: collabRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: collabSignals,
+    });
+  }
+
+  const improveSignals = matchRule(improveRule, analysisText);
+  if (improveSignals) {
+    return buildDetection({
+      source,
+      intent: improveRule.intent,
+      confidence: improveRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: improveSignals,
+    });
+  }
+
+  const brandSignals = matchRule(brandRule, analysisText);
+  if (brandSignals) {
+    return buildDetection({
+      source,
+      intent: brandRule.intent,
+      confidence: brandRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: brandSignals,
+    });
+  }
+
+  const positioningSignals = matchRule(positioningRule, analysisText);
+  if (positioningSignals) {
+    return buildDetection({
+      source,
+      intent: positioningRule.intent,
+      confidence: positioningRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: positioningSignals,
+    });
+  }
+
+  const discoverSignals = matchRule(discoverNarrativeRule, analysisText);
+  if (discoverSignals) {
+    return buildDetection({
+      source,
+      intent: discoverNarrativeRule.intent,
+      confidence: discoverNarrativeRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: discoverSignals,
+    });
+  }
+
+  const validateSignals = matchRule(validateRule, analysisText);
+  if (validateSignals) {
+    return buildDetection({
+      source,
+      intent: validateRule.intent,
+      confidence: validateRule.confidence,
+      originalQuestion,
+      normalizedQuestion,
+      signals: validateSignals,
+    });
+  }
+
+  if (hasGenericQuestion(originalQuestion)) {
+    return buildDetection({
+      source,
+      intent: "general_question",
+      confidence: 0.45,
+      originalQuestion,
+      normalizedQuestion,
+      signals: ["generic_question"],
+    });
+  }
+
+  return buildDetection({
+    source,
+    intent: "unknown",
+    confidence: 0.2,
+    originalQuestion,
+    normalizedQuestion,
+    signals: [],
+  });
+}

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts
@@ -1,0 +1,284 @@
+import fs from "fs";
+import path from "path";
+import { buildPostCreationAdaptiveAnswerKey } from "../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../postCreationAdaptiveTypes";
+import { extractNarrativeAssets } from "./narrativeAssetExtractor";
+import { buildAdaptiveInputFromNarrativeSource } from "./narrativeSourceAdaptiveAdapter";
+import { detectNarrativeSourceIntent } from "./narrativeSourceIntentRouter";
+import { createEmptyNarrativeSource, type NarrativeAsset, type NarrativeSource } from "./narrativeSourceTypes";
+
+const forbiddenLanguage = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "erro",
+  "gabarito",
+  "resposta correta",
+];
+
+function makeSource(params: Partial<NarrativeSource> = {}): NarrativeSource {
+  return {
+    ...createEmptyNarrativeSource({
+      id: params.id || "source-pipeline-test",
+      sourceType: params.sourceType || "video_simulated",
+    }),
+    ...params,
+    metadata: params.metadata || {},
+  };
+}
+
+function runNarrativeSourcePipeline(source: NarrativeSource) {
+  const sourceIntent = detectNarrativeSourceIntent(source);
+  const extraction = extractNarrativeAssets({ source, intentDetection: sourceIntent });
+  const adaptiveInput = buildAdaptiveInputFromNarrativeSource({
+    source,
+    intentDetection: sourceIntent,
+    extraction,
+  });
+  const adaptiveDetection = detectPostCreationAdaptiveIntent(adaptiveInput.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection: adaptiveDetection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => {
+    const option = question.options.find((candidate) => candidate.recommended) || question.options[0]!;
+
+    return {
+      questionId: question.id,
+      key: question.mapKey,
+      optionId: option.id,
+      value: null,
+    };
+  });
+  const answerKey = buildPostCreationAdaptiveAnswerKey({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+  });
+  const plan = buildPostCreationAdaptiveStrategicPlan({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+  });
+
+  return {
+    source,
+    sourceIntent,
+    extraction,
+    adaptiveInput,
+    adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}
+
+function assetValues(result: ReturnType<typeof runNarrativeSourcePipeline>, type: NarrativeAsset["type"]) {
+  return result.extraction.assets.filter((asset) => asset.type === type).map((asset) => asset.value);
+}
+
+const pipelineScenarios = [
+  {
+    name: "video validate posting",
+    source: makeSource({
+      creatorQuestion: "Gravei esse vídeo e quero saber se vale postar",
+      transcript: "Mostro minha rotina de skincare pela manhã com cuidado e autocuidado.",
+      visualDescription: "Pessoa organizando produtos de skincare na bancada.",
+    }),
+  },
+  {
+    name: "video improve content",
+    source: makeSource({
+      creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+      rawText: "Bastidor de trabalho mostrando processo e gravação.",
+      transcript: "Mostro uma reunião e o processo de produção do conteúdo.",
+    }),
+  },
+  {
+    name: "video discover narrative",
+    source: makeSource({
+      creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+      transcript: "Bastidor do processo de produção e organização do trabalho.",
+      visualDescription: "Mesa com roteiro, gravação e cenas de bastidor.",
+    }),
+  },
+  {
+    name: "video brand potential",
+    source: makeSource({
+      creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+      transcript: "Mostro minha rotina de skincare e autocuidado pela manhã.",
+    }),
+  },
+  {
+    name: "video adapt to ad",
+    source: makeSource({
+      creatorQuestion: "Quero transformar esse vídeo em uma publi para uma marca de skincare",
+      transcript: "Rotina de autocuidado com produtos organizados na bancada.",
+    }),
+  },
+  {
+    name: "video collab",
+    source: makeSource({
+      creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+      rawText: "Bastidor de trabalho com processo de produção e decisões criativas.",
+    }),
+  },
+  {
+    name: "video positioning",
+    source: makeSource({
+      creatorQuestion: "Quero saber se esse vídeo combina com meu posicionamento e autoridade",
+      rawText: "Opinião sobre um tema do mercado com autoridade e identidade própria.",
+    }),
+  },
+  {
+    name: "comment to post",
+    source: makeSource({
+      sourceType: "comment",
+      rawText: "Comentaram isso aqui: como você organiza sua rotina? Me perguntaram no direct.",
+    }),
+  },
+  {
+    name: "safe fallback",
+    source: makeSource(),
+  },
+];
+
+describe("Narrative Source Engine pipeline QA", () => {
+  it("feeds a simulated video validation source into validate_pauta", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[0]!.source);
+
+    expect(result.sourceIntent.intent).toBe("validate_before_posting");
+    expect(assetValues(result, "central_theme")).toContain("rotina de autocuidado");
+    expect(result.adaptiveInput.modeHint).toBe("validate_pauta");
+    expect(result.adaptiveDetection.mode).toBe("validate_pauta");
+    expect(result.questions.length).toBeGreaterThanOrEqual(3);
+    expect(result.plan.pauta).toBeTruthy();
+    expect(result.plan.nextActions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("feeds a simulated video improvement source into validate_pauta", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[1]!.source);
+
+    expect(result.sourceIntent.intent).toBe("improve_content");
+    expect(result.extraction.assets.some((asset) => asset.type === "weakness" || asset.type === "hook_signal")).toBe(true);
+    expect(result.adaptiveInput.modeHint).toBe("validate_pauta");
+    expect(result.adaptiveDetection.mode).toBe("validate_pauta");
+    expect(result.plan.hook || result.plan.fiveW2H.how).toBeTruthy();
+    expect(result.answerKey.summary).toBeTruthy();
+  });
+
+  it("feeds a simulated narrative discovery source into discover_pauta", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[2]!.source);
+
+    expect(result.sourceIntent.intent).toBe("discover_narrative");
+    expect(
+      result.extraction.assets.some((asset) => asset.type === "narrative_pattern" || asset.type === "content_proposal")
+    ).toBe(true);
+    expect(result.adaptiveInput.modeHint).toBe("discover_pauta");
+    expect(result.adaptiveDetection.mode).toBe("discover_pauta");
+    expect(result.questions[0]?.mapKey).toBe("narrative");
+    expect(result.plan.narrative).toBeTruthy();
+  });
+
+  it("feeds a simulated brand potential source into brand_match", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[3]!.source);
+
+    expect(result.sourceIntent.intent).toBe("brand_potential");
+    expect(result.extraction.assets.some((asset) => asset.type === "brand_territory")).toBe(true);
+    expect(result.adaptiveInput.modeHint).toBe("brand_match");
+    expect(result.adaptiveDetection.mode).toBe("brand_match");
+    expect(result.plan.brandMatch?.enabled).toBe(true);
+    expect(result.plan.collabMatch).toBeNull();
+  });
+
+  it("feeds a simulated ad adaptation source into brand_match", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[4]!.source);
+
+    expect(result.sourceIntent.intent).toBe("adapt_to_ad");
+    expect(result.adaptiveInput.modeHint).toBe("brand_match");
+    expect(result.adaptiveDetection.mode).toBe("brand_match");
+    expect(result.adaptiveInput.input).toContain("publi");
+    expect(result.plan.brandMatch?.enabled).toBe(true);
+  });
+
+  it("feeds a simulated collab source into collab_match", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[5]!.source);
+
+    expect(result.sourceIntent.intent).toBe("collab_potential");
+    expect(assetValues(result, "collab_opportunity")).toContain("criador complementar");
+    expect(result.adaptiveInput.modeHint).toBe("collab_match");
+    expect(result.adaptiveDetection.mode).toBe("collab_match");
+    expect(result.plan.collabMatch?.enabled).toBe(true);
+  });
+
+  it("feeds a simulated positioning source into validate_pauta", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[6]!.source);
+
+    expect(result.sourceIntent.intent).toBe("positioning_fit");
+    expect(result.extraction.assets.some((asset) => asset.type === "creator_role" || asset.type === "narrative_pattern")).toBe(true);
+    expect(result.adaptiveInput.modeHint).toBe("validate_pauta");
+    expect(result.adaptiveDetection.mode).toBe("validate_pauta");
+    expect(result.plan.pauta).toBeTruthy();
+  });
+
+  it("feeds a comment source into a post path", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[7]!.source);
+
+    expect(assetValues(result, "content_proposal")).toContain("comment_to_post");
+    expect(result.adaptiveInput.input).toMatch(/comentaram|perguntaram|rotina/i);
+    expect(["comment_to_post", "validate_pauta"]).toContain(result.adaptiveDetection.mode);
+    expect(result.plan.pauta).toBeTruthy();
+    expect(result.plan.nextActions.length).toBeGreaterThan(0);
+  });
+
+  it("keeps sparse sources safe through the full pipeline", () => {
+    const result = runNarrativeSourcePipeline(pipelineScenarios[8]!.source);
+
+    expect(result.sourceIntent.intent).toBe("unknown");
+    expect(assetValues(result, "central_theme")).toContain("tema ainda pouco definido");
+    expect(result.adaptiveInput.input).toBeTruthy();
+    expect(["unknown", "validate_pauta"]).toContain(result.adaptiveDetection.mode);
+    expect(result.plan.nextActions.length).toBeGreaterThan(0);
+  });
+
+  it("keeps generated language safe across the full narrative-to-adaptive pipeline", () => {
+    for (const scenario of pipelineScenarios) {
+      const result = runNarrativeSourcePipeline(scenario.source);
+      const generatedText = JSON.stringify({
+        sourceIntent: result.sourceIntent,
+        extraction: result.extraction,
+        adaptiveInput: result.adaptiveInput,
+        adaptiveDetection: result.adaptiveDetection,
+        questions: result.questions,
+        answerKey: result.answerKey,
+        plan: result.plan,
+      }).toLowerCase();
+
+      for (const forbidden of forbiddenLanguage) {
+        expect(generatedText).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it("keeps the pipeline QA isolated from UI and external dependencies", () => {
+    const source = fs.readFileSync(path.join(__dirname, "narrativeSourcePipeline.test.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).not.toMatch(/React|from ["']react["']/);
+    expect(imports).not.toMatch(/BoardShell|PostCreationFunnelBoardShell/);
+    expect(imports).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(imports).not.toMatch(/Prisma|prisma|banco/);
+    expect(imports).not.toMatch(/components?\//);
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts
@@ -1,0 +1,77 @@
+import {
+  SUPPORTED_NARRATIVE_SOURCE_INTENTS,
+  SUPPORTED_NARRATIVE_SOURCE_TYPES,
+  createEmptyNarrativeSource,
+  isSupportedNarrativeSourceIntent,
+  isSupportedNarrativeSourceType,
+} from "./narrativeSourceTypes";
+
+const forbiddenLanguage = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+];
+
+describe("narrativeSourceTypes", () => {
+  it("recognizes valid source types", () => {
+    for (const sourceType of SUPPORTED_NARRATIVE_SOURCE_TYPES) {
+      expect(isSupportedNarrativeSourceType(sourceType)).toBe(true);
+    }
+  });
+
+  it("rejects invalid source types", () => {
+    expect(isSupportedNarrativeSourceType("video_upload")).toBe(false);
+    expect(isSupportedNarrativeSourceType("instagram_reel")).toBe(false);
+    expect(isSupportedNarrativeSourceType("")).toBe(false);
+  });
+
+  it("recognizes valid intents", () => {
+    for (const intent of SUPPORTED_NARRATIVE_SOURCE_INTENTS) {
+      expect(isSupportedNarrativeSourceIntent(intent)).toBe(true);
+    }
+  });
+
+  it("rejects invalid intents", () => {
+    expect(isSupportedNarrativeSourceIntent("make_it_viral")).toBe(false);
+    expect(isSupportedNarrativeSourceIntent("score_content")).toBe(false);
+    expect(isSupportedNarrativeSourceIntent("")).toBe(false);
+  });
+
+  it("creates an empty narrative source with safe defaults", () => {
+    const source = createEmptyNarrativeSource({
+      id: "source-1",
+      sourceType: "video_simulated",
+    });
+
+    expect(source).toEqual({
+      id: "source-1",
+      sourceType: "video_simulated",
+      rawText: null,
+      creatorQuestion: null,
+      transcript: null,
+      visualDescription: null,
+      metadata: {},
+      createdAt: null,
+    });
+  });
+
+  it("does not use absolute-promise or score language in defaults", () => {
+    const source = createEmptyNarrativeSource({
+      id: "source-language",
+      sourceType: "text_prompt",
+    });
+    const text = JSON.stringify({
+      source,
+      sourceTypes: SUPPORTED_NARRATIVE_SOURCE_TYPES,
+      intents: SUPPORTED_NARRATIVE_SOURCE_INTENTS,
+    }).toLowerCase();
+
+    for (const term of forbiddenLanguage) {
+      expect(text).not.toContain(term);
+    }
+  });
+});

--- a/src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.ts
+++ b/src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.ts
@@ -1,0 +1,132 @@
+export const SUPPORTED_NARRATIVE_SOURCE_TYPES = [
+  "text_prompt",
+  "comment",
+  "script",
+  "caption",
+  "video_simulated",
+  "video_upload_future",
+  "brand_brief_future",
+  "instagram_post_future",
+] as const;
+
+export type NarrativeSourceType = (typeof SUPPORTED_NARRATIVE_SOURCE_TYPES)[number];
+
+export const SUPPORTED_NARRATIVE_SOURCE_INTENTS = [
+  "validate_before_posting",
+  "improve_content",
+  "discover_narrative",
+  "brand_potential",
+  "adapt_to_ad",
+  "collab_potential",
+  "positioning_fit",
+  "general_question",
+  "unknown",
+] as const;
+
+export type NarrativeSourceIntent = (typeof SUPPORTED_NARRATIVE_SOURCE_INTENTS)[number];
+
+export type NarrativeAssetType =
+  | "central_theme"
+  | "narrative_pattern"
+  | "content_proposal"
+  | "emotional_tone"
+  | "audience_reaction"
+  | "brand_territory"
+  | "collab_opportunity"
+  | "creator_role"
+  | "visual_context"
+  | "hook_signal"
+  | "weakness"
+  | "format_fit"
+  | "category";
+
+export type CreatorNarrativeSignalType =
+  | "recurring_theme"
+  | "preferred_format"
+  | "creator_role"
+  | "brand_territory"
+  | "recurring_insecurity"
+  | "audience_goal"
+  | "content_strength"
+  | "content_weakness"
+  | "positioning_signal";
+
+export type NarrativeSourceMetadata = {
+  title?: string | null;
+  durationSeconds?: number | null;
+  platform?: "instagram" | "tiktok" | "youtube" | "unknown" | null;
+  format?: "reel" | "photo" | "carousel" | "short_video" | "long_video" | "unknown" | null;
+  campaignContext?: string | null;
+};
+
+export type NarrativeSource = {
+  id: string;
+  sourceType: NarrativeSourceType;
+  rawText: string | null;
+  creatorQuestion: string | null;
+  transcript: string | null;
+  visualDescription: string | null;
+  metadata: NarrativeSourceMetadata;
+  createdAt?: string | null;
+};
+
+export type NarrativeSourceIntentDetection = {
+  intent: NarrativeSourceIntent;
+  confidence: number;
+  sourceType: NarrativeSourceType;
+  originalQuestion: string;
+  normalizedQuestion: string;
+  signals: string[];
+};
+
+export type NarrativeAsset = {
+  id: string;
+  type: NarrativeAssetType;
+  value: string;
+  confidence: number;
+  evidence?: string | null;
+};
+
+export type CreatorNarrativeSignal = {
+  id: string;
+  signalType: CreatorNarrativeSignalType;
+  value: string;
+  confidence: number;
+  sourceType: NarrativeSourceType;
+  shouldPersistLater: boolean;
+  evidence?: string | null;
+};
+
+export type NarrativeSourceDiagnostic = {
+  source: NarrativeSource;
+  intentDetection: NarrativeSourceIntentDetection;
+  assets: NarrativeAsset[];
+  profileSignals: CreatorNarrativeSignal[];
+  summary: string;
+  suggestedNextStep: string;
+};
+
+export function isSupportedNarrativeSourceType(value: string): value is NarrativeSourceType {
+  return SUPPORTED_NARRATIVE_SOURCE_TYPES.includes(value as NarrativeSourceType);
+}
+
+export function isSupportedNarrativeSourceIntent(value: string): value is NarrativeSourceIntent {
+  return SUPPORTED_NARRATIVE_SOURCE_INTENTS.includes(value as NarrativeSourceIntent);
+}
+
+export function createEmptyNarrativeSource(params: {
+  id: string;
+  sourceType: NarrativeSourceType;
+  createdAt?: string | null;
+}): NarrativeSource {
+  return {
+    id: params.id,
+    sourceType: params.sourceType,
+    rawText: null,
+    creatorQuestion: null,
+    transcript: null,
+    visualDescription: null,
+    metadata: {},
+    createdAt: params.createdAt ?? null,
+  };
+}

--- a/src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts
@@ -1,0 +1,120 @@
+import { detectPostCreationAdaptiveIntent } from "./postCreationAdaptiveRouter";
+import { buildPostCreationAdaptiveQuiz } from "./postCreationAdaptiveQuizBuilder";
+import { buildPostCreationAdaptiveAnswerKey } from "./postCreationAdaptiveAnswerKey";
+import type { PostCreationAdaptiveAnswer } from "./postCreationAdaptiveTypes";
+
+describe("buildPostCreationAdaptiveAnswerKey", () => {
+  const validateDetection = detectPostCreationAdaptiveIntent("Quero gravar um POV sobre rotina");
+  const validateQuestions = buildPostCreationAdaptiveQuiz({ detection: validateDetection });
+
+  it("evaluates a perfect match with recommended answers", () => {
+    const answers: PostCreationAdaptiveAnswer[] = validateQuestions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+
+    const result = buildPostCreationAdaptiveAnswerKey({
+      detection: validateDetection,
+      questions: validateQuestions,
+      answers,
+    });
+
+    expect(result.answeredQuestions).toBe(result.totalQuestions);
+    expect(result.recommendedMatches).toBe(result.totalQuestions);
+    expect(result.summary).toContain("alinhada");
+    expect(result.evaluations.every((e) => e.isRecommendedChoice)).toBe(true);
+  });
+
+  it("evaluates choices that differ from recommendations", () => {
+    const answers: PostCreationAdaptiveAnswer[] = validateQuestions.map((q, index) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      // Choose non-recommended for the first question
+      optionId: index === 0
+        ? q.options.find((o) => !o.recommended)?.id || q.options[1]!.id
+        : q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+
+    const result = buildPostCreationAdaptiveAnswerKey({
+      detection: validateDetection,
+      questions: validateQuestions,
+      answers,
+    });
+
+    expect(result.recommendedMatches).toBeLessThan(result.totalQuestions);
+    expect(result.adjustments.length).toBeGreaterThan(0);
+    expect(result.summary).toContain("ajuste");
+  });
+
+  it("handles missing answers gracefully", () => {
+    const answers: PostCreationAdaptiveAnswer[] = [
+      {
+        questionId: validateQuestions[0]!.id,
+        key: validateQuestions[0]!.mapKey,
+        optionId: validateQuestions[0]!.options[0]!.id,
+        value: null,
+      },
+    ];
+
+    const result = buildPostCreationAdaptiveAnswerKey({
+      detection: validateDetection,
+      questions: validateQuestions,
+      answers,
+    });
+
+    expect(result.answeredQuestions).toBe(1);
+    expect(result.evaluations.some((e) => e.selectedOptionId === null)).toBe(true);
+    expect(result.adjustments.some((a) => a.includes("pendente"))).toBe(true);
+    expect(result.summary).toContain("ajuste");
+  });
+
+  it("works with unknown mode", () => {
+    const unknownDetection = detectPostCreationAdaptiveIntent("me ajuda");
+    const unknownQuestions = buildPostCreationAdaptiveQuiz({ detection: unknownDetection });
+    const answers: PostCreationAdaptiveAnswer[] = [];
+
+    const result = buildPostCreationAdaptiveAnswerKey({
+      detection: unknownDetection,
+      questions: unknownQuestions,
+      answers,
+    });
+
+    expect(result.mode).toBe("unknown");
+    expect(result.summary).toContain("faltam escolhas");
+    expect(result.evaluations.length).toBe(unknownQuestions.length);
+  });
+
+  it("enforces consultative and safe language", () => {
+    const answers: PostCreationAdaptiveAnswer[] = validateQuestions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options[0]!.id,
+      value: null,
+    }));
+
+    const result = buildPostCreationAdaptiveAnswerKey({
+      detection: validateDetection,
+      questions: validateQuestions,
+      answers,
+    });
+
+    const fullText = [
+      result.summary,
+      ...result.strengths,
+      ...result.adjustments,
+      ...result.evaluations.map((e) => e.reason),
+    ].join(" ").toLowerCase();
+
+    const forbiddenWords = [
+      "acertou", "errou", "erro", "errado", "venceu", "perdeu",
+      "nota", "pontuação", "garantido", "comprovado", "certeza", "sempre performa"
+    ];
+
+    for (const word of forbiddenWords) {
+      expect(fullText).not.toContain(word);
+    }
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptiveAnswerKey.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveAnswerKey.ts
@@ -1,0 +1,86 @@
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveAnswerEvaluation,
+  PostCreationAdaptiveAnswerKeyResult,
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+} from "./postCreationAdaptiveTypes";
+
+export function buildPostCreationAdaptiveAnswerKey(params: {
+  detection: PostCreationAdaptiveIntentDetection;
+  questions: PostCreationAdaptiveQuestion[];
+  answers: PostCreationAdaptiveAnswer[];
+}): PostCreationAdaptiveAnswerKeyResult {
+  const { detection, questions, answers } = params;
+  const mode = detection.mode;
+
+  const evaluations: PostCreationAdaptiveAnswerEvaluation[] = questions.map((question) => {
+    const answer = answers.find((a) => a.questionId === question.id);
+    const selectedOptionId = answer?.optionId || null;
+    const selectedOption = question.options.find((o) => o.id === selectedOptionId);
+
+    const recommendedOption = question.options.find((o) => o.recommended);
+    const recommendedOptionId = recommendedOption?.id || null;
+
+    const isRecommendedChoice = Boolean(selectedOptionId && selectedOptionId === recommendedOptionId);
+
+    let reason = "";
+    if (!selectedOptionId) {
+      reason = "Este ponto ainda precisa de uma escolha para consolidar a estratégia.";
+    } else if (isRecommendedChoice) {
+      reason = selectedOption?.reason || "Essa escolha fortalece a coerência da pauta.";
+    } else {
+      reason = recommendedOption?.reason || "Ajustar esse ponto pode trazer mais clareza para a intenção do post.";
+    }
+
+    return {
+      questionId: question.id,
+      key: question.mapKey,
+      selectedOptionId,
+      selectedLabel: selectedOption?.label || null,
+      recommendedOptionId,
+      recommendedLabel: recommendedOption?.label || null,
+      isRecommendedChoice,
+      reason,
+    };
+  });
+
+  const totalQuestions = questions.length;
+  const answeredQuestions = evaluations.filter((e) => e.selectedOptionId !== null).length;
+  const recommendedMatches = evaluations.filter((e) => e.isRecommendedChoice).length;
+
+  const strengths = evaluations
+    .filter((e) => e.isRecommendedChoice && e.selectedLabel)
+    .map((e) => `Ponto forte: ${e.selectedLabel}.`);
+
+  const adjustments = evaluations
+    .filter((e) => !e.isRecommendedChoice)
+    .map((e) => {
+      if (!e.selectedOptionId) {
+        return `Ponto pendente: ${e.key}.`;
+      }
+      return `Sugestão de ajuste: considerar ${e.recommendedLabel} para maior coerência.`;
+    });
+
+  let summary = "";
+  if (answeredQuestions === 0) {
+    summary = "Ainda faltam escolhas para consolidar uma recomendação estratégica.";
+  } else if (recommendedMatches === totalQuestions) {
+    summary = "Sua leitura está bem alinhada com o caminho sugerido para essa intenção.";
+  } else if (recommendedMatches >= totalQuestions / 2) {
+    summary = "Sua leitura tem bons sinais, mas alguns pontos pedem ajuste para deixar a pauta mais coerente.";
+  } else {
+    summary = "A pauta pode ganhar mais força com alguns ajustes na direção estratégica.";
+  }
+
+  return {
+    mode,
+    totalQuestions,
+    answeredQuestions,
+    recommendedMatches,
+    evaluations,
+    strengths,
+    adjustments,
+    summary,
+  };
+}

--- a/src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts
@@ -1,0 +1,129 @@
+import {
+  getPostCreationAdaptiveLocalOverride,
+  isPostCreationAdaptiveEnvEnabled,
+  isPostCreationAdaptiveTester,
+  setPostCreationAdaptiveLocalOverride,
+  shouldShowPostCreationAdaptiveExperience,
+} from "./postCreationAdaptiveFeatureFlag";
+
+const ENV_KEY = "NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED";
+const STORAGE_KEY = "d2c:postCreationAdaptiveEnabled";
+
+const originalEnvValue = process.env[ENV_KEY];
+
+function searchParams(query: string) {
+  return new URLSearchParams(query);
+}
+
+describe("postCreationAdaptiveFeatureFlag", () => {
+  afterEach(() => {
+    if (typeof originalEnvValue === "string") {
+      process.env[ENV_KEY] = originalEnvValue;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("enables globally when env flag is 1", () => {
+    process.env[ENV_KEY] = "1";
+
+    expect(isPostCreationAdaptiveEnvEnabled()).toBe(true);
+    expect(shouldShowPostCreationAdaptiveExperience({ role: "user" })).toBe(true);
+  });
+
+  it("does not enable globally when env flag is absent or off", () => {
+    delete process.env[ENV_KEY];
+    expect(isPostCreationAdaptiveEnvEnabled()).toBe(false);
+
+    process.env[ENV_KEY] = "0";
+    expect(isPostCreationAdaptiveEnvEnabled()).toBe(false);
+  });
+
+  it("treats admin as tester", () => {
+    expect(isPostCreationAdaptiveTester({ role: "admin" })).toBe(true);
+  });
+
+  it("treats dev as tester", () => {
+    expect(isPostCreationAdaptiveTester({ role: "dev" })).toBe(true);
+  });
+
+  it("does not treat common user as tester", () => {
+    expect(isPostCreationAdaptiveTester({ role: "user" })).toBe(false);
+    expect(isPostCreationAdaptiveTester({ role: null })).toBe(false);
+  });
+
+  it("does not enable common user with adaptiveBoard=1", () => {
+    delete process.env[ENV_KEY];
+
+    expect(
+      shouldShowPostCreationAdaptiveExperience({
+        role: "user",
+        searchParams: searchParams("adaptiveBoard=1"),
+      }),
+    ).toBe(false);
+    expect(getPostCreationAdaptiveLocalOverride()).toBe(false);
+  });
+
+  it("enables admin with adaptiveBoard=1", () => {
+    delete process.env[ENV_KEY];
+
+    expect(
+      shouldShowPostCreationAdaptiveExperience({
+        role: "admin",
+        searchParams: searchParams("adaptiveBoard=1"),
+      }),
+    ).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("disables admin with adaptiveBoard=0", () => {
+    delete process.env[ENV_KEY];
+    setPostCreationAdaptiveLocalOverride(true);
+
+    expect(
+      shouldShowPostCreationAdaptiveExperience({
+        role: "admin",
+        searchParams: searchParams("adaptiveBoard=0"),
+      }),
+    ).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("uses localStorage override for admin or dev", () => {
+    delete process.env[ENV_KEY];
+    setPostCreationAdaptiveLocalOverride(true);
+
+    expect(shouldShowPostCreationAdaptiveExperience({ role: "admin" })).toBe(true);
+    expect(shouldShowPostCreationAdaptiveExperience({ role: "dev" })).toBe(true);
+  });
+
+  it("does not use localStorage override for common user", () => {
+    delete process.env[ENV_KEY];
+    setPostCreationAdaptiveLocalOverride(true);
+
+    expect(shouldShowPostCreationAdaptiveExperience({ role: "user" })).toBe(false);
+  });
+
+  it("does not break when window is unavailable", () => {
+    const originalWindow = global.window;
+    Reflect.deleteProperty(global, "window");
+
+    expect(getPostCreationAdaptiveLocalOverride()).toBe(false);
+    expect(() => setPostCreationAdaptiveLocalOverride(true)).not.toThrow();
+
+    Object.defineProperty(global, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it("setLocalOverride saves and removes correctly", () => {
+    setPostCreationAdaptiveLocalOverride(true);
+    expect(getPostCreationAdaptiveLocalOverride()).toBe(true);
+
+    setPostCreationAdaptiveLocalOverride(false);
+    expect(getPostCreationAdaptiveLocalOverride()).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.ts
@@ -1,0 +1,61 @@
+const ADAPTIVE_ENV_FLAG = "NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED";
+const ADAPTIVE_LOCAL_STORAGE_KEY = "d2c:postCreationAdaptiveEnabled";
+
+type SearchParamsLike = {
+  get(name: string): string | null;
+};
+
+export function isPostCreationAdaptiveEnvEnabled(): boolean {
+  return process.env[ADAPTIVE_ENV_FLAG] === "1";
+}
+
+export function isPostCreationAdaptiveTester(params: {
+  role?: string | null;
+  userId?: string | null;
+}): boolean {
+  const role = String(params.role || "").trim().toLowerCase();
+  return role === "admin" || role === "dev";
+}
+
+export function getPostCreationAdaptiveLocalOverride(): boolean {
+  try {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(ADAPTIVE_LOCAL_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setPostCreationAdaptiveLocalOverride(enabled: boolean): void {
+  try {
+    if (typeof window === "undefined") return;
+    if (enabled) {
+      window.localStorage.setItem(ADAPTIVE_LOCAL_STORAGE_KEY, "1");
+      return;
+    }
+    window.localStorage.removeItem(ADAPTIVE_LOCAL_STORAGE_KEY);
+  } catch {
+    return;
+  }
+}
+
+export function shouldShowPostCreationAdaptiveExperience(params: {
+  role?: string | null;
+  userId?: string | null;
+  searchParams?: SearchParamsLike | null;
+}): boolean {
+  if (isPostCreationAdaptiveEnvEnabled()) return true;
+  if (!isPostCreationAdaptiveTester({ role: params.role, userId: params.userId })) return false;
+
+  const queryOverride = params.searchParams?.get("adaptiveBoard");
+  if (queryOverride === "1") {
+    setPostCreationAdaptiveLocalOverride(true);
+    return true;
+  }
+  if (queryOverride === "0") {
+    setPostCreationAdaptiveLocalOverride(false);
+    return false;
+  }
+
+  return getPostCreationAdaptiveLocalOverride();
+}

--- a/src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
@@ -88,6 +88,8 @@ describe("Post Creation Adaptive Pipeline QA", () => {
     expect(plan.pauta).toBeTruthy();
     expect(plan.scenes.length).toBeGreaterThanOrEqual(2);
     expect(plan.nextActions.length).toBeGreaterThanOrEqual(3);
+    expect(plan.collabMatch).toBeNull();
+    expect(plan.nextActions.some((a) => /collab|parceiro/i.test(a))).toBe(false);
   });
 
   it("validates format_guidance journey", () => {
@@ -123,11 +125,20 @@ describe("Post Creation Adaptive Pipeline QA", () => {
     expect(detection.mode).toBe("brand_match");
     expect(plan.brandMatch?.enabled).toBe(true);
     expect(plan.brandMatch?.category).toMatch(/skincare|beauty|beleza|autocuidado/i);
+    expect(plan.collabMatch).toBeNull();
     expect(plan.nextActions.some((a) => /marca|encaixe|parceria/i.test(a))).toBe(true);
   });
 
   it("validates collab_match journey", () => {
     const { detection, plan } = runPipeline("Quero fazer uma collab para gerar comentários");
+
+    expect(detection.mode).toBe("collab_match");
+    expect(plan.collabMatch?.enabled).toBe(true);
+    expect(plan.nextActions.some((a) => /collab|parceiro/i.test(a))).toBe(true);
+  });
+
+  it("routes explicit collab validation input into collab_match", () => {
+    const { detection, plan } = runPipeline("Quero gravar um vídeo sobre rotina com uma collab");
 
     expect(detection.mode).toBe("collab_match");
     expect(plan.collabMatch?.enabled).toBe(true);

--- a/src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
@@ -1,0 +1,198 @@
+import { detectPostCreationAdaptiveIntent } from "./postCreationAdaptiveRouter";
+import { buildPostCreationAdaptiveQuiz } from "./postCreationAdaptiveQuizBuilder";
+import { buildPostCreationAdaptiveAnswerKey } from "./postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "./postCreationAdaptivePlanBuilder";
+import type { PostCreationAdaptiveAnswer } from "./postCreationAdaptiveTypes";
+
+const pipelineCases = [
+  {
+    name: "validate_pauta",
+    input: "Quero gravar um POV sobre rotina",
+  },
+  {
+    name: "format_guidance",
+    input: "Qual formato usar para uma publi de skincare?",
+  },
+  {
+    name: "discover_pauta",
+    input: "Não sei o que postar amanhã",
+  },
+  {
+    name: "create_by_goal",
+    input: "Quero gerar mais comentários",
+  },
+  {
+    name: "brand_match",
+    input: "Quero atrair marcas de skincare",
+  },
+  {
+    name: "collab_match",
+    input: "Quero fazer uma collab para gerar comentários",
+  },
+  {
+    name: "comment_to_post",
+    input: "Comentaram isso aqui: como você organiza sua rotina?",
+  },
+  {
+    name: "weekly_plan",
+    input: "Não sei o que postar essa semana para atrair marcas",
+  },
+  {
+    name: "unknown",
+    input: "me ajuda",
+  },
+];
+
+const forbiddenLanguage = [
+  "garantido",
+  "comprovado",
+  "certeza",
+  "sempre performa",
+  "acerto",
+  "acertou",
+  "erro",
+  "errou",
+  "errado",
+  "nota",
+  "pontuação",
+  "venceu",
+  "perdeu",
+  "viralizar garantido",
+  "crescer garantido",
+];
+
+function runPipeline(input: string) {
+  const detection = detectPostCreationAdaptiveIntent(input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+    questionId: q.id,
+    key: q.mapKey,
+    optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+    value: null,
+  }));
+
+  const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+  const plan = buildPostCreationAdaptiveStrategicPlan({ detection, questions, answers, answerKey });
+
+  return { detection, questions, answers, answerKey, plan };
+}
+
+describe("Post Creation Adaptive Pipeline QA", () => {
+  it("validates validate_pauta journey", () => {
+    const { detection, questions, answerKey, plan } = runPipeline("Quero gravar um POV sobre rotina");
+
+    expect(detection.mode).toBe("validate_pauta");
+    expect(questions.length).toBeGreaterThanOrEqual(3);
+    expect(questions.length).toBeLessThanOrEqual(5);
+    expect(answerKey.answeredQuestions).toBe(questions.length);
+    expect(plan.pauta).toBeTruthy();
+    expect(plan.scenes.length).toBeGreaterThanOrEqual(2);
+    expect(plan.nextActions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("validates format_guidance journey", () => {
+    const { detection, questions, plan } = runPipeline("Qual formato usar para uma publi de skincare?");
+
+    expect(detection.mode).toBe("format_guidance");
+    expect(questions[0]?.mapKey).not.toBe("format");
+    expect(questions[questions.length - 1]?.mapKey).toBe("format");
+    expect(plan.format).toBeTruthy();
+  });
+
+  it("validates discover_pauta journey", () => {
+    const { detection, questions, plan } = runPipeline("Não sei o que postar amanhã");
+
+    expect(detection.mode).toBe("discover_pauta");
+    expect(questions[0]?.mapKey).toBe("narrative");
+    expect(plan.narrative).toBeTruthy();
+    expect(plan.nextActions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("validates create_by_goal journey", () => {
+    const { detection, questions, answerKey, plan } = runPipeline("Quero gerar mais comentários");
+
+    expect(detection.mode).toBe("create_by_goal");
+    expect(questions[0]?.mapKey).toBe("objective");
+    expect(answerKey.summary).toMatch(/caminho sugerido|recomendação estratégica|direção estratégica/i);
+    expect(plan.objective).toBeTruthy();
+  });
+
+  it("validates brand_match journey", () => {
+    const { detection, plan } = runPipeline("Quero atrair marcas de skincare");
+
+    expect(detection.mode).toBe("brand_match");
+    expect(plan.brandMatch?.enabled).toBe(true);
+    expect(plan.brandMatch?.category).toMatch(/skincare|beauty|beleza|autocuidado/i);
+    expect(plan.nextActions.some((a) => /marca|encaixe|parceria/i.test(a))).toBe(true);
+  });
+
+  it("validates collab_match journey", () => {
+    const { detection, plan } = runPipeline("Quero fazer uma collab para gerar comentários");
+
+    expect(detection.mode).toBe("collab_match");
+    expect(plan.collabMatch?.enabled).toBe(true);
+    expect(plan.nextActions.some((a) => /collab|parceiro/i.test(a))).toBe(true);
+  });
+
+  it("validates comment_to_post journey", () => {
+    const { detection, questions, plan } = runPipeline("Comentaram isso aqui: como você organiza sua rotina?");
+
+    expect(detection.mode).toBe("comment_to_post");
+    expect(plan.pauta).toMatch(/como voce organiza sua rotina/i);
+    const keys = questions.map((q) => q.mapKey);
+    expect(keys).toEqual(expect.arrayContaining(["why", "format", "narrative", "cta"]));
+  });
+
+  it("validates weekly_plan journey", () => {
+    const { detection, questions, plan } = runPipeline("Não sei o que postar essa semana para atrair marcas");
+
+    expect(detection.mode).toBe("weekly_plan");
+    const keys = questions.map((q) => q.mapKey);
+    expect(keys).toEqual(expect.arrayContaining(["objective", "schedule", "format", "narrative"]));
+    expect(plan.fiveW2H.when).toBeTruthy();
+  });
+
+  it("validates unknown journey safely", () => {
+    const { detection, questions, plan } = runPipeline("me ajuda");
+
+    expect(detection.mode).toBe("unknown");
+    expect(questions.length).toBeGreaterThanOrEqual(2);
+    expect(plan.nextActions.some((a) => /refinar|clarificação/i.test(a) || /clarificacao/i.test(a) || /ideia/i.test(a))).toBe(true);
+  });
+
+  it("enforces consultative language across the entire pipeline output", () => {
+    for (const { input } of pipelineCases) {
+      const { detection, questions, answerKey, plan } = runPipeline(input);
+
+      const fullText = JSON.stringify({
+        mode: detection.mode,
+        questions: questions.map((q) => ({
+          title: q.title,
+          helper: q.helper,
+          options: q.options.map((option) => ({
+            label: option.label,
+            reason: option.reason,
+          })),
+        })),
+        answerKey: {
+          summary: answerKey.summary,
+          strengths: answerKey.strengths,
+          adjustments: answerKey.adjustments,
+          evaluationReasons: answerKey.evaluations.map((evaluation) => evaluation.reason),
+        },
+        plan
+      }).toLowerCase();
+
+      for (const word of forbiddenLanguage) {
+        expect(fullText).not.toContain(word);
+      }
+    }
+  });
+
+  it("sanitizes forbidden words if they come from user input", () => {
+    const { plan } = runPipeline("Quero viralizar garantido");
+
+    expect(JSON.stringify(plan).toLowerCase()).not.toContain("garantido");
+    expect(plan.pauta).toContain("direção");
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
@@ -28,6 +28,8 @@ describe("buildPostCreationAdaptiveStrategicPlan", () => {
     expect(plan.fiveW2H.what).toBe(plan.pauta);
     expect(plan.scenes.length).toBeGreaterThanOrEqual(2);
     expect(plan.nextActions.length).toBeGreaterThanOrEqual(3);
+    expect(plan.collabMatch).toBeNull();
+    expect(plan.nextActions.some((a) => /collab|parceiro/i.test(a))).toBe(false);
   });
 
   it("handles brand_match mode correctly", () => {
@@ -50,6 +52,7 @@ describe("buildPostCreationAdaptiveStrategicPlan", () => {
 
     expect(plan.brandMatch?.enabled).toBe(true);
     expect(plan.brandMatch?.category).toMatch(/skincare|beleza|autocuidado/i);
+    expect(plan.collabMatch).toBeNull();
     expect(plan.nextActions.some((a) => a.toLowerCase().includes("marca"))).toBe(true);
   });
 
@@ -73,6 +76,29 @@ describe("buildPostCreationAdaptiveStrategicPlan", () => {
 
     expect(plan.collabMatch?.enabled).toBe(true);
     expect(plan.nextActions.some((a) => a.toLowerCase().includes("collab"))).toBe(true);
+  });
+
+  it("keeps explicit collab input on the collab_match path", () => {
+    const detection = detectPostCreationAdaptiveIntent("Quero gravar um vídeo sobre rotina com uma collab");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(detection.mode).toBe("collab_match");
+    expect(plan.collabMatch?.enabled).toBe(true);
+    expect(plan.nextActions.some((a) => /collab|parceiro/i.test(a))).toBe(true);
   });
 
   it("handles comment_to_post mode correctly", () => {

--- a/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
@@ -1,0 +1,146 @@
+import { detectPostCreationAdaptiveIntent } from "./postCreationAdaptiveRouter";
+import { buildPostCreationAdaptiveQuiz } from "./postCreationAdaptiveQuizBuilder";
+import { buildPostCreationAdaptiveAnswerKey } from "./postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "./postCreationAdaptivePlanBuilder";
+import type { PostCreationAdaptiveAnswer } from "./postCreationAdaptiveTypes";
+
+describe("buildPostCreationAdaptiveStrategicPlan", () => {
+  it("builds a complete plan for validate_pauta with recommended answers", () => {
+    const detection = detectPostCreationAdaptiveIntent("Quero gravar um POV sobre rotina");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(plan.pauta).toBe("rotina");
+    expect(plan.objective).toBeTruthy();
+    expect(plan.fiveW2H.what).toBe(plan.pauta);
+    expect(plan.scenes.length).toBeGreaterThanOrEqual(2);
+    expect(plan.nextActions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("handles brand_match mode correctly", () => {
+    const detection = detectPostCreationAdaptiveIntent("Quero atrair marcas de skincare");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(plan.brandMatch?.enabled).toBe(true);
+    expect(plan.brandMatch?.category).toMatch(/skincare|beleza|autocuidado/i);
+    expect(plan.nextActions.some((a) => a.toLowerCase().includes("marca"))).toBe(true);
+  });
+
+  it("handles collab_match mode correctly", () => {
+    const detection = detectPostCreationAdaptiveIntent("Quero fazer uma collab para gerar comentários");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(plan.collabMatch?.enabled).toBe(true);
+    expect(plan.nextActions.some((a) => a.toLowerCase().includes("collab"))).toBe(true);
+  });
+
+  it("handles comment_to_post mode correctly", () => {
+    const detection = detectPostCreationAdaptiveIntent("Comentaram isso aqui: como você organiza sua rotina?");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options.find((o) => o.recommended)?.id || q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(plan.pauta).toContain("como voce organiza sua rotina");
+    expect(plan.fiveW2H.what).toBe(plan.pauta);
+  });
+
+  it("handles unknown mode safely", () => {
+    const detection = detectPostCreationAdaptiveIntent("me ajuda");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = [];
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    expect(plan).toBeTruthy();
+    expect(plan.nextActions.some((a) => a.includes("Refinar"))).toBe(true);
+  });
+
+  it("enforces consultative and safe language across the entire plan", () => {
+    const detection = detectPostCreationAdaptiveIntent("Quero viralizar garantido");
+    const questions = buildPostCreationAdaptiveQuiz({ detection });
+    const answers: PostCreationAdaptiveAnswer[] = questions.map((q) => ({
+      questionId: q.id,
+      key: q.mapKey,
+      optionId: q.options[0]!.id,
+      value: null,
+    }));
+    const answerKey = buildPostCreationAdaptiveAnswerKey({ detection, questions, answers });
+
+    const plan = buildPostCreationAdaptiveStrategicPlan({
+      detection,
+      questions,
+      answers,
+      answerKey,
+    });
+
+    const fullText = JSON.stringify(plan).toLowerCase();
+
+    const forbiddenWords = [
+      "garantido", "comprovado", "certeza", "sempre performa",
+      "acertou", "errou", "nota", "pontuação", "viralizar garantido", "crescer garantido"
+    ];
+
+    for (const word of forbiddenWords) {
+      expect(fullText).not.toContain(word);
+    }
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.ts
@@ -1,0 +1,122 @@
+import type {
+  PostCreationAdaptiveAnswer,
+  PostCreationAdaptiveAnswerKeyResult,
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationAdaptiveQuestionMapKey,
+  PostCreationStrategicPlan,
+  PostCreationFiveW2HPlan,
+  PostCreationAdaptiveScene,
+} from "./postCreationAdaptiveTypes";
+import { compactPromptSnippet } from "./postCreationAdaptiveQuizBuilder";
+
+export function buildPostCreationAdaptiveStrategicPlan(params: {
+  detection: PostCreationAdaptiveIntentDetection;
+  questions: PostCreationAdaptiveQuestion[];
+  answers: PostCreationAdaptiveAnswer[];
+  answerKey: PostCreationAdaptiveAnswerKeyResult;
+}): PostCreationStrategicPlan {
+  const { detection, questions, answers, answerKey } = params;
+
+  const getAnswerLabel = (key: PostCreationAdaptiveQuestionMapKey): string | null => {
+    const answer = answers.find((a) => a.key === key);
+    if (!answer?.optionId) return null;
+    const question = questions.find((q) => q.mapKey === key);
+    const option = question?.options.find((o) => o.id === answer.optionId);
+    return option?.label || null;
+  };
+
+  const pauta = compactPromptSnippet(
+    detection.detectedPauta || detection.sourceComment || detection.originalInput,
+    100
+  );
+
+  const sanitizeText = (text: string | null): string | null => {
+    if (!text) return null;
+    return text.replace(/\b(garantido|comprovado|certeza|sempre performa|acerto|erro|nota|pontuação|venceu|perdeu)\b/gi, "direção");
+  };
+
+  const sanitizedPauta = sanitizeText(pauta);
+
+  const objective = getAnswerLabel("objective");
+  const narrative = getAnswerLabel("narrative");
+  const format = getAnswerLabel("format");
+  const hook = getAnswerLabel("hook");
+  const cta = getAnswerLabel("cta");
+  const effort = getAnswerLabel("effort");
+
+  const fiveW2H: PostCreationFiveW2HPlan = {
+    who: "Sua audiência no Instagram",
+    what: sanitizedPauta,
+    where: "Instagram",
+    when: "Próxima janela de publicação",
+    why: sanitizeText(answerKey.summary) || "",
+    how: `${format || "Formato a definir"} com narrativa de ${narrative || "estilo próprio"}.`,
+    howMuch: effort || "Esforço estratégico equilibrado",
+  };
+
+  const scenes: PostCreationAdaptiveScene[] = [
+    {
+      id: "scene-1",
+      title: "Gancho Visual",
+      visual: "Cena de impacto inicial.",
+      message: hook || "Início direto ao ponto para prender a atenção.",
+    },
+    {
+      id: "scene-2",
+      title: "Desenvolvimento",
+      visual: "Desenvolvimento da ideia central.",
+      message: narrative || "Exploração do território narrativo escolhido.",
+    },
+    {
+      id: "scene-3",
+      title: "Fechamento e Convite",
+      visual: "Finalização com clareza.",
+      message: cta || "Convite para a audiência interagir.",
+    },
+  ];
+
+  const brandMatch = {
+    enabled: detection.mode === "brand_match" || Boolean(getAnswerLabel("brand")),
+    category: detection.brandCategory || getAnswerLabel("brand"),
+    angle: getAnswerLabel("how"),
+  };
+
+  const collabMatch = {
+    enabled: detection.mode === "collab_match" || Boolean(getAnswerLabel("collab")),
+    creatorProfile: getAnswerLabel("who") || getAnswerLabel("collab"),
+    collaborationAngle: getAnswerLabel("why"),
+  };
+
+  const nextActions: string[] = [
+    "Revisar o roteiro com base nas cenas sugeridas.",
+    "Preparar os elementos visuais para o formato escolhido.",
+    "Observar a resposta da audiência para validar o caminho.",
+  ];
+
+  if (detection.mode === "unknown") {
+    nextActions.unshift("Refinar a ideia central para ganhar mais clareza.");
+  }
+
+  if (brandMatch.enabled) {
+    nextActions.push("Verificar se o encaixe da marca parece orgânico na cena.");
+  }
+
+  if (collabMatch.enabled) {
+    nextActions.push("Alinhar a dinâmica de troca com o parceiro de collab.");
+  }
+
+  return {
+    pauta: sanitizedPauta,
+    objective,
+    narrative,
+    format,
+    hook,
+    cta,
+    fiveW2H,
+    scenes,
+    brandMatch: brandMatch.enabled ? brandMatch : null,
+    collabMatch: collabMatch.enabled ? collabMatch : null,
+    nextActions,
+  };
+}

--- a/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.ts
+++ b/src/app/dashboard/boards/postCreationAdaptivePlanBuilder.ts
@@ -26,6 +26,11 @@ export function buildPostCreationAdaptiveStrategicPlan(params: {
     return option?.label || null;
   };
 
+  const getAnswerOptionId = (key: PostCreationAdaptiveQuestionMapKey): string | null => {
+    const answer = answers.find((a) => a.key === key);
+    return answer?.optionId || null;
+  };
+
   const pauta = compactPromptSnippet(
     detection.detectedPauta || detection.sourceComment || detection.originalInput,
     100
@@ -44,6 +49,12 @@ export function buildPostCreationAdaptiveStrategicPlan(params: {
   const hook = getAnswerLabel("hook");
   const cta = getAnswerLabel("cta");
   const effort = getAnswerLabel("effort");
+  const collabOptionId = getAnswerOptionId("collab");
+  const collabAnswerLabel = getAnswerLabel("collab");
+  const hasExplicitCollabSignal =
+    detection.mode === "collab_match" ||
+    detection.signals.some((signal) => /\b(collab|colab|colaboracao|conteudo junto|criador parceiro|parceria)\b/.test(signal)) ||
+    /\b(collab|colab|colaboracao|conteudo junto|criador parceiro|parceria)\b/.test(detection.normalizedInput);
 
   const fiveW2H: PostCreationFiveW2HPlan = {
     who: "Sua audiência no Instagram",
@@ -83,8 +94,10 @@ export function buildPostCreationAdaptiveStrategicPlan(params: {
   };
 
   const collabMatch = {
-    enabled: detection.mode === "collab_match" || Boolean(getAnswerLabel("collab")),
-    creatorProfile: getAnswerLabel("who") || getAnswerLabel("collab"),
+    enabled:
+      detection.mode === "collab_match" ||
+      (hasExplicitCollabSignal && collabOptionId === "collab"),
+    creatorProfile: getAnswerLabel("who") || collabAnswerLabel,
     collaborationAngle: getAnswerLabel("why"),
   };
 

--- a/src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts
@@ -1,0 +1,298 @@
+import type { PostCreationAdaptiveMode, PostCreationAdaptiveQuestionMapKey } from "./postCreationAdaptiveTypes";
+import { detectPostCreationAdaptiveIntent } from "./postCreationAdaptiveRouter";
+import { buildPostCreationAdaptiveQuiz } from "./postCreationAdaptiveQuizBuilder";
+
+function quizFor(input: string) {
+  return buildPostCreationAdaptiveQuiz({
+    detection: detectPostCreationAdaptiveIntent(input),
+  });
+}
+
+function mapKeysFor(input: string) {
+  return quizFor(input).map((question) => question.mapKey);
+}
+
+function detectionForMode(mode: PostCreationAdaptiveMode) {
+  return {
+    mode,
+    confidence: mode === "unknown" ? 0.25 : 0.8,
+    normalizedInput: mode,
+    originalInput: mode,
+    detectedPauta: null,
+    objective: null,
+    brandCategory: null,
+    sourceComment: null,
+    signals: [],
+    suggestedStage: mode === "unknown" ? ("intent" as const) : ("quiz" as const),
+  };
+}
+
+const adaptiveModes: PostCreationAdaptiveMode[] = [
+  "validate_pauta",
+  "discover_pauta",
+  "create_by_goal",
+  "format_guidance",
+  "brand_match",
+  "collab_match",
+  "comment_to_post",
+  "weekly_plan",
+  "unknown",
+];
+
+describe("buildPostCreationAdaptiveQuiz", () => {
+  it("returns between 3 and 5 questions for validate_pauta", () => {
+    const quiz = quizFor("Quero gravar um POV sobre minha família fazendo barulho");
+
+    expect(quiz.length).toBeGreaterThanOrEqual(3);
+    expect(quiz.length).toBeLessThanOrEqual(5);
+  });
+
+  it("builds discover_pauta questions around narrative, objective, format, and effort", () => {
+    const keys = mapKeysFor("Não sei o que postar amanhã");
+
+    expect(keys).toEqual(expect.arrayContaining(["narrative", "objective", "format", "effort"]));
+  });
+
+  it("builds create_by_goal questions around objective, narrative, format, and CTA", () => {
+    const keys = mapKeysFor("Quero gerar mais comentários");
+
+    expect(keys).toEqual(expect.arrayContaining(["objective", "narrative", "format", "cta"]));
+  });
+
+  it("builds format_guidance questions around narrative, objective, hook, effort and format", () => {
+    const keys = mapKeysFor("Quero saber qual formato usar");
+
+    expect(keys).toEqual(expect.arrayContaining(["narrative", "objective", "hook", "effort", "format"]));
+  });
+
+  it("builds brand_match questions around brand, how, narrative, format and why", () => {
+    const keys = mapKeysFor("Quero atrair marcas de skincare");
+
+    expect(keys).toEqual(expect.arrayContaining(["brand", "how", "narrative", "format", "why"]));
+  });
+
+  it("builds collab_match questions around collab, why, objective and narrative", () => {
+    const keys = mapKeysFor("Quero fazer uma collab para gerar comentários");
+
+    expect(keys).toEqual(expect.arrayContaining(["collab", "why", "objective", "narrative"]));
+  });
+
+  it("builds comment_to_post questions around why, format, narrative, and CTA", () => {
+    const keys = mapKeysFor("Alguém comentou isso aqui e quero transformar em post");
+
+    expect(keys).toEqual(expect.arrayContaining(["why", "format", "narrative", "cta"]));
+  });
+
+  it("builds weekly_plan questions around objective, schedule, format and narrative", () => {
+    const keys = mapKeysFor("Quero planejar meus posts da semana");
+
+    expect(keys).toEqual(expect.arrayContaining(["objective", "schedule", "format", "narrative"]));
+  });
+
+  it("returns clarification questions for unknown intent", () => {
+    const quiz = quizFor("me ajuda");
+    const keys = quiz.map((question) => question.mapKey);
+
+    expect(keys).toEqual(expect.arrayContaining(["objective", "what"]));
+    expect(quiz[0]?.title).toMatch(/achar o melhor caminho/i);
+  });
+
+  it("gives every generated question exactly 4 options", () => {
+    for (const mode of adaptiveModes) {
+      const quiz = buildPostCreationAdaptiveQuiz({ detection: detectionForMode(mode) });
+      expect(quiz.every((question) => question.options.length === 4)).toBe(true);
+    }
+  });
+
+  it("does not return more than 5 questions for any mode", () => {
+    for (const mode of adaptiveModes) {
+      const quiz = buildPostCreationAdaptiveQuiz({ detection: detectionForMode(mode) });
+      expect(quiz.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("gives every question id, title, type, mapKey, and options", () => {
+    const quiz = quizFor("Quero atrair marcas de skincare");
+
+    for (const question of quiz) {
+      expect(question.id).toBeTruthy();
+      expect(question.title).toBeTruthy();
+      expect(question.type).toBeTruthy();
+      expect(question.mapKey).toBeTruthy();
+      expect(Array.isArray(question.options)).toBe(true);
+    }
+  });
+
+  it("marks recommended options where a strategic default makes sense", () => {
+    const quiz = quizFor("Quero transformar comentário em conteúdo");
+    const questionsWithRecommended = quiz.filter((question) =>
+      question.options.some((option) => option.recommended)
+    );
+
+    expect(questionsWithRecommended.length).toBeGreaterThan(0);
+  });
+
+  it("uses only declared map keys", () => {
+    const allowedKeys = new Set<PostCreationAdaptiveQuestionMapKey>([
+      "who",
+      "what",
+      "where",
+      "when",
+      "why",
+      "how",
+      "how_much",
+      "hook",
+      "cta",
+      "format",
+      "narrative",
+      "objective",
+      "brand",
+      "collab",
+      "effort",
+      "schedule",
+    ]);
+    const quiz = quizFor("Quero planejar meus posts da semana");
+
+    expect(quiz.every((question) => allowedKeys.has(question.mapKey))).toBe(true);
+  });
+
+  it("uses more human language for validate_pauta", () => {
+    const quiz = quizFor("Quero gravar um POV sobre minha família fazendo barulho");
+
+    expect(quiz[0]?.id).toBe("validate-objective");
+    expect(quiz[0]?.title).toMatch(/provocar em quem assistir/i);
+    expect(quiz[1]?.title).toMatch(/força dessa ideia/i);
+    expect(quiz[2]?.title).toMatch(/primeiros 2 segundos/i);
+    expect(quiz[3]?.title).toMatch(/entrar na brincadeira/i);
+  });
+
+  it("uses more human language for discover_pauta", () => {
+    const quiz = quizFor("Não sei o que postar amanhã");
+
+    expect(quiz[0]?.id).toBe("discover-territory");
+    expect(quiz[0]?.title).toMatch(/território/i);
+    expect(quiz[1]?.title).toMatch(/reação/i);
+    expect(quiz[2]?.title).toMatch(/topa produzir/i);
+    expect(quiz[3]?.title).toMatch(/fôlego/i);
+  });
+
+  it("uses more human language for brand_match", () => {
+    const quiz = quizFor("Quero atrair marcas de skincare");
+
+    expect(quiz[0]?.id).toBe("brand-category");
+    expect(quiz[0]?.title).toMatch(/caberia naturalmente/i);
+    expect(quiz[1]?.title).toMatch(/sem parecer interrupção/i);
+    expect(quiz[4]?.title).toMatch(/match/i);
+  });
+
+  it("uses specific language for format_guidance", () => {
+    const quiz = quizFor("Melhor reels ou carrossel para uma pauta de skincare?");
+
+    expect(quiz).toHaveLength(5);
+    expect(quiz[0]?.id).toBe("format-narrative");
+    expect(quiz[0]?.title).toMatch(/força principal/i);
+    expect(quiz[0]?.helper).toMatch(/precisa carregar/i);
+    expect(quiz[1]?.title).toMatch(/reação esse conteúdo/i);
+    expect(quiz[2]?.title).toMatch(/abrir para segurar atenção/i);
+    expect(quiz[4]?.title).toMatch(/formato parece mais coerente/i);
+  });
+
+  it("keeps copy consultative and avoids absolute or game terms", () => {
+    for (const mode of adaptiveModes) {
+      const quiz = buildPostCreationAdaptiveQuiz({ detection: detectionForMode(mode) });
+      const text = quiz.map((q) => `${q.title} ${q.helper || ""} ${q.options.map((o) => o.label + " " + (o.reason || "")).join(" ")}`).join(" ").toLowerCase();
+
+      expect(text).not.toMatch(/garantido|comprovado|certeza|sempre performa|acertar|erro|errado|venceu|perdeu/i);
+    }
+  });
+
+  it("preserves primary ids and mapKeys for every mode", () => {
+    const expectedByMode: Record<PostCreationAdaptiveMode, Array<[string, PostCreationAdaptiveQuestionMapKey]>> = {
+      validate_pauta: [
+        ["validate-objective", "objective"],
+        ["validate-why", "why"],
+        ["validate-hook", "hook"],
+        ["validate-cta", "cta"],
+        ["validate-opportunity", "collab"], // mapKey can be brand or collab based on signal, detectionForMode signal is empty
+      ],
+      discover_pauta: [
+        ["discover-territory", "narrative"],
+        ["discover-objective", "objective"],
+        ["discover-format", "format"],
+        ["discover-effort", "effort"],
+      ],
+      create_by_goal: [
+        ["goal-response", "objective"],
+        ["goal-narrative", "narrative"],
+        ["goal-format", "format"],
+        ["goal-cta", "cta"],
+      ],
+      format_guidance: [
+        ["format-narrative", "narrative"],
+        ["format-objective", "objective"],
+        ["format-hook", "hook"],
+        ["format-effort", "effort"],
+        ["format-primary", "format"],
+      ],
+      brand_match: [
+        ["brand-category", "brand"],
+        ["brand-how", "how"],
+        ["brand-narrative", "narrative"],
+        ["brand-format", "format"],
+        ["brand-why", "why"],
+      ],
+      collab_match: [
+        ["collab-type", "collab"],
+        ["collab-why", "why"],
+        ["collab-objective", "objective"],
+        ["collab-narrative", "narrative"],
+      ],
+      comment_to_post: [
+        ["comment-why", "why"],
+        ["comment-format", "format"],
+        ["comment-narrative", "narrative"],
+        ["comment-cta", "cta"],
+      ],
+      weekly_plan: [
+        ["weekly-objective", "objective"],
+        ["weekly-schedule", "schedule"],
+        ["weekly-format", "format"],
+        ["weekly-narrative", "narrative"],
+      ],
+      unknown: [
+        ["unknown-intent", "objective"],
+        ["unknown-what", "what"],
+      ],
+    };
+
+    for (const mode of adaptiveModes) {
+      const quiz = buildPostCreationAdaptiveQuiz({ detection: detectionForMode(mode) });
+      const received = quiz.map((question) => [question.id, question.mapKey]);
+      expect(received).toEqual(expectedByMode[mode]);
+    }
+  });
+
+  it("personalizes format_guidance with detected pauta", () => {
+    const quiz = quizFor("Qual formato usar para uma publi de skincare?");
+    const helper = quiz[0]?.helper || "";
+    expect(helper).toMatch(/uma publi de skincare/i);
+  });
+
+  it("personalizes brand_match with detected brand category", () => {
+    const quiz = quizFor("Quero atrair marcas de skincare");
+    const helper = quiz[0]?.helper || "";
+    expect(helper).toMatch(/skincare/i);
+  });
+
+  it("personalizes comment_to_post with source comment", () => {
+    const quiz = quizFor("Comentaram isso aqui: como você organiza sua rotina?");
+    const helper = quiz[0]?.helper || "";
+    expect(helper).toMatch(/como voce organiza sua rotina/i);
+  });
+
+  it("personalizes create_by_goal with detected objective", () => {
+    const quiz = quizFor("Quero gerar mais comentários");
+    const helper = quiz[0]?.helper || "";
+    expect(helper).toMatch(/comentarios/i);
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.ts
@@ -1,0 +1,611 @@
+import type {
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveQuestion,
+  PostCreationAdaptiveQuestionMapKey,
+  PostCreationAdaptiveQuestionOption,
+  PostCreationAdaptiveQuestionType,
+} from "./postCreationAdaptiveTypes";
+
+type QuestionInput = {
+  id: string;
+  type: PostCreationAdaptiveQuestionType;
+  title: string;
+  helper?: string;
+  mapKey: PostCreationAdaptiveQuestionMapKey;
+  options: PostCreationAdaptiveQuestionOption[];
+};
+
+function option(
+  id: string,
+  label: string,
+  reason?: string,
+  recommended?: boolean
+): PostCreationAdaptiveQuestionOption {
+  return {
+    id,
+    label,
+    ...(reason ? { reason } : {}),
+    ...(recommended ? { recommended: true } : {}),
+  };
+}
+
+export function compactPromptSnippet(value?: string | null, maxLength = 90): string | null {
+  if (!value) return null;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (!trimmed) return null;
+  return trimmed.length > maxLength ? trimmed.substring(0, maxLength - 3) + "..." : trimmed;
+}
+
+function question(input: QuestionInput): PostCreationAdaptiveQuestion {
+  return {
+    id: input.id,
+    type: input.type,
+    title: input.title,
+    helper: input.helper || null,
+    mapKey: input.mapKey,
+    options: input.options,
+    required: true,
+  };
+}
+
+function validatePautaQuestions(detection: PostCreationAdaptiveIntentDetection): PostCreationAdaptiveQuestion[] {
+  const hasCommercialSignal = detection.signals.some((signal) => /marca|collab|colab|parceria/.test(signal));
+
+  return [
+    question({
+      id: "validate-objective",
+      type: "strategic_choice",
+      title: "O que esse post precisa provocar em quem assistir?",
+      helper: detection.detectedPauta ? `Vamos dar mais intenção para: ${detection.detectedPauta}.` : "Escolha a reação que deve guiar a execução.",
+      mapKey: "objective",
+      options: [
+        option("comments", "Fazer a galera comentar", "Funciona quando a ideia tem identificação ou uma tensão boa para responder.", true),
+        option("reach", "Fazer mais gente compartilhar", "Pede uma abertura simples, reconhecível e fácil de repassar."),
+        option("saves", "Fazer alguém salvar pra usar depois", "Combina com dica prática, passo claro ou aprendizado reaproveitável."),
+        option("brand_collab", "Abrir espaço pra marca/collab", "Ajuda a deixar a pauta útil sem perder naturalidade comercial."),
+      ],
+    }),
+    question({
+      id: "validate-why",
+      type: "strategic_choice",
+      title: "Onde está a força dessa ideia?",
+      helper: "A melhor execução é a que deixa a ideia óbvia sem precisar explicar demais.",
+      mapKey: "why",
+      options: [
+        option("scene_reaction", "Na sua reação", "A expressão e o timing entregam a piada ou a tensão rápido.", true),
+        option("tutorial", "Na solução que você mostra", "Funciona quando a pauta resolve algo que a audiência vive."),
+        option("direct_story", "Na história do jeito que você conta", "Bom quando contexto pessoal ou opinião fazem a ideia crescer."),
+        option("trend", "Na trend que encaixa sem forçar", "Aumenta familiaridade se a brincadeira já combina com o tema."),
+      ],
+    }),
+    question({
+      id: "validate-hook",
+      type: "strategic_choice",
+      title: "O que precisa aparecer nos primeiros 2 segundos?",
+      helper: "A abertura precisa entregar a tensão antes da pessoa pensar em passar.",
+      mapKey: "hook",
+      options: [
+        option("pov", "Um POV que já coloca a pessoa dentro", "Bom para transformar contexto em cena reconhecível.", true),
+        option("direct_question", "Uma pergunta que dá vontade de responder", "Faz a pessoa entrar mentalmente na conversa."),
+        option("pain_sentence", "Uma frase que nomeia o incômodo", "Mostra de cara que você entendeu a situação."),
+        option("practical_promise", "Uma promessa útil e direta", "Abre com valor claro para quem quer resolver algo."),
+      ],
+    }),
+    question({
+      id: "validate-cta",
+      type: "preference",
+      title: "Que pergunta faria a galera entrar na brincadeira?",
+      helper: "O CTA bom parece continuação da cena, não aviso de fim de post.",
+      mapKey: "cta",
+      options: [
+        option("specific_question", "Perguntar se isso também acontece com ela", "Aumenta comentários porque a pessoa só precisa se reconhecer.", true),
+        option("tag_someone", "Pedir pra marcar quem vive isso", "Bom quando a situação tem cara de grupo ou amizade."),
+        option("save", "Pedir pra salvar pra usar depois", "Combina com dica, lista ou passo que vale voltar."),
+        option("follow", "Chamar pra acompanhar a continuação", "Funciona melhor quando a ideia pode virar série."),
+      ],
+    }),
+    question({
+      id: "validate-opportunity",
+      type: "strategic_choice",
+      title: "Depois dessa ideia, qual caminho faria mais sentido?",
+      helper: "A ideia pode continuar crescendo sem perder o jeito natural.",
+      mapKey: hasCommercialSignal ? "brand" : "collab",
+      options: [
+        option("brand", "Uma ponte natural com marca", "Boa se existe produto, rotina ou solução aparecendo na cena.", hasCommercialSignal),
+        option("collab", "Uma collab com outra visão", "Boa quando outra pessoa deixaria a situação mais rica."),
+        option("series", "Uma série de variações", "Expande assunto que rende repetição sem ficar igual.", !hasCommercialSignal),
+        option("organic_test", "Um teste orgânico rápido", "Mantém foco em aprender com a resposta da audiência."),
+      ],
+    }),
+  ];
+}
+
+function discoverPautaQuestions(): PostCreationAdaptiveQuestion[] {
+  return [
+    question({
+      id: "discover-territory",
+      type: "strategic_choice",
+      title: "Qual território parece mais vivo para explorar agora?",
+      helper: "Quando falta ideia, começar por um território ajuda a transformar sensação solta em direção de conteúdo.",
+      mapKey: "narrative",
+      options: [
+        option("audience_pain", "Uma dor que sua audiência vive", "Bom para criar identificação, conversa e próximos posts.", true),
+        option("real_backstage", "Um bastidor seu", "Bom para aproximar, mostrar processo e dar contexto real."),
+        option("held_opinion", "Uma opinião que você vem segurando", "Bom para posicionamento, comentários e clareza de ponto de vista."),
+        option("routine_scene", "Uma situação comum da rotina", "Bom para transformar vida real em cena reconhecível."),
+      ],
+    }),
+    question({
+      id: "discover-objective",
+      type: "strategic_choice",
+      title: "Que reação esse território deveria puxar?",
+      helper: "Depois de escolher o território, a reação ajuda a definir o caminho da pauta.",
+      mapKey: "objective",
+      options: [
+        option("reach", "Algo leve pra mais gente ver", "Pede uma ideia simples, forte e compartilhável.", true),
+        option("comments", "Algo que puxe conversa", "Pede tensão, identificação ou pergunta boa."),
+        option("authority", "Algo que mostre seu ponto de vista", "Pede critério, opinião ou bastidor com substância."),
+        option("brands", "Algo que deixe marcas de olho", "Pede contexto real de uso e encaixe comercial natural."),
+      ],
+    }),
+    question({
+      id: "discover-format",
+      type: "preference",
+      title: "O que você realmente topa produzir hoje?",
+      helper: "A melhor ideia é a que sai do papel sem virar uma novela de produção.",
+      mapKey: "format",
+      options: [
+        option("simple_reels", "Um reels simples e gravável", "Boa relação entre velocidade, clareza e alcance.", true),
+        option("carousel", "Um carrossel bem salvável", "Bom quando a ideia precisa de ordem e consulta depois."),
+        option("behind_scenes", "Um bastidor real", "Funciona quando existe processo acontecendo para mostrar."),
+        option("story", "Um story pra testar conversa", "Bom para sentir a resposta antes de virar post maior."),
+      ],
+    }),
+    question({
+      id: "discover-effort",
+      type: "constraint",
+      title: "Quanto fôlego você tem pra esse conteúdo?",
+      helper: "A ideia precisa caber no seu dia, não só ficar bonita no plano.",
+      mapKey: "effort",
+      options: [
+        option("low", "Baixo, quero resolver rápido", "Uma cena, uma ideia e pouca produção.", true),
+        option("medium", "Médio, dá pra caprichar um pouco", "Roteiro curto com exemplo ou virada."),
+        option("high", "Alto, quero construir melhor", "Mais cenas, prova, edição e acabamento."),
+        option("batch", "Quero gravar mais de uma ideia de uma vez", "Bom para aproveitar energia de produção, mas pode diluir a precisão de cada pauta."),
+      ],
+    }),
+  ];
+}
+
+function createByGoalQuestions(detection: PostCreationAdaptiveIntentDetection): PostCreationAdaptiveQuestion[] {
+  const goal = compactPromptSnippet(detection.objective, 40);
+
+  return [
+    question({
+      id: "goal-response",
+      type: "strategic_choice",
+      title: "Que tipo de reação você quer provocar?",
+      helper: goal
+        ? `Você já trouxe o objetivo: ${goal}. Agora vamos qualificar o tipo de reação que faz mais sentido.`
+        : "Quando o objetivo já está claro, o próximo passo é entender a qualidade da resposta que você quer gerar.",
+      mapKey: "objective",
+      options: [
+        option("identification", "Identificação: ‘isso acontece comigo’", "Bom para comentários espontâneos e sensação de comunidade.", true),
+        option("opinion", "Opinião: ‘eu penso diferente’", "Bom para abrir conversa, contraste e posicionamento."),
+        option("question", "Pedido: ‘me explica melhor’", "Bom para transformar curiosidade em próximos conteúdos."),
+        option("share", "Marcação: ‘alguém precisa ver isso’", "Bom para ampliar alcance por identificação compartilhável."),
+      ],
+    }),
+    question({
+      id: "goal-narrative",
+      type: "preference",
+      title: "Qual caminho narrativo combina mais com esse objetivo?",
+      helper: "O conteúdo tende a funcionar melhor quando o objetivo não força um jeito que não parece seu.",
+      mapKey: "narrative",
+      options: [
+        option("humor", "Brincar com a situação", "Bom para alcance e identificação.", true),
+        option("opinion", "Falar sem rodeio", "Bom para comentário e autoridade."),
+        option("backstage", "Mostrar o bastidor", "Bom para proximidade e confiança."),
+        option("tutorial", "Ensinar de um jeito simples", "Bom para salvamento e clareza."),
+      ],
+    }),
+    question({
+      id: "goal-format",
+      type: "strategic_choice",
+      title: "Qual formato dá mais chance desse objetivo acontecer?",
+      helper: "O formato certo faz a reação desejada parecer mais fácil.",
+      mapKey: "format",
+      options: [
+        option("reels", "Reels direto ao ponto", "Melhor para alcance e resposta rápida.", true),
+        option("carousel", "Carrossel organizado", "Melhor para salvar, comparar e consultar."),
+        option("stories", "Stories em conversa", "Melhor para teste e resposta imediata."),
+        option("photo_post", "Post foto com legenda forte", "Melhor para opinião curta ou contexto visual."),
+      ],
+    }),
+    question({
+      id: "goal-cta",
+      type: "strategic_choice",
+      title: "Qual convite deixa o próximo passo óbvio?",
+      helper: "O CTA não precisa gritar. Ele só precisa continuar a intenção do post.",
+      mapKey: "cta",
+      options: [
+        option("answer_question", "Responder uma pergunta específica", "Direto para comentários.", true),
+        option("send_to_friend", "Enviar para quem precisa ver", "Direto para compartilhamento."),
+        option("save_for_later", "Salvar pra usar depois", "Direto para salvamentos."),
+        option("click_link", "Clicar porque tem algo útil lá", "Direto para conversão."),
+      ],
+    }),
+  ];
+}
+
+function formatGuidanceQuestions(detection: PostCreationAdaptiveIntentDetection): PostCreationAdaptiveQuestion[] {
+  const pauta = compactPromptSnippet(detection.detectedPauta, 60);
+
+  return [
+    question({
+      id: "format-narrative",
+      type: "strategic_choice",
+      title: "Onde está a força principal dessa pauta?",
+      helper: pauta
+        ? `Antes de escolher o formato de ${pauta}, vale entender o que precisa carregar a ideia.`
+        : "Antes de escolher o formato, vale entender o que precisa carregar a ideia.",
+      mapKey: "narrative",
+      options: [
+        option("scene_motion", "Cena, reação ou movimento", "Pede vídeo curto, ritmo e contexto visual rápido.", true),
+        option("step_by_step", "Lista, passo a passo ou organização", "Pede estrutura clara para a pessoa consultar ou salvar."),
+        option("opinion_positioning", "Opinião, tensão ou posicionamento", "Pede fala direta, argumento e ponto de vista."),
+        option("backstage_context", "Bastidor, contexto ou rotina real", "Pede proximidade e construção de cena com naturalidade."),
+      ],
+    }),
+    question({
+      id: "format-objective",
+      type: "strategic_choice",
+      title: "Qual reação esse conteúdo deveria puxar primeiro?",
+      helper: "O formato fica mais claro quando a intenção da audiência está definida.",
+      mapKey: "objective",
+      options: [
+        option("reach", "Alcance e descoberta", "Pede formato fácil de entender e compartilhar rápido.", true),
+        option("saves", "Salvamento e consulta", "Pede estrutura clara, lista ou passo que a pessoa queira rever."),
+        option("comments", "Comentário e conversa", "Pede identificação, tensão ou pergunta que abra resposta."),
+        option("clicks", "Clique ou conversão", "Pede promessa objetiva e motivo claro para o próximo passo."),
+      ],
+    }),
+    question({
+      id: "format-hook",
+      type: "strategic_choice",
+      title: "Como a ideia precisa abrir para segurar atenção?",
+      helper: "A abertura indica se a pauta precisa mostrar, prometer, perguntar ou comparar.",
+      mapKey: "hook",
+      options: [
+        option("visual_tension", "Tensão visual imediata", "Funciona quando a pessoa entende a cena antes da explicação.", true),
+        option("practical_promise", "Promessa prática", "Funciona quando o valor está em resolver algo de forma clara."),
+        option("direct_question", "Pergunta direta", "Funciona quando o conteúdo depende de identificação ou opinião."),
+        option("contrast", "Antes/depois ou contraste", "Funciona quando a diferença precisa aparecer rápido."),
+      ],
+    }),
+    question({
+      id: "format-effort",
+      type: "constraint",
+      title: "Quanto esforço de produção cabe agora?",
+      helper: "O melhor formato também precisa caber no tempo e na energia disponíveis.",
+      mapKey: "effort",
+      options: [
+        option("low", "Baixo, quero resolver rápido", "Favorece stories, foto com legenda ou reels simples.", true),
+        option("medium", "Médio, dá pra estruturar melhor", "Favorece carrossel curto ou reels com roteiro enxuto."),
+        option("high", "Alto, quero caprichar na entrega", "Favorece vídeo com cenas, edição e prova visual."),
+        option("batch", "Quero gravar em lote", "Bom para aproveitar produção, mas exige formatos fáceis de repetir."),
+      ],
+    }),
+    question({
+      id: "format-primary",
+      type: "strategic_choice",
+      title: "Com essa leitura, qual formato parece mais coerente?",
+      helper: detection.detectedPauta
+        ? `Agora sim, vamos escolher o formato mais coerente para: ${detection.detectedPauta}.`
+        : "Agora sim, o formato entra como consequência da intenção, da execução e do esforço.",
+      mapKey: "format",
+      options: [
+        option("reels", "Reels", "Faz sentido quando a força está em cena, ritmo, reação ou movimento.", true),
+        option("carousel", "Carrossel", "Faz sentido quando a ideia precisa de ordem, comparação ou consulta depois."),
+        option("photo_post", "Foto com legenda forte", "Faz sentido quando imagem e opinião carregam a mensagem sem muita edição."),
+        option("stories", "Stories", "Faz sentido quando a intenção é testar conversa rápida ou bastidor próximo."),
+      ],
+    }),
+  ];
+}
+
+function brandMatchQuestions(detection: PostCreationAdaptiveIntentDetection): PostCreationAdaptiveQuestion[] {
+  const brand = compactPromptSnippet(detection.brandCategory, 40);
+
+  return [
+    question({
+      id: "brand-category",
+      type: "strategic_choice",
+      title: "Que tipo de marca caberia naturalmente no seu conteúdo?",
+      helper: brand
+        ? `Você citou ${brand}. Vamos buscar um encaixe que pareça natural.`
+        : "Escolha o território comercial que entraria sem cara de interrupção.",
+      mapKey: "brand",
+      options: [
+        option("beauty_selfcare", "Beleza ou autocuidado", "Entra bem em rotina, pausa, preparação e transformação.", detection.brandCategory === "beleza" || detection.brandCategory === "skincare"),
+        option("technology", "Tecnologia do dia a dia", "Funciona como ferramenta, solução ou conflito cotidiano."),
+        option("home_comfort", "Casa, conforto e rotina", "Combina com cenas domésticas, bem-estar e vida real."),
+        option("food_wellness", "Alimentação e bem-estar", "Entra bem em energia, cuidado, pausa e hábito."),
+      ],
+    }),
+    question({
+      id: "brand-how",
+      type: "strategic_choice",
+      title: "Como a marca entra sem parecer interrupção?",
+      helper: "O melhor encaixe comercial resolve ou melhora algo que já está acontecendo.",
+      mapKey: "how",
+      options: [
+        option("natural_solution", "Como solução natural da cena", "Reduz sensação de publi forçada.", true),
+        option("routine_item", "Como item que já estaria ali", "Bom para produto recorrente e hábito real."),
+        option("review", "Como opinião com critério", "Bom quando a audiência precisa entender se vale a pena."),
+        option("direct_ad", "Como proposta assumida", "Funciona quando a oferta é clara e combina com o perfil."),
+      ],
+    }),
+    question({
+      id: "brand-narrative",
+      type: "strategic_choice",
+      title: "Qual história faz a marca parecer parte do assunto?",
+      helper: "A narrativa boa cria motivo para a marca estar ali.",
+      mapKey: "narrative",
+      options: [
+        option("problem_solution", "Um problema que ela resolve", "Cria encaixe comercial claro.", true),
+        option("real_routine", "Uma rotina onde ela aparece", "Mostra contexto de uso sem discurso forçado."),
+        option("transformation", "Uma mudança antes e depois", "Bom quando o produto ajuda a visualizar resultado."),
+        option("backstage", "Um bastidor com ferramenta", "Bom para mostrar processo, escolha e critério."),
+      ],
+    }),
+    question({
+      id: "brand-format",
+      type: "preference",
+      title: "Qual entrega venderia a ideia sem pesar a mão?",
+      helper: "A entrega precisa caber no tipo de marca e no jeito que você já cria.",
+      mapKey: "format",
+      options: [
+        option("reels", "Reels com cena clara", "Bom para narrativa, demonstration e alcance.", true),
+        option("stories", "Stories com conversa", "Bom para demonstração rápida e resposta."),
+        option("carousel", "Carrossel com argumento", "Bom para prova, comparação e salvamento."),
+        option("package", "Pacote com pontos de contato", "Bom para campanha que precisa aparecer mais de uma vez."),
+      ],
+    }),
+    question({
+      id: "brand-why",
+      type: "strategic_choice",
+      title: "Qual argumento faria a marca entender o match?",
+      helper: "Pense no motivo que deixaria a parceria fácil de defender.",
+      mapKey: "why",
+      options: [
+        option("organic_match", "O encaixe é natural", "Defende que a marca já cabe na narrativa.", true),
+        option("audience_pain", "A audiência sente essa dor", "Mostra relevância para quem assiste."),
+        option("usage_context", "O produto aparece em uso real", "Defende presença concreta, não decorativa."),
+        option("data_proof", "Existe prova de performance", "Ajuda quando a conversa precisa de resultado."),
+      ],
+    }),
+  ];
+}
+
+function collabMatchQuestions(): PostCreationAdaptiveQuestion[] {
+  return [
+    question({
+      id: "collab-type",
+      type: "strategic_choice",
+      title: "Que tipo de creator acrescentaria algo real?",
+      helper: "A collab precisa trazer contraste, repertório ou cena, não só mais uma pessoa no vídeo.",
+      mapKey: "collab",
+      options: [
+        option("reaction", "Alguém para reagir junto", "Fácil de executar e bom para comentário.", true),
+        option("debate", "Alguém com outra opinião", "Bom para contraste e autoridade."),
+        option("challenge", "Alguém para entrar em desafio", "Bom para alcance e participação."),
+        option("joint_scene", "Alguém para dividir a cena", "Bom para humor ou narrativa cotidiana."),
+      ],
+    }),
+    question({
+      id: "collab-why",
+      type: "strategic_choice",
+      title: "Quem faria essa ideia crescer de verdade?",
+      helper: "O parceiro ideal adiciona tensão, prova ou público novo.",
+      mapKey: "why",
+      options: [
+        option("same_niche", "Alguém do mesmo nicho", "Aumenta precisão da conversa.", true),
+        option("complementary_niche", "Alguém de nicho complementar", "Cria ponte para audiência nova."),
+        option("similar_audience", "Alguém com audiência parecida", "Facilita identificação e troca real."),
+        option("larger_creator", "Alguém maior para validar", "Prioriza alcance e prova social."),
+      ],
+    }),
+    question({
+      id: "collab-objective",
+      type: "strategic_choice",
+      title: "O que faria essa collab valer a pena?",
+      helper: "Sem um papel claro, collab vira participação solta.",
+      mapKey: "objective",
+      options: [
+        option("reach", "Chegar em mais gente", "Pede formato simples e compartilhável.", true),
+        option("comments", "Criar conversa nos comentários", "Pede tensão ou discordância saudável."),
+        option("authority", "Mostrar repertório", "Pede troca de critério ou experiência."),
+        option("brand", "Abrir ponte com marca", "Pede narrativa com potencial comercial."),
+      ],
+    }),
+    question({
+      id: "collab-narrative",
+      type: "strategic_choice",
+      title: "Qual dinâmica justifica as duas pessoas no conteúdo?",
+      helper: "A collab fica melhor quando a presença de cada creator muda a história.",
+      mapKey: "narrative",
+      options: [
+        option("opinion_contrast", "Contraste de opiniões", "Cria tensão produtiva.", true),
+        option("shared_experience", "Experiência compartilhada", "Cria identificação e conversa."),
+        option("before_after", "Antes e depois", "Cria transformação clara."),
+        option("humor", "Humor de dupla", "Cria leveza e alcance."),
+      ],
+    }),
+  ];
+}
+
+function commentToPostQuestions(detection: PostCreationAdaptiveIntentDetection): PostCreationAdaptiveQuestion[] {
+  const comment = compactPromptSnippet(detection.sourceComment, 60);
+
+  return [
+    question({
+      id: "comment-why",
+      type: "strategic_choice",
+      title: "O que esse comentário está te entregando?",
+      helper: comment
+        ? `Partindo de "${comment}", vamos entender se existe dúvida, dor, identificação ou pauta inteira.`
+        : "Por trás de um comentário pode ter dúvida, dor, piada ou pauta inteira.",
+      mapKey: "why",
+      options: [
+        option("question", "Uma dúvida real", "Pede resposta clara e útil.", true),
+        option("identification", "Uma identificação forte", "Pede POV ou cena reconhecível."),
+        option("frustration", "Uma frustração escondida", "Pede acolhimento e virada prática."),
+        option("tip_request", "Um pedido de dica", "Pede tutorial curto e direto."),
+      ],
+    }),
+    question({
+      id: "comment-format",
+      type: "strategic_choice",
+      title: "Qual resposta vira conteúdo, e não só reply?",
+      helper: "O comentário pode ser ponto de partida para algo que mais gente reconhece.",
+      mapKey: "format",
+      options: [
+        option("reply_reels", "Reels respondendo o comentário", "Aproveita o contexto e mostra que veio da audiência.", true),
+        option("carousel", "Carrossel com resposta em partes", "Organiza a ideia para salvar e consultar."),
+        option("story", "Story para abrir conversa", "Bom para resposta imediata e novas perguntas."),
+        option("direct_video", "Vídeo direto olhando pra câmera", "Bom para opinião ou explicação curta."),
+      ],
+    }),
+    question({
+      id: "comment-narrative",
+      type: "strategic_choice",
+      title: "Qual ângulo faz esse comentário render mais?",
+      helper: "A resposta pode ensinar, virar cena ou marcar seu posicionamento.",
+      mapKey: "narrative",
+      options: [
+        option("practical_answer", "Responder com algo aplicável", "Entrega valor direto.", true),
+        option("pov", "Transformar em POV", "Faz o comentário virar cena."),
+        option("opinion", "Assumir uma opinião", "Bom para posicionamento."),
+        option("backstage", "Mostrar como você lida com isso", "Traz bastidor e prova prática."),
+      ],
+    }),
+    question({
+      id: "comment-cta",
+      type: "strategic_choice",
+      title: "Como puxar mais comentários a partir desse?",
+      helper: "O melhor CTA transforma uma resposta em fila de próximas pautas.",
+      mapKey: "cta",
+      options: [
+        option("anyone_else", "Perguntar quem mais passa por isso", "Aumenta identificação.", true),
+        option("ask_examples", "Pedir exemplos parecidos", "Gera repertório para novos conteúdos."),
+        option("ask_questions", "Pedir novas dúvidas", "Abre fila de respostas."),
+        option("save", "Pedir pra salvar a resposta", "Funciona quando a resposta é prática."),
+      ],
+    }),
+  ];
+}
+
+function weeklyPlanQuestions(): PostCreationAdaptiveQuestion[] {
+  return [
+    question({
+      id: "weekly-objective",
+      type: "strategic_choice",
+      title: "Qual clima essa semana precisa ter?",
+      helper: "Uma semana boa tem intenção clara, não só uma lista de posts.",
+      mapKey: "objective",
+      options: [
+        option("grow", "Mais descoberta", "Prioriza alcance e posts fáceis de compartilhar.", true),
+        option("engage", "Mais conversa", "Prioriza comunidade, resposta e bastidor."),
+        option("sell", "Mais intenção de compra", "Prioriza oferta, prova e clareza."),
+        option("brands", "Mais vitrine para marcas", "Prioriza narrativa comercial orgânica."),
+      ],
+    }),
+    question({
+      id: "weekly-schedule",
+      type: "constraint",
+      title: "Quantos conteúdos você realmente consegue sustentar?",
+      helper: "Cadência boa é a que você consegue cumprir sem matar a qualidade.",
+      mapKey: "schedule",
+      options: [
+        option("two", "2 conteúdos", "Plano leve, com foco em qualidade."),
+        option("three", "3 conteúdos", "Boa cadência para consistência.", true),
+        option("five", "5 conteúdos", "Semana forte sem exigir todo dia."),
+        option("daily", "Todos os dias", "Boa para sprint de crescimento."),
+      ],
+    }),
+    question({
+      id: "weekly-format",
+      type: "preference",
+      title: "Qual mistura deixa a semana mais viva?",
+      helper: "A mistura define quando você alcança, aprofunda e conversa.",
+      mapKey: "format",
+      options: [
+        option("reels_stories", "Reels + stories", "Combina alcance e conversa.", true),
+        option("reels_carousel", "Reels + carrossel", "Combina alcance e salvamento."),
+        option("only_reels", "Só reels por enquanto", "Foco total em descoberta."),
+        option("full_mix", "Mistura completa", "Bom para semana editorial mais rica."),
+      ],
+    }),
+    question({
+      id: "weekly-narrative",
+      type: "strategic_choice",
+      title: "Qual fio deve costurar os posts da semana?",
+      helper: "Esse eixo evita que cada conteúdo pareça uma ideia solta.",
+      mapKey: "narrative",
+      options: [
+        option("strongest", "O que já costuma funcionar", "Explora um caminho que tende a performar.", true),
+        option("new", "Um teste novo", "Abre espaço para aprendizado."),
+        option("commercial", "Uma vitrine comercial discreta", "Prepara oportunidade de marca ou venda."),
+        option("community", "Uma conversa com a comunidade", "Puxa pertencimento e resposta."),
+      ],
+    }),
+  ];
+}
+
+function unknownQuestions(): PostCreationAdaptiveQuestion[] {
+  return [
+    question({
+      id: "unknown-intent",
+      type: "confirmation",
+      title: "Vamos achar o melhor caminho pra começar?",
+      helper: "Escolha o ponto de partida que mais parece com o que você precisa hoje.",
+      mapKey: "objective",
+      options: [
+        option("validate_pauta", "Tenho uma ideia e quero melhorar", "Vamos lapidar execução, gancho e próximo passo.", true),
+        option("discover_pauta", "Quero sair do branco", "Vamos encontrar uma pauta gravável."),
+        option("brand_match", "Quero abrir espaço pra marca", "Vamos procurar um encaixe comercial natural."),
+        option("weekly_plan", "Quero organizar a semana", "Vamos montar uma cadência possível."),
+      ],
+    }),
+    question({
+      id: "unknown-what",
+      type: "confirmation",
+      title: "Você já tem alguma faísca de conteúdo?",
+      helper: "Mesmo uma ideia pequena já ajuda a escolher o próximo passo.",
+      mapKey: "what",
+      options: [
+        option("yes", "Sim, tenho uma ideia", "Vamos refinar execução.", true),
+        option("no", "Ainda não", "Vamos descobrir um caminho."),
+        option("goal_only", "Tenho só um objetivo", "Vamos transformar meta em narrativa."),
+        option("comment", "Tenho um comentário da audiência", "Vamos transformar resposta em post."),
+      ],
+    }),
+  ];
+}
+
+export function buildPostCreationAdaptiveQuiz(params: {
+  detection: PostCreationAdaptiveIntentDetection;
+}): PostCreationAdaptiveQuestion[] {
+  const mode = params.detection.mode;
+
+  if (mode === "validate_pauta") return validatePautaQuestions(params.detection);
+  if (mode === "discover_pauta") return discoverPautaQuestions();
+  if (mode === "create_by_goal") return createByGoalQuestions(params.detection);
+  if (mode === "format_guidance") return formatGuidanceQuestions(params.detection);
+  if (mode === "brand_match") return brandMatchQuestions(params.detection);
+  if (mode === "collab_match") return collabMatchQuestions();
+  if (mode === "comment_to_post") return commentToPostQuestions(params.detection);
+  if (mode === "weekly_plan") return weeklyPlanQuestions();
+  return unknownQuestions();
+}

--- a/src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts
@@ -1,0 +1,155 @@
+import { detectPostCreationAdaptiveIntent } from "./postCreationAdaptiveRouter";
+
+describe("detectPostCreationAdaptiveIntent", () => {
+  it("detects an existing pauta to validate", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero gravar um POV sobre minha família fazendo barulho");
+
+    expect(result.mode).toBe("validate_pauta");
+    expect(result.detectedPauta).toContain("minha familia fazendo barulho");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("prioritizes weekly plan when the user explicitly mentions the week, even if lacking ideas or mentioning brands", () => {
+    const result = detectPostCreationAdaptiveIntent("Não sei o que postar essa semana para atrair marcas");
+
+    expect(result.mode).toBe("weekly_plan");
+  });
+
+  it("prioritizes format guidance even when mentioning a brand campaign or publi", () => {
+    const result1 = detectPostCreationAdaptiveIntent("Qual formato usar para uma publi de skincare?");
+    expect(result1.mode).toBe("format_guidance");
+    expect(result1.detectedPauta).toContain("uma publi de skincare");
+
+    const result2 = detectPostCreationAdaptiveIntent("Melhor reels ou carrossel para uma campanha de skincare?");
+    expect(result2.mode).toBe("format_guidance");
+  });
+
+  it("prioritizes discover pauta over brand match when lacking ideas", () => {
+    const result = detectPostCreationAdaptiveIntent("Não sei o que postar para atrair marcas");
+
+    expect(result.mode).toBe("discover_pauta");
+  });
+
+  it("prioritizes collab match over create by goal", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero fazer uma collab para gerar comentários");
+
+    expect(result.mode).toBe("collab_match");
+  });
+
+  it("detects goal-based post creation", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero gerar mais comentários");
+
+    expect(result.mode).toBe("create_by_goal");
+    expect(result.objective).toContain("comentarios");
+  });
+
+  it("detects brand match intent", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero atrair marcas de skincare");
+
+    expect(result.mode).toBe("brand_match");
+    expect(result.brandCategory).toBe("skincare");
+  });
+
+  it("detects collab intent", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero fazer collab com alguém do meu nicho");
+
+    expect(result.mode).toBe("collab_match");
+  });
+
+  it("detects comment-to-post intent explicitly", () => {
+    const result = detectPostCreationAdaptiveIntent("Comentaram isso aqui e quero transformar em post");
+
+    expect(result.mode).toBe("comment_to_post");
+  });
+
+  it("detects comment-to-post intent with specific source comment", () => {
+    const result = detectPostCreationAdaptiveIntent("Comentaram isso aqui: como você organiza sua rotina?");
+
+    expect(result.mode).toBe("comment_to_post");
+    expect(result.sourceComment).toContain("como voce organiza sua rotina");
+  });
+
+  it("detects weekly planning intent", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero planejar meus posts da semana");
+
+    expect(result.mode).toBe("weekly_plan");
+  });
+
+  it("detects explicit format guidance intent", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero saber qual formato usar");
+
+    expect(result.mode).toBe("format_guidance");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("detects format guidance with ideal format language", () => {
+    const result = detectPostCreationAdaptiveIntent("Qual formato é melhor pra essa ideia?");
+
+    expect(result.mode).toBe("format_guidance");
+  });
+
+  it("detects format guidance phrased as what to post", () => {
+    const result = detectPostCreationAdaptiveIntent("Qual formato devo postar?");
+
+    expect(result.mode).toBe("format_guidance");
+  });
+
+  it("detects format guidance from format alternatives", () => {
+    const result = detectPostCreationAdaptiveIntent("Devo fazer reels ou carrossel?");
+
+    expect(result.mode).toBe("format_guidance");
+    expect(result.signals.some((signal) => signal.includes("reels") && signal.includes("carrossel"))).toBe(true);
+  });
+
+  it("detects short story or reels format guidance", () => {
+    const result = detectPostCreationAdaptiveIntent("Story ou reels?");
+
+    expect(result.mode).toBe("format_guidance");
+  });
+
+  it("preserves pauta context when detecting format guidance", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero saber qual formato usar para uma pauta sobre rotina");
+
+    expect(result.mode).toBe("format_guidance");
+    expect(result.detectedPauta).toContain("uma pauta sobre rotina");
+  });
+
+  it("returns unknown for vague input", () => {
+    const result = detectPostCreationAdaptiveIntent("me ajuda");
+
+    expect(result.mode).toBe("unknown");
+    expect(result.confidence).toBe(0.25);
+    expect(result.suggestedStage).toBe("intent");
+  });
+
+  it("normalizes accents before detecting comment-to-post intent", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero transformar comentário em conteúdo");
+
+    expect(result.mode).toBe("comment_to_post");
+    expect(result.normalizedInput).toBe("quero transformar comentario em conteudo");
+  });
+
+  it("prioritizes brand match over pauta validation when intent is purely commercial", () => {
+    const result = detectPostCreationAdaptiveIntent("Quero fazer uma pauta para atrair marca de beleza");
+    expect(result.mode).toBe("brand_match");
+  });
+
+  it("continues detecting concrete creative ideas as pauta validation", () => {
+    expect(detectPostCreationAdaptiveIntent("Quero gravar um POV sobre rotina").mode).toBe("validate_pauta");
+    expect(detectPostCreationAdaptiveIntent("Pensei em gravar um vídeo sobre minha rotina no trabalho").mode).toBe("validate_pauta");
+  });
+
+  it("prioritizes format guidance over broad discover, validate, and goal signals", () => {
+    expect(detectPostCreationAdaptiveIntent("Não sei o que postar, qual formato usar?").mode).toBe("format_guidance");
+    expect(detectPostCreationAdaptiveIntent("Quero gravar uma pauta, devo fazer reels ou carrossel?").mode).toBe("format_guidance");
+    expect(detectPostCreationAdaptiveIntent("Quero mais alcance, qual formato tem mais chance?").mode).toBe("format_guidance");
+    expect(detectPostCreationAdaptiveIntent("Quero saber qual formato usar para uma pauta").mode).toBe("format_guidance");
+    expect(detectPostCreationAdaptiveIntent("Não sei se faço reels, carrossel ou story").mode).toBe("format_guidance");
+  });
+
+  it("keeps older routing when there is no format signal", () => {
+    expect(detectPostCreationAdaptiveIntent("Não sei o que postar amanhã").mode).toBe("discover_pauta");
+    expect(detectPostCreationAdaptiveIntent("Quero gerar mais comentários").mode).toBe("create_by_goal");
+    expect(detectPostCreationAdaptiveIntent("Quero gravar um POV sobre rotina").mode).toBe("validate_pauta");
+  });
+});

--- a/src/app/dashboard/boards/postCreationAdaptiveRouter.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveRouter.ts
@@ -1,0 +1,338 @@
+import type {
+  PostCreationAdaptiveIntentDetection,
+  PostCreationAdaptiveMode,
+  PostCreationAdaptiveStage,
+} from "./postCreationAdaptiveTypes";
+
+type IntentMatch = {
+  mode: PostCreationAdaptiveMode;
+  confidence: number;
+  signals: string[];
+  detectedPauta?: string | null;
+  objective?: string | null;
+  brandCategory?: string | null;
+  sourceComment?: string | null;
+};
+
+function normalizeInput(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[“”"']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compactExtractedText(value?: string | null): string | null {
+  const normalized = (value || "")
+    .replace(/^[\s:.,;!?-]+/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized.length >= 3 ? normalized : null;
+}
+
+function collectSignals(normalizedInput: string, patterns: RegExp[]): string[] {
+  return patterns
+    .map((pattern) => normalizedInput.match(pattern)?.[0] || null)
+    .filter((signal): signal is string => Boolean(signal));
+}
+
+function findFirstCapture(normalizedInput: string, patterns: RegExp[]): string | null {
+  for (const pattern of patterns) {
+    const match = normalizedInput.match(pattern);
+    const captured = compactExtractedText(match?.[1]);
+    if (captured) return captured;
+  }
+  return null;
+}
+
+function detectCommentToPost(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bcomentario\b/,
+    /\bcomentaram\b/,
+    /\balguem comentou\b/,
+    /\bresponder comentario\b/,
+    /\btransformar comentario em (post|conteudo)\b/,
+    /\bduvida da audiencia\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  const sourceComment = findFirstCapture(normalizedInput, [
+    /(?:alguem comentou|comentaram|comentario|responder comentario|transformar comentario em post|transformar comentario em conteudo)\s*(?:isso aqui|que)?\s*[:\-]?\s*(.+)/,
+    /(?:duvida da audiencia)\s*[:\-]?\s*(.+)/,
+  ]);
+
+  return {
+    mode: "comment_to_post",
+    confidence: sourceComment ? 0.85 : 0.75,
+    signals,
+    sourceComment,
+  };
+}
+
+function detectBrandMatch(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bmarca\b/,
+    /\bmarcas\b/,
+    /\bpubli\b/,
+    /\bpublicidade\b/,
+    /\bparceria\b/,
+    /\bcampanha\b/,
+    /\bbrand\b/,
+    /\bpatrocinio\b/,
+    /\batrair marcas\b/,
+    /\bmarca de [a-z0-9 ]+\b/,
+    /\bmarcas de [a-z0-9 ]+\b/,
+    /\bfone de ouvido\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  const brandCategory = findFirstCapture(normalizedInput, [
+    /(?:atrair|encaixar|chamar|conseguir)\s+marcas?\s+de\s+(.+)/,
+    /marcas?\s+de\s+(.+)/,
+    /\b(fone de ouvido)\b/,
+    /\b(skincare|beleza|audio|tecnologia|moda|fitness|comida|bebida)\b/,
+  ]);
+
+  return {
+    mode: "brand_match",
+    confidence: brandCategory ? 0.85 : 0.72,
+    signals,
+    brandCategory,
+  };
+}
+
+function detectCollabMatch(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bcollab\b/,
+    /\bcolab\b/,
+    /\bcolaboracao\b/,
+    /\bcriar com outro creator\b/,
+    /\bconteudo junto\b/,
+    /\bcriador parceiro\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  return {
+    mode: "collab_match",
+    confidence: 0.82,
+    signals,
+  };
+}
+
+function detectWeeklyPlan(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bplanejar (?:a )?semana\b/,
+    /\bminha semana\b/,
+    /\bposts da semana\b/,
+    /\bessa semana\b/,
+    /\bcalendario\b/,
+    /\bplanejamento semanal\b/,
+    /\bsemana de conteudo\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  return {
+    mode: "weekly_plan",
+    confidence: 0.78,
+    signals,
+  };
+}
+
+function detectFormatGuidance(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bqual formato\b/,
+    /\bque formato\b/,
+    /\bem que formato\b/,
+    /\bquero saber (?:o|qual) formato\b/,
+    /\bformato usar\b/,
+    /\bmelhor formato\b/,
+    /\bformato ideal\b/,
+    /\bqual formato (?:performa|funciona) melhor\b/,
+    /\bdevo fazer (?:em )?(?:reels?|video|carrossel|foto|story|stories?)\b/,
+    /\b(?:reels?|video|foto|carrossel|story|stories?)\s+ou\s+(?:reels?|video|foto|carrossel|story|stories?)\b/,
+    /\bnao sei se faco (?:reels?|video|foto|carrossel|story|stories?)(?:,\s*(?:reels?|video|foto|carrossel|story|stories?))*\s+ou\s+(?:reels?|video|foto|carrossel|story|stories?)\b/,
+    /\bpostar em reels\b/,
+    /\bformato postar\b/,
+    /\bfazer em carrossel\b/,
+    /\btipo de post\b/,
+    /\bformato performa\b/,
+    /\bformato tem mais chance\b/,
+    /\bfunciona melhor em (?:reels?|video|carrossel|foto|story|stories?)\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  const detectedPauta = findFirstCapture(normalizedInput, [
+    /(?:qual|que)\s+formato\s+(?:eu\s+)?(?:devo\s+)?(?:usar|postar|fazer)(?:\s+(?:para|pra|sobre|de|em))?\s+(.+)/,
+    /(?:formato|tipo de post)\s+(?:usar|tem mais chance|performa|funciona melhor)(?:\s+(?:para|pra|sobre|de|em))?\s+(.+)/,
+    /(?:reels?|video|foto|carrossel|story|stories?)\s+ou\s+(?:reels?|video|foto|carrossel|story|stories?)(?:\s+(?:para|pra|sobre|de|em))?\s+(.+)/,
+    /(?:devo fazer|melhor eu fazer)(?:\s+(?:em|um|uma))?\s+(?:reels?|video|foto|carrossel|story|stories?)(?:\s+(?:para|pra|sobre|de|em))?\s+(.+)/,
+  ]);
+
+  return {
+    mode: "format_guidance",
+    confidence: detectedPauta ? 0.9 : 0.84,
+    signals,
+    detectedPauta,
+  };
+}
+
+function detectDiscoverPauta(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bnao sei o que postar\b/,
+    /\bme da ideias\b/,
+    /\bme de ideias\b/,
+    /\bpreciso de ideias\b/,
+    /\bto sem ideia\b/,
+    /\bo que postar\b/,
+    /\bideia de post\b/,
+    /\bideias de conteudo\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  return {
+    mode: "discover_pauta",
+    confidence: signals.some((signal) => signal.includes("nao sei") || signal.includes("o que postar") || signal.includes("to sem ideia")) ? 0.85 : 0.72,
+    signals,
+  };
+}
+
+function detectValidatePauta(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bquero gravar\b/,
+    /\bquero fazer um video\b/,
+    /\bquero fazer uma pauta\b/,
+    /\bquero criar um reels\b/,
+    /\bquero criar uma pauta\b/,
+    /\bpensei em gravar\b/,
+    /\bminha pauta\b/,
+    /\bpauta sobre\b/,
+    /\bvou gravar\b/,
+    /\bideia de video\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  const detectedPauta = findFirstCapture(normalizedInput, [
+    /(?:quero|vou)\s+gravar(?:\s+(?:um|uma))?(?:\s+(?:video|reels?|pov|post|conteudo))?\s*(?:sobre|de)?\s+(.+)/,
+    /pensei em gravar(?:\s+(?:um|uma))?(?:\s+(?:video|reels?|pov|post|conteudo))?\s*(?:sobre|de)?\s+(.+)/,
+    /(?:quero fazer|quero criar)(?:\s+(?:um|uma))?(?:\s+(?:video|reels?|post|pauta|conteudo))\s*(?:sobre|de)?\s+(.+)/,
+    /(?:minha pauta|pauta sobre|ideia de video)\s*(?:e|eh|sobre|de)?\s*[:\-]?\s*(.+)/,
+  ]);
+
+  return {
+    mode: "validate_pauta",
+    confidence: detectedPauta ? 0.85 : 0.68,
+    signals,
+    detectedPauta,
+  };
+}
+
+function detectCreateByGoal(normalizedInput: string): IntentMatch | null {
+  const patterns = [
+    /\bquero gerar comentarios\b/,
+    /\bquero gerar mais comentarios\b/,
+    /\bquero mais comentarios\b/,
+    /\bquero mais alcance\b/,
+    /\bquero engajamento\b/,
+    /\bquero salvar\b/,
+    /\bquero vender\b/,
+    /\bquero crescer\b/,
+    /\bquero atrair seguidores\b/,
+  ];
+  const signals = collectSignals(normalizedInput, patterns);
+  if (!signals.length) return null;
+
+  const objective = findFirstCapture(normalizedInput, [
+    /quero\s+(gerar comentarios|gerar mais comentarios|mais comentarios|mais alcance|engajamento|salvar|vender|crescer|atrair seguidores)\b/,
+  ]);
+
+  return {
+    mode: "create_by_goal",
+    confidence: objective ? 0.82 : 0.68,
+    signals,
+    objective,
+  };
+}
+
+function getSuggestedStage(match: IntentMatch | null): PostCreationAdaptiveStage {
+  return match?.mode && match.mode !== "unknown" ? "quiz" : "intent";
+}
+
+export function detectPostCreationAdaptiveIntent(input: string): PostCreationAdaptiveIntentDetection {
+  const originalInput = typeof input === "string" ? input : "";
+  const normalizedInput = normalizeInput(originalInput);
+
+  if (!normalizedInput) {
+    return {
+      mode: "unknown",
+      confidence: 0.25,
+      normalizedInput,
+      originalInput,
+      detectedPauta: null,
+      objective: null,
+      brandCategory: null,
+      sourceComment: null,
+      signals: [],
+      suggestedStage: "intent",
+    };
+  }
+
+  const brandMatch = detectBrandMatch(normalizedInput);
+  const isStrongBrandIntent =
+    brandMatch &&
+    collectSignals(normalizedInput, [
+      /\batrair marca/,
+      /\batrair marcas/,
+      /\bconseguir publi/,
+      /\bencaixar marca/,
+      /\bcampanha\b/,
+      /\bpublicidade\b/,
+    ]).length > 0;
+
+  const match =
+    detectCommentToPost(normalizedInput) ||
+    detectFormatGuidance(normalizedInput) ||
+    detectWeeklyPlan(normalizedInput) ||
+    detectDiscoverPauta(normalizedInput) ||
+    detectCollabMatch(normalizedInput) ||
+    (isStrongBrandIntent ? brandMatch : null) ||
+    detectValidatePauta(normalizedInput) ||
+    brandMatch ||
+    detectCreateByGoal(normalizedInput);
+
+  if (!match) {
+    return {
+      mode: "unknown",
+      confidence: 0.25,
+      normalizedInput,
+      originalInput,
+      detectedPauta: null,
+      objective: null,
+      brandCategory: null,
+      sourceComment: null,
+      signals: [],
+      suggestedStage: "intent",
+    };
+  }
+
+  return {
+    mode: match.mode,
+    confidence: match.confidence,
+    normalizedInput,
+    originalInput,
+    detectedPauta: match.detectedPauta || null,
+    objective: match.objective || null,
+    brandCategory: match.brandCategory || null,
+    sourceComment: match.sourceComment || null,
+    signals: match.signals,
+    suggestedStage: getSuggestedStage(match),
+  };
+}

--- a/src/app/dashboard/boards/postCreationAdaptiveTypes.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveTypes.ts
@@ -133,3 +133,25 @@ export type PostCreationAdaptiveState = {
   createdAt?: string | null;
   updatedAt?: string | null;
 };
+
+export type PostCreationAdaptiveAnswerEvaluation = {
+  questionId: string;
+  key: PostCreationAdaptiveQuestionMapKey;
+  selectedOptionId: string | null;
+  selectedLabel: string | null;
+  recommendedOptionId: string | null;
+  recommendedLabel: string | null;
+  isRecommendedChoice: boolean;
+  reason: string;
+};
+
+export type PostCreationAdaptiveAnswerKeyResult = {
+  mode: PostCreationAdaptiveMode;
+  totalQuestions: number;
+  answeredQuestions: number;
+  recommendedMatches: number;
+  evaluations: PostCreationAdaptiveAnswerEvaluation[];
+  strengths: string[];
+  adjustments: string[];
+  summary: string;
+};

--- a/src/app/dashboard/boards/postCreationAdaptiveTypes.ts
+++ b/src/app/dashboard/boards/postCreationAdaptiveTypes.ts
@@ -1,0 +1,135 @@
+export type PostCreationAdaptiveMode =
+  | "validate_pauta"
+  | "discover_pauta"
+  | "create_by_goal"
+  | "format_guidance"
+  | "brand_match"
+  | "collab_match"
+  | "comment_to_post"
+  | "weekly_plan"
+  | "unknown";
+
+export type PostCreationAdaptiveStage = "intent" | "quiz" | "plan" | "legacy_handoff";
+
+export type PostCreationAdaptiveQuestionType =
+  | "strategic_choice"
+  | "preference"
+  | "constraint"
+  | "confirmation";
+
+export type PostCreationAdaptiveQuestionMapKey =
+  | "who"
+  | "what"
+  | "where"
+  | "when"
+  | "why"
+  | "how"
+  | "how_much"
+  | "hook"
+  | "cta"
+  | "format"
+  | "narrative"
+  | "objective"
+  | "brand"
+  | "collab"
+  | "effort"
+  | "schedule";
+
+export type PostCreationAdaptiveIntentDetection = {
+  mode: PostCreationAdaptiveMode;
+  confidence: number;
+  normalizedInput: string;
+  originalInput: string;
+  detectedPauta: string | null;
+  objective: string | null;
+  brandCategory: string | null;
+  sourceComment: string | null;
+  signals: string[];
+  suggestedStage: PostCreationAdaptiveStage;
+};
+
+export type PostCreationAdaptiveQuestionOption = {
+  id: string;
+  label: string;
+  reason?: string | null;
+  description?: string | null;
+  value?: string | null;
+  recommended?: boolean;
+};
+
+export type PostCreationAdaptiveQuestion = {
+  id: string;
+  mapKey: PostCreationAdaptiveQuestionMapKey;
+  type: PostCreationAdaptiveQuestionType;
+  title: string;
+  helper?: string | null;
+  options: PostCreationAdaptiveQuestionOption[];
+  required: boolean;
+  multiSelect?: boolean;
+};
+
+export type PostCreationAdaptiveAnswer = {
+  questionId: string;
+  key: PostCreationAdaptiveQuestionMapKey;
+  value: string | string[] | boolean | null;
+  optionId?: string | null;
+  answeredAt?: string | null;
+};
+
+export type PostCreationFiveW2HPlan = {
+  who: string | null;
+  what: string | null;
+  where: string | null;
+  when: string | null;
+  why: string | null;
+  how: string | null;
+  howMuch: string | null;
+};
+
+export type PostCreationAdaptiveScene = {
+  id: string;
+  title: string;
+  visual: string;
+  message: string;
+  direction?: string | null;
+};
+
+export type PostCreationAdaptiveBrandMatchPlan = {
+  enabled: boolean;
+  category?: string | null;
+  angle?: string | null;
+  desiredBrandSignals?: string[];
+};
+
+export type PostCreationAdaptiveCollabMatchPlan = {
+  enabled: boolean;
+  creatorProfile?: string | null;
+  collaborationAngle?: string | null;
+};
+
+export type PostCreationStrategicPlan = {
+  pauta: string | null;
+  objective: string | null;
+  narrative: string | null;
+  format: string | null;
+  hook: string | null;
+  cta: string | null;
+  fiveW2H: PostCreationFiveW2HPlan;
+  scenes: PostCreationAdaptiveScene[];
+  brandMatch: PostCreationAdaptiveBrandMatchPlan | null;
+  collabMatch: PostCreationAdaptiveCollabMatchPlan | null;
+  nextActions: string[];
+};
+
+export type PostCreationAdaptiveState = {
+  stage: PostCreationAdaptiveStage;
+  mode: PostCreationAdaptiveMode;
+  detection: PostCreationAdaptiveIntentDetection | null;
+  originalInput: string;
+  questions: PostCreationAdaptiveQuestion[];
+  answers: PostCreationAdaptiveAnswer[];
+  plan: PostCreationStrategicPlan | null;
+  legacyHandoffReady: boolean;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};


### PR DESCRIPTION
## Contexto

Reintrodução incremental do Board Adaptativo V2 após o revert do PR #784, agora também com a fundação do Narrative Source Engine.

Este PR permanece em draft e não deve ser mergeado ainda. Nenhuma das novas experiências está conectada ao fluxo real do produto.

## O que este PR inclui

## Adaptive Board V2

### V2A — Fundação tipada e feature flag
- Tipos base do fluxo adaptativo.
- Feature flag isolada.
- Testes da feature flag.

### V2B — Roteador de intenção
- Detecção heurística de intenção.
- Priorização entre validar pauta, descobrir pauta, formato, marca, collab, comentário e planejamento semanal.

### V2C — Quiz Builder
- Geração determinística de perguntas por modo.
- Linguagem consultiva, sem tom de prova/jogo.

### V2D — AnswerKey
- Leitura estratégica das respostas.
- Pontos fortes e ajustes recomendados.
- Sem score visual.

### V2E — Strategic Plan Builder
- Plano estratégico com 5W2H, cenas, próximos passos e blocos opcionais de marca/collab.

### V2F — QA do pipeline invisível
- Teste ponta a ponta do pipeline:
  Router → QuizBuilder → AnswerKey → PlanBuilder.

### V2G — Correção de collabMatch
- Impede que validate_pauta gere collabMatch automaticamente sem sinal explícito.

### V2H — UI Preview isolada
- Componentes de preview movidos por props.
- Sem BoardShell, endpoint, OpenAI, banco ou fluxo real.

### V2I/V2J — Harness interno do Adaptive V2
- Rota interna `/dashboard/boards/adaptive-v2-preview`.
- Cenários controlados por query param.
- Proteção por `NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED`.

### V2K/V2L — Documentação e QA manual
- Status do rollout.
- Checklist de QA manual para revisão futura no browser.

## Narrative Source Engine

A NSE é uma camada para transformar fontes criativas em leitura estratégica. A proposta não é criar uma ferramenta isolada de análise de vídeo, mas representar qualquer fonte criativa como uma `NarrativeSource` capaz de revelar intenção, assets narrativos, sinais de perfil e entrada para o Adaptive V2.

Vídeo entra como fonte futura/rica, mas neste PR aparece apenas como `video_simulated`. Não há upload real, transcrição automática, extração de frames ou análise multimodal.

### NSE1 — Contratos puros de fontes narrativas
- Define `NarrativeSource`, intents, assets, sinais de perfil e diagnóstico.
- Sem UI, upload, banco, OpenAI ou integração real.

### NSE2 — Roteador de intenção da fonte
- Cria `detectNarrativeSourceIntent(source)`.
- Detecta intenções como validar antes de postar, melhorar conteúdo, descobrir narrativa, potencial de marca, publi, collab e posicionamento.

### NSE3 — Extractor simulado de assets narrativos
- Cria `extractNarrativeAssets(...)`.
- Extrai assets e sinais por heurísticas determinísticas.
- Cobre rotina/skincare, bastidor, gancho, marca, collab, posicionamento, comentário e fallback seguro.

### NSE4 — Adapter para Adaptive V2
- Cria `buildAdaptiveInputFromNarrativeSource(...)`.
- Transforma a fonte analisada em `input`, `modeHint`, `sourceSummary` e `signals` para o Adaptive V2.
- Não chama Router, QuizBuilder, AnswerKey ou PlanBuilder dentro do adapter.

### NSE5 — Pipeline QA NSE → Adaptive V2
- Valida em teste o fluxo:
  NarrativeSource → IntentRouter → AssetExtractor → Adapter → Adaptive V2 Router → QuizBuilder → AnswerKey → PlanBuilder.

### NSE6 — Preview isolada por props
- Componentes em `components/narrativeSource/`.
- Mostram fonte, intenção, assets, sinais de perfil, ponte para Adaptive V2 e plano recebido.
- Não rodam pipeline internamente.

### NSE7 — Harness interno com cenários controlados
- Rota interna `/dashboard/boards/narrative-source-preview`.
- Proteção por `NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1`.
- Cenários:
  - `video-validate`
  - `video-brand-potential`
  - `video-discover-narrative`
  - `video-improve-content`
  - `video-collab`
  - `comment-to-post`
  - `script-to-plan`

### NSE8 — Documentação e QA manual
- README de rollout da NSE.
- Checklist manual em `NARRATIVE_SOURCE_ENGINE_QA.md`.

## Fora de escopo

- Integração com `PostCreationFunnelBoardShell`.
- Exibição no produto real.
- Input livre do usuário.
- Upload real de vídeo.
- Transcrição automática.
- Extração de frames.
- Análise multimodal.
- Banco de dados.
- Persistência de sinais de perfil.
- Treino real da conta.
- OpenAI.
- Endpoints.
- Handoff para Planner, Media Kit, marcas, collabs reais ou DNA Narrativo.
- Link em navegação/menu.
- Liberação para usuários.

## Flags internas

### Adaptive V2 preview

```bash
NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED=1
```

Rota:

```text
/dashboard/boards/adaptive-v2-preview
```

### Narrative Source Engine preview

```bash
NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1
```

Rota:

```text
/dashboard/boards/narrative-source-preview
```

## QA recomendada

### Adaptive V2

```bash
npm test -- --runInBand src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
npm test -- --runInBand src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts
npm test -- --runInBand src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts
```

### Narrative Source Engine

```bash
npm test -- --runInBand src/app/dashboard/boards/narrative-source-preview/page.test.tsx
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceFeatureFlag.test.ts
npm test -- --runInBand src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts
npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts
```

### Typecheck

```bash
npm run typecheck
```

## Status

Draft. Não fazer merge ainda.

Antes de qualquer integração real, revisar visualmente os harnesses, decidir proteção por sessão admin/dev, política de persistência e estratégia separada para upload real de vídeo.