### PR TITLE
feat: add admin guards to internal previews

### DIFF
--- a/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
+++ b/src/app/dashboard/boards/POST_CREATION_ADAPTIVE_V2_PLAN.md
@@ -11,7 +11,7 @@ A implementação atual cobre:
 - Lógica pura de detecção, perguntas, leitura estratégica e plano.
 - QA de pipeline completo: Router -> QuizBuilder -> AnswerKey -> PlanBuilder.
 - UI preview isolada, renderizada apenas por props.
-- Harness interno em rota própria, protegido por env flag.
+- Harness interno em rota própria, protegido por env flag e sessão admin/dev.
 - Cenários controlados do pipeline para visualização interna.
 
 A implementação atual não cobre:
@@ -55,6 +55,7 @@ NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED=1
 ```
 
 Com a flag desligada, a rota renderiza um estado bloqueado e não monta a preview.
+Com a flag ligada, a rota ainda exige sessão interna com `role: "admin"`, `role: "dev"`, `isAdmin` ou `isDev`.
 
 ### Cenários disponíveis
 
@@ -79,7 +80,7 @@ Se `scenario` estiver ausente ou inválido, o harness usa `validate-pauta` como 
 - A V2 não usa OpenAI.
 - A V2 não tem input livre.
 - A V2 usa cenários controlados no harness.
-- A proteção atual é por env flag, não por sessão admin/dev.
+- A proteção atual combina env flag e sessão admin/dev.
 - O harness não adiciona link em menu ou navegação principal.
 
 ## Critérios Antes de Conectar no BoardShell
@@ -89,7 +90,7 @@ Antes de qualquer integração experimental com o BoardShell:
 - Validar visualmente o harness em browser real.
 - Revisar linguagem e tom com foco em mentoria consultiva.
 - Decidir explicitamente se haverá score visual ou se a V2 seguirá sem score.
-- Se necessário, proteger acesso por sessão admin/dev além da env flag.
+- Revisar se a política admin/dev deve ser centralizada com outros acessos internos do produto.
 - Definir handoff para fluxo real sem quebrar o legado.
 - Definir se e como haverá salvar pauta.
 - Criar plano de rollback.
@@ -113,7 +114,6 @@ npm run typecheck
 ## Próximas Fases Sugeridas
 
 - V2L: QA visual manual no harness.
-- V2M: Proteção por sessão admin/dev.
-- V2N: Integração experimental no BoardShell atrás da flag.
+- V2M: Integração experimental no BoardShell atrás da flag.
 - V2O: Handoff para plano real ou salvar pauta.
 - V2P: Decisão sobre liberar para beta interno.

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/react";
 import AdaptiveV2PreviewPage from "./page";
 
 const originalEnvValue = process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED;
+const adminViewer = { role: "admin" };
+const devViewer = { role: "dev" };
+const commonViewer = { role: "user" };
 
 afterEach(() => {
   if (originalEnvValue === undefined) {
@@ -15,20 +18,29 @@ afterEach(() => {
 });
 
 describe("AdaptiveV2PreviewPage", () => {
-  it("renders a blocked state when the internal flag is off", () => {
+  it("renders a blocked state when the internal flag is off", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "0";
 
-    render(<AdaptiveV2PreviewPage />);
+    render(await AdaptiveV2PreviewPage({ viewer: adminViewer }));
 
-    expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
-    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.getByText("Board Adaptativo V2")).toBeInTheDocument();
+    expect(screen.getByText("Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota.")).toBeInTheDocument();
     expect(screen.queryByText("Leitura inicial")).not.toBeInTheDocument();
   });
 
-  it("renders the default validate-pauta scenario when enabled without scenario", () => {
+  it("blocks common users even when the flag is on", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
-    render(<AdaptiveV2PreviewPage />);
+    render(await AdaptiveV2PreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Leitura inicial")).not.toBeInTheDocument();
+  });
+
+  it("renders the default validate-pauta scenario when enabled for admin", async () => {
+    process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
+
+    render(await AdaptiveV2PreviewPage({ viewer: adminViewer }));
 
     expect(screen.getByText("Preview interno — Board Adaptativo V2")).toBeInTheDocument();
     expect(screen.getByText("Leitura inicial")).toBeInTheDocument();
@@ -39,10 +51,10 @@ describe("AdaptiveV2PreviewPage", () => {
     expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
   });
 
-  it("renders the brand match scenario from search params", () => {
+  it("renders the brand match scenario from search params", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
-    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "brand-match" }} />);
+    render(await AdaptiveV2PreviewPage({ searchParams: { scenario: "brand-match" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Match com marca").length).toBeGreaterThan(0);
     expect(screen.getAllByText("brand_match").length).toBeGreaterThan(0);
@@ -50,29 +62,31 @@ describe("AdaptiveV2PreviewPage", () => {
     expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
   });
 
-  it("renders the collab match scenario from search params", () => {
+  it("renders the collab match scenario from search params for dev", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
-    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "collab-match" }} />);
+    render(await AdaptiveV2PreviewPage({ searchParams: { scenario: "collab-match" }, viewer: devViewer }));
 
     expect(screen.getAllByText("Match com collab").length).toBeGreaterThan(0);
     expect(screen.getAllByText("collab_match").length).toBeGreaterThan(0);
     expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
   });
 
-  it("falls back to the default scenario when search params are invalid", () => {
+  it("falls back to the default scenario when search params are invalid", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
-    render(<AdaptiveV2PreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+    render(await AdaptiveV2PreviewPage({ searchParams: { scenario: "missing-scenario" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Validar pauta").length).toBeGreaterThan(0);
     expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
   });
 
-  it("continues without proof or visual score language", () => {
+  it("continues without proof or visual score language", async () => {
     process.env.NEXT_PUBLIC_POST_CREATION_ADAPTIVE_ENABLED = "1";
 
-    const { container } = render(<AdaptiveV2PreviewPage searchParams={{ scenario: "brand-match" }} />);
+    const { container } = render(
+      await AdaptiveV2PreviewPage({ searchParams: { scenario: "brand-match" }, viewer: adminViewer }),
+    );
     const text = container.textContent?.toLowerCase() || "";
 
     for (const forbidden of ["score", "nota", "pontuação", "acerto", "erro", "gabarito", "resposta correta"]) {

--- a/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
+++ b/src/app/dashboard/boards/adaptive-v2-preview/page.tsx
@@ -3,30 +3,46 @@ import {
   ADAPTIVE_V2_PREVIEW_SCENARIOS,
   buildAdaptiveV2PreviewScenario,
 } from "../components/adaptiveV2/buildAdaptiveV2PreviewScenario";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
 import { isPostCreationAdaptiveEnvEnabled } from "../postCreationAdaptiveFeatureFlag";
 
 type AdaptiveV2PreviewPageProps = {
   searchParams?: {
     scenario?: string | string[];
   };
+  viewer?: InternalPreviewUser | null;
 };
 
-export default function AdaptiveV2PreviewPage({ searchParams }: AdaptiveV2PreviewPageProps = {}) {
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+        <h1 className="mt-2 text-2xl font-semibold">Board Adaptativo V2</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function AdaptiveV2PreviewPage({ searchParams, viewer }: AdaptiveV2PreviewPageProps = {}) {
   const isEnabled = isPostCreationAdaptiveEnvEnabled();
 
   if (!isEnabled) {
-    return (
-      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
-        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
-          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Board Adaptativo V2</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-700">
-            Esta tela usa cenários controlados e permanece bloqueada enquanto a flag interna da experiência adaptativa
-            estiver desligada.
-          </p>
-        </section>
-      </main>
-    );
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
   }
 
   const preview = buildAdaptiveV2PreviewScenario(searchParams?.scenario);

--- a/src/app/dashboard/boards/internalPreviewAccess.test.ts
+++ b/src/app/dashboard/boards/internalPreviewAccess.test.ts
@@ -1,0 +1,31 @@
+import { canAccessInternalPreview } from "./internalPreviewAccess";
+
+describe("canAccessInternalPreview", () => {
+  it("returns true for isAdmin true", () => {
+    expect(canAccessInternalPreview({ isAdmin: true })).toBe(true);
+  });
+
+  it("returns true for isDev true", () => {
+    expect(canAccessInternalPreview({ isDev: true })).toBe(true);
+  });
+
+  it("returns true for role admin", () => {
+    expect(canAccessInternalPreview({ role: "admin" })).toBe(true);
+    expect(canAccessInternalPreview({ role: "ADMIN" })).toBe(true);
+  });
+
+  it("returns true for role dev", () => {
+    expect(canAccessInternalPreview({ role: "dev" })).toBe(true);
+    expect(canAccessInternalPreview({ role: " DEV " })).toBe(true);
+  });
+
+  it("returns false for common roles", () => {
+    expect(canAccessInternalPreview({ role: "user" })).toBe(false);
+    expect(canAccessInternalPreview({ role: "guest" })).toBe(false);
+  });
+
+  it("returns false for missing user", () => {
+    expect(canAccessInternalPreview(null)).toBe(false);
+    expect(canAccessInternalPreview(undefined)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/internalPreviewAccess.ts
+++ b/src/app/dashboard/boards/internalPreviewAccess.ts
@@ -1,0 +1,24 @@
+export type InternalPreviewUser = {
+  role?: string | null;
+  isAdmin?: boolean | null;
+  isDev?: boolean | null;
+  email?: string | null;
+};
+
+export function canAccessInternalPreview(user: InternalPreviewUser | null | undefined): boolean {
+  if (!user) return false;
+  if (user.isAdmin === true || user.isDev === true) return true;
+
+  const normalizedRole = typeof user.role === "string" ? user.role.trim().toLowerCase() : "";
+  return normalizedRole === "admin" || normalizedRole === "dev";
+}
+
+export async function getCurrentInternalPreviewUser(): Promise<InternalPreviewUser | null> {
+  const [{ getServerSession }, { authOptions }] = await Promise.all([
+    import("next-auth"),
+    import("@/app/api/auth/[...nextauth]/route"),
+  ]);
+  const session = await getServerSession(authOptions);
+
+  return session?.user || null;
+}

--- a/src/app/dashboard/boards/narrative-source-preview/page.test.tsx
+++ b/src/app/dashboard/boards/narrative-source-preview/page.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/react";
 import NarrativeSourcePreviewPage from "./page";
 
 const originalEnvValue = process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED;
+const adminViewer = { role: "admin" };
+const devViewer = { role: "dev" };
+const commonViewer = { role: "user" };
 
 afterEach(() => {
   if (originalEnvValue === undefined) {
@@ -15,20 +18,29 @@ afterEach(() => {
 });
 
 describe("NarrativeSourcePreviewPage", () => {
-  it("renders a blocked state when the internal flag is off", () => {
+  it("renders a blocked state when the internal flag is off", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "0";
 
-    render(<NarrativeSourcePreviewPage />);
+    render(await NarrativeSourcePreviewPage({ viewer: adminViewer }));
 
-    expect(screen.getByText("Preview interno — Narrative Source Engine")).toBeInTheDocument();
-    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.getByText("Narrative Source Engine")).toBeInTheDocument();
+    expect(screen.getByText("Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota.")).toBeInTheDocument();
     expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
   });
 
-  it("renders the default video validation scenario when enabled without scenario", () => {
+  it("blocks common users even when the flag is on", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    render(<NarrativeSourcePreviewPage />);
+    render(await NarrativeSourcePreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
+  });
+
+  it("renders the default video validation scenario when enabled for admin", async () => {
+    process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
+
+    render(await NarrativeSourcePreviewPage({ viewer: adminViewer }));
 
     expect(screen.getByText("Preview interno — Narrative Source Engine")).toBeInTheDocument();
     expect(screen.getByText("Fonte narrativa")).toBeInTheDocument();
@@ -38,10 +50,10 @@ describe("NarrativeSourcePreviewPage", () => {
     expect(screen.getAllByText("Vídeo: validar antes de postar").length).toBeGreaterThan(0);
   });
 
-  it("renders the brand potential scenario from search params", () => {
+  it("renders the brand potential scenario from search params", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-brand-potential" }} />);
+    render(await NarrativeSourcePreviewPage({ searchParams: { scenario: "video-brand-potential" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Vídeo: potencial de marca").length).toBeGreaterThan(0);
     expect(screen.getAllByText("brand_potential").length).toBeGreaterThan(0);
@@ -50,39 +62,41 @@ describe("NarrativeSourcePreviewPage", () => {
     expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
   });
 
-  it("renders the collab scenario from search params", () => {
+  it("renders the collab scenario from search params for dev", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-collab" }} />);
+    render(await NarrativeSourcePreviewPage({ searchParams: { scenario: "video-collab" }, viewer: devViewer }));
 
     expect(screen.getAllByText("collab_potential").length).toBeGreaterThan(0);
     expect(screen.getAllByText("collab_match").length).toBeGreaterThan(0);
     expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
   });
 
-  it("renders the comment-to-post scenario from search params", () => {
+  it("renders the comment-to-post scenario from search params", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "comment-to-post" }} />);
+    render(await NarrativeSourcePreviewPage({ searchParams: { scenario: "comment-to-post" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("comment").length).toBeGreaterThan(0);
     expect(screen.getAllByText("comment_to_post").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/rotina/i).length).toBeGreaterThan(0);
   });
 
-  it("falls back to the default scenario when search params are invalid", () => {
+  it("falls back to the default scenario when search params are invalid", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    render(<NarrativeSourcePreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+    render(await NarrativeSourcePreviewPage({ searchParams: { scenario: "missing-scenario" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Vídeo: validar antes de postar").length).toBeGreaterThan(0);
     expect(screen.getAllByText("validate_before_posting").length).toBeGreaterThan(0);
   });
 
-  it("continues without forbidden or game language", () => {
+  it("continues without forbidden or game language", async () => {
     process.env.NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED = "1";
 
-    const { container } = render(<NarrativeSourcePreviewPage searchParams={{ scenario: "video-brand-potential" }} />);
+    const { container } = render(
+      await NarrativeSourcePreviewPage({ searchParams: { scenario: "video-brand-potential" }, viewer: adminViewer }),
+    );
     const text = container.textContent?.toLowerCase() || "";
 
     for (const forbidden of [

--- a/src/app/dashboard/boards/narrative-source-preview/page.tsx
+++ b/src/app/dashboard/boards/narrative-source-preview/page.tsx
@@ -3,30 +3,46 @@ import {
   buildNarrativeSourcePreviewScenario,
   NARRATIVE_SOURCE_PREVIEW_SCENARIOS,
 } from "../components/narrativeSource/buildNarrativeSourcePreviewScenario";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
 import { isNarrativeSourceEngineEnabled } from "../narrativeSource/narrativeSourceFeatureFlag";
 
 type NarrativeSourcePreviewPageProps = {
   searchParams?: {
     scenario?: string | string[];
   };
+  viewer?: InternalPreviewUser | null;
 };
 
-export default function NarrativeSourcePreviewPage({ searchParams }: NarrativeSourcePreviewPageProps = {}) {
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+        <h1 className="mt-2 text-2xl font-semibold">Narrative Source Engine</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function NarrativeSourcePreviewPage({ searchParams, viewer }: NarrativeSourcePreviewPageProps = {}) {
   const isEnabled = isNarrativeSourceEngineEnabled();
 
   if (!isEnabled) {
-    return (
-      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
-        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
-          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Narrative Source Engine</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-700">
-            Esta tela usa cenários controlados e permanece bloqueada enquanto a flag interna do Narrative Source
-            Engine estiver desligada.
-          </p>
-        </section>
-      </main>
-    );
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
   }
 
   const preview = buildNarrativeSourcePreviewScenario(searchParams?.scenario);

--- a/src/app/dashboard/boards/narrativeSource/README.md
+++ b/src/app/dashboard/boards/narrativeSource/README.md
@@ -20,7 +20,7 @@ Vídeo é uma fonte futura e rica, mas a NSE ainda não faz upload, transcriçã
 | NSE4 | Concluída | `narrativeSourceAdaptiveAdapter.ts`, `narrativeSourceAdaptiveAdapter.test.ts` | Transforma a fonte analisada em input textual para o Adaptive V2. | Não roda Router, QuizBuilder, AnswerKey ou PlanBuilder dentro do adapter. |
 | NSE5 | Concluída | `narrativeSourcePipeline.test.ts` | Valida em teste o pipeline NSE -> Adaptive V2 completo. | Não cria lógica nova de produção e não conecta o fluxo real. |
 | NSE6 | Concluída | `components/narrativeSource/*` | Renderiza preview visual isolada por props. | Não roda pipeline internamente, não cria rota e não chama serviços. |
-| NSE7 | Concluída | `narrative-source-preview/page.tsx`, `buildNarrativeSourcePreviewScenario.ts`, `narrativeSourceFeatureFlag.ts` | Cria harness interno com cenários controlados e flag própria. | Não adiciona navegação/menu, input livre, upload, endpoint ou BoardShell. |
+| NSE7 | Concluída | `narrative-source-preview/page.tsx`, `buildNarrativeSourcePreviewScenario.ts`, `narrativeSourceFeatureFlag.ts` | Cria harness interno com cenários controlados, flag própria e proteção admin/dev compartilhada. | Não adiciona navegação/menu, input livre, upload, endpoint ou BoardShell. |
 
 ## Arquitetura atual
 
@@ -61,6 +61,8 @@ Flag necessária:
 ```text
 NEXT_PUBLIC_NARRATIVE_SOURCE_ENGINE_ENABLED=1
 ```
+
+Além da flag, a rota exige sessão interna com `role: "admin"`, `role: "dev"`, `isAdmin` ou `isDev`. Quando a flag está desligada ou a sessão não tem permissão, o pipeline de preview não é montado.
 
 Cenários disponíveis:
 
@@ -132,8 +134,7 @@ npm run typecheck
 ## Próximas fases sugeridas
 
 - NSE9: QA manual visual do harness.
-- NSE10: proteção por sessão admin/dev.
-- NSE11: integração experimental com BoardShell atrás de flag.
+- NSE10: integração experimental com BoardShell atrás de flag.
 - VU1: fundação de upload de vídeo, em PR separado.
 - VU2: transcrição e frames.
 - VU3: análise multimodal com IA.

--- a/src/app/dashboard/boards/video-upload-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-upload-preview/page.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/react";
 import VideoUploadPreviewPage from "./page";
 
 const originalEnvValue = process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED;
+const adminViewer = { role: "admin" };
+const devViewer = { role: "dev" };
+const commonViewer = { role: "user" };
 
 afterEach(() => {
   if (originalEnvValue === undefined) {
@@ -15,21 +18,31 @@ afterEach(() => {
 });
 
 describe("VideoUploadPreviewPage", () => {
-  it("renders a blocked state when the internal flag is off", () => {
+  it("renders a blocked state when the internal flag is off", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "0";
 
-    render(<VideoUploadPreviewPage />);
+    render(await VideoUploadPreviewPage({ viewer: adminViewer }));
 
     expect(screen.getByText("Video Upload Foundation")).toBeInTheDocument();
-    expect(screen.getByText(/permanece bloqueada/i)).toBeInTheDocument();
+    expect(screen.getByText("Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota.")).toBeInTheDocument();
     expect(screen.queryByText("Preview interno — Video Upload Foundation")).not.toBeInTheDocument();
     expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
   });
 
-  it("renders transcript-skincare as the default scenario when enabled without scenario", () => {
+  it("blocks common users even when the flag is on", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage />);
+    render(await VideoUploadPreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Video Upload Foundation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Fonte narrativa")).not.toBeInTheDocument();
+  });
+
+  it("renders transcript-skincare as the default scenario when enabled for admin", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
+
+    render(await VideoUploadPreviewPage({ viewer: adminViewer }));
 
     expect(screen.getByText("Preview interno — Video Upload Foundation")).toBeInTheDocument();
     expect(screen.getAllByText("Vídeo simulado: rotina de skincare").length).toBeGreaterThan(0);
@@ -39,10 +52,10 @@ describe("VideoUploadPreviewPage", () => {
     expect(screen.getByText("Plano gerado")).toBeInTheDocument();
   });
 
-  it("renders the brand frames and OCR scenario", () => {
+  it("renders the brand frames and OCR scenario", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "brand-frames-ocr" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "brand-frames-ocr" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Vídeo simulado: potencial de marca").length).toBeGreaterThan(0);
     expect(screen.getAllByText("validation ok").length).toBeGreaterThan(0);
@@ -53,10 +66,10 @@ describe("VideoUploadPreviewPage", () => {
     expect(screen.queryByText("Encaixe com collab")).not.toBeInTheDocument();
   });
 
-  it("renders the visual backstage scenario", () => {
+  it("renders the visual backstage scenario", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "visual-backstage" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "visual-backstage" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("discover_narrative").length).toBeGreaterThan(0);
     expect(screen.getAllByText("discover_pauta").length).toBeGreaterThan(0);
@@ -64,20 +77,20 @@ describe("VideoUploadPreviewPage", () => {
     expect(screen.getAllByText(/bastidor/i).length).toBeGreaterThan(0);
   });
 
-  it("renders the improve hook scenario", () => {
+  it("renders the improve hook scenario", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "improve-hook" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "improve-hook" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("improve_content").length).toBeGreaterThan(0);
     expect(screen.getAllByText("validate_pauta").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/weakness|hook_signal/).length).toBeGreaterThan(0);
   });
 
-  it("renders the collab scenario with empty artifacts", () => {
+  it("renders the collab scenario with empty artifacts for dev", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "collab-empty-artifacts" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "collab-empty-artifacts" }, viewer: devViewer }));
 
     expect(screen.getByText("Sem artifacts simulados para este cenário.")).toBeInTheDocument();
     expect(screen.getAllByText("readiness false").length).toBeGreaterThan(0);
@@ -86,10 +99,10 @@ describe("VideoUploadPreviewPage", () => {
     expect(screen.getByText("Encaixe com collab")).toBeInTheDocument();
   });
 
-  it("renders the invalid draft state without running NSE or Adaptive V2", () => {
+  it("renders the invalid draft state without running NSE or Adaptive V2 when authorized", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "invalid-draft" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "invalid-draft" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("validation pendente").length).toBeGreaterThan(0);
     expect(screen.getByText("Draft não validado")).toBeInTheDocument();
@@ -97,19 +110,21 @@ describe("VideoUploadPreviewPage", () => {
     expect(screen.queryByText("Plano gerado")).not.toBeInTheDocument();
   });
 
-  it("falls back to the transcript skincare scenario when search params are invalid", () => {
+  it("falls back to the transcript skincare scenario when search params are invalid", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    render(<VideoUploadPreviewPage searchParams={{ scenario: "missing-scenario" }} />);
+    render(await VideoUploadPreviewPage({ searchParams: { scenario: "missing-scenario" }, viewer: adminViewer }));
 
     expect(screen.getAllByText("Vídeo simulado: rotina de skincare").length).toBeGreaterThan(0);
     expect(screen.getAllByText("validate_before_posting").length).toBeGreaterThan(0);
   });
 
-  it("continues without forbidden or game language", () => {
+  it("continues without forbidden or game language", async () => {
     process.env.NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED = "1";
 
-    const { container } = render(<VideoUploadPreviewPage searchParams={{ scenario: "brand-frames-ocr" }} />);
+    const { container } = render(
+      await VideoUploadPreviewPage({ searchParams: { scenario: "brand-frames-ocr" }, viewer: adminViewer }),
+    );
     const text = container.textContent?.toLowerCase() || "";
 
     for (const forbidden of [

--- a/src/app/dashboard/boards/video-upload-preview/page.tsx
+++ b/src/app/dashboard/boards/video-upload-preview/page.tsx
@@ -3,12 +3,18 @@ import {
   buildVideoUploadPreviewScenario,
   VIDEO_UPLOAD_PREVIEW_SCENARIOS,
 } from "../components/videoUpload/buildVideoUploadPreviewScenario";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
 import { isVideoUploadPreviewEnabled } from "../videoUpload/videoUploadPreviewFeatureFlag";
 
 type VideoUploadPreviewPageProps = {
   searchParams?: {
     scenario?: string | string[];
   };
+  viewer?: InternalPreviewUser | null;
 };
 
 function formatBytes(value: number | null): string {
@@ -27,21 +33,32 @@ function CompactBlock({ label, value }: { label: string; value: string | null })
   );
 }
 
-export default function VideoUploadPreviewPage({ searchParams }: VideoUploadPreviewPageProps = {}) {
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+        <h1 className="mt-2 text-2xl font-semibold">Video Upload Foundation</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function VideoUploadPreviewPage({ searchParams, viewer }: VideoUploadPreviewPageProps = {}) {
   const isEnabled = isVideoUploadPreviewEnabled();
 
   if (!isEnabled) {
-    return (
-      <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
-        <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
-          <h1 className="mt-2 text-2xl font-semibold">Video Upload Foundation</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-700">
-            Esta tela permanece bloqueada enquanto a flag interna de preview de vídeo estiver desligada.
-          </p>
-        </section>
-      </main>
-    );
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
   }
 
   const preview = buildVideoUploadPreviewScenario(searchParams?.scenario);

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -190,10 +190,11 @@ Arquivos principais:
 O que faz:
 
 - cria uma rota interna em `/dashboard/boards/video-upload-preview`;
-- protege a rota com `NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED=1`;
+- protege a rota com `NEXT_PUBLIC_VIDEO_UPLOAD_PREVIEW_ENABLED=1` e sessão admin/dev;
 - renderiza cenários fixos de `VideoUploadDraft + VideoProcessingArtifacts`;
 - mostra validação, readiness, artifacts simulados, `NarrativeSource` enriquecida, intenção NSE, entrada Adaptive V2 e plano estratégico;
 - aborta NSE/Adaptive quando o draft controlado não passa pela validação;
+- não monta o pipeline quando a flag está desligada ou a sessão não tem permissão;
 - mantém QA de linguagem segura e isolamento de imports.
 
 O que não faz:
@@ -266,6 +267,7 @@ Na prática, existem dois níveis de prova:
 - Adapter para `NarrativeSource` enriquecida.
 - QA de pipeline completo com artifacts simulados.
 - Harness interno com cenários simulados atrás de feature flag.
+- Proteção admin/dev compartilhada para previews internos.
 - Checklist manual do preview interno.
 - Testes de linguagem segura e isolamento de escopo.
 


### PR DESCRIPTION
## Contexto

Este PR é stacked sobre o PR #788 (`feat/video-upload-simulated-preview`) e adiciona a fase GUARD1.

A proposta é blindar os previews internos com uma segunda camada de proteção: além da feature flag correspondente, o usuário precisa ser admin/dev.

Este PR permanece em draft e não deve ser mergeado ainda.

## GUARD1 — Proteção admin/dev para previews internos

Previews protegidos:

```text
/dashboard/boards/adaptive-v2-preview
/dashboard/boards/narrative-source-preview
/dashboard/boards/video-upload-preview
```

## Regra de acesso

A preview só renderiza se:

1. A feature flag correspondente estiver ligada.
2. A sessão atual for de usuário admin/dev.

Se qualquer uma das duas condições falhar:

- renderiza estado bloqueado;
- não monta a preview;
- não roda pipeline/helper de cenário.

## Helper criado

```text
src/app/dashboard/boards/internalPreviewAccess.ts
```

Regras cobertas:

- `isAdmin: true` permite acesso;
- `isDev: true` permite acesso;
- `role: "admin"` permite acesso;
- `role: "dev"` permite acesso;
- usuário comum não acessa;
- sessão ausente não acessa.

## Integração de sessão

As páginas usam o padrão existente do projeto:

```text
getServerSession(authOptions)
```

## Arquivos principais

Criados:

- `src/app/dashboard/boards/internalPreviewAccess.ts`
- `src/app/dashboard/boards/internalPreviewAccess.test.ts`

Modificados:

- `src/app/dashboard/boards/adaptive-v2-preview/page.tsx`
- `src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx`
- `src/app/dashboard/boards/narrative-source-preview/page.tsx`
- `src/app/dashboard/boards/narrative-source-preview/page.test.tsx`
- `src/app/dashboard/boards/video-upload-preview/page.tsx`
- `src/app/dashboard/boards/video-upload-preview/page.test.tsx`
- docs do Adaptive V2, Narrative Source e Video Upload

## Fora de escopo

Este PR não inclui:

- upload real;
- endpoint;
- storage;
- OpenAI;
- ffmpeg;
- banco/Prisma;
- UI real de produto;
- BoardShell;
- navegação/menu;
- conexão com usuários reais.

## QA relatada

Testes novos e páginas protegidas passaram:

```bash
npm test -- --runInBand src/app/dashboard/boards/internalPreviewAccess.test.ts
npm test -- --runInBand src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx
npm test -- --runInBand src/app/dashboard/boards/narrative-source-preview/page.test.tsx
npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
npm run typecheck
git diff --check
```

Também foram rodadas regressões VU, NSE e Adaptive V2.

## Status

Draft. Não fazer merge ainda.

Este PR deve permanecer empilhado sobre #788 até as fundações anteriores serem revisadas.