### PR TITLE
feat: add video temporary storage contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -231,6 +231,33 @@ O que não faz:
 - não cria UI nova;
 - não conecta no produto real.
 
+### STOR1 — Contratos de storage temporário
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoTemporaryStorageTypes.ts`
+- `videoTemporaryStorageTypes.test.ts`
+
+O que faz:
+
+- define providers futuros de storage temporário sem acoplar SDK real;
+- define status, visibilidade, política de retenção e objeto temporário;
+- cria helpers puros para calcular expiração, marcar upload simulado e marcar remoção;
+- valida vínculo com draft, chave temporária, data de expiração, acesso público e status reconhecido;
+- mantém `publicUrl` sempre nulo nesta fase.
+
+O que não faz:
+
+- não cria storage real;
+- não gera URL assinada;
+- não usa S3, Vercel Blob, R2, GCS ou SDK de provider;
+- não cria upload real;
+- não cria endpoint;
+- não salva nada em banco;
+- não conecta no produto real.
+
 ## Arquitetura Atual
 
 ```text
@@ -239,6 +266,8 @@ VideoUploadDraft
 validateVideoUploadDraft
 ↓
 buildNarrativeSourceFromVideoUploadDraft
+↓
+VideoTemporaryStorageObject futuro
 ↓
 VideoProcessingArtifacts simulados
 ↓
@@ -269,6 +298,7 @@ Na prática, existem dois níveis de prova:
 - Harness interno com cenários simulados atrás de feature flag.
 - Proteção admin/dev compartilhada para previews internos.
 - Checklist manual do preview interno.
+- Contratos puros de storage temporário com retenção e validação.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -276,6 +306,8 @@ Na prática, existem dois níveis de prova:
 - Upload real.
 - Endpoint.
 - Storage.
+- Provider real de storage temporário.
+- URL assinada gerada por serviço real.
 - Transcrição automática.
 - Extração real de frames.
 - OCR real.
@@ -302,6 +334,8 @@ Antes de qualquer upload real, ainda é preciso decidir:
 
 - provedor de storage temporário;
 - política de retenção e exclusão do vídeo;
+- contrato de URL assinada e escopo de acesso;
+- estratégia de remoção após processamento;
 - limite final de tamanho e duração;
 - extração de duração no client, no server ou em ambos;
 - provedor de transcrição;
@@ -319,6 +353,7 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts
@@ -331,7 +366,7 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
-- VU10: contrato de storage temporário, ainda sem implementação real.
-- VU11: contrato de providers de transcrição, frames e OCR.
-- VU12: documentação de custos, limites e retenção.
-- VU13: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.
+- STOR2: contrato de URL assinada, ainda sem provider real.
+- VU10: contrato de providers de transcrição, frames e OCR.
+- VU11: documentação de custos, limites e retenção.
+- VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
@@ -1,0 +1,283 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY,
+  VideoTemporaryStorageObject,
+  calculateTemporaryStorageExpiration,
+  createEmptyVideoTemporaryStorageObject,
+  isTemporaryStorageExpired,
+  markTemporaryStorageDeleted,
+  markTemporaryStorageUploaded,
+  validateTemporaryStorageObject,
+} from "./videoTemporaryStorageTypes";
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function emptyObject(overrides: Partial<VideoTemporaryStorageObject> = {}): VideoTemporaryStorageObject {
+  return {
+    ...createEmptyVideoTemporaryStorageObject({
+      id: "temp-storage-1",
+      draftId: "draft-1",
+      provider: "local_mock",
+    }),
+    ...overrides,
+    metadata: {
+      ...createEmptyVideoTemporaryStorageObject({
+        id: "temp-storage-1",
+        draftId: "draft-1",
+        provider: "local_mock",
+      }).metadata,
+      ...overrides.metadata,
+    },
+  };
+}
+
+function uploadedObject(overrides: Partial<VideoTemporaryStorageObject> = {}): VideoTemporaryStorageObject {
+  return {
+    ...markTemporaryStorageUploaded({
+      object: emptyObject(),
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T12:00:00.000Z",
+      retentionHours: 24,
+      signedUrl: "https://signed.example/video.mp4",
+      metadata: {
+        durationSeconds: 45,
+        checksum: "checksum-1",
+      },
+    }),
+    ...overrides,
+    metadata: {
+      durationSeconds: 45,
+      checksum: "checksum-1",
+      ...overrides.metadata,
+    },
+  };
+}
+
+function issueCodes(object: VideoTemporaryStorageObject, now = "2026-05-14T13:00:00.000Z") {
+  return validateTemporaryStorageObject({ object, now }).issues.map((issue) => issue.code);
+}
+
+describe("videoTemporaryStorageTypes", () => {
+  it("creates an empty temporary storage object with safe defaults", () => {
+    expect(createEmptyVideoTemporaryStorageObject({ id: "storage-empty", draftId: "draft-empty" })).toEqual({
+      id: "storage-empty",
+      draftId: "draft-empty",
+      provider: "unknown",
+      status: "not_requested",
+      storageKey: null,
+      originalFileName: null,
+      mimeType: null,
+      sizeBytes: null,
+      uploadedAt: null,
+      expiresAt: null,
+      deletedAt: null,
+      publicUrl: null,
+      signedUrl: null,
+      metadata: {},
+    });
+  });
+
+  it("keeps the default temporary storage policy private and short-lived", () => {
+    expect(DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY).toEqual({
+      provider: "unknown",
+      maxRetentionHours: 24,
+      deleteAfterProcessing: true,
+      visibility: "signed_url_only",
+      allowPublicAccess: false,
+    });
+  });
+
+  it("calculates expiration from uploadedAt and retentionHours", () => {
+    expect(
+      calculateTemporaryStorageExpiration({
+        uploadedAt: "2026-05-14T12:00:00.000Z",
+        retentionHours: 6,
+      }),
+    ).toBe("2026-05-14T18:00:00.000Z");
+  });
+
+  it("returns null expiration for invalid dates or retention", () => {
+    expect(calculateTemporaryStorageExpiration({ uploadedAt: "not-a-date", retentionHours: 6 })).toBeNull();
+    expect(
+      calculateTemporaryStorageExpiration({
+        uploadedAt: "2026-05-14T12:00:00.000Z",
+        retentionHours: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("detects expired temporary storage when now is at or after expiresAt", () => {
+    expect(
+      isTemporaryStorageExpired({
+        now: "2026-05-15T12:00:00.000Z",
+        expiresAt: "2026-05-15T12:00:00.000Z",
+      }),
+    ).toBe(true);
+    expect(
+      isTemporaryStorageExpired({
+        now: "2026-05-15T12:00:01.000Z",
+        expiresAt: "2026-05-15T12:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not mark temporary storage expired before expiresAt", () => {
+    expect(
+      isTemporaryStorageExpired({
+        now: "2026-05-15T11:59:59.000Z",
+        expiresAt: "2026-05-15T12:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null or invalid expiration comparisons", () => {
+    expect(isTemporaryStorageExpired({ now: "2026-05-15T12:00:00.000Z", expiresAt: null })).toBe(false);
+    expect(isTemporaryStorageExpired({ now: "invalid", expiresAt: "2026-05-15T12:00:00.000Z" })).toBe(false);
+    expect(isTemporaryStorageExpired({ now: "2026-05-15T12:00:00.000Z", expiresAt: "invalid" })).toBe(false);
+  });
+
+  it("marks temporary storage as uploaded with storage key, expiration, and metadata", () => {
+    const result = markTemporaryStorageUploaded({
+      object: emptyObject({
+        originalFileName: "video.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 12,
+        metadata: { checksum: "existing-checksum" },
+      }),
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T12:00:00.000Z",
+      retentionHours: 2,
+      signedUrl: "https://signed.example/video.mp4",
+      metadata: { durationSeconds: 45 },
+    });
+
+    expect(result).toMatchObject({
+      status: "uploaded",
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T12:00:00.000Z",
+      expiresAt: "2026-05-14T14:00:00.000Z",
+      signedUrl: "https://signed.example/video.mp4",
+      metadata: {
+        checksum: "existing-checksum",
+        durationSeconds: 45,
+      },
+    });
+    expect(result.publicUrl).toBeNull();
+  });
+
+  it("marks temporary storage as deleted and clears URLs", () => {
+    const result = markTemporaryStorageDeleted({
+      object: uploadedObject(),
+      deletedAt: "2026-05-14T13:00:00.000Z",
+    });
+
+    expect(result.status).toBe("deleted");
+    expect(result.deletedAt).toBe("2026-05-14T13:00:00.000Z");
+    expect(result.publicUrl).toBeNull();
+    expect(result.signedUrl).toBeNull();
+  });
+
+  it("validates an uploaded temporary storage object", () => {
+    const result = validateTemporaryStorageObject({
+      object: uploadedObject(),
+      now: "2026-05-14T13:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects temporary storage objects without a draft id", () => {
+    expect(issueCodes(uploadedObject({ draftId: " " }))).toContain("missing_draft_id");
+  });
+
+  it("rejects uploaded temporary storage objects without a storage key", () => {
+    expect(issueCodes(uploadedObject({ storageKey: null }))).toContain("missing_storage_key");
+  });
+
+  it("rejects uploaded temporary storage objects without expiration", () => {
+    expect(issueCodes(uploadedObject({ expiresAt: null }))).toContain("missing_expiration");
+  });
+
+  it("rejects public URLs when policy does not allow public access", () => {
+    const object = {
+      ...uploadedObject(),
+      publicUrl: "https://public.example/video.mp4",
+    } as unknown as VideoTemporaryStorageObject;
+
+    expect(issueCodes(object)).toContain("public_access_not_allowed");
+  });
+
+  it("rejects expired temporary storage objects", () => {
+    expect(issueCodes(uploadedObject(), "2026-05-15T12:00:00.000Z")).toContain("expired_object");
+  });
+
+  it("rejects unknown storage statuses", () => {
+    const object = {
+      ...uploadedObject(),
+      status: "unexpected",
+    } as unknown as VideoTemporaryStorageObject;
+
+    expect(issueCodes(object)).toContain("invalid_status");
+  });
+
+  it("keeps validation issue language safe", () => {
+    const object = {
+      ...uploadedObject({
+        draftId: "",
+        storageKey: null,
+        expiresAt: null,
+      }),
+      publicUrl: "https://public.example/video.mp4",
+      status: "unexpected",
+    } as unknown as VideoTemporaryStorageObject;
+    const result = validateTemporaryStorageObject({
+      object,
+      now: "2026-05-15T12:00:00.000Z",
+    });
+    const text = JSON.stringify(result.issues.map((issue) => issue.message)).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, services, real storage, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoTemporaryStorageTypes.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).toBe("");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("upload service");
+    expect(source).not.toContain("storage provider SDK");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.ts
@@ -1,0 +1,238 @@
+export type VideoTemporaryStorageProvider =
+  | "future_s3"
+  | "future_vercel_blob"
+  | "future_cloudflare_r2"
+  | "future_gcs"
+  | "local_mock"
+  | "unknown";
+
+export type VideoTemporaryStorageStatus =
+  | "not_requested"
+  | "upload_url_requested"
+  | "upload_pending"
+  | "uploaded"
+  | "processing_locked"
+  | "expired"
+  | "deleted"
+  | "failed";
+
+export type VideoTemporaryStorageVisibility = "private" | "signed_url_only";
+
+export type VideoTemporaryStoragePolicy = {
+  provider: VideoTemporaryStorageProvider;
+  maxRetentionHours: number;
+  deleteAfterProcessing: boolean;
+  visibility: VideoTemporaryStorageVisibility;
+  allowPublicAccess: boolean;
+};
+
+export type VideoTemporaryStorageObject = {
+  id: string;
+  draftId: string;
+  provider: VideoTemporaryStorageProvider;
+  status: VideoTemporaryStorageStatus;
+  storageKey: string | null;
+  originalFileName: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  uploadedAt: string | null;
+  expiresAt: string | null;
+  deletedAt: string | null;
+  publicUrl: null;
+  signedUrl: string | null;
+  metadata: {
+    durationSeconds?: number | null;
+    checksum?: string | null;
+  };
+};
+
+export type VideoTemporaryStorageValidationIssueCode =
+  | "missing_storage_key"
+  | "missing_expiration"
+  | "public_access_not_allowed"
+  | "expired_object"
+  | "missing_draft_id"
+  | "invalid_status";
+
+export type VideoTemporaryStorageValidationIssue = {
+  code: VideoTemporaryStorageValidationIssueCode;
+  message: string;
+};
+
+export type VideoTemporaryStorageValidationResult = {
+  ok: boolean;
+  issues: VideoTemporaryStorageValidationIssue[];
+};
+
+export const DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY: VideoTemporaryStoragePolicy = {
+  provider: "unknown",
+  maxRetentionHours: 24,
+  deleteAfterProcessing: true,
+  visibility: "signed_url_only",
+  allowPublicAccess: false,
+};
+
+const VALID_TEMPORARY_STORAGE_STATUSES: VideoTemporaryStorageStatus[] = [
+  "not_requested",
+  "upload_url_requested",
+  "upload_pending",
+  "uploaded",
+  "processing_locked",
+  "expired",
+  "deleted",
+  "failed",
+];
+
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime());
+}
+
+function validationIssue(code: VideoTemporaryStorageValidationIssueCode): VideoTemporaryStorageValidationIssue {
+  const messages: Record<VideoTemporaryStorageValidationIssueCode, string> = {
+    missing_storage_key: "Arquivo temporário sem chave de armazenamento.",
+    missing_expiration: "Arquivo temporário sem data de expiração.",
+    public_access_not_allowed: "Acesso público não permitido para este arquivo.",
+    expired_object: "Arquivo temporário expirado.",
+    missing_draft_id: "Objeto sem vínculo com draft.",
+    invalid_status: "Status de armazenamento não reconhecido.",
+  };
+
+  return {
+    code,
+    message: messages[code],
+  };
+}
+
+export function createEmptyVideoTemporaryStorageObject(params: {
+  id: string;
+  draftId: string;
+  provider?: VideoTemporaryStorageProvider;
+}): VideoTemporaryStorageObject {
+  return {
+    id: params.id,
+    draftId: params.draftId,
+    provider: params.provider || "unknown",
+    status: "not_requested",
+    storageKey: null,
+    originalFileName: null,
+    mimeType: null,
+    sizeBytes: null,
+    uploadedAt: null,
+    expiresAt: null,
+    deletedAt: null,
+    publicUrl: null,
+    signedUrl: null,
+    metadata: {},
+  };
+}
+
+export function calculateTemporaryStorageExpiration(params: {
+  uploadedAt: string;
+  retentionHours?: number;
+}): string | null {
+  const uploadedAt = new Date(params.uploadedAt);
+  const retentionHours = params.retentionHours ?? DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY.maxRetentionHours;
+
+  if (!isValidDate(uploadedAt) || typeof retentionHours !== "number" || retentionHours <= 0) {
+    return null;
+  }
+
+  return new Date(uploadedAt.getTime() + retentionHours * 60 * 60 * 1000).toISOString();
+}
+
+export function isTemporaryStorageExpired(params: {
+  now: string;
+  expiresAt: string | null;
+}): boolean {
+  if (!params.expiresAt) return false;
+
+  const now = new Date(params.now);
+  const expiresAt = new Date(params.expiresAt);
+
+  if (!isValidDate(now) || !isValidDate(expiresAt)) return false;
+
+  return now.getTime() >= expiresAt.getTime();
+}
+
+export function markTemporaryStorageUploaded(params: {
+  object: VideoTemporaryStorageObject;
+  storageKey: string;
+  uploadedAt: string;
+  retentionHours?: number;
+  signedUrl?: string | null;
+  metadata?: VideoTemporaryStorageObject["metadata"];
+}): VideoTemporaryStorageObject {
+  return {
+    ...params.object,
+    status: "uploaded",
+    storageKey: params.storageKey,
+    uploadedAt: params.uploadedAt,
+    expiresAt: calculateTemporaryStorageExpiration({
+      uploadedAt: params.uploadedAt,
+      retentionHours: params.retentionHours,
+    }),
+    signedUrl: params.signedUrl ?? params.object.signedUrl,
+    metadata: {
+      ...params.object.metadata,
+      ...params.metadata,
+    },
+  };
+}
+
+export function markTemporaryStorageDeleted(params: {
+  object: VideoTemporaryStorageObject;
+  deletedAt: string;
+}): VideoTemporaryStorageObject {
+  return {
+    ...params.object,
+    status: "deleted",
+    deletedAt: params.deletedAt,
+    publicUrl: null,
+    signedUrl: null,
+  };
+}
+
+export function validateTemporaryStorageObject(params: {
+  object: VideoTemporaryStorageObject;
+  policy?: VideoTemporaryStoragePolicy;
+  now?: string;
+}): VideoTemporaryStorageValidationResult {
+  const policy = params.policy || DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY;
+  const object = params.object;
+  const issues: VideoTemporaryStorageValidationIssue[] = [];
+
+  if (!object.draftId.trim()) {
+    issues.push(validationIssue("missing_draft_id"));
+  }
+
+  if (!VALID_TEMPORARY_STORAGE_STATUSES.includes(object.status)) {
+    issues.push(validationIssue("invalid_status"));
+  }
+
+  if ((object.status === "uploaded" || object.status === "processing_locked") && !object.storageKey) {
+    issues.push(validationIssue("missing_storage_key"));
+  }
+
+  if ((object.status === "uploaded" || object.status === "processing_locked") && !object.expiresAt) {
+    issues.push(validationIssue("missing_expiration"));
+  }
+
+  if (object.publicUrl !== null && !policy.allowPublicAccess) {
+    issues.push(validationIssue("public_access_not_allowed"));
+  }
+
+  if (
+    object.expiresAt &&
+    isTemporaryStorageExpired({
+      now: params.now || new Date().toISOString(),
+      expiresAt: object.expiresAt,
+    })
+  ) {
+    issues.push(validationIssue("expired_object"));
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}


### PR DESCRIPTION
## Contexto

Este PR é stacked sobre o PR #789 (`feat/internal-preview-admin-guards`) e adiciona a fase STOR1 do épico Video Upload Foundation.

A proposta é criar apenas contratos puros para uma futura camada de storage temporário de vídeo, sem implementar storage real, upload real, endpoint, banco, SDK de provider ou UI.

Este PR permanece em draft e não deve ser mergeado ainda.

## STOR1 — Contratos puros de storage temporário de vídeo

Cria tipos e helpers para representar uma futura política de armazenamento temporário de vídeos.

## O que foi implementado

Arquivos criados:

- `src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.ts`
- `src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts`

Arquivo atualizado:

- `src/app/dashboard/boards/videoUpload/README.md`

## Tipos principais

- `VideoTemporaryStorageProvider`
- `VideoTemporaryStorageStatus`
- `VideoTemporaryStorageVisibility`
- `VideoTemporaryStoragePolicy`
- `VideoTemporaryStorageObject`
- `VideoTemporaryStorageValidationIssue`
- `VideoTemporaryStorageValidationResult`

## Helpers criados

- `createEmptyVideoTemporaryStorageObject`
- `calculateTemporaryStorageExpiration`
- `isTemporaryStorageExpired`
- `markTemporaryStorageUploaded`
- `markTemporaryStorageDeleted`
- `validateTemporaryStorageObject`

## Política padrão

A política padrão mantém a abordagem segura:

- provider `unknown`;
- retenção de 24 horas;
- remoção após processamento;
- visibilidade `signed_url_only`;
- acesso público desabilitado.

## O que este PR não faz

- Não cria storage real.
- Não usa SDK de provider.
- Não gera signed URL real.
- Não cria upload real.
- Não cria endpoint.
- Não cria UI.
- Não usa banco/Prisma.
- Não usa OpenAI.
- Não usa ffmpeg.
- Não conecta no BoardShell.
- Não altera navegação/menu.

## QA relatada

```bash
npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
npm run typecheck
git diff --check
```

Também foram rodadas regressões de guards/previews, VU, NSE e Adaptive V2.

## Status

Draft. Não fazer merge ainda.

Este PR deve permanecer empilhado sobre #789 até as fundações anteriores serem revisadas. A implementação real de storage/provider deve ficar para uma fase futura separada.