### PR TITLE
feat: add video upload simulated preview harness

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/buildVideoUploadPreviewScenario.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoUploadPreviewScenario.ts
@@ -1,0 +1,241 @@
+import { buildPostCreationAdaptiveAnswerKey } from "../../postCreationAdaptiveAnswerKey";
+import { buildPostCreationAdaptiveStrategicPlan } from "../../postCreationAdaptivePlanBuilder";
+import { buildPostCreationAdaptiveQuiz } from "../../postCreationAdaptiveQuizBuilder";
+import { detectPostCreationAdaptiveIntent } from "../../postCreationAdaptiveRouter";
+import type { PostCreationAdaptiveAnswer } from "../../postCreationAdaptiveTypes";
+import { extractNarrativeAssets } from "../../narrativeSource/narrativeAssetExtractor";
+import { buildAdaptiveInputFromNarrativeSource } from "../../narrativeSource/narrativeSourceAdaptiveAdapter";
+import { detectNarrativeSourceIntent } from "../../narrativeSource/narrativeSourceIntentRouter";
+import {
+  createEmptyVideoProcessingArtifacts,
+  type VideoProcessingArtifacts,
+} from "../../videoUpload/videoProcessingArtifacts";
+import {
+  buildProcessedNarrativeSourceFromVideoUpload,
+  hasEnoughProcessedContextForNarrativeAnalysis,
+} from "../../videoUpload/videoUploadProcessedNarrativeSource";
+import { validateVideoUploadDraft, type VideoUploadDraft } from "../../videoUpload/videoUploadTypes";
+
+const oneMb = 1024 * 1024;
+
+export type VideoUploadPreviewScenario = {
+  id: string;
+  label: string;
+  draft: VideoUploadDraft;
+  artifacts: VideoProcessingArtifacts;
+};
+
+function draft(overrides: Partial<VideoUploadDraft>): VideoUploadDraft {
+  return {
+    id: `video-preview-${overrides.fileName || "draft"}`,
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 36 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero saber se vale postar",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function artifacts(overrides: Partial<VideoProcessingArtifacts> = {}): VideoProcessingArtifacts {
+  return {
+    ...createEmptyVideoProcessingArtifacts(),
+    ...overrides,
+    transcript: {
+      ...createEmptyVideoProcessingArtifacts().transcript,
+      ...overrides.transcript,
+    },
+  };
+}
+
+export const VIDEO_UPLOAD_PREVIEW_SCENARIOS: VideoUploadPreviewScenario[] = [
+  {
+    id: "transcript-skincare",
+    label: "Vídeo simulado: rotina de skincare",
+    draft: draft({
+      id: "video-preview-transcript-skincare",
+      fileName: "rotina-skincare.mp4",
+      creatorQuestion: "Quero saber se vale postar",
+    }),
+    artifacts: artifacts({
+      transcript: {
+        fullText: "Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.",
+        language: "pt-BR",
+        provider: "manual",
+        segments: [],
+      },
+    }),
+  },
+  {
+    id: "visual-backstage",
+    label: "Vídeo simulado: bastidor de criação",
+    draft: draft({
+      id: "video-preview-visual-backstage",
+      fileName: "bastidor-criacao.mp4",
+      creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+    }),
+    artifacts: artifacts({
+      visualSummary: "Pessoa em reunião mostrando bastidores de trabalho e processo de criação.",
+    }),
+  },
+  {
+    id: "brand-frames-ocr",
+    label: "Vídeo simulado: potencial de marca",
+    draft: draft({
+      id: "video-preview-brand-frames-ocr",
+      fileName: "skincare-marca.mp4",
+      creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+    }),
+    artifacts: artifacts({
+      frames: [
+        {
+          id: "frame-opening",
+          timestampSeconds: 1,
+          label: "opening",
+          description: "Produtos de skincare aparecem sobre a bancada",
+        } as VideoProcessingArtifacts["frames"][number],
+        {
+          id: "frame-middle",
+          timestampSeconds: 8,
+          label: "middle",
+          description: "Pessoa aplica produto no rosto",
+        } as VideoProcessingArtifacts["frames"][number],
+      ],
+      ocr: [
+        { timestampSeconds: 2, text: "Rotina da manhã", confidence: 0.8 },
+        { timestampSeconds: 6, text: "Autocuidado real", confidence: 0.78 },
+      ],
+    }),
+  },
+  {
+    id: "improve-hook",
+    label: "Vídeo simulado: melhorar gancho",
+    draft: draft({
+      id: "video-preview-improve-hook",
+      fileName: "gancho-fraco.mp4",
+      creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+    }),
+    artifacts: artifacts({
+      transcript: {
+        fullText: "O começo está lento antes de mostrar bastidor de trabalho e processo de criação.",
+        language: "pt-BR",
+        provider: "manual",
+        segments: [],
+      },
+    }),
+  },
+  {
+    id: "collab-empty-artifacts",
+    label: "Vídeo simulado: collab sem artifacts",
+    draft: draft({
+      id: "video-preview-collab-empty-artifacts",
+      fileName: "collab.mp4",
+      creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+    }),
+    artifacts: createEmptyVideoProcessingArtifacts(),
+  },
+  {
+    id: "invalid-draft",
+    label: "Vídeo simulado: draft inválido",
+    draft: draft({
+      id: "video-preview-invalid-draft",
+      fileName: null,
+      mimeType: null,
+      sizeBytes: null,
+      creatorQuestion: "",
+    }),
+    artifacts: artifacts({
+      transcript: {
+        fullText: "Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.",
+        language: "pt-BR",
+        provider: "manual",
+        segments: [],
+      },
+    }),
+  },
+];
+
+export const DEFAULT_VIDEO_UPLOAD_PREVIEW_SCENARIO_ID = "transcript-skincare";
+
+function normalizeScenarioId(value?: string | string[] | null) {
+  if (Array.isArray(value)) return value[0] || DEFAULT_VIDEO_UPLOAD_PREVIEW_SCENARIO_ID;
+  return value || DEFAULT_VIDEO_UPLOAD_PREVIEW_SCENARIO_ID;
+}
+
+export function getVideoUploadPreviewScenario(value?: string | string[] | null) {
+  const scenarioId = normalizeScenarioId(value);
+  return (
+    VIDEO_UPLOAD_PREVIEW_SCENARIOS.find((scenario) => scenario.id === scenarioId) ||
+    VIDEO_UPLOAD_PREVIEW_SCENARIOS[0]!
+  );
+}
+
+export function buildVideoUploadPreviewScenario(value?: string | string[] | null) {
+  const scenario = getVideoUploadPreviewScenario(value);
+  const validation = validateVideoUploadDraft(scenario.draft);
+  const readiness = hasEnoughProcessedContextForNarrativeAnalysis({
+    draft: scenario.draft,
+    artifacts: scenario.artifacts,
+  });
+  const narrativeSource = buildProcessedNarrativeSourceFromVideoUpload({
+    draft: scenario.draft,
+    artifacts: scenario.artifacts,
+  });
+
+  if (!narrativeSource) {
+    return {
+      scenario,
+      validation,
+      readiness,
+      narrativeSource: null,
+      sourceIntent: null,
+      extraction: null,
+      adaptiveInput: null,
+      adaptiveDetection: null,
+      questions: [],
+      answers: [],
+      answerKey: null,
+      plan: null,
+    };
+  }
+
+  const sourceIntent = detectNarrativeSourceIntent(narrativeSource);
+  const extraction = extractNarrativeAssets({ source: narrativeSource, intentDetection: sourceIntent });
+  const adaptiveInput = buildAdaptiveInputFromNarrativeSource({
+    source: narrativeSource,
+    intentDetection: sourceIntent,
+    extraction,
+  });
+  const adaptiveDetection = detectPostCreationAdaptiveIntent(adaptiveInput.input);
+  const questions = buildPostCreationAdaptiveQuiz({ detection: adaptiveDetection });
+  const answers: PostCreationAdaptiveAnswer[] = questions.map((question) => ({
+    questionId: question.id,
+    key: question.mapKey,
+    optionId: question.options.find((option) => option.recommended)?.id || question.options[0]!.id,
+    value: null,
+  }));
+  const answerKey = buildPostCreationAdaptiveAnswerKey({ detection: adaptiveDetection, questions, answers });
+  const plan = buildPostCreationAdaptiveStrategicPlan({
+    detection: adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+  });
+
+  return {
+    scenario,
+    validation,
+    readiness,
+    narrativeSource,
+    sourceIntent,
+    extraction,
+    adaptiveInput,
+    adaptiveDetection,
+    questions,
+    answers,
+    answerKey,
+    plan,
+  };
+}

--- a/src/app/dashboard/boards/video-upload-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-upload-preview/page.test.tsx
@@ -1,0 +1,155 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import VideoUploadPreviewPage from "./page";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = originalEnvValue;
+});
+
+describe("VideoUploadPreviewPage", () => {
+  it("renders a blocked state when the internal flag is off", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "0";
+
+    render(<VideoUploadPreviewPage />);
+
+    expect(screen.getByText("Video Upload Foundation")).toBeInTheDocument();
+    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Video Upload Foundation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
+  });
+
+  it("renders transcript-skincare as the default scenario when enabled without scenario", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage />);
+
+    expect(screen.getByText("Preview interno — Video Upload Foundation")).toBeInTheDocument();
+    expect(screen.getAllByText("Vídeo simulado: rotina de skincare").length).toBeGreaterThan(0);
+    expect(screen.getByText("Fonte narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Intenção da fonte")).toBeInTheDocument();
+    expect(screen.getByText("Assets narrativos")).toBeInTheDocument();
+    expect(screen.getByText("Plano gerado")).toBeInTheDocument();
+  });
+
+  it("renders the brand frames and OCR scenario", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "brand-frames-ocr" }} />);
+
+    expect(screen.getAllByText("Vídeo simulado: potencial de marca").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validation ok").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("video_upload_future").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("brand_potential").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("brand_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com marca")).toBeInTheDocument();
+    expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
+  });
+
+  it("renders the visual backstage scenario", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "visual-backstage" }} />);
+
+    expect(screen.getAllByText("discover_narrative").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("discover_pauta").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pessoa em reunião mostrando bastidores de trabalho e processo de criação.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/bastidor/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the improve hook scenario", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "improve-hook" }} />);
+
+    expect(screen.getAllByText("improve_content").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/weakness|hook_signal/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the collab scenario with empty artifacts", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "collab-empty-artifacts" }} />);
+
+    expect(screen.getByText("Sem artifacts simulados para este cenário.")).toBeInTheDocument();
+    expect(screen.getAllByText("readiness false").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("collab_potential").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("collab_match").length).toBeGreaterThan(0);
+    expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
+  });
+
+  it("renders the invalid draft state without running NSE or Adaptive V2", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "invalid-draft" }} />);
+
+    expect(screen.getAllByText("validation pendente").length).toBeGreaterThan(0);
+    expect(screen.getByText("Draft não validado")).toBeInTheDocument();
+    expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
+    expect(screen.queryByText("Plano gerado")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the transcript skincare scenario when search params are invalid", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(<VideoUploadPreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+
+    expect(screen.getAllByText("Vídeo simulado: rotina de skincare").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("validate_before_posting").length).toBeGreaterThan(0);
+  });
+
+  it("continues without forbidden or game language", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    const { container } = render(<VideoUploadPreviewPage searchParams={{ scenario: "brand-frames-ocr" }} />);
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import product shell, external services, or real file interactions", () => {
+    const pageSource = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+    const scenarioSource = fs.readFileSync(
+      path.join(__dirname, "../components/videoUpload/buildVideoUploadPreviewScenario.ts"),
+      "utf8",
+    );
+    const source = `${pageSource}\n${scenarioSource}`;
+
+    expect(source).not.toMatch(/PostCreationFunnelBoardShell/);
+    expect(source).not.toMatch(/BoardShell/);
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/OpenAI/);
+    expect(source).not.toMatch(/openai/);
+    expect(source).not.toMatch(/prisma/);
+    expect(source).not.toMatch(/storage/i);
+    expect(source).not.toMatch(/ffmpeg/i);
+    expect(source).not.toMatch(/upload service/i);
+    expect(source).not.toMatch(/route handlers?/i);
+    expect(source).not.toMatch(/usePostCreation/);
+    expect(source).not.toMatch(/file picker/i);
+  });
+});

--- a/src/app/dashboard/boards/video-upload-preview/page.tsx
+++ b/src/app/dashboard/boards/video-upload-preview/page.tsx
@@ -1,0 +1,175 @@
+import { NarrativeSourcePreview } from "../components/narrativeSource";
+import {
+  buildVideoUploadPreviewScenario,
+  VIDEO_UPLOAD_PREVIEW_SCENARIOS,
+} from "../components/videoUpload/buildVideoUploadPreviewScenario";
+import { isVideoUploadPreviewEnabled } from "../videoUpload/videoUploadPreviewFeatureFlag";
+
+type VideoUploadPreviewPageProps = {
+  searchParams?: {
+    scenario?: string | string[];
+  };
+};
+
+function formatBytes(value: number | null): string {
+  if (typeof value !== "number") return "não informado";
+  return `${Math.round((value / (1024 * 1024)) * 10) / 10} MB`;
+}
+
+function CompactBlock({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-lg bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
+    </div>
+  );
+}
+
+export default function VideoUploadPreviewPage({ searchParams }: VideoUploadPreviewPageProps = {}) {
+  const isEnabled = isVideoUploadPreviewEnabled();
+
+  if (!isEnabled) {
+    return (
+      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+          <h1 className="mt-2 text-2xl font-semibold">Video Upload Foundation</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela permanece bloqueada enquanto a flag interna de preview de vídeo estiver desligada.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const preview = buildVideoUploadPreviewScenario(searchParams?.scenario);
+  const { scenario, validation, readiness, narrativeSource, sourceIntent, adaptiveDetection } = preview;
+  const draft = validation.normalizedDraft;
+  const artifacts = scenario.artifacts;
+  const statusLabel = validation.ok ? "validation ok" : "validation pendente";
+  const readinessLabel = readiness ? "readiness true" : "readiness false";
+  const hasArtifactDetails =
+    Boolean(artifacts.transcript.fullText) ||
+    Boolean(artifacts.visualSummary) ||
+    artifacts.frames.length > 0 ||
+    artifacts.ocr.length > 0;
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Video Upload Foundation</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa cenários controlados. Não há upload real, processamento real ou conexão com o fluxo do
+            produto.
+          </p>
+        </header>
+
+        <section className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap gap-2">
+            {VIDEO_UPLOAD_PREVIEW_SCENARIOS.map((candidate) => {
+              const isActive = candidate.id === scenario.id;
+
+              return (
+                <a
+                  key={candidate.id}
+                  href={`/dashboard/boards/video-upload-preview?scenario=${candidate.id}`}
+                  className={
+                    isActive
+                      ? "rounded-full bg-zinc-950 px-3 py-1.5 text-sm font-semibold text-white"
+                      : "rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700"
+                  }
+                >
+                  {candidate.label}
+                </a>
+              );
+            })}
+          </div>
+
+          <dl className="mt-4 grid gap-3 text-sm md:grid-cols-5">
+            <CompactBlock label="Cenário ativo" value={scenario.label} />
+            <CompactBlock label="Validação" value={statusLabel} />
+            <CompactBlock label="Readiness" value={readinessLabel} />
+            <CompactBlock label="Intent detectada" value={sourceIntent?.intent || "não avaliada"} />
+            <CompactBlock label="Adaptive mode" value={adaptiveDetection?.mode || "não avaliado"} />
+          </dl>
+        </section>
+
+        <section className="mb-5 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Draft do vídeo</p>
+            <h2 className="mt-1 text-lg font-semibold text-zinc-950">Dados simulados</h2>
+            <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+              <CompactBlock label="Arquivo" value={draft.fileName || "não informado"} />
+              <CompactBlock label="MIME" value={draft.mimeType || "não informado"} />
+              <CompactBlock label="Tamanho" value={formatBytes(draft.sizeBytes)} />
+              <CompactBlock
+                label="Duração"
+                value={typeof draft.durationSeconds === "number" ? `${draft.durationSeconds}s` : "não informada"}
+              />
+              <CompactBlock label="Pergunta" value={draft.creatorQuestion || "não informada"} />
+              <CompactBlock label="Source type" value={narrativeSource?.sourceType || "não gerado"} />
+            </dl>
+            {!validation.ok ? (
+              <div className="mt-4 rounded-lg bg-zinc-50 p-3">
+                <h3 className="text-sm font-semibold text-zinc-950">Pendências de validação</h3>
+                <ul className="mt-2 space-y-1 text-sm leading-6 text-zinc-700">
+                  {validation.errors.map((item) => (
+                    <li key={item.code}>{item.message}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Artifacts simulados</p>
+            <h2 className="mt-1 text-lg font-semibold text-zinc-950">Contexto de processamento</h2>
+            {hasArtifactDetails ? (
+              <dl className="mt-4 grid gap-3 text-sm">
+                <CompactBlock label="Transcrição" value={artifacts.transcript.fullText} />
+                <CompactBlock label="Resumo visual" value={artifacts.visualSummary} />
+                <CompactBlock
+                  label="Frames"
+                  value={artifacts.frames.map((frame) => frame.description).filter(Boolean).join(" | ") || null}
+                />
+                <CompactBlock
+                  label="Texto na tela"
+                  value={artifacts.ocr.map((item) => item.text).filter(Boolean).join(" | ") || null}
+                />
+              </dl>
+            ) : (
+              <p className="mt-4 rounded-lg bg-zinc-50 p-3 text-sm leading-6 text-zinc-700">
+                Sem artifacts simulados para este cenário.
+              </p>
+            )}
+          </div>
+        </section>
+
+        {narrativeSource && preview.extraction && preview.adaptiveInput ? (
+          <NarrativeSourcePreview
+            source={narrativeSource}
+            sourceIntent={preview.sourceIntent}
+            extraction={preview.extraction}
+            adaptiveInput={preview.adaptiveInput}
+            adaptiveDetection={preview.adaptiveDetection}
+            questions={preview.questions}
+            answerKey={preview.answerKey}
+            plan={preview.plan}
+          />
+        ) : (
+          <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Pipeline pausado</p>
+            <h2 className="mt-1 text-lg font-semibold text-zinc-950">Draft não validado</h2>
+            <p className="mt-3 text-sm leading-6 text-zinc-700">
+              A prévia não roda NSE ou Adaptive V2 quando o draft controlado não passa pela validação.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -175,6 +175,39 @@ O que não faz:
 - não cria storage;
 - não cria UI.
 
+### VU8 — Harness interno com artifacts simulados
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../video-upload-preview/page.tsx`
+- `../video-upload-preview/page.test.tsx`
+- `../components/videoUpload/buildVideoUploadPreviewScenario.ts`
+- `videoUploadPreviewFeatureFlag.ts`
+- `videoUploadPreviewFeatureFlag.test.ts`
+
+O que faz:
+
+- cria uma rota interna em `/dashboard/boards/video-upload-preview`;
+- protege a rota com `NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED=1`;
+- renderiza cenários fixos de `VideoUploadDraft + VideoProcessingArtifacts`;
+- mostra validação, readiness, artifacts simulados, `NarrativeSource` enriquecida, intenção NSE, entrada Adaptive V2 e plano estratégico;
+- aborta NSE/Adaptive quando o draft controlado não passa pela validação;
+- mantém QA de linguagem segura e isolamento de imports.
+
+O que não faz:
+
+- não cria upload real;
+- não cria file picker;
+- não aceita input livre;
+- não cria endpoint;
+- não cria storage;
+- não usa ffmpeg;
+- não usa OpenAI;
+- não conecta no BoardShell;
+- não adiciona link em navegação ou menu.
+
 ## Arquitetura Atual
 
 ```text
@@ -210,6 +243,7 @@ Na prática, existem dois níveis de prova:
 - Helpers para transcrição e descrição visual a partir de artefatos.
 - Adapter para `NarrativeSource` enriquecida.
 - QA de pipeline completo com artifacts simulados.
+- Harness interno com cenários simulados atrás de feature flag.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -258,6 +292,8 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ## QA Recomendada
 
 ```bash
+npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
@@ -270,7 +306,6 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
-- VU8: fixture/harness interno com artifacts simulados, sem input livre.
 - VU9: contrato de storage temporário, ainda sem implementação real.
 - VU10: contrato de providers de transcrição, frames e OCR.
 - VU11: documentação de custos, limites e retenção.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -208,6 +208,28 @@ O que não faz:
 - não conecta no BoardShell;
 - não adiciona link em navegação ou menu.
 
+### VU9 — Checklist manual do Video Upload Preview
+
+Status: concluído.
+
+Arquivo principal:
+
+- `VIDEO_UPLOAD_PREVIEW_QA.md`
+
+O que faz:
+
+- documenta a QA manual da rota `/dashboard/boards/video-upload-preview`;
+- lista URLs de todos os cenários controlados;
+- define checklist geral, mobile, por cenário, linguagem proibida e segurança de produto;
+- cria tabela de achados para revisão visual antes de qualquer avanço para storage ou upload real.
+
+O que não faz:
+
+- não altera lógica;
+- não altera testes;
+- não cria UI nova;
+- não conecta no produto real.
+
 ## Arquitetura Atual
 
 ```text
@@ -244,6 +266,7 @@ Na prática, existem dois níveis de prova:
 - Adapter para `NarrativeSource` enriquecida.
 - QA de pipeline completo com artifacts simulados.
 - Harness interno com cenários simulados atrás de feature flag.
+- Checklist manual do preview interno.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -306,7 +329,7 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
-- VU9: contrato de storage temporário, ainda sem implementação real.
-- VU10: contrato de providers de transcrição, frames e OCR.
-- VU11: documentação de custos, limites e retenção.
-- VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.
+- VU10: contrato de storage temporário, ainda sem implementação real.
+- VU11: contrato de providers de transcrição, frames e OCR.
+- VU12: documentação de custos, limites e retenção.
+- VU13: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_UPLOAD_PREVIEW_QA.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_UPLOAD_PREVIEW_QA.md
@@ -1,0 +1,161 @@
+# Video Upload Preview — QA Manual
+
+## Objetivo
+
+Este checklist serve para validar visualmente a rota interna `/dashboard/boards/video-upload-preview` usando cenários simulados de vídeo.
+
+A revisão não envolve upload real. O objetivo é verificar se o harness mostra com clareza como um `VideoUploadDraft` e `VideoProcessingArtifacts` simulados podem virar uma `NarrativeSource`, passar pela NSE e alimentar o Adaptive V2.
+
+## Pré-requisitos
+
+- Estar na branch `feat/video-upload-simulated-preview`.
+- Rodar o app localmente.
+- Usar `NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED=1`.
+- Acessar `/dashboard/boards/video-upload-preview`.
+- Manter o PR em draft.
+- Não conectar a usuários reais.
+
+## URLs Dos Cenários
+
+- `/dashboard/boards/video-upload-preview?scenario=transcript-skincare`
+- `/dashboard/boards/video-upload-preview?scenario=visual-backstage`
+- `/dashboard/boards/video-upload-preview?scenario=brand-frames-ocr`
+- `/dashboard/boards/video-upload-preview?scenario=improve-hook`
+- `/dashboard/boards/video-upload-preview?scenario=collab-empty-artifacts`
+- `/dashboard/boards/video-upload-preview?scenario=invalid-draft`
+
+## Checklist Geral
+
+Validar visualmente:
+
+- O título `Preview interno — Video Upload Foundation` aparece.
+- O aviso de que são cenários controlados aparece.
+- A lista de cenários aparece.
+- O cenário ativo está correto.
+- O draft do vídeo está visível.
+- A validação do draft está visível.
+- A readiness está visível.
+- Os artifacts simulados estão visíveis.
+- A fonte narrativa aparece quando aplicável.
+- A intenção detectada aparece.
+- O adaptive mode aparece.
+- O plano gerado aparece quando aplicável.
+- O estado bloqueado aparece com a flag off.
+- Não há input livre, textarea ou file picker.
+- Não há qualquer sugestão de upload real.
+
+## Checklist Por Cenário
+
+### transcript-skincare
+
+- `validation ok` aparece.
+- `readiness true` aparece.
+- A transcrição está preenchida.
+- A intent é `validate_before_posting`.
+- O adaptive mode é `validate_pauta`.
+- O plano é gerado.
+
+### visual-backstage
+
+- A `visualDescription` está preenchida.
+- A intent é `discover_narrative`.
+- O adaptive mode é `discover_pauta`.
+- O plano tem narrativa preenchida.
+
+### brand-frames-ocr
+
+- Frames e OCR aparecem.
+- A `visualDescription` contém contexto visual.
+- A intent é `brand_potential`.
+- O adaptive mode é `brand_match`.
+- O bloco `Encaixe com marca` aparece.
+- O bloco `Encaixe com collab` não aparece sem motivo.
+
+### improve-hook
+
+- A intent é `improve_content`.
+- O adaptive mode é `validate_pauta`.
+- Os assets indicam `weakness` ou `hook_signal`.
+- O plano sugere ajuste sem tom escolar.
+
+### collab-empty-artifacts
+
+- Os artifacts estão vazios.
+- `readiness false` aparece.
+- O pipeline ainda roda pela `creatorQuestion`.
+- A intent é `collab_potential`.
+- O adaptive mode é `collab_match`.
+- O bloco `Encaixe com collab` aparece.
+
+### invalid-draft
+
+- `validation ok false` ou estado equivalente de não validação aparece.
+- NSE e Adaptive V2 não rodam.
+- O plano gerado não aparece.
+- O estado parece `não validado`, não `erro`.
+
+## Checklist Mobile
+
+Testar em largura mobile:
+
+- Links de cenário quebram linha sem sobrepor.
+- Cards não criam overflow horizontal.
+- Blocos de artifacts continuam legíveis.
+- `NarrativeSourcePreview` encaixa bem.
+- Plano e próximos passos são escaneáveis.
+- A página mantém scroll natural.
+
+## Checklist De Linguagem Proibida
+
+Reprovar se aparecer na UI:
+
+- garantido
+- certeza
+- comprovado
+- viralizar
+- score
+- nota
+- pontuação
+- acerto
+- erro
+- gabarito
+- resposta correta
+- venceu
+- perdeu
+- salvo
+- treinado
+- definitivo
+- aprendido permanentemente
+
+Se for necessário falar de validação, usar `não validado`, `pendência` ou `precisa de contexto`, evitando `erro` na UI.
+
+## Checklist De Segurança De Produto
+
+Confirmar que:
+
+- Não existe upload real.
+- Não existe botão de enviar arquivo.
+- Não existe file picker.
+- Não existe endpoint.
+- Não existe storage.
+- Não existe OpenAI.
+- Não existe ffmpeg.
+- Não existe banco.
+- Não existe conexão com BoardShell.
+- Não existe link em navegação/menu.
+- Não existe input livre do usuário.
+
+## Achados
+
+| Cenário | Problema encontrado | Severidade | Sugestão de ajuste | Status |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+
+## Próxima Decisão
+
+Depois da QA manual, decidir entre:
+
+- ajuste visual/copy no harness;
+- proteção por sessão admin/dev;
+- manter como preview interno;
+- só depois discutir storage temporário real.

--- a/src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
@@ -1,0 +1,28 @@
+import { isVideoUploadPreviewEnabled } from "./videoUploadPreviewFeatureFlag";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = originalEnvValue;
+});
+
+describe("videoUploadPreviewFeatureFlag", () => {
+  it("enables the video upload preview when env flag is 1", () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    expect(isVideoUploadPreviewEnabled()).toBe(true);
+  });
+
+  it("keeps the video upload preview disabled when env flag is absent or off", () => {
+    delete process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+    expect(isVideoUploadPreviewEnabled()).toBe(false);
+
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "0";
+    expect(isVideoUploadPreviewEnabled()).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.ts
@@ -1,0 +1,5 @@
+const VIDEO_UPLOAD_PREVIEW_ENV_FLAG = "NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED";
+
+export function isVideoUploadPreviewEnabled(): boolean {
+  return process.env[VIDEO_UPLOAD_PREVIEW_ENV_FLAG] === "1";
+}


### PR DESCRIPTION
## Contexto

Este PR é stacked sobre o PR #787 (`feat/video-upload-narrative-source-v1`) e adiciona as fases VU8/VU9 do épico Video Upload Foundation.

A proposta é criar um harness interno para visualizar, com cenários controlados, como um vídeo futuro poderia virar fonte narrativa enriquecida e alimentar a NSE + Adaptive V2.

Este PR permanece em draft e não deve ser mergeado ainda.

## VU8 — Harness interno com artifacts simulados

Cria uma rota interna:

```text
/dashboard/boards/video-upload-preview
```

A rota renderiza cenários fixos de `VideoUploadDraft + VideoProcessingArtifacts` e mostra:

- draft do vídeo;
- validação do draft;
- readiness da análise;
- artifacts simulados;
- `NarrativeSource` enriquecida;
- intenção detectada pela NSE;
- adaptive mode detectado;
- plano estratégico gerado.

## Cenários disponíveis

- `transcript-skincare`
- `visual-backstage`
- `brand-frames-ocr`
- `improve-hook`
- `collab-empty-artifacts`
- `invalid-draft`

## Proteção

Flag isolada:

```bash
NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED=1
```

Com a flag desligada, a página renderiza estado bloqueado e não monta a preview.

## VU9 — Checklist manual de QA

Cria o arquivo:

```text
src/app/dashboard/boards/videoUpload/VIDEO_UPLOAD_PREVIEW_QA.md
```

O checklist documenta:

- pré-requisitos;
- URLs dos cenários;
- checklist geral;
- checklist por cenário;
- checklist mobile;
- linguagem proibida;
- segurança de produto;
- tabela de achados;
- próxima decisão antes de storage/upload real.

## Escopo

Este PR não inclui:

- upload real;
- endpoint;
- storage;
- transcrição real;
- frames reais;
- OCR real;
- análise multimodal;
- OpenAI;
- ffmpeg;
- banco/Prisma;
- UI de produto real;
- input livre;
- textarea;
- file picker;
- BoardShell;
- hooks reais;
- navegação/menu;
- conexão com usuários reais.

## QA relatada

```bash
npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
npm run typecheck
git diff --check
```

Também foram rodadas regressões VU, NSE e Adaptive V2 conforme a base dos PRs empilhados.

## Status

Draft. Não fazer merge ainda.

Este PR deve permanecer empilhado sobre #787 até as fundações anteriores serem revisadas. Antes de qualquer avanço para storage ou upload real, executar a QA manual do harness e decidir se haverá ajuste visual/copy ou proteção por sessão admin/dev.