### PR TITLE
feat: add video storage retention contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -285,6 +285,33 @@ O que não faz:
 - não salva sessão em banco;
 - não conecta no produto real.
 
+### STOR3 — Contratos de retenção e cleanup
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoStorageRetentionContracts.ts`
+- `videoStorageRetentionContracts.test.ts`
+
+O que faz:
+
+- define política de retenção para vídeos temporários;
+- define decisão de retenção, ação de cleanup, motivo e mensagem;
+- cria contrato de job de cleanup sem executar remoção real;
+- cria helpers puros para decidir cleanup, criar job, marcar fila/execução/conclusão/falha e validar tentativas;
+- cobre objetos expirados, uploads abortados, arquivos processados e fallback de manter pela política.
+
+O que não faz:
+
+- não cria cron ou job real;
+- não deleta arquivo real;
+- não chama provider de storage;
+- não usa SDK de storage;
+- não cria endpoint;
+- não salva nada em banco;
+- não conecta no produto real.
+
 ## Arquitetura Atual
 
 ```text
@@ -297,6 +324,8 @@ VideoUploadSession futuro
 buildNarrativeSourceFromVideoUploadDraft
 ↓
 VideoTemporaryStorageObject futuro
+↓
+VideoRetentionPolicy / VideoCleanupJob futuros
 ↓
 VideoProcessingArtifacts simulados
 ↓
@@ -329,6 +358,7 @@ Na prática, existem dois níveis de prova:
 - Checklist manual do preview interno.
 - Contratos puros de storage temporário com retenção e validação.
 - Contratos puros de sessão de upload e interface conceitual de provider.
+- Contratos puros de retenção e cleanup de vídeo temporário.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -340,6 +370,9 @@ Na prática, existem dois níveis de prova:
 - URL assinada gerada por serviço real.
 - Sessão persistida de upload.
 - Provider real de URL temporária.
+- Cleanup real.
+- Cron ou job real de remoção.
+- Deleção real de arquivo.
 - Transcrição automática.
 - Extração real de frames.
 - OCR real.
@@ -368,6 +401,8 @@ Antes de qualquer upload real, ainda é preciso decidir:
 - política de retenção e exclusão do vídeo;
 - contrato de URL assinada e escopo de acesso;
 - estratégia de remoção após processamento;
+- janela de retenção por plano e por status de processamento;
+- auditoria de cleanup e tentativas de remoção;
 - limite final de tamanho e duração;
 - extração de duração no client, no server ou em ambos;
 - provedor de transcrição;
@@ -385,6 +420,7 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts
@@ -399,7 +435,7 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
-- STOR3: contrato de auditoria e limpeza de objetos temporários.
+- STOR4: contrato de auditoria de cleanup e eventos de retenção.
 - VU10: contrato de providers de transcrição, frames e OCR.
 - VU11: documentação de custos, limites e retenção.
 - VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts
@@ -1,0 +1,385 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VideoTemporaryStorageObject,
+  createEmptyVideoTemporaryStorageObject,
+  markTemporaryStorageUploaded,
+} from "./videoTemporaryStorageTypes";
+import { VideoUploadSession, createVideoUploadSession } from "./videoUploadSessionContracts";
+import {
+  DEFAULT_VIDEO_RETENTION_POLICY,
+  VideoCleanupJob,
+  createVideoCleanupJob,
+  decideVideoRetentionAction,
+  markVideoCleanupJobCompleted,
+  markVideoCleanupJobFailed,
+  markVideoCleanupJobQueued,
+  markVideoCleanupJobRunning,
+  shouldRetryVideoCleanupJob,
+  validateVideoCleanupJob,
+} from "./videoStorageRetentionContracts";
+
+const oneMb = 1024 * 1024;
+const now = "2026-05-14T12:00:00.000Z";
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function storageObject(overrides: Partial<VideoTemporaryStorageObject> = {}): VideoTemporaryStorageObject {
+  return {
+    ...createEmptyVideoTemporaryStorageObject({
+      id: "storage-1",
+      draftId: "draft-1",
+      provider: "local_mock",
+    }),
+    ...overrides,
+    metadata: {
+      ...overrides.metadata,
+    },
+  };
+}
+
+function uploadedStorage(overrides: Partial<VideoTemporaryStorageObject> = {}): VideoTemporaryStorageObject {
+  return {
+    ...markTemporaryStorageUploaded({
+      object: storageObject(),
+      storageKey: "temporary/video.mp4",
+      uploadedAt: "2026-05-14T10:00:00.000Z",
+      retentionHours: 24,
+    }),
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<VideoUploadSession> = {}): VideoUploadSession {
+  return {
+    ...createVideoUploadSession({
+      id: "session-1",
+      draft: {
+        id: "draft-1",
+        source: "local_file",
+        fileName: "video.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 10 * oneMb,
+        durationSeconds: 45,
+        creatorQuestion: "Quero saber se vale postar.",
+        createdAt: null,
+      },
+      userId: "user-1",
+      createdAt: "2026-05-14T09:00:00.000Z",
+      provider: "local_mock",
+    }),
+    ...overrides,
+  };
+}
+
+function cleanupJob(overrides: Partial<VideoCleanupJob> = {}): VideoCleanupJob {
+  return {
+    ...createVideoCleanupJob({
+      id: "cleanup-1",
+      storageObject: uploadedStorage(),
+      sessionId: "session-1",
+      decision: decideVideoRetentionAction({
+        storageObject: uploadedStorage({ status: "processing_locked" }),
+        session: session({ status: "uploaded" }),
+        now,
+      }),
+      createdAt: now,
+    }),
+    ...overrides,
+  };
+}
+
+function issueCodes(job: VideoCleanupJob) {
+  return validateVideoCleanupJob({ job }).issues.map((issue) => issue.code);
+}
+
+describe("videoStorageRetentionContracts", () => {
+  it("uses safe default retention policy values", () => {
+    expect(DEFAULT_VIDEO_RETENTION_POLICY).toEqual({
+      deleteAfterProcessing: true,
+      deleteFailedUploadsAfterHours: 24,
+      deleteAbortedUploadsAfterHours: 24,
+      deleteExpiredObjects: true,
+      keepArtifactsAfterVideoDeletion: true,
+      maxCleanupAttempts: 3,
+    });
+  });
+
+  it("returns no_action when there is no storage object", () => {
+    expect(decideVideoRetentionAction({ storageObject: null, now })).toEqual({
+      shouldCleanup: false,
+      action: "no_action",
+      reason: "unknown",
+      message: "Nenhum arquivo temporário para avaliar.",
+    });
+  });
+
+  it("returns no_action when the storage object is already deleted", () => {
+    expect(decideVideoRetentionAction({ storageObject: storageObject({ status: "deleted" }), now })).toEqual({
+      shouldCleanup: false,
+      action: "no_action",
+      reason: "policy_cleanup",
+      message: "Arquivo temporário já marcado como removido.",
+    });
+  });
+
+  it("decides to delete expired temporary files", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: uploadedStorage({ expiresAt: "2026-05-14T11:59:00.000Z" }),
+      now,
+    });
+
+    expect(result).toEqual({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "expired",
+      message: "Arquivo temporário expirado e elegível para remoção.",
+    });
+  });
+
+  it("keeps expired temporary files when policy disables expired cleanup", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: uploadedStorage({ expiresAt: "2026-05-14T11:59:00.000Z" }),
+      policy: {
+        ...DEFAULT_VIDEO_RETENTION_POLICY,
+        deleteExpiredObjects: false,
+      },
+      now,
+    });
+
+    expect(result.action).toBe("keep");
+    expect(result.shouldCleanup).toBe(false);
+  });
+
+  it("decides to delete old aborted upload files", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: uploadedStorage(),
+      session: session({ status: "aborted", updatedAt: "2026-05-13T11:59:00.000Z" }),
+      now,
+    });
+
+    expect(result).toMatchObject({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "aborted",
+    });
+  });
+
+  it("keeps recent aborted upload files", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: uploadedStorage(),
+      session: session({ status: "aborted", updatedAt: "2026-05-14T11:30:00.000Z" }),
+      now,
+    });
+
+    expect(result.action).toBe("keep");
+    expect(result.shouldCleanup).toBe(false);
+  });
+
+  it("decides to delete processed temporary files with the safe processing rule", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: uploadedStorage({ status: "processing_locked" }),
+      session: session({ status: "uploaded" }),
+      now,
+    });
+
+    expect(result).toEqual({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "processed",
+      message: "Arquivo temporário elegível para remoção após processamento.",
+    });
+  });
+
+  it("keeps the temporary file when no cleanup rule applies", () => {
+    const result = decideVideoRetentionAction({
+      storageObject: storageObject({ status: "upload_pending" }),
+      session: session({ status: "created" }),
+      now,
+    });
+
+    expect(result).toEqual({
+      shouldCleanup: false,
+      action: "keep",
+      reason: "policy_cleanup",
+      message: "Arquivo temporário mantido pela política atual.",
+    });
+  });
+
+  it("creates a not_started cleanup job with default attempts", () => {
+    const decision = decideVideoRetentionAction({
+      storageObject: uploadedStorage({ expiresAt: "2026-05-14T11:59:00.000Z" }),
+      now,
+    });
+    const job = createVideoCleanupJob({
+      id: "cleanup-1",
+      storageObject: uploadedStorage(),
+      sessionId: "session-1",
+      decision,
+      createdAt: now,
+    });
+
+    expect(job).toEqual({
+      id: "cleanup-1",
+      storageObjectId: "storage-1",
+      sessionId: "session-1",
+      status: "not_started",
+      action: "delete_temporary_file",
+      reason: "expired",
+      attempts: 0,
+      maxAttempts: 3,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+      message: "Arquivo temporário expirado e elegível para remoção.",
+    });
+  });
+
+  it("marks cleanup jobs as queued", () => {
+    expect(markVideoCleanupJobQueued({ job: cleanupJob(), updatedAt: "2026-05-14T12:05:00.000Z" })).toMatchObject({
+      status: "queued",
+      updatedAt: "2026-05-14T12:05:00.000Z",
+    });
+  });
+
+  it("marks cleanup jobs as running and increments attempts", () => {
+    expect(markVideoCleanupJobRunning({ job: cleanupJob({ attempts: 1 }), updatedAt: "2026-05-14T12:05:00.000Z" })).toMatchObject({
+      status: "running",
+      attempts: 2,
+      updatedAt: "2026-05-14T12:05:00.000Z",
+    });
+  });
+
+  it("marks cleanup jobs as completed", () => {
+    expect(
+      markVideoCleanupJobCompleted({
+        job: cleanupJob(),
+        completedAt: "2026-05-14T12:10:00.000Z",
+        message: "Arquivo temporário marcado como removido.",
+      }),
+    ).toMatchObject({
+      status: "completed",
+      updatedAt: "2026-05-14T12:10:00.000Z",
+      completedAt: "2026-05-14T12:10:00.000Z",
+      message: "Arquivo temporário marcado como removido.",
+    });
+  });
+
+  it("marks cleanup jobs as failed", () => {
+    expect(
+      markVideoCleanupJobFailed({
+        job: cleanupJob(),
+        updatedAt: "2026-05-14T12:10:00.000Z",
+        message: "Limpeza será tentada novamente.",
+      }),
+    ).toMatchObject({
+      status: "failed",
+      updatedAt: "2026-05-14T12:10:00.000Z",
+      message: "Limpeza será tentada novamente.",
+    });
+  });
+
+  it("allows retry when a failed cleanup job still has attempts left", () => {
+    expect(shouldRetryVideoCleanupJob(cleanupJob({ status: "failed", attempts: 1, maxAttempts: 3 }))).toBe(true);
+  });
+
+  it("does not allow retry when attempts reached the limit", () => {
+    expect(shouldRetryVideoCleanupJob(cleanupJob({ status: "failed", attempts: 3, maxAttempts: 3 }))).toBe(false);
+  });
+
+  it("validates a cleanup job", () => {
+    expect(validateVideoCleanupJob({ job: cleanupJob() })).toEqual({
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects cleanup jobs without an id", () => {
+    expect(issueCodes(cleanupJob({ id: "" }))).toContain("missing_cleanup_job_id");
+  });
+
+  it("rejects cleanup jobs without a storage object id", () => {
+    expect(issueCodes(cleanupJob({ storageObjectId: "" }))).toContain("missing_storage_object");
+  });
+
+  it("rejects unknown cleanup actions", () => {
+    const job = {
+      ...cleanupJob(),
+      action: "unexpected",
+    } as unknown as VideoCleanupJob;
+
+    expect(issueCodes(job)).toContain("invalid_cleanup_action");
+  });
+
+  it("rejects unknown cleanup statuses", () => {
+    const job = {
+      ...cleanupJob(),
+      status: "unexpected",
+    } as unknown as VideoCleanupJob;
+
+    expect(issueCodes(job)).toContain("invalid_status");
+  });
+
+  it("rejects queued or running jobs when cleanup is not required", () => {
+    expect(issueCodes(cleanupJob({ action: "no_action", status: "queued" }))).toContain("cleanup_not_required");
+    expect(issueCodes(cleanupJob({ action: "no_action", status: "running" }))).toContain("cleanup_not_required");
+  });
+
+  it("keeps retention and cleanup messages safe", () => {
+    const decisions = [
+      decideVideoRetentionAction({ storageObject: null, now }),
+      decideVideoRetentionAction({ storageObject: storageObject({ status: "deleted" }), now }),
+      decideVideoRetentionAction({ storageObject: uploadedStorage({ expiresAt: "2026-05-14T11:59:00.000Z" }), now }),
+      decideVideoRetentionAction({ storageObject: storageObject(), now }),
+    ];
+    const invalidJob = {
+      ...cleanupJob({
+        id: "",
+        storageObjectId: "",
+        action: "unexpected",
+        status: "unexpected",
+      }),
+    } as unknown as VideoCleanupJob;
+    const messages = [
+      ...decisions.map((item) => item.message),
+      ...validateVideoCleanupJob({ job: invalidJob }).issues.map((issue) => issue.message),
+    ].join(" ").toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(messages).not.toContain(term);
+    }
+    expect(messages).not.toContain("erro");
+  });
+
+  it("does not import UI, real cleanup, providers, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoStorageRetentionContracts.ts"), "utf8");
+
+    expect(source).toContain("./videoTemporaryStorageTypes");
+    expect(source).toContain("./videoUploadSessionContracts");
+    expect(source).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("banco");
+    expect(source).not.toContain("components/");
+    expect(source).not.toContain("hooks/");
+    expect(source).not.toContain("endpoint");
+    expect(source).not.toContain("upload service real");
+    expect(source).not.toContain("storage provider SDK");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.ts
@@ -1,0 +1,350 @@
+import {
+  VideoTemporaryStorageObject,
+  isTemporaryStorageExpired,
+} from "./videoTemporaryStorageTypes";
+import { VideoUploadSession } from "./videoUploadSessionContracts";
+
+export type VideoRetentionReason =
+  | "expired"
+  | "processed"
+  | "failed"
+  | "aborted"
+  | "manual_request"
+  | "policy_cleanup"
+  | "unknown";
+
+export type VideoRetentionAction =
+  | "keep"
+  | "delete_temporary_file"
+  | "mark_expired"
+  | "mark_deleted"
+  | "no_action";
+
+export type VideoRetentionDecision = {
+  shouldCleanup: boolean;
+  action: VideoRetentionAction;
+  reason: VideoRetentionReason;
+  message: string;
+};
+
+export type VideoCleanupJobStatus =
+  | "not_started"
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "skipped";
+
+export type VideoCleanupJob = {
+  id: string;
+  storageObjectId: string;
+  sessionId: string | null;
+  status: VideoCleanupJobStatus;
+  action: VideoRetentionAction;
+  reason: VideoRetentionReason;
+  attempts: number;
+  maxAttempts: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  message: string | null;
+};
+
+export type VideoRetentionPolicy = {
+  deleteAfterProcessing: boolean;
+  deleteFailedUploadsAfterHours: number;
+  deleteAbortedUploadsAfterHours: number;
+  deleteExpiredObjects: boolean;
+  keepArtifactsAfterVideoDeletion: boolean;
+  maxCleanupAttempts: number;
+};
+
+export type VideoRetentionIssueCode =
+  | "missing_storage_object"
+  | "missing_cleanup_job_id"
+  | "invalid_cleanup_action"
+  | "max_attempts_reached"
+  | "cleanup_not_required"
+  | "invalid_status";
+
+export type VideoRetentionIssue = {
+  code: VideoRetentionIssueCode;
+  message: string;
+};
+
+export type VideoCleanupValidationResult = {
+  ok: boolean;
+  issues: VideoRetentionIssue[];
+};
+
+export const DEFAULT_VIDEO_RETENTION_POLICY: VideoRetentionPolicy = {
+  deleteAfterProcessing: true,
+  deleteFailedUploadsAfterHours: 24,
+  deleteAbortedUploadsAfterHours: 24,
+  deleteExpiredObjects: true,
+  keepArtifactsAfterVideoDeletion: true,
+  maxCleanupAttempts: 3,
+};
+
+const VALID_RETENTION_ACTIONS: VideoRetentionAction[] = [
+  "keep",
+  "delete_temporary_file",
+  "mark_expired",
+  "mark_deleted",
+  "no_action",
+];
+
+const VALID_CLEANUP_STATUSES: VideoCleanupJobStatus[] = [
+  "not_started",
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "skipped",
+];
+
+function retentionIssue(code: VideoRetentionIssueCode): VideoRetentionIssue {
+  const messages: Record<VideoRetentionIssueCode, string> = {
+    missing_storage_object: "Job de limpeza sem arquivo temporário.",
+    missing_cleanup_job_id: "Job de limpeza sem identificador.",
+    invalid_cleanup_action: "Ação de limpeza não reconhecida.",
+    max_attempts_reached: "Limite de tentativas de limpeza atingido.",
+    cleanup_not_required: "Limpeza não necessária para este job.",
+    invalid_status: "Status de limpeza não reconhecido.",
+  };
+
+  return {
+    code,
+    message: messages[code],
+  };
+}
+
+function decision(params: {
+  shouldCleanup: boolean;
+  action: VideoRetentionAction;
+  reason: VideoRetentionReason;
+  message: string;
+}): VideoRetentionDecision {
+  return params;
+}
+
+function ageIsAtLeastHours(params: { since: string | null; now: string; hours: number }): boolean {
+  if (!params.since || params.hours <= 0) return false;
+
+  const since = new Date(params.since);
+  const now = new Date(params.now);
+
+  if (Number.isNaN(since.getTime()) || Number.isNaN(now.getTime())) return false;
+
+  return now.getTime() - since.getTime() >= params.hours * 60 * 60 * 1000;
+}
+
+export function decideVideoRetentionAction(params: {
+  storageObject: VideoTemporaryStorageObject | null;
+  session?: VideoUploadSession | null;
+  policy?: VideoRetentionPolicy;
+  now: string;
+}): VideoRetentionDecision {
+  const policy = params.policy || DEFAULT_VIDEO_RETENTION_POLICY;
+  const storageObject = params.storageObject;
+  const session = params.session || null;
+
+  if (!storageObject) {
+    return decision({
+      shouldCleanup: false,
+      action: "no_action",
+      reason: "unknown",
+      message: "Nenhum arquivo temporário para avaliar.",
+    });
+  }
+
+  if (storageObject.status === "deleted") {
+    return decision({
+      shouldCleanup: false,
+      action: "no_action",
+      reason: "policy_cleanup",
+      message: "Arquivo temporário já marcado como removido.",
+    });
+  }
+
+  if (
+    policy.deleteExpiredObjects &&
+    isTemporaryStorageExpired({
+      now: params.now,
+      expiresAt: storageObject.expiresAt,
+    })
+  ) {
+    return decision({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "expired",
+      message: "Arquivo temporário expirado e elegível para remoção.",
+    });
+  }
+
+  if (
+    policy.deleteAfterProcessing &&
+    session?.status === "uploaded" &&
+    (storageObject.status === "processing_locked" || storageObject.status === "uploaded")
+  ) {
+    return decision({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "processed",
+      message: "Arquivo temporário elegível para remoção após processamento.",
+    });
+  }
+
+  if (
+    session?.status === "aborted" &&
+    ageIsAtLeastHours({
+      since: session.updatedAt,
+      now: params.now,
+      hours: policy.deleteAbortedUploadsAfterHours,
+    })
+  ) {
+    return decision({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "aborted",
+      message: "Upload interrompido elegível para remoção.",
+    });
+  }
+
+  if (
+    session?.status === "failed" &&
+    ageIsAtLeastHours({
+      since: session.updatedAt,
+      now: params.now,
+      hours: policy.deleteFailedUploadsAfterHours,
+    })
+  ) {
+    return decision({
+      shouldCleanup: true,
+      action: "delete_temporary_file",
+      reason: "failed",
+      message: "Upload interrompido elegível para remoção.",
+    });
+  }
+
+  return decision({
+    shouldCleanup: false,
+    action: "keep",
+    reason: "policy_cleanup",
+    message: "Arquivo temporário mantido pela política atual.",
+  });
+}
+
+export function createVideoCleanupJob(params: {
+  id: string;
+  storageObject: VideoTemporaryStorageObject;
+  sessionId?: string | null;
+  decision: VideoRetentionDecision;
+  createdAt: string;
+  maxAttempts?: number;
+}): VideoCleanupJob {
+  return {
+    id: params.id,
+    storageObjectId: params.storageObject.id,
+    sessionId: params.sessionId ?? null,
+    status: "not_started",
+    action: params.decision.action,
+    reason: params.decision.reason,
+    attempts: 0,
+    maxAttempts: params.maxAttempts ?? DEFAULT_VIDEO_RETENTION_POLICY.maxCleanupAttempts,
+    createdAt: params.createdAt,
+    updatedAt: params.createdAt,
+    completedAt: null,
+    message: params.decision.message,
+  };
+}
+
+export function markVideoCleanupJobQueued(params: {
+  job: VideoCleanupJob;
+  updatedAt: string;
+}): VideoCleanupJob {
+  return {
+    ...params.job,
+    status: "queued",
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function markVideoCleanupJobRunning(params: {
+  job: VideoCleanupJob;
+  updatedAt: string;
+}): VideoCleanupJob {
+  return {
+    ...params.job,
+    status: "running",
+    attempts: params.job.attempts + 1,
+    updatedAt: params.updatedAt,
+  };
+}
+
+export function markVideoCleanupJobCompleted(params: {
+  job: VideoCleanupJob;
+  completedAt: string;
+  message?: string | null;
+}): VideoCleanupJob {
+  return {
+    ...params.job,
+    status: "completed",
+    updatedAt: params.completedAt,
+    completedAt: params.completedAt,
+    message: params.message ?? params.job.message,
+  };
+}
+
+export function markVideoCleanupJobFailed(params: {
+  job: VideoCleanupJob;
+  updatedAt: string;
+  message?: string | null;
+}): VideoCleanupJob {
+  return {
+    ...params.job,
+    status: "failed",
+    updatedAt: params.updatedAt,
+    message: params.message ?? params.job.message,
+  };
+}
+
+export function shouldRetryVideoCleanupJob(job: VideoCleanupJob): boolean {
+  return job.status === "failed" && job.attempts < job.maxAttempts;
+}
+
+export function validateVideoCleanupJob(params: {
+  job: VideoCleanupJob;
+}): VideoCleanupValidationResult {
+  const job = params.job;
+  const issues: VideoRetentionIssue[] = [];
+
+  if (!job.id.trim()) {
+    issues.push(retentionIssue("missing_cleanup_job_id"));
+  }
+
+  if (!job.storageObjectId.trim()) {
+    issues.push(retentionIssue("missing_storage_object"));
+  }
+
+  if (!VALID_RETENTION_ACTIONS.includes(job.action)) {
+    issues.push(retentionIssue("invalid_cleanup_action"));
+  }
+
+  if (!VALID_CLEANUP_STATUSES.includes(job.status)) {
+    issues.push(retentionIssue("invalid_status"));
+  }
+
+  if (job.status === "failed" && job.attempts >= job.maxAttempts) {
+    issues.push(retentionIssue("max_attempts_reached"));
+  }
+
+  if ((job.status === "queued" || job.status === "running") && job.action === "no_action") {
+    issues.push(retentionIssue("cleanup_not_required"));
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #791. Adiciona a fase STOR3: contratos puros de retenção e cleanup de vídeo temporário.

## Inclui

- `videoStorageRetentionContracts.ts`
- `videoStorageRetentionContracts.test.ts`
- atualização do README de `videoUpload`

## Helpers

- `decideVideoRetentionAction`
- `createVideoCleanupJob`
- `markVideoCleanupJobQueued`
- `markVideoCleanupJobRunning`
- `markVideoCleanupJobCompleted`
- `markVideoCleanupJobFailed`
- `shouldRetryVideoCleanupJob`
- `validateVideoCleanupJob`

## Fora de escopo

Não há cleanup real, cron real, provider real, SDK, storage real, upload real, endpoint, UI, banco, OpenAI, ffmpeg, BoardShell ou navegação/menu.

## QA relatada

- `videoStorageRetentionContracts.test.ts` passou
- `videoUploadSessionContracts.test.ts` passou
- `videoTemporaryStorageTypes.test.ts` passou
- regressões guard/previews, VU, NSE e Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.