### PR TITLE
feat: add video upload narrative source foundation

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -73,11 +73,45 @@ O retorno usa:
 
 O arquivo não importa tipos da NSE nesta fase para manter o acoplamento baixo. A compatibilidade é conceitual e deve ser formalizada em uma fase posterior.
 
+## VU2 — Bridge tipada com NarrativeSource
+
+Status: concluído nesta branch.
+
+Arquivos principais:
+
+- `videoUploadNarrativeSourceBridge.ts`: converte um `VideoUploadDraft` validado em `NarrativeSource`.
+- `videoUploadNarrativeSourceBridge.test.ts`: cobre conversão, `id`, `createdAt`, formato curto/longo, helper de prontidão e isolamento de escopo.
+
+O que existe:
+
+- `buildNarrativeSourceFromVideoUploadDraft`;
+- `isVideoUploadReadyForNarrativeSource`;
+- import tipado de `NarrativeSource`;
+- uso de `validateVideoUploadDraft` como fonte da verdade;
+- conversão para `sourceType: "video_upload_future"`;
+- metadados básicos de vídeo preservados.
+
+O que continua fora do escopo:
+
+- upload real;
+- endpoint;
+- storage;
+- transcrição;
+- frames;
+- OpenAI;
+- banco;
+- UI;
+- BoardShell;
+- navegação real.
+
+Esta fase prova apenas que um vídeo já validado pode ser representado como uma fonte narrativa futura. A bridge não infere transcrição, não descreve visualmente o vídeo e não salva nada.
+
 ## QA
 
 Comandos recomendados para esta fundação:
 
 ```bash
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
 npm run typecheck
 git diff --check

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1,0 +1,91 @@
+# Video Upload Foundation
+
+Este diretório guarda a fundação pura do épico VU. A intenção é preparar, em fases pequenas, uma forma futura de receber vídeo como fonte narrativa sem tratar vídeo como produto separado.
+
+Nesta fase, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
+
+## VU1 — Contratos puros e validação
+
+Status: concluído nesta branch.
+
+Arquivos principais:
+
+- `videoUploadTypes.ts`: tipos, limites padrão, validação pura e bridge conceitual para fonte narrativa.
+- `videoUploadTypes.test.ts`: cobertura dos tipos utilitários, validações, bridge e isolamento de escopo.
+
+O que existe:
+
+- status de processamento futuro;
+- fontes possíveis de vídeo;
+- MIME types aceitos;
+- limites padrão de duração e tamanho;
+- códigos e mensagens de validação;
+- criação de draft vazio;
+- validação determinística de draft;
+- bridge compatível com a ideia de `video_upload_future`.
+
+O que não existe:
+
+- upload real;
+- endpoint;
+- storage;
+- transcrição;
+- extração de frames;
+- análise multimodal;
+- OpenAI;
+- banco;
+- UI;
+- BoardShell;
+- integração com o fluxo real.
+
+## Limites padrão
+
+- Duração máxima: 60 segundos.
+- Tamanho máximo: 100 MB.
+- Formatos aceitos: `video/mp4`, `video/quicktime`, `video/webm`.
+- Pergunta do criador obrigatória.
+
+## Validação
+
+`validateVideoUploadDraft` normaliza `fileName`, `mimeType` e `creatorQuestion`, preserva tamanho e duração, e retorna erros exibíveis de forma simples.
+
+Validações atuais:
+
+- arquivo obrigatório;
+- formato suportado;
+- limite de tamanho;
+- duração informada;
+- limite de duração;
+- pergunta do criador quando exigida;
+- nome de arquivo sem caracteres simples de risco.
+
+## Bridge narrativa
+
+`buildNarrativeSourceBridgeFromVideoUpload` só retorna dados quando o draft passa pela validação.
+
+O retorno usa:
+
+- `sourceType: "video_upload_future"`;
+- `creatorQuestion` normalizada;
+- `transcript: null`;
+- `visualDescription: null`;
+- metadados básicos do vídeo.
+
+O arquivo não importa tipos da NSE nesta fase para manter o acoplamento baixo. A compatibilidade é conceitual e deve ser formalizada em uma fase posterior.
+
+## QA
+
+Comandos recomendados para esta fundação:
+
+```bash
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
+npm run typecheck
+git diff --check
+```
+
+## Próximas fases sugeridas
+
+- VU2: fixture/harness de pré-validação sem upload real.
+- VU3: contrato de storage temporário, ainda sem implementação real.
+- VU4: contrato de transcrição e frames.
+- VU5: integração conceitual com NSE em teste, sem produto real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -106,12 +106,58 @@ O que continua fora do escopo:
 
 Esta fase prova apenas que um vídeo já validado pode ser representado como uma fonte narrativa futura. A bridge não infere transcrição, não descreve visualmente o vídeo e não salva nada.
 
+## VU3 — QA do pipeline VideoUpload → NSE → Adaptive V2
+
+Status: concluído nesta branch.
+
+Arquivo principal:
+
+- `videoUploadPipeline.test.ts`: teste ponta a ponta, apenas em ambiente de QA, cobrindo `VideoUploadDraft` validado até o plano estratégico Adaptive V2.
+
+Pipeline validado:
+
+```text
+VideoUploadDraft
+↓
+validateVideoUploadDraft
+↓
+buildNarrativeSourceFromVideoUploadDraft
+↓
+detectNarrativeSourceIntent
+↓
+extractNarrativeAssets
+↓
+buildAdaptiveInputFromNarrativeSource
+↓
+Adaptive V2 Router
+↓
+QuizBuilder
+↓
+AnswerKey
+↓
+PlanBuilder
+```
+
+O teste cobre:
+
+- vídeo válido para validar antes de postar;
+- vídeo válido para potencial de marca;
+- vídeo válido para melhorar gancho;
+- vídeo válido para collab;
+- draft inválido sem rodar NSE/Adaptive;
+- vídeo longo com limites customizados;
+- linguagem segura nos outputs gerados;
+- isolamento de imports.
+
+Esta fase não cria lógica nova de produção. O pipeline existe apenas como teste de integridade.
+
 ## QA
 
 Comandos recomendados para esta fundação:
 
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
 npm run typecheck
 git diff --check

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1,120 +1,181 @@
 # Video Upload Foundation
 
-Este diretório guarda a fundação pura do épico VU. A intenção é preparar, em fases pequenas, uma forma futura de receber vídeo como fonte narrativa sem tratar vídeo como produto separado.
+Este diretório guarda a fundação pura do épico VU. A intenção é preparar, em fases pequenas, uma entrada futura de vídeo como fonte narrativa, sem tratar vídeo como produto separado.
 
-Nesta fase, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
+O vídeo ainda não é enviado de verdade e ainda não é processado de verdade. A fundação existe para manter essa futura experiência conectada à promessa da D2C: transformar fontes criativas em narrativa, estratégia e sinais úteis para entender o perfil do criador.
 
-## VU1 — Contratos puros e validação
+Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
-Status: concluído nesta branch.
+## Visão Geral
 
-Arquivos principais:
+O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.
 
-- `videoUploadTypes.ts`: tipos, limites padrão, validação pura e bridge conceitual para fonte narrativa.
-- `videoUploadTypes.test.ts`: cobertura dos tipos utilitários, validações, bridge e isolamento de escopo.
+O que esta fundação permite validar agora:
 
-O que existe:
+- um draft de vídeo pode ser representado e validado de forma determinística;
+- um draft válido pode virar uma `NarrativeSource` do tipo `video_upload_future`;
+- artefatos simulados de processamento podem enriquecer `transcript` e `visualDescription`;
+- a fonte enriquecida pode alimentar o Narrative Source Engine;
+- a NSE pode alimentar o Adaptive V2;
+- o Adaptive V2 pode gerar um plano estratégico em ambiente de teste.
 
-- status de processamento futuro;
-- fontes possíveis de vídeo;
-- MIME types aceitos;
-- limites padrão de duração e tamanho;
-- códigos e mensagens de validação;
-- criação de draft vazio;
-- validação determinística de draft;
-- bridge compatível com a ideia de `video_upload_future`.
+O que ela não faz:
 
-O que não existe:
+- não recebe arquivo real;
+- não processa arquivo real;
+- não salva vídeo;
+- não extrai transcrição, frames ou OCR reais;
+- não chama OpenAI;
+- não conecta nada ao produto real.
 
-- upload real;
-- endpoint;
-- storage;
-- transcrição;
-- extração de frames;
-- análise multimodal;
-- OpenAI;
-- banco;
-- UI;
-- BoardShell;
-- integração com o fluxo real.
+## Mapa Das Fases
 
-## Limites padrão
+### VU1 — Contratos puros e validação
 
-- Duração máxima: 60 segundos.
-- Tamanho máximo: 100 MB.
-- Formatos aceitos: `video/mp4`, `video/quicktime`, `video/webm`.
-- Pergunta do criador obrigatória.
-
-## Validação
-
-`validateVideoUploadDraft` normaliza `fileName`, `mimeType` e `creatorQuestion`, preserva tamanho e duração, e retorna erros exibíveis de forma simples.
-
-Validações atuais:
-
-- arquivo obrigatório;
-- formato suportado;
-- limite de tamanho;
-- duração informada;
-- limite de duração;
-- pergunta do criador quando exigida;
-- nome de arquivo sem caracteres simples de risco.
-
-## Bridge narrativa
-
-`buildNarrativeSourceBridgeFromVideoUpload` só retorna dados quando o draft passa pela validação.
-
-O retorno usa:
-
-- `sourceType: "video_upload_future"`;
-- `creatorQuestion` normalizada;
-- `transcript: null`;
-- `visualDescription: null`;
-- metadados básicos do vídeo.
-
-O arquivo não importa tipos da NSE nesta fase para manter o acoplamento baixo. A compatibilidade é conceitual e deve ser formalizada em uma fase posterior.
-
-## VU2 — Bridge tipada com NarrativeSource
-
-Status: concluído nesta branch.
+Status: concluído.
 
 Arquivos principais:
 
-- `videoUploadNarrativeSourceBridge.ts`: converte um `VideoUploadDraft` validado em `NarrativeSource`.
-- `videoUploadNarrativeSourceBridge.test.ts`: cobre conversão, `id`, `createdAt`, formato curto/longo, helper de prontidão e isolamento de escopo.
+- `videoUploadTypes.ts`
+- `videoUploadTypes.test.ts`
 
-O que existe:
+O que faz:
 
-- `buildNarrativeSourceFromVideoUploadDraft`;
-- `isVideoUploadReadyForNarrativeSource`;
-- import tipado de `NarrativeSource`;
-- uso de `validateVideoUploadDraft` como fonte da verdade;
-- conversão para `sourceType: "video_upload_future"`;
-- metadados básicos de vídeo preservados.
+- define status futuros de upload/processamento;
+- define origens possíveis de vídeo;
+- define MIME types aceitos;
+- define limites padrão;
+- cria `VideoUploadDraft`;
+- valida draft de vídeo de forma pura;
+- cria uma bridge conceitual para `video_upload_future`.
 
-O que continua fora do escopo:
+O que não faz:
 
-- upload real;
-- endpoint;
-- storage;
-- transcrição;
-- frames;
-- OpenAI;
-- banco;
-- UI;
-- BoardShell;
-- navegação real.
+- não importa tipos da NSE;
+- não cria upload real;
+- não cria endpoint;
+- não cria storage;
+- não cria UI.
 
-Esta fase prova apenas que um vídeo já validado pode ser representado como uma fonte narrativa futura. A bridge não infere transcrição, não descreve visualmente o vídeo e não salva nada.
+### VU2 — Bridge tipada com NarrativeSource
 
-## VU3 — QA do pipeline VideoUpload → NSE → Adaptive V2
+Status: concluído.
 
-Status: concluído nesta branch.
+Arquivos principais:
+
+- `videoUploadNarrativeSourceBridge.ts`
+- `videoUploadNarrativeSourceBridge.test.ts`
+
+O que faz:
+
+- converte `VideoUploadDraft` validado em `NarrativeSource`;
+- usa `validateVideoUploadDraft` como fonte da verdade;
+- preserva `id`, `createdAt`, `creatorQuestion` e metadados básicos;
+- define `sourceType: "video_upload_future"`;
+- mantém `rawText`, `transcript` e `visualDescription` vazios.
+
+O que não faz:
+
+- não infere transcrição;
+- não descreve visualmente o vídeo;
+- não salva nada;
+- não roda NSE;
+- não roda Adaptive V2.
+
+### VU3 — QA do pipeline VideoUpload → NSE → Adaptive V2
+
+Status: concluído.
 
 Arquivo principal:
 
-- `videoUploadPipeline.test.ts`: teste ponta a ponta, apenas em ambiente de QA, cobrindo `VideoUploadDraft` validado até o plano estratégico Adaptive V2.
+- `videoUploadPipeline.test.ts`
 
-Pipeline validado:
+O que faz:
+
+- valida, apenas em teste, o caminho `VideoUploadDraft` → `NarrativeSource` → NSE → Adaptive V2;
+- cobre vídeos válidos para validação, marca, melhoria de gancho, collab e vídeo longo com limites customizados;
+- garante abort seguro para draft inválido;
+- verifica linguagem segura e isolamento de imports.
+
+O que não faz:
+
+- não cria lógica nova de produção;
+- não processa vídeo real;
+- não cria rota, endpoint ou UI.
+
+### VU4 — Contratos de artefatos de processamento
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoProcessingArtifacts.ts`
+- `videoProcessingArtifacts.test.ts`
+
+O que faz:
+
+- define contratos para transcrição, segmentos, frames-chave, OCR, sinais técnicos, resumo visual e notas de processamento;
+- cria helpers puros para montar texto de transcrição e descrição visual a partir de artefatos;
+- identifica se há contexto utilizável.
+
+O que não faz:
+
+- não usa ffmpeg;
+- não usa OpenAI;
+- não transcreve;
+- não extrai frames;
+- não executa OCR;
+- não salva artefatos.
+
+### VU5 — Adapter de artefatos para NarrativeSource
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoUploadProcessedNarrativeSource.ts`
+- `videoUploadProcessedNarrativeSource.test.ts`
+
+O que faz:
+
+- combina `VideoUploadDraft` validado com `VideoProcessingArtifacts` simulados;
+- usa `buildNarrativeSourceFromVideoUploadDraft` como base;
+- preenche `transcript` via `buildTranscriptTextFromArtifacts`;
+- preenche `visualDescription` via `buildVisualDescriptionFromArtifacts`;
+- preserva metadata, `id`, `createdAt` e `creatorQuestion`;
+- cria helper para saber se há contexto suficiente para análise narrativa.
+
+O que não faz:
+
+- não roda NSE;
+- não roda Adaptive V2;
+- não processa vídeo real;
+- não salva nada.
+
+### VU6 — QA do pipeline com artefatos simulados
+
+Status: concluído.
+
+Arquivo principal:
+
+- `videoUploadProcessedPipeline.test.ts`
+
+O que faz:
+
+- valida, apenas em teste, o pipeline com `VideoUploadDraft + VideoProcessingArtifacts`;
+- cobre transcript de rotina/skincare, visual summary de bastidor, frames + OCR para marca, artifacts vazios e draft inválido;
+- demonstra `hasEnoughProcessedContextForNarrativeAnalysis`;
+- garante linguagem segura e isolamento de imports.
+
+O que não faz:
+
+- não cria lógica nova de produção;
+- não cria upload real;
+- não cria endpoint;
+- não cria storage;
+- não cria UI.
+
+## Arquitetura Atual
 
 ```text
 VideoUploadDraft
@@ -123,135 +184,78 @@ validateVideoUploadDraft
 ↓
 buildNarrativeSourceFromVideoUploadDraft
 ↓
-detectNarrativeSourceIntent
-↓
-extractNarrativeAssets
-↓
-buildAdaptiveInputFromNarrativeSource
-↓
-Adaptive V2 Router
-↓
-QuizBuilder
-↓
-AnswerKey
-↓
-PlanBuilder
-```
-
-O teste cobre:
-
-- vídeo válido para validar antes de postar;
-- vídeo válido para potencial de marca;
-- vídeo válido para melhorar gancho;
-- vídeo válido para collab;
-- draft inválido sem rodar NSE/Adaptive;
-- vídeo longo com limites customizados;
-- linguagem segura nos outputs gerados;
-- isolamento de imports.
-
-Esta fase não cria lógica nova de produção. O pipeline existe apenas como teste de integridade.
-
-## VU4 — Contratos de artefatos de processamento
-
-Status: concluído nesta branch.
-
-Arquivos principais:
-
-- `videoProcessingArtifacts.ts`: tipos e helpers puros para representar artefatos futuros de processamento de vídeo.
-- `videoProcessingArtifacts.test.ts`: cobertura dos defaults, transcrição, descrição visual, OCR, sinais úteis e isolamento de escopo.
-
-Artefatos representados:
-
-- status de processamento;
-- transcrição completa e por segmentos;
-- frames-chave;
-- OCR/texto na tela;
-- sinais técnicos;
-- resumo visual;
-- notas de processamento.
-
-Helpers criados:
-
-- `createEmptyVideoProcessingArtifacts`;
-- `mergeTranscriptSegments`;
-- `buildTranscriptTextFromArtifacts`;
-- `buildVisualDescriptionFromArtifacts`;
-- `hasUsableVideoProcessingArtifacts`.
-
-Esta fase não processa vídeo real. Ela apenas prepara a forma dos dados que, no futuro, poderão enriquecer uma `NarrativeSource` com transcrição, contexto visual e sinais técnicos.
-
-## VU5 — Adapter de artefatos para NarrativeSource
-
-Status: concluído nesta branch.
-
-Arquivos principais:
-
-- `videoUploadProcessedNarrativeSource.ts`: combina `VideoUploadDraft` validado com `VideoProcessingArtifacts` simulados para gerar uma `NarrativeSource` enriquecida.
-- `videoUploadProcessedNarrativeSource.test.ts`: cobre draft inválido, artifacts vazios, transcript, visual description, preservação de metadata e isolamento de escopo.
-
-Helpers criados:
-
-- `buildProcessedNarrativeSourceFromVideoUpload`;
-- `hasEnoughProcessedContextForNarrativeAnalysis`.
-
-O adapter:
-
-- usa `buildNarrativeSourceFromVideoUploadDraft` como base;
-- preserva `rawText: null`;
-- preserva `creatorQuestion`, `metadata`, `id` e `createdAt` da base;
-- preenche `transcript` via `buildTranscriptTextFromArtifacts`;
-- preenche `visualDescription` via `buildVisualDescriptionFromArtifacts`;
-- não roda NSE;
-- não roda Adaptive V2;
-- não processa vídeo real.
-
-## VU6 — QA do pipeline com artefatos simulados
-
-Status: concluído nesta branch.
-
-Arquivo principal:
-
-- `videoUploadProcessedPipeline.test.ts`: teste ponta a ponta, apenas em QA, cobrindo `VideoUploadDraft + VideoProcessingArtifacts` até o plano Adaptive V2.
-
-Pipeline validado:
-
-```text
-VideoUploadDraft
-+
-VideoProcessingArtifacts
+VideoProcessingArtifacts simulados
 ↓
 buildProcessedNarrativeSourceFromVideoUpload
 ↓
-detectNarrativeSourceIntent
+NSE
 ↓
-extractNarrativeAssets
+Adaptive V2
 ↓
-buildAdaptiveInputFromNarrativeSource
-↓
-Adaptive V2 Router
-↓
-QuizBuilder
-↓
-AnswerKey
-↓
-PlanBuilder
+Strategic Plan
 ```
 
-O teste cobre:
+Na prática, existem dois níveis de prova:
 
-- transcript de rotina/skincare melhorando a extração narrativa;
-- visual summary de bastidor melhorando narrativa de processo;
-- frames e OCR alimentando potencial de marca;
-- artifacts vazios ainda permitindo rota por `creatorQuestion`;
-- draft inválido abortando NSE/Adaptive;
-- `hasEnoughProcessedContextForNarrativeAnalysis`;
-- linguagem segura e isolamento de imports.
+- `VideoUploadDraft` validado já pode virar uma `NarrativeSource` básica.
+- `VideoUploadDraft + VideoProcessingArtifacts` simulados já pode virar uma `NarrativeSource` enriquecida com `transcript` e `visualDescription`.
 
-Esta fase não cria lógica nova de produção e não processa vídeo real.
+## O Que Existe Hoje
 
-## QA
+- Validação pura de draft de vídeo.
+- Limites padrão de duração, tamanho e pergunta obrigatória.
+- MIME types aceitos: `video/mp4`, `video/quicktime`, `video/webm`.
+- Bridge tipada para `NarrativeSource`.
+- Contratos de artefatos de processamento.
+- Helpers para transcrição e descrição visual a partir de artefatos.
+- Adapter para `NarrativeSource` enriquecida.
+- QA de pipeline completo com artifacts simulados.
+- Testes de linguagem segura e isolamento de escopo.
 
-Comandos recomendados para esta fundação:
+## O Que Ainda Não Existe
+
+- Upload real.
+- Endpoint.
+- Storage.
+- Transcrição automática.
+- Extração real de frames.
+- OCR real.
+- Análise multimodal.
+- OpenAI.
+- ffmpeg.
+- Banco ou persistência.
+- UI.
+- BoardShell.
+- Navegação ou menu.
+- Liberação para usuário.
+
+## Conexão Com A NSE E A Promessa Da D2C
+
+O vídeo é uma fonte narrativa. Ele pode carregar falas, contexto visual, ritmo, cenas, texto na tela e intenção do criador.
+
+Nesta fundação, a transcrição e a `visualDescription` enriquecem a leitura sem transformar vídeo em produto isolado. A fonte enriquecida alimenta a NSE, a NSE transforma a fonte em intenção, assets narrativos e sinais de perfil, e o Adaptive V2 transforma essa leitura em plano estratégico.
+
+Isso prepara a futura experiência: envie um vídeo e descubra qual narrativa ele comunica, como melhorar a pauta e que direção estratégica faz sentido.
+
+## Critérios Antes De Upload Real
+
+Antes de qualquer upload real, ainda é preciso decidir:
+
+- provedor de storage temporário;
+- política de retenção e exclusão do vídeo;
+- limite final de tamanho e duração;
+- extração de duração no client, no server ou em ambos;
+- provedor de transcrição;
+- estratégia de frames-chave;
+- estratégia de OCR;
+- estratégia de análise multimodal;
+- custo estimado por análise;
+- rate limit por plano;
+- consentimento do usuário para usar análise no perfil narrativo;
+- plano de rollback;
+- feature flag para manter a experiência desligada em produção até aprovação.
+
+## QA Recomendada
 
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
@@ -264,8 +268,10 @@ npm run typecheck
 git diff --check
 ```
 
-## Próximas fases sugeridas
+## Próximas Fases Sugeridas
 
-- VU7: fixture/harness interno com artefatos simulados.
-- VU8: contrato de storage temporário, ainda sem implementação real.
-- VU9: documentação de rollout antes de qualquer upload real.
+- VU8: fixture/harness interno com artifacts simulados, sem input livre.
+- VU9: contrato de storage temporário, ainda sem implementação real.
+- VU10: contrato de providers de transcrição, frames e OCR.
+- VU11: documentação de custos, limites e retenção.
+- VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -151,11 +151,41 @@ O teste cobre:
 
 Esta fase não cria lógica nova de produção. O pipeline existe apenas como teste de integridade.
 
+## VU4 — Contratos de artefatos de processamento
+
+Status: concluído nesta branch.
+
+Arquivos principais:
+
+- `videoProcessingArtifacts.ts`: tipos e helpers puros para representar artefatos futuros de processamento de vídeo.
+- `videoProcessingArtifacts.test.ts`: cobertura dos defaults, transcrição, descrição visual, OCR, sinais úteis e isolamento de escopo.
+
+Artefatos representados:
+
+- status de processamento;
+- transcrição completa e por segmentos;
+- frames-chave;
+- OCR/texto na tela;
+- sinais técnicos;
+- resumo visual;
+- notas de processamento.
+
+Helpers criados:
+
+- `createEmptyVideoProcessingArtifacts`;
+- `mergeTranscriptSegments`;
+- `buildTranscriptTextFromArtifacts`;
+- `buildVisualDescriptionFromArtifacts`;
+- `hasUsableVideoProcessingArtifacts`.
+
+Esta fase não processa vídeo real. Ela apenas prepara a forma dos dados que, no futuro, poderão enriquecer uma `NarrativeSource` com transcrição, contexto visual e sinais técnicos.
+
 ## QA
 
 Comandos recomendados para esta fundação:
 
 ```bash
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
@@ -165,7 +195,7 @@ git diff --check
 
 ## Próximas fases sugeridas
 
-- VU2: fixture/harness de pré-validação sem upload real.
-- VU3: contrato de storage temporário, ainda sem implementação real.
-- VU4: contrato de transcrição e frames.
-- VU5: integração conceitual com NSE em teste, sem produto real.
+- VU5: adapter puro de artefatos para enriquecer `NarrativeSource`.
+- VU6: fixture/harness interno com artefatos simulados.
+- VU7: contrato de storage temporário, ainda sem implementação real.
+- VU8: documentação de rollout antes de qualquer upload real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -180,12 +180,38 @@ Helpers criados:
 
 Esta fase não processa vídeo real. Ela apenas prepara a forma dos dados que, no futuro, poderão enriquecer uma `NarrativeSource` com transcrição, contexto visual e sinais técnicos.
 
+## VU5 — Adapter de artefatos para NarrativeSource
+
+Status: concluído nesta branch.
+
+Arquivos principais:
+
+- `videoUploadProcessedNarrativeSource.ts`: combina `VideoUploadDraft` validado com `VideoProcessingArtifacts` simulados para gerar uma `NarrativeSource` enriquecida.
+- `videoUploadProcessedNarrativeSource.test.ts`: cobre draft inválido, artifacts vazios, transcript, visual description, preservação de metadata e isolamento de escopo.
+
+Helpers criados:
+
+- `buildProcessedNarrativeSourceFromVideoUpload`;
+- `hasEnoughProcessedContextForNarrativeAnalysis`.
+
+O adapter:
+
+- usa `buildNarrativeSourceFromVideoUploadDraft` como base;
+- preserva `rawText: null`;
+- preserva `creatorQuestion`, `metadata`, `id` e `createdAt` da base;
+- preenche `transcript` via `buildTranscriptTextFromArtifacts`;
+- preenche `visualDescription` via `buildVisualDescriptionFromArtifacts`;
+- não roda NSE;
+- não roda Adaptive V2;
+- não processa vídeo real.
+
 ## QA
 
 Comandos recomendados para esta fundação:
 
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
@@ -195,7 +221,6 @@ git diff --check
 
 ## Próximas fases sugeridas
 
-- VU5: adapter puro de artefatos para enriquecer `NarrativeSource`.
 - VU6: fixture/harness interno com artefatos simulados.
 - VU7: contrato de storage temporário, ainda sem implementação real.
 - VU8: documentação de rollout antes de qualquer upload real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -205,12 +205,57 @@ O adapter:
 - não roda Adaptive V2;
 - não processa vídeo real.
 
+## VU6 — QA do pipeline com artefatos simulados
+
+Status: concluído nesta branch.
+
+Arquivo principal:
+
+- `videoUploadProcessedPipeline.test.ts`: teste ponta a ponta, apenas em QA, cobrindo `VideoUploadDraft + VideoProcessingArtifacts` até o plano Adaptive V2.
+
+Pipeline validado:
+
+```text
+VideoUploadDraft
++
+VideoProcessingArtifacts
+↓
+buildProcessedNarrativeSourceFromVideoUpload
+↓
+detectNarrativeSourceIntent
+↓
+extractNarrativeAssets
+↓
+buildAdaptiveInputFromNarrativeSource
+↓
+Adaptive V2 Router
+↓
+QuizBuilder
+↓
+AnswerKey
+↓
+PlanBuilder
+```
+
+O teste cobre:
+
+- transcript de rotina/skincare melhorando a extração narrativa;
+- visual summary de bastidor melhorando narrativa de processo;
+- frames e OCR alimentando potencial de marca;
+- artifacts vazios ainda permitindo rota por `creatorQuestion`;
+- draft inválido abortando NSE/Adaptive;
+- `hasEnoughProcessedContextForNarrativeAnalysis`;
+- linguagem segura e isolamento de imports.
+
+Esta fase não cria lógica nova de produção e não processa vídeo real.
+
 ## QA
 
 Comandos recomendados para esta fundação:
 
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
@@ -221,6 +266,6 @@ git diff --check
 
 ## Próximas fases sugeridas
 
-- VU6: fixture/harness interno com artefatos simulados.
-- VU7: contrato de storage temporário, ainda sem implementação real.
-- VU8: documentação de rollout antes de qualquer upload real.
+- VU7: fixture/harness interno com artefatos simulados.
+- VU8: contrato de storage temporário, ainda sem implementação real.
+- VU9: documentação de rollout antes de qualquer upload real.

--- a/src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
@@ -1,0 +1,287 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildTranscriptTextFromArtifacts,
+  buildVisualDescriptionFromArtifacts,
+  createEmptyVideoProcessingArtifacts,
+  hasUsableVideoProcessingArtifacts,
+  mergeTranscriptSegments,
+  type VideoProcessingArtifacts,
+  type VideoTranscriptSegment,
+} from "./videoProcessingArtifacts";
+
+const forbiddenGeneratedTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function artifacts(overrides: Partial<VideoProcessingArtifacts> = {}): VideoProcessingArtifacts {
+  return {
+    ...createEmptyVideoProcessingArtifacts(),
+    ...overrides,
+    transcript: {
+      ...createEmptyVideoProcessingArtifacts().transcript,
+      ...overrides.transcript,
+    },
+  };
+}
+
+describe("videoProcessingArtifacts", () => {
+  it("creates empty processing artifacts with safe defaults", () => {
+    expect(createEmptyVideoProcessingArtifacts()).toEqual({
+      status: "pending",
+      transcript: {
+        fullText: null,
+        language: null,
+        segments: [],
+        provider: "unknown",
+      },
+      frames: [],
+      ocr: [],
+      technicalSignals: [],
+      visualSummary: null,
+      processingNotes: [],
+    });
+  });
+
+  it("orders transcript segments by startSeconds and joins text", () => {
+    const segments: VideoTranscriptSegment[] = [
+      { startSeconds: 8, endSeconds: 10, text: "de skincare.", confidence: 0.8 },
+      { startSeconds: 0, endSeconds: 3, text: "Mostro minha rotina", confidence: 0.9 },
+      { startSeconds: 4, endSeconds: 7, text: "pela manhã", confidence: 0.85 },
+    ];
+
+    expect(mergeTranscriptSegments(segments)).toBe("Mostro minha rotina pela manhã de skincare.");
+  });
+
+  it("ignores empty transcript segment text", () => {
+    const segments: VideoTranscriptSegment[] = [
+      { startSeconds: 0, endSeconds: 1, text: "  ", confidence: null },
+      { startSeconds: 2, endSeconds: 3, text: "Conteúdo com bastidor", confidence: 0.7 },
+      { startSeconds: 4, endSeconds: 5, text: "", confidence: null },
+    ];
+
+    expect(mergeTranscriptSegments(segments)).toBe("Conteúdo com bastidor");
+  });
+
+  it("uses transcript fullText when available", () => {
+    const result = buildTranscriptTextFromArtifacts(
+      artifacts({
+        transcript: {
+          fullText: "  Texto completo da transcrição.  ",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [{ startSeconds: 0, endSeconds: 2, text: "Trecho alternativo", confidence: 0.8 }],
+        },
+      }),
+    );
+
+    expect(result).toBe("Texto completo da transcrição.");
+  });
+
+  it("uses transcript segments when fullText is empty", () => {
+    const result = buildTranscriptTextFromArtifacts(
+      artifacts({
+        transcript: {
+          fullText: " ",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [
+            { startSeconds: 2, endSeconds: 4, text: "em vídeo", confidence: 0.8 },
+            { startSeconds: 0, endSeconds: 1, text: "Roteiro falado", confidence: 0.8 },
+          ],
+        },
+      }),
+    );
+
+    expect(result).toBe("Roteiro falado em vídeo");
+  });
+
+  it("returns null when transcript has no text", () => {
+    expect(buildTranscriptTextFromArtifacts(createEmptyVideoProcessingArtifacts())).toBeNull();
+  });
+
+  it("uses visualSummary when available", () => {
+    expect(
+      buildVisualDescriptionFromArtifacts(
+        artifacts({
+          visualSummary: "  Pessoa organizando produtos na bancada.  ",
+          frames: [
+            {
+              id: "frame-1",
+              timestampSeconds: 1,
+              label: "opening",
+              description: "Resumo alternativo",
+              imageStorageKey: null,
+            },
+          ],
+        }),
+      ),
+    ).toBe("Pessoa organizando produtos na bancada.");
+  });
+
+  it("builds a visual description from frame descriptions", () => {
+    const result = buildVisualDescriptionFromArtifacts(
+      artifacts({
+        frames: [
+          {
+            id: "frame-middle",
+            timestampSeconds: 8,
+            label: "middle",
+            description: "Pessoa mostra a textura do produto.",
+            imageStorageKey: null,
+          },
+          {
+            id: "frame-opening",
+            timestampSeconds: 1,
+            label: "opening",
+            description: "Produtos de skincare aparecem na bancada.",
+            imageStorageKey: null,
+          },
+        ],
+      }),
+    );
+
+    expect(result).toBe("Frames: Produtos de skincare aparecem na bancada. Pessoa mostra a textura do produto.");
+  });
+
+  it("includes OCR text when available", () => {
+    const result = buildVisualDescriptionFromArtifacts(
+      artifacts({
+        frames: [
+          {
+            id: "frame-opening",
+            timestampSeconds: 1,
+            label: "opening",
+            description: "Tela inicial com título.",
+            imageStorageKey: null,
+          },
+        ],
+        ocr: [
+          { timestampSeconds: 2, text: "Rotina da manhã", confidence: 0.8 },
+          { timestampSeconds: 5, text: "Autocuidado real", confidence: 0.78 },
+        ],
+      }),
+    );
+
+    expect(result).toBe("Frames: Tela inicial com título. Texto na tela: Rotina da manhã Autocuidado real");
+  });
+
+  it("returns null when there is no useful visual data", () => {
+    expect(buildVisualDescriptionFromArtifacts(createEmptyVideoProcessingArtifacts())).toBeNull();
+  });
+
+  it("returns false for empty processing artifacts", () => {
+    expect(hasUsableVideoProcessingArtifacts(createEmptyVideoProcessingArtifacts())).toBe(false);
+  });
+
+  it("returns true when transcript text exists", () => {
+    expect(
+      hasUsableVideoProcessingArtifacts(
+        artifacts({
+          transcript: {
+            fullText: "Transcrição do vídeo.",
+            language: "pt-BR",
+            provider: "manual",
+            segments: [],
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when frame descriptions exist", () => {
+    expect(
+      hasUsableVideoProcessingArtifacts(
+        artifacts({
+          frames: [
+            {
+              id: "frame-1",
+              timestampSeconds: 3,
+              label: "opening",
+              description: "Pessoa fala com a câmera.",
+              imageStorageKey: null,
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when OCR text exists", () => {
+    expect(
+      hasUsableVideoProcessingArtifacts(
+        artifacts({
+          ocr: [{ timestampSeconds: 2, text: "Texto na tela", confidence: 0.75 }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps helper-generated language safe", () => {
+    const generated = {
+      empty: createEmptyVideoProcessingArtifacts(),
+      transcript: buildTranscriptTextFromArtifacts(
+        artifacts({
+          transcript: {
+            fullText: null,
+            language: "pt-BR",
+            provider: "manual",
+            segments: [{ startSeconds: 0, endSeconds: 2, text: "Trecho sobre rotina.", confidence: 0.8 }],
+          },
+        }),
+      ),
+      visual: buildVisualDescriptionFromArtifacts(
+        artifacts({
+          frames: [
+            {
+              id: "frame-1",
+              timestampSeconds: 1,
+              label: "opening",
+              description: "Pessoa abre o vídeo em casa.",
+              imageStorageKey: null,
+            },
+          ],
+          ocr: [{ timestampSeconds: 2, text: "Rotina real", confidence: 0.7 }],
+        }),
+      ),
+    };
+    const text = JSON.stringify(generated).toLowerCase();
+
+    for (const forbidden of forbiddenGeneratedTerms) {
+      expect(text).not.toContain(forbidden);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, services, storage, upload, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoProcessingArtifacts.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).toBe("");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("upload service");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.ts
@@ -1,0 +1,133 @@
+export type VideoProcessingStatus =
+  | "pending"
+  | "extracting_metadata"
+  | "transcribing"
+  | "extracting_frames"
+  | "extracting_ocr"
+  | "summarizing"
+  | "completed"
+  | "failed";
+
+export type VideoTranscriptSegment = {
+  startSeconds: number;
+  endSeconds: number;
+  text: string;
+  confidence: number | null;
+};
+
+export type VideoTranscriptArtifact = {
+  fullText: string | null;
+  language: string | null;
+  segments: VideoTranscriptSegment[];
+  provider: "future_openai" | "future_assemblyai" | "manual" | "unknown";
+};
+
+export type VideoFrameArtifact = {
+  id: string;
+  timestampSeconds: number;
+  label: "opening" | "middle" | "closing" | "scene_change" | "manual" | "unknown";
+  description: string | null;
+  imageStorageKey: string | null;
+};
+
+export type VideoOcrArtifact = {
+  timestampSeconds: number;
+  text: string;
+  confidence: number | null;
+};
+
+export type VideoTechnicalSignal = {
+  type:
+    | "duration"
+    | "opening_density"
+    | "face_presence"
+    | "camera_movement"
+    | "text_overlay"
+    | "scene_change"
+    | "audio_presence"
+    | "unknown";
+  value: string;
+  confidence: number | null;
+};
+
+export type VideoProcessingArtifacts = {
+  status: VideoProcessingStatus;
+  transcript: VideoTranscriptArtifact;
+  frames: VideoFrameArtifact[];
+  ocr: VideoOcrArtifact[];
+  technicalSignals: VideoTechnicalSignal[];
+  visualSummary: string | null;
+  processingNotes: string[];
+};
+
+function normalizeText(value: string | null): string {
+  return value?.trim().replace(/\s+/g, " ") || "";
+}
+
+export function createEmptyVideoProcessingArtifacts(): VideoProcessingArtifacts {
+  return {
+    status: "pending",
+    transcript: {
+      fullText: null,
+      language: null,
+      segments: [],
+      provider: "unknown",
+    },
+    frames: [],
+    ocr: [],
+    technicalSignals: [],
+    visualSummary: null,
+    processingNotes: [],
+  };
+}
+
+export function mergeTranscriptSegments(segments: VideoTranscriptSegment[]): string {
+  return [...segments]
+    .sort((a, b) => a.startSeconds - b.startSeconds)
+    .map((segment) => normalizeText(segment.text))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+export function buildTranscriptTextFromArtifacts(artifacts: VideoProcessingArtifacts): string | null {
+  const fullText = normalizeText(artifacts.transcript.fullText);
+  if (fullText) return fullText;
+
+  const segmentText = mergeTranscriptSegments(artifacts.transcript.segments);
+  return segmentText || null;
+}
+
+export function buildVisualDescriptionFromArtifacts(artifacts: VideoProcessingArtifacts): string | null {
+  const visualSummary = normalizeText(artifacts.visualSummary);
+  if (visualSummary) return visualSummary;
+
+  const frameDescriptions = artifacts.frames
+    .slice()
+    .sort((a, b) => a.timestampSeconds - b.timestampSeconds)
+    .map((frame) => normalizeText(frame.description))
+    .filter(Boolean);
+  const ocrTexts = artifacts.ocr
+    .slice()
+    .sort((a, b) => a.timestampSeconds - b.timestampSeconds)
+    .map((item) => normalizeText(item.text))
+    .filter(Boolean);
+  const parts: string[] = [];
+
+  if (frameDescriptions.length > 0) {
+    parts.push(`Frames: ${frameDescriptions.join(" ")}`);
+  }
+
+  if (ocrTexts.length > 0) {
+    parts.push(`Texto na tela: ${ocrTexts.join(" ")}`);
+  }
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+export function hasUsableVideoProcessingArtifacts(artifacts: VideoProcessingArtifacts): boolean {
+  if (buildTranscriptTextFromArtifacts(artifacts)) return true;
+  if (buildVisualDescriptionFromArtifacts(artifacts)) return true;
+
+  return artifacts.technicalSignals.some((signal) => signal.type !== "unknown" && Boolean(normalizeText(signal.value)));
+}

--- a/src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
@@ -1,0 +1,205 @@
+import fs from "fs";
+import path from "path";
+
+import type { VideoUploadDraft, VideoUploadLimits } from "./videoUploadTypes";
+import {
+  DEFAULT_VIDEO_UPLOAD_LIMITS,
+  buildNarrativeSourceBridgeFromVideoUpload,
+  validateVideoUploadDraft,
+} from "./videoUploadTypes";
+import {
+  buildNarrativeSourceFromVideoUploadDraft,
+  isVideoUploadReadyForNarrativeSource,
+} from "./videoUploadNarrativeSourceBridge";
+
+const oneMb = 1024 * 1024;
+
+const relaxedLongVideoLimits: VideoUploadLimits = {
+  ...DEFAULT_VIDEO_UPLOAD_LIMITS,
+  maxDurationSeconds: 180,
+};
+
+const forbiddenGeneratedTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function validDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "video-upload-draft-1",
+    source: "local_file",
+    fileName: "  rotina.mp4  ",
+    mimeType: "  VIDEO/MP4  ",
+    sizeBytes: 32 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "  Quero saber se este vídeo vira uma boa pauta.  ",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("videoUploadNarrativeSourceBridge", () => {
+  it("returns null for invalid drafts", () => {
+    expect(
+      buildNarrativeSourceFromVideoUploadDraft({
+        draft: validDraft({
+          fileName: null,
+          mimeType: null,
+          sizeBytes: null,
+        }),
+      }),
+    ).toBeNull();
+
+    expect(
+      buildNarrativeSourceFromVideoUploadDraft({
+        draft: validDraft({
+          creatorQuestion: "",
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a NarrativeSource for valid drafts", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft(),
+    });
+
+    expect(source).toEqual({
+      id: "video-upload-draft-1",
+      sourceType: "video_upload_future",
+      rawText: null,
+      creatorQuestion: "Quero saber se este vídeo vira uma boa pauta.",
+      transcript: null,
+      visualDescription: null,
+      metadata: {
+        title: "rotina.mp4",
+        durationSeconds: 45,
+        platform: "unknown",
+        format: "short_video",
+        campaignContext: null,
+      },
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+  });
+
+  it("uses a custom id when provided", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft(),
+      id: "narrative-source-video-1",
+    });
+
+    expect(source?.id).toBe("narrative-source-video-1");
+  });
+
+  it("uses a custom createdAt when provided", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft(),
+      createdAt: "2026-05-15T10:00:00.000Z",
+    });
+
+    expect(source?.createdAt).toBe("2026-05-15T10:00:00.000Z");
+  });
+
+  it("uses draft id when a custom id is not provided", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft({ id: "draft-id-source" }),
+    });
+
+    expect(source?.id).toBe("draft-id-source");
+  });
+
+  it("uses draft createdAt when a custom createdAt is not provided", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft({ createdAt: "2026-05-16T11:00:00.000Z" }),
+    });
+
+    expect(source?.createdAt).toBe("2026-05-16T11:00:00.000Z");
+  });
+
+  it("returns long_video when custom limits allow longer duration", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft({
+        durationSeconds: 120,
+      }),
+      limits: relaxedLongVideoLimits,
+    });
+
+    expect(source?.metadata.format).toBe("long_video");
+    expect(source?.metadata.durationSeconds).toBe(120);
+  });
+
+  it("reports whether a video upload is ready for NarrativeSource conversion", () => {
+    expect(isVideoUploadReadyForNarrativeSource(validDraft())).toBe(true);
+    expect(isVideoUploadReadyForNarrativeSource(validDraft({ creatorQuestion: "" }))).toBe(false);
+  });
+
+  it("uses validateVideoUploadDraft as the validation source of truth", () => {
+    const draft = validDraft({
+      durationSeconds: 120,
+    });
+
+    expect(validateVideoUploadDraft(draft).ok).toBe(false);
+    expect(isVideoUploadReadyForNarrativeSource(draft)).toBe(false);
+    expect(buildNarrativeSourceFromVideoUploadDraft({ draft })).toBeNull();
+
+    expect(validateVideoUploadDraft(draft, relaxedLongVideoLimits).ok).toBe(true);
+    expect(isVideoUploadReadyForNarrativeSource(draft, relaxedLongVideoLimits)).toBe(true);
+    expect(buildNarrativeSourceFromVideoUploadDraft({ draft, limits: relaxedLongVideoLimits })).not.toBeNull();
+  });
+
+  it("matches the existing conceptual bridge fields for a valid draft", () => {
+    const draft = validDraft();
+    const typedSource = buildNarrativeSourceFromVideoUploadDraft({ draft });
+    const conceptualBridge = buildNarrativeSourceBridgeFromVideoUpload(draft);
+
+    expect(typedSource?.sourceType).toBe(conceptualBridge?.sourceType);
+    expect(typedSource?.creatorQuestion).toBe(conceptualBridge?.creatorQuestion);
+    expect(typedSource?.transcript).toBe(conceptualBridge?.transcript);
+    expect(typedSource?.visualDescription).toBe(conceptualBridge?.visualDescription);
+    expect(typedSource?.metadata).toEqual(conceptualBridge?.metadata);
+  });
+
+  it("keeps generated bridge strings free from absolute-promise and score language", () => {
+    const source = buildNarrativeSourceFromVideoUploadDraft({
+      draft: validDraft(),
+    });
+    const text = JSON.stringify(source).toLowerCase();
+
+    for (const term of forbiddenGeneratedTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, services, storage, or product integrations", () => {
+    const sourcePath = path.join(__dirname, "videoUploadNarrativeSourceBridge.ts");
+    const source = fs.readFileSync(sourcePath, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).toContain("narrativeSourceTypes");
+    expect(importLines).toContain("videoUploadTypes");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("upload service");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.ts
@@ -1,0 +1,51 @@
+import type { NarrativeSource } from "../narrativeSource/narrativeSourceTypes";
+import type { VideoUploadDraft, VideoUploadLimits } from "./videoUploadTypes";
+import { DEFAULT_VIDEO_UPLOAD_LIMITS, validateVideoUploadDraft } from "./videoUploadTypes";
+
+type BuildNarrativeSourceFromVideoUploadDraftParams = {
+  draft: VideoUploadDraft;
+  id?: string;
+  createdAt?: string | null;
+  limits?: VideoUploadLimits;
+};
+
+function getNarrativeVideoFormat(durationSeconds: number | null): "short_video" | "long_video" | "unknown" {
+  if (durationSeconds === null) return "unknown";
+  return durationSeconds <= 90 ? "short_video" : "long_video";
+}
+
+export function isVideoUploadReadyForNarrativeSource(
+  draft: VideoUploadDraft,
+  limits: VideoUploadLimits = DEFAULT_VIDEO_UPLOAD_LIMITS,
+): boolean {
+  return validateVideoUploadDraft(draft, limits).ok;
+}
+
+export function buildNarrativeSourceFromVideoUploadDraft({
+  draft,
+  id,
+  createdAt,
+  limits = DEFAULT_VIDEO_UPLOAD_LIMITS,
+}: BuildNarrativeSourceFromVideoUploadDraftParams): NarrativeSource | null {
+  const validation = validateVideoUploadDraft(draft, limits);
+  if (!validation.ok) return null;
+
+  const { normalizedDraft } = validation;
+
+  return {
+    id: id || normalizedDraft.id,
+    sourceType: "video_upload_future",
+    rawText: null,
+    creatorQuestion: normalizedDraft.creatorQuestion,
+    transcript: null,
+    visualDescription: null,
+    metadata: {
+      title: normalizedDraft.fileName,
+      durationSeconds: normalizedDraft.durationSeconds,
+      platform: "unknown",
+      format: getNarrativeVideoFormat(normalizedDraft.durationSeconds),
+      campaignContext: null,
+    },
+    createdAt: createdAt ?? normalizedDraft.createdAt ?? null,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
@@ -1,0 +1,284 @@
+import fs from "fs";
+import path from "path";
+
+import { buildPostCreationAdaptiveAnswerKey } from "../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../postCreationAdaptiveTypes";
+import { extractNarrativeAssets } from "../narrativeSource/narrativeAssetExtractor";
+import { buildAdaptiveInputFromNarrativeSource } from "../narrativeSource/narrativeSourceAdaptiveAdapter";
+import { detectNarrativeSourceIntent } from "../narrativeSource/narrativeSourceIntentRouter";
+import type { NarrativeAsset } from "../narrativeSource/narrativeSourceTypes";
+import { buildNarrativeSourceFromVideoUploadDraft } from "./videoUploadNarrativeSourceBridge";
+import {
+  DEFAULT_VIDEO_UPLOAD_LIMITS,
+  type VideoUploadDraft,
+  type VideoUploadLimits,
+  validateVideoUploadDraft,
+} from "./videoUploadTypes";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenGeneratedTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+const relaxedLongVideoLimits: VideoUploadLimits = {
+  ...DEFAULT_VIDEO_UPLOAD_LIMITS,
+  maxDurationSeconds: 180,
+};
+
+function makeDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "video-upload-pipeline-draft",
+    source: "local_file",
+    fileName: "rotina-skincare.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 34 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Gravei esse vídeo e quero saber se vale postar",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function runVideoUploadNarrativePipeline(draft: VideoUploadDraft, limits: VideoUploadLimits = DEFAULT_VIDEO_UPLOAD_LIMITS) {
+  const validation = validateVideoUploadDraft(draft, limits);
+  const narrativeSource = buildNarrativeSourceFromVideoUploadDraft({ draft, limits });
+
+  if (!validation.ok || !narrativeSource) {
+    return {
+      validation,
+      narrativeSource,
+      sourceIntent: null,
+      extraction: null,
+      adaptiveInput: null,
+      adaptiveDetection: null,
+      questions: [],
+      answers: [],
+      answerKey: null,
+      plan: null,
+    };
+  }
+
+  const sourceIntent = detectNarrativeSourceIntent(narrativeSource);
+  const extraction = extractNarrativeAssets({ source: narrativeSource, intentDetection: sourceIntent });
+  const adaptiveInput = buildAdaptiveInputFromNarrativeSource({
+    source: narrativeSource,
+    intentDetection: sourceIntent,
+    extraction,
+  });
+  const adaptiveDetection = detectPostCreationAdaptiveIntent(adaptiveInput.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection: adaptiveDetection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => {
+    const option = question.options.find((candidate) => candidate.recommended) || question.options[0]!;
+
+    return {
+      questionId: question.id,
+      key: question.mapKey,
+      optionId: option.id,
+      value: null,
+    };
+  });
+  const answerKey = buildPostCreationAdaptiveAnswerKey({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+  });
+  const plan = buildPostCreationAdaptiveStrategicPlan({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+  });
+
+  return {
+    validation,
+    narrativeSource,
+    sourceIntent,
+    extraction,
+    adaptiveInput,
+    adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}
+
+function assetValues(result: ReturnType<typeof runVideoUploadNarrativePipeline>, type: NarrativeAsset["type"]) {
+  return result.extraction?.assets.filter((asset) => asset.type === type).map((asset) => asset.value) || [];
+}
+
+const validPipelineScenarios = [
+  {
+    name: "validate posting",
+    draft: makeDraft({
+      fileName: "rotina-skincare.mp4",
+      creatorQuestion: "Gravei esse vídeo e quero saber se vale postar",
+    }),
+  },
+  {
+    name: "brand potential",
+    draft: makeDraft({
+      fileName: "rotina-skincare-autocuidado.mp4",
+      creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas de skincare",
+    }),
+  },
+  {
+    name: "improve hook",
+    draft: makeDraft({
+      fileName: "bastidor-trabalho.mp4",
+      creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+    }),
+  },
+  {
+    name: "collab",
+    draft: makeDraft({
+      fileName: "bastidor-processo.mp4",
+      creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+    }),
+  },
+  {
+    name: "long video",
+    draft: makeDraft({
+      fileName: "rotina-skincare-longa.mp4",
+      durationSeconds: 120,
+      creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas de skincare",
+    }),
+    limits: relaxedLongVideoLimits,
+  },
+];
+
+describe("VideoUploadDraft to Narrative Source and Adaptive V2 pipeline QA", () => {
+  it("feeds a valid video draft into validate_pauta", () => {
+    const result = runVideoUploadNarrativePipeline(validPipelineScenarios[0]!.draft);
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.narrativeSource?.sourceType).toBe("video_upload_future");
+    expect(result.sourceIntent?.intent).toBe("validate_before_posting");
+    expect(result.adaptiveDetection?.mode).toBe("validate_pauta");
+    expect(result.plan?.pauta).toBeTruthy();
+    expect(result.plan?.nextActions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("feeds a valid video draft into brand_match", () => {
+    const result = runVideoUploadNarrativePipeline(validPipelineScenarios[1]!.draft);
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.sourceIntent?.intent).toBe("brand_potential");
+    expect(result.adaptiveDetection?.mode).toBe("brand_match");
+    expect(result.plan?.brandMatch?.enabled).toBe(true);
+    expect(result.plan?.collabMatch).toBeNull();
+  });
+
+  it("feeds a valid video draft into improve_content and validate_pauta", () => {
+    const result = runVideoUploadNarrativePipeline(validPipelineScenarios[2]!.draft);
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.sourceIntent?.intent).toBe("improve_content");
+    expect(result.extraction?.assets.some((asset) => asset.type === "weakness" || asset.type === "hook_signal")).toBe(true);
+    expect(result.adaptiveDetection?.mode).toBe("validate_pauta");
+    expect(result.answerKey?.summary).toBeTruthy();
+    expect(result.plan?.pauta).toBeTruthy();
+  });
+
+  it("feeds a valid video draft into collab_match", () => {
+    const result = runVideoUploadNarrativePipeline(validPipelineScenarios[3]!.draft);
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.sourceIntent?.intent).toBe("collab_potential");
+    expect(result.adaptiveDetection?.mode).toBe("collab_match");
+    expect(result.plan?.collabMatch?.enabled).toBe(true);
+  });
+
+  it("does not run NSE or Adaptive V2 for invalid drafts", () => {
+    const result = runVideoUploadNarrativePipeline(
+      makeDraft({
+        fileName: null,
+        mimeType: null,
+        sizeBytes: null,
+        creatorQuestion: "",
+      }),
+    );
+
+    expect(result.validation.ok).toBe(false);
+    expect(result.narrativeSource).toBeNull();
+    expect(result.sourceIntent).toBeNull();
+    expect(result.extraction).toBeNull();
+    expect(result.adaptiveInput).toBeNull();
+    expect(result.adaptiveDetection).toBeNull();
+    expect(result.questions).toEqual([]);
+    expect(result.answers).toEqual([]);
+    expect(result.answerKey).toBeNull();
+    expect(result.plan).toBeNull();
+  });
+
+  it("feeds a long video when custom limits allow it", () => {
+    const scenario = validPipelineScenarios[4]!;
+    const result = runVideoUploadNarrativePipeline(scenario.draft, scenario.limits);
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.narrativeSource?.metadata.format).toBe("long_video");
+    expect(result.sourceIntent).toBeTruthy();
+    expect(result.adaptiveDetection).toBeTruthy();
+    expect(result.plan?.nextActions.length).toBeGreaterThan(0);
+  });
+
+  it("keeps generated outputs free from absolute-promise and score language", () => {
+    for (const scenario of validPipelineScenarios) {
+      const result = runVideoUploadNarrativePipeline(scenario.draft, scenario.limits);
+      const generatedText = JSON.stringify({
+        validationMessages: result.validation.errors.map((error) => error.message),
+        narrativeSource: result.narrativeSource && {
+          ...result.narrativeSource,
+          creatorQuestion: null,
+        },
+        sourceIntent: result.sourceIntent && {
+          ...result.sourceIntent,
+          originalQuestion: "",
+          normalizedQuestion: "",
+        },
+        extraction: result.extraction,
+        adaptiveInput: result.adaptiveInput,
+        adaptiveDetection: result.adaptiveDetection,
+        questions: result.questions,
+        answerKey: result.answerKey,
+        plan: result.plan,
+      }).toLowerCase();
+
+      for (const forbidden of forbiddenGeneratedTerms) {
+        expect(generatedText).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it("keeps the video upload pipeline QA isolated from UI and external dependencies", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoUploadPipeline.test.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).not.toMatch(/React|from ["']react["']/);
+    expect(imports).not.toMatch(/UI|BoardShell|PostCreationFunnelBoardShell/);
+    expect(imports).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(imports).not.toMatch(/Prisma|prisma|banco/);
+    expect(imports).not.toMatch(/storage|upload service/);
+    expect(imports).not.toMatch(/components?\//);
+    expect(assetValues(runVideoUploadNarrativePipeline(validPipelineScenarios[1]!.draft), "brand_territory").length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
@@ -1,0 +1,303 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  createEmptyVideoProcessingArtifacts,
+  type VideoProcessingArtifacts,
+} from "./videoProcessingArtifacts";
+import {
+  buildProcessedNarrativeSourceFromVideoUpload,
+  hasEnoughProcessedContextForNarrativeAnalysis,
+} from "./videoUploadProcessedNarrativeSource";
+import type { VideoUploadDraft } from "./videoUploadTypes";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenGeneratedTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function validDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "processed-video-draft",
+    source: "local_file",
+    fileName: "  rotina-skincare.mp4  ",
+    mimeType: " VIDEO/MP4 ",
+    sizeBytes: 28 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "  Quero entender se esse vídeo vira pauta.  ",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function artifacts(overrides: Partial<VideoProcessingArtifacts> = {}): VideoProcessingArtifacts {
+  return {
+    ...createEmptyVideoProcessingArtifacts(),
+    ...overrides,
+    transcript: {
+      ...createEmptyVideoProcessingArtifacts().transcript,
+      ...overrides.transcript,
+    },
+  };
+}
+
+describe("videoUploadProcessedNarrativeSource", () => {
+  it("returns null when the video draft is invalid", () => {
+    expect(
+      buildProcessedNarrativeSourceFromVideoUpload({
+        draft: validDraft({ fileName: null, mimeType: null, sizeBytes: null }),
+        artifacts: createEmptyVideoProcessingArtifacts(),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the base NarrativeSource when artifacts are empty", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: createEmptyVideoProcessingArtifacts(),
+    });
+
+    expect(source).toEqual({
+      id: "processed-video-draft",
+      sourceType: "video_upload_future",
+      rawText: null,
+      creatorQuestion: "Quero entender se esse vídeo vira pauta.",
+      transcript: null,
+      visualDescription: null,
+      metadata: {
+        title: "rotina-skincare.mp4",
+        durationSeconds: 45,
+        platform: "unknown",
+        format: "short_video",
+        campaignContext: null,
+      },
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+  });
+
+  it("fills transcript using artifact fullText", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: artifacts({
+        transcript: {
+          fullText: "  Mostro minha rotina de skincare pela manhã.  ",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [],
+        },
+      }),
+    });
+
+    expect(source?.transcript).toBe("Mostro minha rotina de skincare pela manhã.");
+  });
+
+  it("fills transcript using segments when fullText is missing", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: artifacts({
+        transcript: {
+          fullText: null,
+          language: "pt-BR",
+          provider: "manual",
+          segments: [
+            { startSeconds: 3, endSeconds: 5, text: "com os produtos na bancada.", confidence: 0.8 },
+            { startSeconds: 0, endSeconds: 2, text: "Começo mostrando a rotina", confidence: 0.85 },
+          ],
+        },
+      }),
+    });
+
+    expect(source?.transcript).toBe("Começo mostrando a rotina com os produtos na bancada.");
+  });
+
+  it("fills visualDescription using visualSummary", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: artifacts({
+        visualSummary: "  Pessoa organiza produtos de skincare em uma bancada clara.  ",
+      }),
+    });
+
+    expect(source?.visualDescription).toBe("Pessoa organiza produtos de skincare em uma bancada clara.");
+  });
+
+  it("fills visualDescription using frames and OCR when visualSummary is missing", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: artifacts({
+        frames: [
+          {
+            id: "frame-middle",
+            timestampSeconds: 8,
+            label: "middle",
+            description: "Pessoa aplica o produto no rosto.",
+            imageStorageKey: null,
+          },
+          {
+            id: "frame-opening",
+            timestampSeconds: 1,
+            label: "opening",
+            description: "Produtos aparecem sobre a bancada.",
+            imageStorageKey: null,
+          },
+        ],
+        ocr: [{ timestampSeconds: 2, text: "Rotina da manhã", confidence: 0.77 }],
+      }),
+    });
+
+    expect(source?.visualDescription).toBe(
+      "Frames: Produtos aparecem sobre a bancada. Pessoa aplica o produto no rosto. Texto na tela: Rotina da manhã",
+    );
+  });
+
+  it("preserves normalized creatorQuestion, id, createdAt, and metadata", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      id: "narrative-source-custom",
+      createdAt: "2026-05-15T10:00:00.000Z",
+      artifacts: artifacts({
+        transcript: {
+          fullText: "Transcrição de apoio.",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [],
+        },
+      }),
+    });
+
+    expect(source?.id).toBe("narrative-source-custom");
+    expect(source?.createdAt).toBe("2026-05-15T10:00:00.000Z");
+    expect(source?.creatorQuestion).toBe("Quero entender se esse vídeo vira pauta.");
+    expect(source?.metadata).toEqual({
+      title: "rotina-skincare.mp4",
+      durationSeconds: 45,
+      platform: "unknown",
+      format: "short_video",
+      campaignContext: null,
+    });
+    expect(source?.rawText).toBeNull();
+  });
+
+  it("returns false for narrative analysis readiness when the draft is invalid", () => {
+    expect(
+      hasEnoughProcessedContextForNarrativeAnalysis({
+        draft: validDraft({ creatorQuestion: "" }),
+        artifacts: artifacts({
+          transcript: {
+            fullText: "Texto útil do vídeo.",
+            language: "pt-BR",
+            provider: "manual",
+            segments: [],
+          },
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for valid draft with empty artifacts", () => {
+    expect(
+      hasEnoughProcessedContextForNarrativeAnalysis({
+        draft: validDraft(),
+        artifacts: createEmptyVideoProcessingArtifacts(),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for valid draft with transcript context", () => {
+    expect(
+      hasEnoughProcessedContextForNarrativeAnalysis({
+        draft: validDraft(),
+        artifacts: artifacts({
+          transcript: {
+            fullText: "Trecho falado no vídeo.",
+            language: "pt-BR",
+            provider: "manual",
+            segments: [],
+          },
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for valid draft with visual frame context", () => {
+    expect(
+      hasEnoughProcessedContextForNarrativeAnalysis({
+        draft: validDraft(),
+        artifacts: artifacts({
+          frames: [
+            {
+              id: "frame-1",
+              timestampSeconds: 1,
+              label: "opening",
+              description: "Pessoa apresenta produtos na bancada.",
+              imageStorageKey: null,
+            },
+          ],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps generated source strings free from absolute-promise and score language", () => {
+    const source = buildProcessedNarrativeSourceFromVideoUpload({
+      draft: validDraft(),
+      artifacts: artifacts({
+        transcript: {
+          fullText: "Trecho sobre rotina de skincare.",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [],
+        },
+        visualSummary: "Pessoa organiza produtos de cuidado pessoal.",
+      }),
+    });
+    const text = JSON.stringify(source).toLowerCase();
+
+    for (const forbidden of forbiddenGeneratedTerms) {
+      expect(text).not.toContain(forbidden);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import pipeline, UI, services, storage, upload, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoUploadProcessedNarrativeSource.ts"), "utf8");
+    const importBlock = source.slice(0, source.indexOf("type BuildProcessedNarrativeSourceFromVideoUploadParams"));
+
+    expect(importBlock).toContain("narrativeSourceTypes");
+    expect(importBlock).toContain("videoProcessingArtifacts");
+    expect(importBlock).toContain("videoUploadNarrativeSourceBridge");
+    expect(importBlock).toContain("videoUploadTypes");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("upload service");
+    expect(source).not.toContain("ffmpeg");
+    expect(source).not.toContain("detectPostCreationAdaptiveIntent");
+    expect(source).not.toContain("buildPostCreationAdaptiveQuiz");
+    expect(source).not.toContain("buildPostCreationAdaptiveAnswerKey");
+    expect(source).not.toContain("buildPostCreationAdaptiveStrategicPlan");
+    expect(source).not.toContain("detectNarrativeSourceIntent");
+    expect(source).not.toContain("extractNarrativeAssets");
+    expect(source).not.toContain("buildAdaptiveInputFromNarrativeSource");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.ts
@@ -1,0 +1,60 @@
+import type { NarrativeSource } from "../narrativeSource/narrativeSourceTypes";
+import {
+  buildTranscriptTextFromArtifacts,
+  buildVisualDescriptionFromArtifacts,
+  hasUsableVideoProcessingArtifacts,
+  type VideoProcessingArtifacts,
+} from "./videoProcessingArtifacts";
+import { buildNarrativeSourceFromVideoUploadDraft } from "./videoUploadNarrativeSourceBridge";
+import type { VideoUploadDraft, VideoUploadLimits } from "./videoUploadTypes";
+
+type BuildProcessedNarrativeSourceFromVideoUploadParams = {
+  draft: VideoUploadDraft;
+  artifacts: VideoProcessingArtifacts;
+  id?: string;
+  createdAt?: string | null;
+  limits?: VideoUploadLimits;
+};
+
+type HasEnoughProcessedContextForNarrativeAnalysisParams = {
+  draft: VideoUploadDraft;
+  artifacts: VideoProcessingArtifacts;
+  limits?: VideoUploadLimits;
+};
+
+export function buildProcessedNarrativeSourceFromVideoUpload({
+  draft,
+  artifacts,
+  id,
+  createdAt,
+  limits,
+}: BuildProcessedNarrativeSourceFromVideoUploadParams): NarrativeSource | null {
+  const baseSource = buildNarrativeSourceFromVideoUploadDraft({
+    draft,
+    id,
+    createdAt,
+    limits,
+  });
+
+  if (!baseSource) return null;
+
+  return {
+    ...baseSource,
+    rawText: null,
+    transcript: buildTranscriptTextFromArtifacts(artifacts),
+    visualDescription: buildVisualDescriptionFromArtifacts(artifacts),
+  };
+}
+
+export function hasEnoughProcessedContextForNarrativeAnalysis({
+  draft,
+  artifacts,
+  limits,
+}: HasEnoughProcessedContextForNarrativeAnalysisParams): boolean {
+  const baseSource = buildNarrativeSourceFromVideoUploadDraft({
+    draft,
+    limits,
+  });
+
+  return Boolean(baseSource && hasUsableVideoProcessingArtifacts(artifacts));
+}

--- a/src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
@@ -1,0 +1,351 @@
+import fs from "fs";
+import path from "path";
+
+import { buildPostCreationAdaptiveAnswerKey } from "../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../postCreationAdaptiveTypes";
+import { extractNarrativeAssets } from "../narrativeSource/narrativeAssetExtractor";
+import { buildAdaptiveInputFromNarrativeSource } from "../narrativeSource/narrativeSourceAdaptiveAdapter";
+import { detectNarrativeSourceIntent } from "../narrativeSource/narrativeSourceIntentRouter";
+import type { NarrativeAsset } from "../narrativeSource/narrativeSourceTypes";
+import {
+  createEmptyVideoProcessingArtifacts,
+  type VideoProcessingArtifacts,
+} from "./videoProcessingArtifacts";
+import {
+  buildProcessedNarrativeSourceFromVideoUpload,
+  hasEnoughProcessedContextForNarrativeAnalysis,
+} from "./videoUploadProcessedNarrativeSource";
+import {
+  DEFAULT_VIDEO_UPLOAD_LIMITS,
+  type VideoUploadDraft,
+  type VideoUploadLimits,
+} from "./videoUploadTypes";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenGeneratedTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function makeDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "processed-video-pipeline-draft",
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 36 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero saber se vale postar",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function artifacts(overrides: Partial<VideoProcessingArtifacts> = {}): VideoProcessingArtifacts {
+  return {
+    ...createEmptyVideoProcessingArtifacts(),
+    ...overrides,
+    transcript: {
+      ...createEmptyVideoProcessingArtifacts().transcript,
+      ...overrides.transcript,
+    },
+  };
+}
+
+function runProcessedVideoNarrativePipeline({
+  draft,
+  artifacts,
+  limits = DEFAULT_VIDEO_UPLOAD_LIMITS,
+}: {
+  draft: VideoUploadDraft;
+  artifacts: VideoProcessingArtifacts;
+  limits?: VideoUploadLimits;
+}) {
+  const narrativeSource = buildProcessedNarrativeSourceFromVideoUpload({
+    draft,
+    artifacts,
+    limits,
+  });
+
+  if (!narrativeSource) {
+    return {
+      narrativeSource,
+      sourceIntent: null,
+      extraction: null,
+      adaptiveInput: null,
+      adaptiveDetection: null,
+      questions: [],
+      answers: [],
+      answerKey: null,
+      plan: null,
+    };
+  }
+
+  const sourceIntent = detectNarrativeSourceIntent(narrativeSource);
+  const extraction = extractNarrativeAssets({ source: narrativeSource, intentDetection: sourceIntent });
+  const adaptiveInput = buildAdaptiveInputFromNarrativeSource({
+    source: narrativeSource,
+    intentDetection: sourceIntent,
+    extraction,
+  });
+  const adaptiveDetection = detectPostCreationAdaptiveIntent(adaptiveInput.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection: adaptiveDetection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => {
+    const option = question.options.find((candidate) => candidate.recommended) || question.options[0]!;
+
+    return {
+      questionId: question.id,
+      key: question.mapKey,
+      optionId: option.id,
+      value: null,
+    };
+  });
+  const answerKey = buildPostCreationAdaptiveAnswerKey({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+  });
+  const plan = buildPostCreationAdaptiveStrategicPlan({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+  });
+
+  return {
+    narrativeSource,
+    sourceIntent,
+    extraction,
+    adaptiveInput,
+    adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}
+
+function assetValues(result: ReturnType<typeof runProcessedVideoNarrativePipeline>, type: NarrativeAsset["type"]) {
+  return result.extraction?.assets.filter((asset) => asset.type === type).map((asset) => asset.value) || [];
+}
+
+const skincareTranscriptScenario = {
+  draft: makeDraft({
+    fileName: "video.mp4",
+    creatorQuestion: "Quero saber se vale postar",
+  }),
+  artifacts: artifacts({
+    transcript: {
+      fullText: "Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.",
+      language: "pt-BR",
+      provider: "manual",
+      segments: [],
+    },
+  }),
+};
+
+const backstageVisualScenario = {
+  draft: makeDraft({
+    fileName: "bastidor.mp4",
+    creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+  }),
+  artifacts: artifacts({
+    visualSummary: "Pessoa em reunião mostrando bastidores de trabalho e processo de criação.",
+  }),
+};
+
+const brandVisualScenario = {
+  draft: makeDraft({
+    fileName: "skincare-visual.mp4",
+    creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+  }),
+  artifacts: artifacts({
+    frames: [
+      {
+        id: "frame-opening",
+        timestampSeconds: 1,
+        label: "opening",
+        description: "Produtos de skincare aparecem sobre a bancada",
+        imageStorageKey: null,
+      },
+      {
+        id: "frame-middle",
+        timestampSeconds: 8,
+        label: "middle",
+        description: "Pessoa aplica produto no rosto",
+        imageStorageKey: null,
+      },
+    ],
+    ocr: [
+      { timestampSeconds: 2, text: "Rotina da manhã", confidence: 0.8 },
+      { timestampSeconds: 6, text: "Autocuidado real", confidence: 0.78 },
+    ],
+  }),
+};
+
+const emptyArtifactCollabScenario = {
+  draft: makeDraft({
+    fileName: "collab.mp4",
+    creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+  }),
+  artifacts: createEmptyVideoProcessingArtifacts(),
+};
+
+const safeLanguageScenarios = [
+  skincareTranscriptScenario,
+  backstageVisualScenario,
+  brandVisualScenario,
+  emptyArtifactCollabScenario,
+];
+
+describe("Processed video upload to Narrative Source and Adaptive V2 pipeline QA", () => {
+  it("uses transcript context to improve routine and skincare extraction", () => {
+    const result = runProcessedVideoNarrativePipeline(skincareTranscriptScenario);
+
+    expect(result.narrativeSource?.transcript).toBe("Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.");
+    expect(result.sourceIntent?.intent).toBe("validate_before_posting");
+    expect(assetValues(result, "central_theme")).toContain("rotina de autocuidado");
+    expect(assetValues(result, "brand_territory")).toContain("autocuidado");
+    expect(result.adaptiveDetection?.mode).toBe("validate_pauta");
+    expect(result.plan?.pauta).toBeTruthy();
+  });
+
+  it("uses visual summary context to improve backstage narrative extraction", () => {
+    const result = runProcessedVideoNarrativePipeline(backstageVisualScenario);
+
+    expect(result.narrativeSource?.visualDescription).toBe(
+      "Pessoa em reunião mostrando bastidores de trabalho e processo de criação.",
+    );
+    expect(result.sourceIntent?.intent).toBe("discover_narrative");
+    expect(
+      result.extraction?.assets.some(
+        (asset) =>
+          (asset.type === "content_proposal" && asset.value === "behind_the_scenes") ||
+          (asset.type === "narrative_pattern" && asset.value === "bastidor real"),
+      ),
+    ).toBe(true);
+    expect(result.adaptiveDetection?.mode).toBe("discover_pauta");
+    expect(result.plan?.narrative).toBeTruthy();
+  });
+
+  it("uses frames and OCR context to feed brand and skincare analysis", () => {
+    const result = runProcessedVideoNarrativePipeline(brandVisualScenario);
+
+    expect(result.narrativeSource?.visualDescription).toContain("Frames:");
+    expect(result.narrativeSource?.visualDescription).toContain("Texto na tela:");
+    expect(
+      result.extraction?.assets.some(
+        (asset) =>
+          (asset.type === "brand_territory" && asset.value === "autocuidado") ||
+          (asset.type === "category" && ["beauty_personal_care", "lifestyle"].includes(asset.value)),
+      ),
+    ).toBe(true);
+    expect(result.adaptiveDetection?.mode).toBe("brand_match");
+    expect(result.plan?.brandMatch?.enabled).toBe(true);
+  });
+
+  it("still runs from creator question when artifacts are empty", () => {
+    const result = runProcessedVideoNarrativePipeline(emptyArtifactCollabScenario);
+
+    expect(result.narrativeSource).toBeTruthy();
+    expect(result.narrativeSource?.transcript).toBeNull();
+    expect(result.narrativeSource?.visualDescription).toBeNull();
+    expect(result.sourceIntent?.intent).toBe("collab_potential");
+    expect(result.adaptiveDetection?.mode).toBe("collab_match");
+    expect(result.plan?.collabMatch?.enabled).toBe(true);
+  });
+
+  it("does not run NSE or Adaptive V2 for invalid drafts", () => {
+    const result = runProcessedVideoNarrativePipeline({
+      draft: makeDraft({
+        fileName: null,
+        mimeType: null,
+        sizeBytes: null,
+        creatorQuestion: "",
+      }),
+      artifacts: skincareTranscriptScenario.artifacts,
+    });
+
+    expect(result.narrativeSource).toBeNull();
+    expect(result.sourceIntent).toBeNull();
+    expect(result.extraction).toBeNull();
+    expect(result.adaptiveDetection).toBeNull();
+    expect(result.questions).toEqual([]);
+    expect(result.plan).toBeNull();
+  });
+
+  it("demonstrates enough processed context checks across scenarios", () => {
+    expect(hasEnoughProcessedContextForNarrativeAnalysis(skincareTranscriptScenario)).toBe(true);
+    expect(hasEnoughProcessedContextForNarrativeAnalysis(backstageVisualScenario)).toBe(true);
+    expect(hasEnoughProcessedContextForNarrativeAnalysis(brandVisualScenario)).toBe(true);
+    expect(hasEnoughProcessedContextForNarrativeAnalysis(emptyArtifactCollabScenario)).toBe(false);
+    expect(
+      hasEnoughProcessedContextForNarrativeAnalysis({
+        draft: makeDraft({
+          fileName: null,
+          mimeType: null,
+          sizeBytes: null,
+          creatorQuestion: "",
+        }),
+        artifacts: skincareTranscriptScenario.artifacts,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps generated outputs free from absolute-promise and score language", () => {
+    for (const scenario of safeLanguageScenarios) {
+      const result = runProcessedVideoNarrativePipeline(scenario);
+      const generatedText = JSON.stringify({
+        narrativeSource: result.narrativeSource && {
+          ...result.narrativeSource,
+          creatorQuestion: null,
+        },
+        sourceIntent: result.sourceIntent && {
+          ...result.sourceIntent,
+          originalQuestion: "",
+          normalizedQuestion: "",
+        },
+        extraction: result.extraction,
+        adaptiveInput: result.adaptiveInput,
+        adaptiveDetection: result.adaptiveDetection,
+        questions: result.questions,
+        answerKey: result.answerKey,
+        plan: result.plan,
+      }).toLowerCase();
+
+      for (const forbidden of forbiddenGeneratedTerms) {
+        expect(generatedText).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it("keeps the processed video pipeline QA isolated from UI and external services", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoUploadProcessedPipeline.test.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).not.toMatch(/React|from ["']react["']/);
+    expect(imports).not.toMatch(/UI|BoardShell|PostCreationFunnelBoardShell/);
+    expect(imports).not.toMatch(/OpenAI|openai/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(imports).not.toMatch(/Prisma|prisma|banco/);
+    expect(imports).not.toMatch(/storage|upload service/);
+    expect(imports).not.toMatch(/components?\//);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
@@ -1,0 +1,208 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  DEFAULT_VIDEO_UPLOAD_LIMITS,
+  SUPPORTED_VIDEO_MIME_TYPES,
+  VideoUploadDraft,
+  buildNarrativeSourceBridgeFromVideoUpload,
+  createEmptyVideoUploadDraft,
+  isSupportedVideoMimeType,
+  validateVideoUploadDraft,
+} from "./videoUploadTypes";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function validDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "video-draft-1",
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 24 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero entender se esse vídeo vira uma boa pauta.",
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function validationCodes(draft: VideoUploadDraft) {
+  return validateVideoUploadDraft(draft).errors.map((error) => error.code);
+}
+
+describe("videoUploadTypes", () => {
+  it("accepts supported video mime types", () => {
+    expect(SUPPORTED_VIDEO_MIME_TYPES).toEqual(["video/mp4", "video/quicktime", "video/webm"]);
+
+    expect(isSupportedVideoMimeType("video/mp4")).toBe(true);
+    expect(isSupportedVideoMimeType("video/quicktime")).toBe(true);
+    expect(isSupportedVideoMimeType("video/webm")).toBe(true);
+  });
+
+  it("rejects unsupported video mime types", () => {
+    expect(isSupportedVideoMimeType("image/png")).toBe(false);
+    expect(isSupportedVideoMimeType("application/pdf")).toBe(false);
+    expect(isSupportedVideoMimeType("video/avi")).toBe(false);
+  });
+
+  it("creates an empty upload draft with safe defaults", () => {
+    expect(createEmptyVideoUploadDraft({ id: "draft-empty" })).toEqual({
+      id: "draft-empty",
+      source: "local_file",
+      fileName: null,
+      mimeType: null,
+      sizeBytes: null,
+      durationSeconds: null,
+      creatorQuestion: null,
+      createdAt: null,
+    });
+  });
+
+  it("validates a complete draft", () => {
+    const result = validateVideoUploadDraft(validDraft());
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.normalizedDraft.fileName).toBe("video.mp4");
+  });
+
+  it("rejects missing file data", () => {
+    expect(
+      validationCodes(
+        validDraft({
+          fileName: null,
+          mimeType: null,
+          sizeBytes: null,
+        }),
+      ),
+    ).toContain("file_required");
+  });
+
+  it("rejects unsupported mime types", () => {
+    expect(validationCodes(validDraft({ mimeType: "video/avi" }))).toContain("unsupported_type");
+  });
+
+  it("rejects files above the size limit", () => {
+    expect(validationCodes(validDraft({ sizeBytes: DEFAULT_VIDEO_UPLOAD_LIMITS.maxFileSizeMb * oneMb + 1 }))).toContain(
+      "file_too_large",
+    );
+  });
+
+  it("rejects missing duration", () => {
+    expect(validationCodes(validDraft({ durationSeconds: null }))).toContain("duration_required");
+  });
+
+  it("rejects duration above the limit", () => {
+    expect(validationCodes(validDraft({ durationSeconds: DEFAULT_VIDEO_UPLOAD_LIMITS.maxDurationSeconds + 1 }))).toContain(
+      "duration_too_long",
+    );
+  });
+
+  it("rejects empty creator question when required", () => {
+    expect(validationCodes(validDraft({ creatorQuestion: "   " }))).toContain("empty_creator_question");
+  });
+
+  it("rejects unsafe filenames", () => {
+    expect(validationCodes(validDraft({ fileName: "../video.mp4" }))).toContain("unsafe_filename");
+    expect(validationCodes(validDraft({ fileName: "..\\video.mp4" }))).toContain("unsafe_filename");
+    expect(validationCodes(validDraft({ fileName: "video<draft>.mp4" }))).toContain("unsafe_filename");
+    expect(validationCodes(validDraft({ fileName: "video|draft.mp4" }))).toContain("unsafe_filename");
+  });
+
+  it("normalizes file name, mime type, and creator question", () => {
+    const result = validateVideoUploadDraft(
+      validDraft({
+        fileName: "  video.mp4  ",
+        mimeType: "  VIDEO/MP4  ",
+        creatorQuestion: "  Quero validar esta pauta em vídeo.  ",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.normalizedDraft.fileName).toBe("video.mp4");
+    expect(result.normalizedDraft.mimeType).toBe("video/mp4");
+    expect(result.normalizedDraft.creatorQuestion).toBe("Quero validar esta pauta em vídeo.");
+  });
+
+  it("returns null bridge for invalid drafts", () => {
+    expect(buildNarrativeSourceBridgeFromVideoUpload(validDraft({ creatorQuestion: "" }))).toBeNull();
+  });
+
+  it("builds a narrative source bridge for valid drafts", () => {
+    const bridge = buildNarrativeSourceBridgeFromVideoUpload(
+      validDraft({
+        fileName: "  rotina.mp4  ",
+        creatorQuestion: "  Quero descobrir a narrativa deste vídeo.  ",
+        durationSeconds: 45,
+      }),
+    );
+
+    expect(bridge).toEqual({
+      sourceType: "video_upload_future",
+      creatorQuestion: "Quero descobrir a narrativa deste vídeo.",
+      transcript: null,
+      visualDescription: null,
+      metadata: {
+        title: "rotina.mp4",
+        durationSeconds: 45,
+        platform: "unknown",
+        format: "short_video",
+        campaignContext: null,
+      },
+    });
+  });
+
+  it("keeps user-facing validation language conservative", () => {
+    const invalidResult = validateVideoUploadDraft(
+      validDraft({
+        fileName: "../video.mp4",
+        mimeType: "application/pdf",
+        sizeBytes: DEFAULT_VIDEO_UPLOAD_LIMITS.maxFileSizeMb * oneMb + 1,
+        durationSeconds: null,
+        creatorQuestion: "",
+      }),
+    );
+    const bridge = buildNarrativeSourceBridgeFromVideoUpload(validDraft());
+    const text = JSON.stringify({
+      messages: invalidResult.errors.map((error) => error.message),
+      bridge,
+    }).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(invalidResult.errors.map((error) => error.message).join(" ").toLowerCase()).not.toContain("erro");
+  });
+
+  it("does not import UI, services, storage, or product integrations", () => {
+    const sourcePath = path.join(__dirname, "videoUploadTypes.ts");
+    const source = fs.readFileSync(sourcePath, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).toBe("");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("upload service");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadTypes.ts
@@ -1,0 +1,206 @@
+export type VideoUploadStatus =
+  | "draft"
+  | "selected"
+  | "validated"
+  | "rejected"
+  | "upload_pending"
+  | "uploaded"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "expired";
+
+export type VideoUploadSource = "local_file" | "future_url" | "future_instagram_media";
+
+export const SUPPORTED_VIDEO_MIME_TYPES = ["video/mp4", "video/quicktime", "video/webm"] as const;
+
+export type VideoMimeType = (typeof SUPPORTED_VIDEO_MIME_TYPES)[number];
+
+export type VideoUploadValidationErrorCode =
+  | "file_required"
+  | "unsupported_type"
+  | "file_too_large"
+  | "duration_too_long"
+  | "duration_required"
+  | "empty_creator_question"
+  | "unsafe_filename";
+
+export type VideoUploadLimits = {
+  maxDurationSeconds: number;
+  maxFileSizeMb: number;
+  acceptedMimeTypes: VideoMimeType[];
+  requireCreatorQuestion: boolean;
+};
+
+export type VideoUploadDraft = {
+  id: string;
+  source: VideoUploadSource;
+  fileName: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  durationSeconds: number | null;
+  creatorQuestion: string | null;
+  createdAt?: string | null;
+};
+
+export type VideoUploadValidationError = {
+  code: VideoUploadValidationErrorCode;
+  message: string;
+};
+
+export type VideoUploadValidationResult = {
+  ok: boolean;
+  errors: VideoUploadValidationError[];
+  normalizedDraft: VideoUploadDraft;
+};
+
+export type VideoUploadNarrativeSourceBridge = {
+  sourceType: "video_upload_future";
+  creatorQuestion: string;
+  transcript: null;
+  visualDescription: null;
+  metadata: {
+    title: string | null;
+    durationSeconds: number | null;
+    platform: "unknown";
+    format: "short_video" | "long_video" | "unknown";
+    campaignContext: null;
+  };
+};
+
+export const DEFAULT_VIDEO_UPLOAD_LIMITS: VideoUploadLimits = {
+  maxDurationSeconds: 60,
+  maxFileSizeMb: 100,
+  acceptedMimeTypes: [...SUPPORTED_VIDEO_MIME_TYPES],
+  requireCreatorQuestion: true,
+};
+
+const BYTES_PER_MB = 1024 * 1024;
+
+function normalizeOptionalText(value: string | null): string | null {
+  const normalized = value?.trim() || "";
+  return normalized || null;
+}
+
+function normalizeMimeType(value: string | null): string | null {
+  const normalized = value?.trim().toLowerCase() || "";
+  return normalized || null;
+}
+
+function hasUnsafeFileName(value: string | null): boolean {
+  if (!value) return false;
+  return /\.\.\/|\.\.\\|[<>|]/.test(value);
+}
+
+function validationError(code: VideoUploadValidationErrorCode): VideoUploadValidationError {
+  const messages: Record<VideoUploadValidationErrorCode, string> = {
+    file_required: "Envie um arquivo de vídeo.",
+    unsupported_type: "Formato de vídeo ainda não suportado.",
+    file_too_large: "O vídeo ultrapassa o limite de tamanho desta etapa.",
+    duration_required: "Informe a duração do vídeo para validar o envio.",
+    duration_too_long: "O vídeo ultrapassa o limite de duração desta etapa.",
+    empty_creator_question: "Explique em uma frase o que você quer descobrir com esse vídeo.",
+    unsafe_filename: "O nome do arquivo contém caracteres não permitidos.",
+  };
+
+  return {
+    code,
+    message: messages[code],
+  };
+}
+
+export function isSupportedVideoMimeType(value: string): value is VideoMimeType {
+  return SUPPORTED_VIDEO_MIME_TYPES.includes(value.trim().toLowerCase() as VideoMimeType);
+}
+
+export function createEmptyVideoUploadDraft(params: {
+  id: string;
+  source?: VideoUploadSource;
+  createdAt?: string | null;
+}): VideoUploadDraft {
+  return {
+    id: params.id,
+    source: params.source || "local_file",
+    fileName: null,
+    mimeType: null,
+    sizeBytes: null,
+    durationSeconds: null,
+    creatorQuestion: null,
+    createdAt: params.createdAt ?? null,
+  };
+}
+
+export function validateVideoUploadDraft(
+  draft: VideoUploadDraft,
+  limits: VideoUploadLimits = DEFAULT_VIDEO_UPLOAD_LIMITS
+): VideoUploadValidationResult {
+  const normalizedDraft: VideoUploadDraft = {
+    ...draft,
+    fileName: normalizeOptionalText(draft.fileName),
+    mimeType: normalizeMimeType(draft.mimeType),
+    creatorQuestion: normalizeOptionalText(draft.creatorQuestion),
+  };
+  const errors: VideoUploadValidationError[] = [];
+
+  if (!normalizedDraft.fileName || !normalizedDraft.mimeType || normalizedDraft.sizeBytes === null) {
+    errors.push(validationError("file_required"));
+  }
+
+  if (normalizedDraft.mimeType && !limits.acceptedMimeTypes.includes(normalizedDraft.mimeType as VideoMimeType)) {
+    errors.push(validationError("unsupported_type"));
+  }
+
+  if (typeof normalizedDraft.sizeBytes === "number" && normalizedDraft.sizeBytes > limits.maxFileSizeMb * BYTES_PER_MB) {
+    errors.push(validationError("file_too_large"));
+  }
+
+  if (normalizedDraft.durationSeconds === null) {
+    errors.push(validationError("duration_required"));
+  } else if (normalizedDraft.durationSeconds > limits.maxDurationSeconds) {
+    errors.push(validationError("duration_too_long"));
+  }
+
+  if (limits.requireCreatorQuestion && !normalizedDraft.creatorQuestion) {
+    errors.push(validationError("empty_creator_question"));
+  }
+
+  if (hasUnsafeFileName(normalizedDraft.fileName)) {
+    errors.push(validationError("unsafe_filename"));
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    normalizedDraft,
+  };
+}
+
+export function buildNarrativeSourceBridgeFromVideoUpload(
+  draft: VideoUploadDraft,
+  limits: VideoUploadLimits = DEFAULT_VIDEO_UPLOAD_LIMITS
+): VideoUploadNarrativeSourceBridge | null {
+  const validation = validateVideoUploadDraft(draft, limits);
+  if (!validation.ok) return null;
+
+  const { normalizedDraft } = validation;
+  const durationSeconds = normalizedDraft.durationSeconds;
+
+  return {
+    sourceType: "video_upload_future",
+    creatorQuestion: normalizedDraft.creatorQuestion || "",
+    transcript: null,
+    visualDescription: null,
+    metadata: {
+      title: normalizedDraft.fileName,
+      durationSeconds,
+      platform: "unknown",
+      format:
+        durationSeconds === null
+          ? "unknown"
+          : durationSeconds <= 90
+            ? "short_video"
+            : "long_video",
+      campaignContext: null,
+    },
+  };
+}


### PR DESCRIPTION
## Contexto

Este PR é stacked sobre o PR #786 (`feat/adaptive-post-creation-board-v2`) e inicia o épico VU — Video Upload Foundation.

A proposta é preparar uma base segura para que, futuramente, um vídeo enviado pelo usuário possa virar uma fonte narrativa (`video_upload_future`) dentro da lógica do Narrative Source Engine.

Este PR permanece em draft e não deve ser mergeado ainda.

## Ideia central

O vídeo não deve ser tratado como produto separado. Ele é uma fonte narrativa futura que pode enriquecer a leitura da D2C com:

- pergunta/intenção do criador;
- metadados básicos do vídeo;
- transcrição futura;
- descrição visual futura;
- frames-chave futuros;
- OCR futuro;
- sinais técnicos futuros.

Tudo isso deve alimentar a NSE e, depois, o Adaptive V2.

## VU1 — Contratos puros e validação de upload futuro

Cria contratos e validações determinísticas para representar uma submissão futura de vídeo.

Inclui:

- status futuros de upload/processamento;
- origem do vídeo;
- MIME types aceitos;
- limites padrão;
- `VideoUploadDraft`;
- `validateVideoUploadDraft`;
- `createEmptyVideoUploadDraft`;
- `isSupportedVideoMimeType`;
- bridge conceitual para `video_upload_future`.

Não importa tipos da NSE nesta fase.

## VU2 — Bridge tipada com NarrativeSource

Cria uma integração mínima e tipada entre `VideoUploadDraft` válido e `NarrativeSource`.

Inclui:

- `buildNarrativeSourceFromVideoUploadDraft`;
- `isVideoUploadReadyForNarrativeSource`;
- uso de `validateVideoUploadDraft` como fonte da verdade;
- conversão para `sourceType: "video_upload_future"`.

Não infere transcrição, descrição visual ou qualquer análise.

## VU3 — QA do pipeline VideoUpload → NSE → Adaptive V2

Adiciona teste ponta a ponta, apenas em ambiente de QA, cobrindo:

```text
VideoUploadDraft
↓
validateVideoUploadDraft
↓
buildNarrativeSourceFromVideoUploadDraft
↓
detectNarrativeSourceIntent
↓
extractNarrativeAssets
↓
buildAdaptiveInputFromNarrativeSource
↓
Adaptive V2 Router
↓
QuizBuilder
↓
AnswerKey
↓
PlanBuilder
```

Valida cenários como:

- vídeo para validar postagem;
- vídeo para potencial de marca;
- vídeo para melhorar gancho;
- vídeo para collab;
- draft inválido abortando o pipeline;
- vídeo longo com limits customizados.

## VU4 — Contratos de artefatos de processamento

Cria contratos puros para artefatos futuros de processamento de vídeo.

Inclui:

- `VideoProcessingArtifacts`;
- transcrição completa e por segmentos;
- frames-chave;
- OCR/texto na tela;
- sinais técnicos;
- resumo visual;
- notas de processamento;
- helpers para montar transcript e visualDescription simulados.

Não usa ffmpeg, OpenAI, OCR real, transcrição real ou storage.

## VU5 — Adapter de artefatos para NarrativeSource

Cria `buildProcessedNarrativeSourceFromVideoUpload`, que combina:

```text
VideoUploadDraft validado
+
VideoProcessingArtifacts simulados
↓
NarrativeSource enriquecida
```

Inclui:

- preenchimento de `transcript` via artefatos;
- preenchimento de `visualDescription` via artefatos;
- preservação de `creatorQuestion`, metadata, id e createdAt;
- `hasEnoughProcessedContextForNarrativeAnalysis`.

Não roda NSE ou Adaptive V2 internamente.

## VU6 — QA do pipeline com artefatos simulados

Adiciona teste ponta a ponta com `VideoProcessingArtifacts` simulados:

```text
VideoUploadDraft
+
VideoProcessingArtifacts
↓
buildProcessedNarrativeSourceFromVideoUpload
↓
NSE
↓
Adaptive V2
↓
Strategic Plan
```

Valida que:

- transcript de rotina/skincare melhora a extração narrativa;
- visual summary de bastidor melhora narrativa de processo;
- frames + OCR alimentam potencial de marca;
- artifacts vazios ainda rodam pela pergunta do criador;
- draft inválido aborta NSE/Adaptive;
- outputs mantêm linguagem segura.

## VU7 — Documentação de rollout

Reorganiza `videoUpload/README.md` como documentação de rollout do Video Upload Foundation.

Documenta:

- visão geral;
- mapa VU1-VU6;
- arquitetura atual;
- o que existe;
- o que ainda não existe;
- conexão com NSE e promessa da D2C;
- critérios antes de upload real;
- QA recomendada;
- próximas fases sugeridas.

## Fora de escopo

Este PR não inclui:

- upload real;
- endpoint;
- storage;
- transcrição automática;
- extração real de frames;
- OCR real;
- análise multimodal;
- OpenAI;
- ffmpeg;
- banco ou persistência;
- UI;
- BoardShell;
- hooks reais;
- navegação/menu;
- liberação para usuário;
- conexão com fluxo real do produto.

## QA recomendada

```bash
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts
npm run typecheck
git diff --check
```

Também foram rodadas regressões NSE e Adaptive V2 conforme a base do PR #786.

## Status

Draft. Não fazer merge ainda.

Este PR deve permanecer empilhado sobre #786 até a fundação Adaptive V2 + Narrative Source Engine ser revisada.

Antes de qualquer upload real, ainda é necessário decidir storage temporário, retenção/exclusão, provedores de transcrição/OCR/frames, custo por análise, limites por plano, consentimento do usuário e rollback.