### PR TITLE
feat: add video processing provider contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -312,6 +312,33 @@ O que não faz:
 - não salva nada em banco;
 - não conecta no produto real.
 
+### PROC1 — Contratos de providers de processamento
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoProcessingProviderContracts.ts`
+- `videoProcessingProviderContracts.test.ts`
+
+O que faz:
+
+- define providers futuros de processamento sem implementar provider real;
+- define tarefas de transcrição, extração de frames, OCR, resumo visual, sinais técnicos e análise multimodal futura;
+- cria contrato de input de processamento a partir de sessão e objeto temporário;
+- cria capabilities conceituais de provider e valida request por tarefa, URL temporária, duração e tamanho;
+- cria helpers puros para resultado de tarefa, conclusão, falha e merge de resultados em `VideoProcessingArtifacts`.
+
+O que não faz:
+
+- não implementa provider real;
+- não usa OpenAI, Whisper, ffmpeg, OCR real ou SDK de processamento;
+- não cria fila ou job real;
+- não cria endpoint;
+- não cria storage real;
+- não salva nada em banco;
+- não conecta no produto real.
+
 ## Arquitetura Atual
 
 ```text
@@ -326,6 +353,8 @@ buildNarrativeSourceFromVideoUploadDraft
 VideoTemporaryStorageObject futuro
 ↓
 VideoRetentionPolicy / VideoCleanupJob futuros
+↓
+VideoProcessingProviderContracts futuros
 ↓
 VideoProcessingArtifacts simulados
 ↓
@@ -359,6 +388,7 @@ Na prática, existem dois níveis de prova:
 - Contratos puros de storage temporário com retenção e validação.
 - Contratos puros de sessão de upload e interface conceitual de provider.
 - Contratos puros de retenção e cleanup de vídeo temporário.
+- Contratos puros de providers de processamento de vídeo.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -373,9 +403,13 @@ Na prática, existem dois níveis de prova:
 - Cleanup real.
 - Cron ou job real de remoção.
 - Deleção real de arquivo.
+- Provider real de processamento.
+- Fila ou job real de processamento.
 - Transcrição automática.
 - Extração real de frames.
 - OCR real.
+- Whisper SDK.
+- OCR SDK.
 - Análise multimodal.
 - OpenAI.
 - ffmpeg.
@@ -406,6 +440,8 @@ Antes de qualquer upload real, ainda é preciso decidir:
 - limite final de tamanho e duração;
 - extração de duração no client, no server ou em ambos;
 - provedor de transcrição;
+- contrato operacional de provider de processamento;
+- estratégia de fila/job de processamento;
 - estratégia de frames-chave;
 - estratégia de OCR;
 - estratégia de análise multimodal;
@@ -420,6 +456,7 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts
@@ -435,7 +472,7 @@ git diff --check
 
 ## Próximas Fases Sugeridas
 
+- PROC2: contrato de fila/job conceitual de processamento.
 - STOR4: contrato de auditoria de cleanup e eventos de retenção.
-- VU10: contrato de providers de transcrição, frames e OCR.
 - VU11: documentação de custos, limites e retenção.
 - VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.

--- a/src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts
@@ -1,0 +1,368 @@
+import fs from "fs";
+import path from "path";
+
+import { VideoUploadDraft } from "./videoUploadTypes";
+import { createVideoUploadSession, markVideoUploadSessionSigned } from "./videoUploadSessionContracts";
+import {
+  VideoProcessingTaskRequest,
+  buildMockVideoProcessingProviderCapabilities,
+  createEmptyVideoProcessingTaskResult,
+  createVideoProcessingTaskRequest,
+  markVideoProcessingTaskCompleted,
+  markVideoProcessingTaskFailed,
+  mergeVideoProcessingTaskResults,
+  validateVideoProcessingTaskRequest,
+} from "./videoProcessingProviderContracts";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function draft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "draft-1",
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 20 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero entender se vale postar.",
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function signedSession(overrides: Partial<VideoUploadDraft> = {}) {
+  const session = createVideoUploadSession({
+    id: "session-1",
+    draft: draft(overrides),
+    userId: "user-1",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    provider: "local_mock",
+  });
+
+  return markVideoUploadSessionSigned({
+    session: {
+      ...session,
+      storageObject: {
+        ...session.storageObject,
+        storageKey: "temporary/video.mp4",
+      },
+    },
+    signedUploadUrl: "https://signed.example/upload",
+    signedUploadUrlExpiresAt: "2026-05-14T12:30:00.000Z",
+    updatedAt: "2026-05-14T12:05:00.000Z",
+  });
+}
+
+function request(overrides: Partial<VideoProcessingTaskRequest> = {}): VideoProcessingTaskRequest {
+  return {
+    ...createVideoProcessingTaskRequest({
+      id: "task-1",
+      session: signedSession(),
+      taskType: "transcription",
+      createdAt: "2026-05-14T12:10:00.000Z",
+    }),
+    ...overrides,
+    input: {
+      ...createVideoProcessingTaskRequest({
+        id: "task-1",
+        session: signedSession(),
+        taskType: "transcription",
+        createdAt: "2026-05-14T12:10:00.000Z",
+      }).input,
+      ...overrides.input,
+    },
+  };
+}
+
+function issueCodes(target: VideoProcessingTaskRequest, capabilities = buildMockVideoProcessingProviderCapabilities()) {
+  return validateVideoProcessingTaskRequest({ request: target, capabilities }).issues.map((issue) => issue.code);
+}
+
+describe("videoProcessingProviderContracts", () => {
+  it("builds mock provider capabilities with safe defaults", () => {
+    expect(buildMockVideoProcessingProviderCapabilities()).toEqual({
+      provider: "local_mock",
+      supportedTasks: ["transcription", "frame_extraction", "ocr", "visual_summary", "technical_signals"],
+      requiresSignedUrl: true,
+      supportsBatch: false,
+      maxDurationSeconds: 90,
+      maxFileSizeMb: 100,
+    });
+  });
+
+  it("creates a task request from a session with storage object and signed URL", () => {
+    expect(request()).toMatchObject({
+      id: "task-1",
+      sessionId: "session-1",
+      storageObjectId: "session-1-storage",
+      taskType: "transcription",
+      provider: "local_mock",
+      createdAt: "2026-05-14T12:10:00.000Z",
+      input: {
+        storageObjectId: "session-1-storage",
+        storageKey: "temporary/video.mp4",
+        signedUrl: "https://signed.example/upload",
+      },
+    });
+  });
+
+  it("preserves mimeType, durationSeconds, and sizeBytes in the input", () => {
+    expect(request().input).toMatchObject({
+      mimeType: "video/mp4",
+      durationSeconds: 45,
+      sizeBytes: 20 * oneMb,
+    });
+  });
+
+  it("validates a supported task request", () => {
+    expect(validateVideoProcessingTaskRequest({ request: request() })).toEqual({
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects requests without a task id", () => {
+    expect(issueCodes(request({ id: " " }))).toContain("missing_task_id");
+  });
+
+  it("rejects requests without a session id", () => {
+    expect(issueCodes(request({ sessionId: " " }))).toContain("missing_session_id");
+  });
+
+  it("rejects requests without a storage object id", () => {
+    expect(issueCodes(request({ storageObjectId: " " }))).toContain("missing_storage_object");
+  });
+
+  it("rejects missing signed URL when the provider requires it", () => {
+    expect(issueCodes(request({ input: { signedUrl: null } }))).toContain("missing_signed_url");
+  });
+
+  it("allows missing signed URL when the provider does not require it", () => {
+    expect(
+      validateVideoProcessingTaskRequest({
+        request: request({ input: { signedUrl: null } }),
+        capabilities: buildMockVideoProcessingProviderCapabilities({ requiresSignedUrl: false }),
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("rejects unsupported task types", () => {
+    expect(
+      issueCodes(
+        request({ taskType: "multimodal_summary" }),
+        buildMockVideoProcessingProviderCapabilities({ supportedTasks: ["transcription"] }),
+      ),
+    ).toContain("unsupported_task");
+  });
+
+  it("rejects videos above the duration limit", () => {
+    expect(issueCodes(request({ input: { durationSeconds: 120 } }))).toContain("duration_too_long");
+  });
+
+  it("rejects videos above the file size limit", () => {
+    expect(issueCodes(request({ input: { sizeBytes: 101 * oneMb } }))).toContain("file_too_large");
+  });
+
+  it("creates an empty task result", () => {
+    expect(createEmptyVideoProcessingTaskResult({ request: request() })).toEqual({
+      taskId: "task-1",
+      taskType: "transcription",
+      provider: "local_mock",
+      status: "not_started",
+      artifacts: {},
+      message: null,
+      completedAt: null,
+    });
+  });
+
+  it("marks a task result as completed with artifacts", () => {
+    const result = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      artifacts: {
+        transcript: {
+          fullText: "Texto transcrito.",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [],
+        },
+      },
+      completedAt: "2026-05-14T12:20:00.000Z",
+      message: "Transcrição concluída.",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.transcript?.fullText).toBe("Texto transcrito.");
+    expect(result.completedAt).toBe("2026-05-14T12:20:00.000Z");
+  });
+
+  it("marks a task result as failed with message", () => {
+    const result = markVideoProcessingTaskFailed({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      message: "Provider indisponível para esta solicitação.",
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.message).toBe("Provider indisponível para esta solicitação.");
+    expect(result.completedAt).toBe("2026-05-14T12:20:00.000Z");
+  });
+
+  it("merges transcript segments from completed task results", () => {
+    const first = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      artifacts: {
+        transcript: {
+          fullText: "Texto principal.",
+          language: "pt-BR",
+          provider: "manual",
+          segments: [{ startSeconds: 0, endSeconds: 2, text: "Começo", confidence: 0.9 }],
+        },
+      },
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+    const second = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request({ id: "task-2" }) }),
+      artifacts: {
+        transcript: {
+          fullText: null,
+          language: "pt-BR",
+          provider: "manual",
+          segments: [{ startSeconds: 3, endSeconds: 5, text: "Fim", confidence: 0.85 }],
+        },
+      },
+      completedAt: "2026-05-14T12:21:00.000Z",
+    });
+
+    const merged = mergeVideoProcessingTaskResults([first, second]);
+
+    expect(merged.status).toBe("completed");
+    expect(merged.transcript.fullText).toBe("Texto principal.");
+    expect(merged.transcript.segments).toHaveLength(2);
+  });
+
+  it("merges frames, OCR, and technical signals", () => {
+    const result = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      artifacts: {
+        frames: [{ id: "frame-1", timestampSeconds: 1, label: "opening", description: "Abertura", imageStorageKey: null }],
+        ocr: [{ timestampSeconds: 2, text: "Texto na tela", confidence: 0.8 }],
+        technicalSignals: [{ type: "duration", value: "45 segundos", confidence: 1 }],
+      },
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+
+    const merged = mergeVideoProcessingTaskResults([result]);
+
+    expect(merged.frames).toHaveLength(1);
+    expect(merged.ocr).toHaveLength(1);
+    expect(merged.technicalSignals).toHaveLength(1);
+  });
+
+  it("uses the first non-empty visual summary", () => {
+    const first = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      artifacts: { visualSummary: " " },
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+    const second = markVideoProcessingTaskCompleted({
+      result: createEmptyVideoProcessingTaskResult({ request: request({ id: "task-2" }) }),
+      artifacts: { visualSummary: "Pessoa mostrando bastidor de criação." },
+      completedAt: "2026-05-14T12:21:00.000Z",
+    });
+
+    expect(mergeVideoProcessingTaskResults([first, second]).visualSummary).toBe("Pessoa mostrando bastidor de criação.");
+  });
+
+  it("returns pending empty artifacts when there are no results", () => {
+    expect(mergeVideoProcessingTaskResults([])).toMatchObject({
+      status: "pending",
+      frames: [],
+      ocr: [],
+      technicalSignals: [],
+      visualSummary: null,
+      processingNotes: [],
+    });
+  });
+
+  it("returns failed artifacts when all results fail", () => {
+    const failed = markVideoProcessingTaskFailed({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      message: "Provider indisponível para esta solicitação.",
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+
+    const merged = mergeVideoProcessingTaskResults([failed]);
+
+    expect(merged.status).toBe("failed");
+    expect(merged.processingNotes).toEqual(["Provider indisponível para esta solicitação."]);
+  });
+
+  it("keeps provider issue and result language safe", () => {
+    const invalidRequest = request({
+      id: "",
+      sessionId: "",
+      storageObjectId: "",
+      input: {
+        storageObjectId: "",
+        signedUrl: null,
+        durationSeconds: 120,
+        sizeBytes: 101 * oneMb,
+      },
+      taskType: "multimodal_summary",
+    });
+    const failed = markVideoProcessingTaskFailed({
+      result: createEmptyVideoProcessingTaskResult({ request: request() }),
+      message: "Provider indisponível para esta solicitação.",
+      completedAt: "2026-05-14T12:20:00.000Z",
+    });
+    const text = JSON.stringify({
+      issues: validateVideoProcessingTaskRequest({ request: invalidRequest }).issues.map((issue) => issue.message),
+      resultMessage: failed.message,
+      notes: mergeVideoProcessingTaskResults([failed]).processingNotes,
+    }).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, real providers, SDKs, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoProcessingProviderContracts.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(source).toContain("./videoProcessingArtifacts");
+    expect(source).toContain("./videoUploadSessionContracts");
+    expect(imports).not.toContain("React");
+    expect(imports).not.toContain("BoardShell");
+    expect(imports).not.toContain("PostCreationFunnelBoardShell");
+    expect(imports).not.toContain("OpenAI");
+    expect(imports).not.toContain("fetch");
+    expect(imports).not.toContain("Prisma");
+    expect(imports).not.toContain("banco");
+    expect(imports).not.toContain("components/");
+    expect(imports).not.toContain("hooks/");
+    expect(imports).not.toContain("endpoint");
+    expect(imports).not.toContain("ffmpeg");
+    expect(source).not.toContain("upload service real");
+    expect(source).not.toContain("storage provider SDK");
+    expect(source).not.toContain("Whisper SDK");
+    expect(source).not.toContain("OCR SDK");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.ts
@@ -1,0 +1,295 @@
+import {
+  VideoProcessingArtifacts,
+  VideoProcessingStatus,
+  createEmptyVideoProcessingArtifacts,
+} from "./videoProcessingArtifacts";
+import { VideoUploadSession } from "./videoUploadSessionContracts";
+
+export type VideoProcessingProviderName =
+  | "future_openai"
+  | "future_whisper"
+  | "future_assemblyai"
+  | "future_ffmpeg"
+  | "future_google_vision"
+  | "future_manual"
+  | "local_mock"
+  | "unknown";
+
+export type VideoProcessingTaskType =
+  | "transcription"
+  | "frame_extraction"
+  | "ocr"
+  | "visual_summary"
+  | "technical_signals"
+  | "multimodal_summary"
+  | "unknown";
+
+export type VideoProcessingTaskStatus =
+  | "not_started"
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "skipped";
+
+export type VideoProcessingInputSource = {
+  storageObjectId: string;
+  storageKey: string | null;
+  signedUrl: string | null;
+  mimeType: string | null;
+  durationSeconds: number | null;
+  sizeBytes: number | null;
+};
+
+export type VideoProcessingProviderCapabilities = {
+  provider: VideoProcessingProviderName;
+  supportedTasks: VideoProcessingTaskType[];
+  requiresSignedUrl: boolean;
+  supportsBatch: boolean;
+  maxDurationSeconds: number | null;
+  maxFileSizeMb: number | null;
+};
+
+export type VideoProcessingTaskRequest = {
+  id: string;
+  sessionId: string;
+  storageObjectId: string;
+  taskType: VideoProcessingTaskType;
+  provider: VideoProcessingProviderName;
+  input: VideoProcessingInputSource;
+  createdAt: string;
+};
+
+export type VideoProcessingTaskResult = {
+  taskId: string;
+  taskType: VideoProcessingTaskType;
+  provider: VideoProcessingProviderName;
+  status: VideoProcessingTaskStatus;
+  artifacts: Partial<VideoProcessingArtifacts>;
+  message: string | null;
+  completedAt: string | null;
+};
+
+export type VideoProcessingProviderIssueCode =
+  | "missing_task_id"
+  | "missing_session_id"
+  | "missing_storage_object"
+  | "missing_input_source"
+  | "missing_signed_url"
+  | "unsupported_task"
+  | "duration_too_long"
+  | "file_too_large"
+  | "invalid_status"
+  | "provider_unavailable";
+
+export type VideoProcessingProviderIssue = {
+  code: VideoProcessingProviderIssueCode;
+  message: string;
+};
+
+export type VideoProcessingProviderValidationResult = {
+  ok: boolean;
+  issues: VideoProcessingProviderIssue[];
+};
+
+const BYTES_PER_MB = 1024 * 1024;
+
+function providerIssue(code: VideoProcessingProviderIssueCode): VideoProcessingProviderIssue {
+  const messages: Record<VideoProcessingProviderIssueCode, string> = {
+    missing_task_id: "Tarefa sem identificador.",
+    missing_session_id: "Tarefa sem vínculo com sessão.",
+    missing_storage_object: "Tarefa sem arquivo temporário.",
+    missing_input_source: "Fonte de processamento ausente.",
+    missing_signed_url: "URL temporária necessária para este processamento.",
+    unsupported_task: "Tipo de processamento não suportado pelo provider.",
+    duration_too_long: "Vídeo acima do limite de duração deste provider.",
+    file_too_large: "Vídeo acima do limite de tamanho deste provider.",
+    invalid_status: "Status de processamento não reconhecido.",
+    provider_unavailable: "Provider indisponível para esta solicitação.",
+  };
+
+  return {
+    code,
+    message: messages[code],
+  };
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.trim().replace(/\s+/g, " ") || "";
+}
+
+function firstNonEmpty(values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const normalized = normalizeText(value);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function mergedStatus(results: VideoProcessingTaskResult[]): VideoProcessingStatus {
+  if (results.some((result) => result.status === "completed")) return "completed";
+  if (results.length > 0 && results.every((result) => result.status === "failed")) return "failed";
+  return "pending";
+}
+
+export function buildMockVideoProcessingProviderCapabilities(
+  params: Partial<VideoProcessingProviderCapabilities> = {},
+): VideoProcessingProviderCapabilities {
+  return {
+    provider: "local_mock",
+    supportedTasks: ["transcription", "frame_extraction", "ocr", "visual_summary", "technical_signals"],
+    requiresSignedUrl: true,
+    supportsBatch: false,
+    maxDurationSeconds: 90,
+    maxFileSizeMb: 100,
+    ...params,
+  };
+}
+
+export function createVideoProcessingTaskRequest(params: {
+  id: string;
+  session: VideoUploadSession;
+  taskType: VideoProcessingTaskType;
+  provider?: VideoProcessingProviderName;
+  createdAt: string;
+}): VideoProcessingTaskRequest {
+  return {
+    id: params.id,
+    sessionId: params.session.id,
+    storageObjectId: params.session.storageObject.id,
+    taskType: params.taskType,
+    provider: params.provider || "local_mock",
+    input: {
+      storageObjectId: params.session.storageObject.id,
+      storageKey: params.session.storageObject.storageKey,
+      signedUrl: params.session.signedUploadUrl || params.session.storageObject.signedUrl,
+      mimeType: params.session.draftSnapshot.mimeType,
+      durationSeconds: params.session.draftSnapshot.durationSeconds,
+      sizeBytes: params.session.draftSnapshot.sizeBytes,
+    },
+    createdAt: params.createdAt,
+  };
+}
+
+export function validateVideoProcessingTaskRequest(params: {
+  request: VideoProcessingTaskRequest;
+  capabilities?: VideoProcessingProviderCapabilities;
+}): VideoProcessingProviderValidationResult {
+  const request = params.request;
+  const capabilities = params.capabilities || buildMockVideoProcessingProviderCapabilities();
+  const issues: VideoProcessingProviderIssue[] = [];
+
+  if (!request.id.trim()) {
+    issues.push(providerIssue("missing_task_id"));
+  }
+
+  if (!request.sessionId.trim()) {
+    issues.push(providerIssue("missing_session_id"));
+  }
+
+  if (!request.storageObjectId.trim()) {
+    issues.push(providerIssue("missing_storage_object"));
+  }
+
+  if (!request.input || !request.input.storageObjectId.trim()) {
+    issues.push(providerIssue("missing_input_source"));
+  }
+
+  if (capabilities.requiresSignedUrl && !request.input?.signedUrl) {
+    issues.push(providerIssue("missing_signed_url"));
+  }
+
+  if (!capabilities.supportedTasks.includes(request.taskType)) {
+    issues.push(providerIssue("unsupported_task"));
+  }
+
+  if (
+    typeof request.input?.durationSeconds === "number" &&
+    typeof capabilities.maxDurationSeconds === "number" &&
+    request.input.durationSeconds > capabilities.maxDurationSeconds
+  ) {
+    issues.push(providerIssue("duration_too_long"));
+  }
+
+  if (
+    typeof request.input?.sizeBytes === "number" &&
+    typeof capabilities.maxFileSizeMb === "number" &&
+    request.input.sizeBytes > capabilities.maxFileSizeMb * BYTES_PER_MB
+  ) {
+    issues.push(providerIssue("file_too_large"));
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+export function createEmptyVideoProcessingTaskResult(params: {
+  request: VideoProcessingTaskRequest;
+}): VideoProcessingTaskResult {
+  return {
+    taskId: params.request.id,
+    taskType: params.request.taskType,
+    provider: params.request.provider,
+    status: "not_started",
+    artifacts: {},
+    message: null,
+    completedAt: null,
+  };
+}
+
+export function markVideoProcessingTaskCompleted(params: {
+  result: VideoProcessingTaskResult;
+  artifacts: Partial<VideoProcessingArtifacts>;
+  completedAt: string;
+  message?: string | null;
+}): VideoProcessingTaskResult {
+  return {
+    ...params.result,
+    status: "completed",
+    artifacts: params.artifacts,
+    message: params.message ?? params.result.message,
+    completedAt: params.completedAt,
+  };
+}
+
+export function markVideoProcessingTaskFailed(params: {
+  result: VideoProcessingTaskResult;
+  message: string;
+  completedAt: string;
+}): VideoProcessingTaskResult {
+  return {
+    ...params.result,
+    status: "failed",
+    message: params.message,
+    completedAt: params.completedAt,
+  };
+}
+
+export function mergeVideoProcessingTaskResults(results: VideoProcessingTaskResult[]): VideoProcessingArtifacts {
+  const completedResults = results.filter((result) => result.status === "completed");
+  const merged = createEmptyVideoProcessingArtifacts();
+  const fullText = firstNonEmpty(completedResults.map((result) => result.artifacts.transcript?.fullText));
+  const language = firstNonEmpty(completedResults.map((result) => result.artifacts.transcript?.language));
+  const provider = completedResults.find((result) => result.artifacts.transcript?.provider)?.artifacts.transcript?.provider;
+
+  return {
+    ...merged,
+    status: mergedStatus(results),
+    transcript: {
+      fullText,
+      language,
+      provider: provider || "unknown",
+      segments: completedResults.flatMap((result) => result.artifacts.transcript?.segments || []),
+    },
+    frames: completedResults.flatMap((result) => result.artifacts.frames || []),
+    ocr: completedResults.flatMap((result) => result.artifacts.ocr || []),
+    technicalSignals: completedResults.flatMap((result) => result.artifacts.technicalSignals || []),
+    visualSummary: firstNonEmpty(completedResults.map((result) => result.artifacts.visualSummary)),
+    processingNotes: results
+      .map((result) => normalizeText(result.message))
+      .filter(Boolean),
+  };
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #792. Adiciona a fase PROC1: contratos puros de providers de processamento de vídeo.

## Inclui

- `videoProcessingProviderContracts.ts`
- `videoProcessingProviderContracts.test.ts`
- atualização do README de `videoUpload`

## Contratos

Define providers futuros, tasks de processamento, capabilities, input source, task request, task result, issues e validation result.

## Helpers

- `buildMockVideoProcessingProviderCapabilities`
- `createVideoProcessingTaskRequest`
- `validateVideoProcessingTaskRequest`
- `createEmptyVideoProcessingTaskResult`
- `markVideoProcessingTaskCompleted`
- `markVideoProcessingTaskFailed`
- `mergeVideoProcessingTaskResults`

## Fora de escopo

Não há provider real, SDK real, OpenAI, Whisper SDK, OCR SDK, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell, cron/job real ou navegação/menu.

## QA relatada

- `videoProcessingProviderContracts.test.ts` passou
- regressões STOR, guards/previews, VU, NSE e Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.