### PR TITLE
feat: add video upload session contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -258,12 +258,41 @@ O que não faz:
 - não salva nada em banco;
 - não conecta no produto real.
 
+### STOR2 — Contratos de sessão de upload e provider
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoUploadSessionContracts.ts`
+- `videoUploadSessionContracts.test.ts`
+
+O que faz:
+
+- define `VideoUploadSession` como contrato futuro entre draft validado, objeto temporário e URL temporária recebida;
+- define status de sessão, issues de validação e capacidades conceituais de provider;
+- cria helpers puros para criar sessão, marcar URL temporária pronta, marcar envio em andamento, marcar enviado e abortar;
+- valida sessão, draft snapshot, vínculo com usuário quando exigido, URL temporária e expiração;
+- cria mocks explícitos de capabilities e prepared upload result para testes/harness futuros.
+
+O que não faz:
+
+- não implementa provider real;
+- não gera URL assinada;
+- não usa S3, Vercel Blob, R2, GCS ou SDK de provider;
+- não cria upload real;
+- não cria endpoint;
+- não salva sessão em banco;
+- não conecta no produto real.
+
 ## Arquitetura Atual
 
 ```text
 VideoUploadDraft
 ↓
 validateVideoUploadDraft
+↓
+VideoUploadSession futuro
 ↓
 buildNarrativeSourceFromVideoUploadDraft
 ↓
@@ -299,6 +328,7 @@ Na prática, existem dois níveis de prova:
 - Proteção admin/dev compartilhada para previews internos.
 - Checklist manual do preview interno.
 - Contratos puros de storage temporário com retenção e validação.
+- Contratos puros de sessão de upload e interface conceitual de provider.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -308,6 +338,8 @@ Na prática, existem dois níveis de prova:
 - Storage.
 - Provider real de storage temporário.
 - URL assinada gerada por serviço real.
+- Sessão persistida de upload.
+- Provider real de URL temporária.
 - Transcrição automática.
 - Extração real de frames.
 - OCR real.
@@ -353,6 +385,7 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts
@@ -366,7 +399,7 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
-- STOR2: contrato de URL assinada, ainda sem provider real.
+- STOR3: contrato de auditoria e limpeza de objetos temporários.
 - VU10: contrato de providers de transcrição, frames e OCR.
 - VU11: documentação de custos, limites e retenção.
 - VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts
@@ -1,0 +1,352 @@
+import fs from "fs";
+import path from "path";
+
+import { VideoUploadDraft } from "./videoUploadTypes";
+import {
+  VideoUploadSession,
+  buildMockPreparedUploadResult,
+  buildMockProviderCapabilities,
+  createVideoUploadSession,
+  isVideoUploadSessionExpired,
+  markVideoUploadSessionAborted,
+  markVideoUploadSessionSigned,
+  markVideoUploadSessionUploaded,
+  markVideoUploadSessionUploading,
+  validateVideoUploadSession,
+} from "./videoUploadSessionContracts";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function validDraft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "draft-1",
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 20 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero entender se vale postar.",
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<VideoUploadSession> = {}): VideoUploadSession {
+  return {
+    ...createVideoUploadSession({
+      id: "session-1",
+      draft: validDraft(),
+      userId: "user-1",
+      createdAt: "2026-05-14T12:00:00.000Z",
+      expiresAt: "2026-05-14T14:00:00.000Z",
+      provider: "local_mock",
+    }),
+    ...overrides,
+  };
+}
+
+function issueCodes(target: VideoUploadSession, now = "2026-05-14T12:30:00.000Z") {
+  return validateVideoUploadSession({ session: target, now, requireUserId: true }).issues.map((issue) => issue.code);
+}
+
+describe("videoUploadSessionContracts", () => {
+  it("creates a video upload session with created status and empty storage object", () => {
+    const result = createVideoUploadSession({
+      id: "session-1",
+      draft: validDraft(),
+      userId: "user-1",
+      createdAt: "2026-05-14T12:00:00.000Z",
+      provider: "local_mock",
+    });
+
+    expect(result).toMatchObject({
+      id: "session-1",
+      draftId: "draft-1",
+      userId: "user-1",
+      status: "created",
+      signedUploadUrl: null,
+      signedUploadUrlExpiresAt: null,
+      createdAt: "2026-05-14T12:00:00.000Z",
+      updatedAt: "2026-05-14T12:00:00.000Z",
+      expiresAt: null,
+      storageObject: {
+        id: "session-1-storage",
+        draftId: "draft-1",
+        provider: "local_mock",
+        status: "not_requested",
+        storageKey: null,
+        publicUrl: null,
+        signedUrl: null,
+        metadata: {},
+      },
+    });
+  });
+
+  it("normalizes the draft snapshot using video upload validation", () => {
+    const result = createVideoUploadSession({
+      id: "session-1",
+      draft: validDraft({
+        fileName: "  Video.MP4  ",
+        mimeType: "  VIDEO/MP4  ",
+        creatorQuestion: "  Quero validar este vídeo.  ",
+      }),
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+
+    expect(result.draftSnapshot.fileName).toBe("Video.MP4");
+    expect(result.draftSnapshot.mimeType).toBe("video/mp4");
+    expect(result.draftSnapshot.creatorQuestion).toBe("Quero validar este vídeo.");
+  });
+
+  it("validates a created session with a valid draft", () => {
+    expect(validateVideoUploadSession({ session: session(), now: "2026-05-14T12:30:00.000Z" })).toEqual({
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects sessions without an id", () => {
+    expect(issueCodes(session({ id: " " }))).toContain("missing_session_id");
+  });
+
+  it("rejects sessions without a draft id", () => {
+    expect(issueCodes(session({ draftId: " " }))).toContain("missing_draft_id");
+  });
+
+  it("rejects missing user id when required", () => {
+    expect(issueCodes(session({ userId: null }))).toContain("missing_user_id");
+  });
+
+  it("rejects invalid draft snapshots", () => {
+    expect(issueCodes(session({ draftSnapshot: validDraft({ creatorQuestion: "" }) }))).toContain("invalid_draft");
+  });
+
+  it("rejects sessions without a storage object", () => {
+    const target = {
+      ...session(),
+      storageObject: null,
+    } as unknown as VideoUploadSession;
+
+    expect(issueCodes(target)).toContain("missing_storage_object");
+  });
+
+  it("marks the session as signed URL ready with received URL data", () => {
+    const result = markVideoUploadSessionSigned({
+      session: session(),
+      signedUploadUrl: "https://signed.example/upload",
+      signedUploadUrlExpiresAt: "2026-05-14T12:45:00.000Z",
+      updatedAt: "2026-05-14T12:10:00.000Z",
+    });
+
+    expect(result.status).toBe("signed_url_ready");
+    expect(result.signedUploadUrl).toBe("https://signed.example/upload");
+    expect(result.signedUploadUrlExpiresAt).toBe("2026-05-14T12:45:00.000Z");
+    expect(result.updatedAt).toBe("2026-05-14T12:10:00.000Z");
+  });
+
+  it("rejects signed_url_ready sessions without a signed upload URL", () => {
+    expect(issueCodes(session({ status: "signed_url_ready", signedUploadUrl: null }))).toContain(
+      "missing_signed_upload_url",
+    );
+  });
+
+  it("detects session expiration from expiresAt", () => {
+    expect(
+      isVideoUploadSessionExpired({
+        session: session({ expiresAt: "2026-05-14T12:30:00.000Z" }),
+        now: "2026-05-14T12:30:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects signed upload URL expiration while signed or uploading", () => {
+    const signed = session({
+      status: "signed_url_ready",
+      signedUploadUrl: "https://signed.example/upload",
+      signedUploadUrlExpiresAt: "2026-05-14T12:30:00.000Z",
+    });
+    const uploading = session({
+      status: "uploading",
+      signedUploadUrl: "https://signed.example/upload",
+      signedUploadUrlExpiresAt: "2026-05-14T12:30:00.000Z",
+    });
+
+    expect(isVideoUploadSessionExpired({ session: signed, now: "2026-05-14T12:30:00.000Z" })).toBe(true);
+    expect(isVideoUploadSessionExpired({ session: uploading, now: "2026-05-14T12:30:00.000Z" })).toBe(true);
+  });
+
+  it("marks the session as uploading", () => {
+    const result = markVideoUploadSessionUploading({
+      session: session(),
+      updatedAt: "2026-05-14T12:20:00.000Z",
+    });
+
+    expect(result.status).toBe("uploading");
+    expect(result.updatedAt).toBe("2026-05-14T12:20:00.000Z");
+  });
+
+  it("marks the session as uploaded, updates storage object, and clears signed URL", () => {
+    const result = markVideoUploadSessionUploaded({
+      session: markVideoUploadSessionSigned({
+        session: session(),
+        signedUploadUrl: "https://signed.example/upload",
+        signedUploadUrlExpiresAt: "2026-05-14T12:45:00.000Z",
+        updatedAt: "2026-05-14T12:10:00.000Z",
+      }),
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T12:30:00.000Z",
+      updatedAt: "2026-05-14T12:31:00.000Z",
+      retentionHours: 2,
+    });
+
+    expect(result.status).toBe("uploaded");
+    expect(result.signedUploadUrl).toBeNull();
+    expect(result.signedUploadUrlExpiresAt).toBeNull();
+    expect(result.updatedAt).toBe("2026-05-14T12:31:00.000Z");
+    expect(result.storageObject).toMatchObject({
+      status: "uploaded",
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T12:30:00.000Z",
+      expiresAt: "2026-05-14T14:30:00.000Z",
+      signedUrl: null,
+      metadata: {
+        durationSeconds: 45,
+      },
+    });
+  });
+
+  it("marks the session as aborted and clears signed URL", () => {
+    const result = markVideoUploadSessionAborted({
+      session: markVideoUploadSessionSigned({
+        session: session(),
+        signedUploadUrl: "https://signed.example/upload",
+        signedUploadUrlExpiresAt: "2026-05-14T12:45:00.000Z",
+        updatedAt: "2026-05-14T12:10:00.000Z",
+      }),
+      updatedAt: "2026-05-14T12:20:00.000Z",
+    });
+
+    expect(result.status).toBe("aborted");
+    expect(result.signedUploadUrl).toBeNull();
+    expect(result.signedUploadUrlExpiresAt).toBeNull();
+    expect(result.updatedAt).toBe("2026-05-14T12:20:00.000Z");
+  });
+
+  it("builds mock provider capabilities with safe defaults", () => {
+    expect(buildMockProviderCapabilities()).toEqual({
+      provider: "local_mock",
+      kind: "temporary_storage",
+      supportsSignedUploadUrl: true,
+      supportsDelete: true,
+      supportsMetadata: true,
+      maxUploadSizeMb: 100,
+    });
+  });
+
+  it("returns a pending provider result when no signed upload URL is supplied", () => {
+    const result = buildMockPreparedUploadResult({
+      session: session(),
+      storageKey: "temporary/video.mp4",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.signedUploadUrl).toBeNull();
+    expect(result.issues.map((issue) => issue.code)).toContain("missing_signed_upload_url");
+    expect(result.storageObject).toMatchObject({
+      status: "upload_url_requested",
+      storageKey: "temporary/video.mp4",
+    });
+  });
+
+  it("returns a prepared provider result when a signed upload URL is supplied", () => {
+    const result = buildMockPreparedUploadResult({
+      session: session(),
+      signedUploadUrl: "https://signed.example/upload",
+      signedUploadUrlExpiresAt: "2026-05-14T12:45:00.000Z",
+      storageKey: "temporary/video.mp4",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      signedUploadUrl: "https://signed.example/upload",
+      signedUploadUrlExpiresAt: "2026-05-14T12:45:00.000Z",
+      issues: [],
+      storageObject: {
+        status: "upload_url_requested",
+        storageKey: "temporary/video.mp4",
+      },
+    });
+  });
+
+  it("rejects unknown session statuses", () => {
+    const target = {
+      ...session(),
+      status: "unexpected",
+    } as unknown as VideoUploadSession;
+
+    expect(issueCodes(target)).toContain("invalid_status");
+  });
+
+  it("keeps session issue language safe", () => {
+    const target = {
+      ...session({
+        id: "",
+        draftId: "",
+        userId: null,
+        draftSnapshot: validDraft({ creatorQuestion: "" }),
+        status: "signed_url_ready",
+        signedUploadUrl: null,
+        signedUploadUrlExpiresAt: "2026-05-14T12:00:00.000Z",
+        expiresAt: "2026-05-14T12:00:00.000Z",
+      }),
+    } as VideoUploadSession;
+    const result = validateVideoUploadSession({
+      session: target,
+      now: "2026-05-14T12:30:00.000Z",
+      requireUserId: true,
+    });
+    const providerResult = buildMockPreparedUploadResult({ session: session() });
+    const text = JSON.stringify({
+      messages: result.issues.map((issue) => issue.message),
+      providerMessages: providerResult.issues.map((issue) => issue.message),
+    }).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, services, real storage, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoUploadSessionContracts.ts"), "utf8");
+
+    expect(source).toContain("./videoUploadTypes");
+    expect(source).toContain("./videoTemporaryStorageTypes");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("upload service real");
+    expect(source).not.toContain("storage provider SDK");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.ts
@@ -1,0 +1,336 @@
+import {
+  DEFAULT_VIDEO_UPLOAD_LIMITS,
+  VideoUploadDraft,
+  validateVideoUploadDraft,
+} from "./videoUploadTypes";
+import {
+  DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY,
+  VideoTemporaryStorageObject,
+  VideoTemporaryStoragePolicy,
+  VideoTemporaryStorageProvider,
+  createEmptyVideoTemporaryStorageObject,
+  isTemporaryStorageExpired,
+  markTemporaryStorageUploaded,
+} from "./videoTemporaryStorageTypes";
+
+export type VideoUploadSessionStatus =
+  | "created"
+  | "signed_url_ready"
+  | "uploading"
+  | "uploaded"
+  | "aborted"
+  | "expired"
+  | "failed";
+
+export type VideoUploadSession = {
+  id: string;
+  draftId: string;
+  userId: string | null;
+  status: VideoUploadSessionStatus;
+  draftSnapshot: VideoUploadDraft;
+  storageObject: VideoTemporaryStorageObject;
+  signedUploadUrl: string | null;
+  signedUploadUrlExpiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+};
+
+export type VideoUploadSessionIssueCode =
+  | "missing_session_id"
+  | "missing_draft_id"
+  | "missing_user_id"
+  | "invalid_draft"
+  | "missing_storage_object"
+  | "missing_signed_upload_url"
+  | "signed_upload_url_expired"
+  | "session_expired"
+  | "invalid_status";
+
+export type VideoUploadSessionIssue = {
+  code: VideoUploadSessionIssueCode;
+  message: string;
+};
+
+export type VideoUploadSessionValidationResult = {
+  ok: boolean;
+  issues: VideoUploadSessionIssue[];
+};
+
+export type VideoUploadProviderKind = "temporary_storage" | "direct_to_provider_future";
+
+export type VideoUploadProviderCapabilities = {
+  provider: VideoTemporaryStorageProvider;
+  kind: VideoUploadProviderKind;
+  supportsSignedUploadUrl: boolean;
+  supportsDelete: boolean;
+  supportsMetadata: boolean;
+  maxUploadSizeMb: number | null;
+};
+
+export type VideoUploadProviderRequest = {
+  sessionId: string;
+  draft: VideoUploadDraft;
+  policy: VideoTemporaryStoragePolicy;
+};
+
+export type VideoUploadProviderPreparedResult = {
+  ok: boolean;
+  storageObject: VideoTemporaryStorageObject | null;
+  signedUploadUrl: string | null;
+  signedUploadUrlExpiresAt: string | null;
+  issues: VideoUploadSessionIssue[];
+};
+
+const VALID_VIDEO_UPLOAD_SESSION_STATUSES: VideoUploadSessionStatus[] = [
+  "created",
+  "signed_url_ready",
+  "uploading",
+  "uploaded",
+  "aborted",
+  "expired",
+  "failed",
+];
+
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime());
+}
+
+function sessionIssue(code: VideoUploadSessionIssueCode): VideoUploadSessionIssue {
+  const messages: Record<VideoUploadSessionIssueCode, string> = {
+    missing_session_id: "Sessão sem identificador.",
+    missing_draft_id: "Sessão sem vínculo com draft.",
+    missing_user_id: "Sessão sem vínculo com usuário.",
+    invalid_draft: "Draft de vídeo não validado para upload.",
+    missing_storage_object: "Sessão sem objeto temporário.",
+    missing_signed_upload_url: "URL temporária de envio ausente.",
+    signed_upload_url_expired: "URL temporária de envio expirada.",
+    session_expired: "Sessão de upload expirada.",
+    invalid_status: "Status de sessão não reconhecido.",
+  };
+
+  return {
+    code,
+    message: messages[code],
+  };
+}
+
+function isExpiredAt(params: { now: string; expiresAt: string | null }): boolean {
+  if (!params.expiresAt) return false;
+
+  const now = new Date(params.now);
+  const expiresAt = new Date(params.expiresAt);
+
+  if (!isValidDate(now) || !isValidDate(expiresAt)) return false;
+
+  return now.getTime() >= expiresAt.getTime();
+}
+
+export function createVideoUploadSession(params: {
+  id: string;
+  draft: VideoUploadDraft;
+  userId?: string | null;
+  createdAt: string;
+  expiresAt?: string | null;
+  provider?: VideoTemporaryStorageProvider;
+}): VideoUploadSession {
+  const validation = validateVideoUploadDraft(params.draft);
+  const draftSnapshot = validation.normalizedDraft;
+
+  return {
+    id: params.id,
+    draftId: draftSnapshot.id,
+    userId: params.userId ?? null,
+    status: "created",
+    draftSnapshot,
+    storageObject: createEmptyVideoTemporaryStorageObject({
+      id: `${params.id}-storage`,
+      draftId: draftSnapshot.id,
+      provider: params.provider || DEFAULT_VIDEO_TEMPORARY_STORAGE_POLICY.provider,
+    }),
+    signedUploadUrl: null,
+    signedUploadUrlExpiresAt: null,
+    createdAt: params.createdAt,
+    updatedAt: params.createdAt,
+    expiresAt: params.expiresAt ?? null,
+  };
+}
+
+export function markVideoUploadSessionSigned(params: {
+  session: VideoUploadSession;
+  signedUploadUrl: string;
+  signedUploadUrlExpiresAt: string;
+  updatedAt: string;
+}): VideoUploadSession {
+  return {
+    ...params.session,
+    status: "signed_url_ready",
+    signedUploadUrl: params.signedUploadUrl,
+    signedUploadUrlExpiresAt: params.signedUploadUrlExpiresAt,
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function markVideoUploadSessionUploading(params: {
+  session: VideoUploadSession;
+  updatedAt: string;
+}): VideoUploadSession {
+  return {
+    ...params.session,
+    status: "uploading",
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function markVideoUploadSessionUploaded(params: {
+  session: VideoUploadSession;
+  storageKey: string;
+  uploadedAt: string;
+  updatedAt: string;
+  retentionHours?: number;
+}): VideoUploadSession {
+  return {
+    ...params.session,
+    status: "uploaded",
+    storageObject: markTemporaryStorageUploaded({
+      object: params.session.storageObject,
+      storageKey: params.storageKey,
+      uploadedAt: params.uploadedAt,
+      retentionHours: params.retentionHours,
+      signedUrl: null,
+      metadata: {
+        durationSeconds: params.session.draftSnapshot.durationSeconds,
+      },
+    }),
+    signedUploadUrl: null,
+    signedUploadUrlExpiresAt: null,
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function markVideoUploadSessionAborted(params: {
+  session: VideoUploadSession;
+  updatedAt: string;
+}): VideoUploadSession {
+  return {
+    ...params.session,
+    status: "aborted",
+    signedUploadUrl: null,
+    signedUploadUrlExpiresAt: null,
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function isVideoUploadSessionExpired(params: {
+  session: VideoUploadSession;
+  now: string;
+}): boolean {
+  if (isExpiredAt({ now: params.now, expiresAt: params.session.expiresAt })) {
+    return true;
+  }
+
+  if (
+    (params.session.status === "signed_url_ready" || params.session.status === "uploading") &&
+    isExpiredAt({
+      now: params.now,
+      expiresAt: params.session.signedUploadUrlExpiresAt,
+    })
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function validateVideoUploadSession(params: {
+  session: VideoUploadSession;
+  now?: string;
+  requireUserId?: boolean;
+}): VideoUploadSessionValidationResult {
+  const session = params.session;
+  const now = params.now || new Date().toISOString();
+  const issues: VideoUploadSessionIssue[] = [];
+
+  if (!session.id.trim()) {
+    issues.push(sessionIssue("missing_session_id"));
+  }
+
+  if (!session.draftId.trim()) {
+    issues.push(sessionIssue("missing_draft_id"));
+  }
+
+  if (params.requireUserId && !session.userId?.trim()) {
+    issues.push(sessionIssue("missing_user_id"));
+  }
+
+  if (!validateVideoUploadDraft(session.draftSnapshot).ok) {
+    issues.push(sessionIssue("invalid_draft"));
+  }
+
+  if (!session.storageObject) {
+    issues.push(sessionIssue("missing_storage_object"));
+  }
+
+  if (!VALID_VIDEO_UPLOAD_SESSION_STATUSES.includes(session.status)) {
+    issues.push(sessionIssue("invalid_status"));
+  }
+
+  if ((session.status === "signed_url_ready" || session.status === "uploading") && !session.signedUploadUrl) {
+    issues.push(sessionIssue("missing_signed_upload_url"));
+  }
+
+  if (
+    (session.status === "signed_url_ready" || session.status === "uploading") &&
+    isTemporaryStorageExpired({
+      now,
+      expiresAt: session.signedUploadUrlExpiresAt,
+    })
+  ) {
+    issues.push(sessionIssue("signed_upload_url_expired"));
+  }
+
+  if (isTemporaryStorageExpired({ now, expiresAt: session.expiresAt })) {
+    issues.push(sessionIssue("session_expired"));
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+export function buildMockProviderCapabilities(
+  params: Partial<VideoUploadProviderCapabilities> = {},
+): VideoUploadProviderCapabilities {
+  return {
+    provider: "local_mock",
+    kind: "temporary_storage",
+    supportsSignedUploadUrl: true,
+    supportsDelete: true,
+    supportsMetadata: true,
+    maxUploadSizeMb: DEFAULT_VIDEO_UPLOAD_LIMITS.maxFileSizeMb,
+    ...params,
+  };
+}
+
+export function buildMockPreparedUploadResult(params: {
+  session: VideoUploadSession;
+  signedUploadUrl?: string;
+  signedUploadUrlExpiresAt?: string;
+  storageKey?: string | null;
+}): VideoUploadProviderPreparedResult {
+  const storageObject: VideoTemporaryStorageObject = {
+    ...params.session.storageObject,
+    status: "upload_url_requested",
+    storageKey: params.storageKey ?? params.session.storageObject.storageKey,
+  };
+  const issues = params.signedUploadUrl ? [] : [sessionIssue("missing_signed_upload_url")];
+
+  return {
+    ok: issues.length === 0,
+    storageObject,
+    signedUploadUrl: params.signedUploadUrl ?? null,
+    signedUploadUrlExpiresAt: params.signedUploadUrlExpiresAt ?? null,
+    issues,
+  };
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #790. Adiciona a fase STOR2: contratos puros de sessão de upload e interface conceitual de provider.

## Inclui

- `videoUploadSessionContracts.ts`
- `videoUploadSessionContracts.test.ts`
- atualização do README de `videoUpload`

## Helpers

- `createVideoUploadSession`
- `markVideoUploadSessionSigned`
- `markVideoUploadSessionUploading`
- `markVideoUploadSessionUploaded`
- `markVideoUploadSessionAborted`
- `isVideoUploadSessionExpired`
- `validateVideoUploadSession`
- `buildMockProviderCapabilities`
- `buildMockPreparedUploadResult`

## Fora de escopo

Não há provider real, SDK, storage real, upload real, endpoint, UI, banco, OpenAI, ffmpeg, BoardShell ou navegação/menu.

## QA relatada

- `videoUploadSessionContracts.test.ts` passou
- `videoTemporaryStorageTypes.test.ts` passou
- regressões guard/previews, VU, NSE e Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.