### PR TITLE
feat: add video processing mock provider

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -389,6 +389,30 @@ O que não faz:
 - não cria endpoint, fila, storage, banco ou UI;
 - não usa OpenAI, Whisper, OCR real, ffmpeg ou SDK de processamento.
 
+### PROVIDER1 — Provider mock in-memory
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoProcessingMockProvider.ts`
+- `videoProcessingMockProvider.test.ts`
+
+O que faz:
+
+- cria um provider local, síncrono e determinístico para simular resultados de processamento;
+- recebe `VideoProcessingTaskRequest` e retorna `VideoProcessingTaskResult`;
+- cobre cenários de rotina/skincare, bastidor/processo, OCR de marca, melhoria de gancho, vazio e falha;
+- valida requests com os contratos de provider antes de simular artifacts;
+- permite batch local para compor resultados e testar `mergeVideoProcessingTaskResults`.
+
+O que não faz:
+
+- não implementa provider real;
+- não faz rede, `fetch`, upload, storage, fila ou job real;
+- não usa OpenAI, Whisper, OCR real, ffmpeg ou SDK de processamento;
+- não cria endpoint, banco, UI ou integração com BoardShell.
+
 ## Arquitetura Atual
 
 ```text
@@ -405,6 +429,8 @@ VideoTemporaryStorageObject futuro
 VideoRetentionPolicy / VideoCleanupJob futuros
 ↓
 VideoProcessingProviderContracts futuros
+↓
+VideoProcessingMockProvider local
 ↓
 VideoProcessingTaskResult mockado
 ↓
@@ -443,6 +469,7 @@ Na prática, existem dois níveis de prova:
 - Contratos puros de providers de processamento de vídeo.
 - QA de pipeline com resultados mockados de provider de processamento.
 - Documentação de rollout e matriz de decisão de providers de processamento.
+- Provider mock in-memory para simulação local sem rede.
 - Testes de linguagem segura e isolamento de escopo.
 
 ## O Que Ainda Não Existe
@@ -510,6 +537,7 @@ Antes de qualquer upload real, ainda é preciso decidir:
 ```bash
 npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts
+npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingProviderPipeline.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts
 npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts

--- a/src/app/dashboard/boards/videoUpload/VIDEO_PROCESSING_PROVIDER_ROLLOUT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_PROCESSING_PROVIDER_ROLLOUT.md
@@ -141,7 +141,8 @@ Flags server-side devem ser preferidas para processamento real, providers e cust
 
 ## Próximos PRs Sugeridos
 
-- PROVIDER1: provider mock in-memory, apenas teste, sem rede.
+- PROVIDER1: provider mock in-memory, apenas teste, sem rede. Concluído como provider local determinístico.
+- PROVIDER2: usar o provider mock em harness ou QA adicional, ainda sem rede.
 - STORAGE1: implementação real de storage temporário.
 - UPLOAD1: endpoint server-side para criar upload session.
 - PROCESS1: transcrição real em ambiente protegido.

--- a/src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.test.ts
@@ -1,0 +1,298 @@
+import fs from "fs";
+import path from "path";
+
+import { createVideoUploadSession, markVideoUploadSessionSigned } from "./videoUploadSessionContracts";
+import { VideoUploadDraft } from "./videoUploadTypes";
+import {
+  VideoProcessingTaskRequest,
+  VideoProcessingTaskType,
+  createVideoProcessingTaskRequest,
+  mergeVideoProcessingTaskResults,
+} from "./videoProcessingProviderContracts";
+import {
+  runVideoProcessingMockProvider,
+  runVideoProcessingMockProviderBatch,
+} from "./videoProcessingMockProvider";
+
+const oneMb = 1024 * 1024;
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+];
+
+function draft(overrides: Partial<VideoUploadDraft> = {}): VideoUploadDraft {
+  return {
+    id: "mock-provider-draft",
+    source: "local_file",
+    fileName: "video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 20 * oneMb,
+    durationSeconds: 45,
+    creatorQuestion: "Quero entender se vale postar.",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function signedSession(overrides: Partial<VideoUploadDraft> = {}) {
+  const session = createVideoUploadSession({
+    id: "mock-provider-session",
+    draft: draft(overrides),
+    userId: "user-1",
+    createdAt: "2026-05-14T12:00:00.000Z",
+    provider: "local_mock",
+  });
+
+  return markVideoUploadSessionSigned({
+    session: {
+      ...session,
+      storageObject: {
+        ...session.storageObject,
+        storageKey: "temporary/video.mp4",
+      },
+    },
+    signedUploadUrl: "https://signed.example/mock-provider",
+    signedUploadUrlExpiresAt: "2026-05-14T12:30:00.000Z",
+    updatedAt: "2026-05-14T12:05:00.000Z",
+  });
+}
+
+function request(taskType: VideoProcessingTaskType, overrides: Partial<VideoProcessingTaskRequest> = {}): VideoProcessingTaskRequest {
+  const base = createVideoProcessingTaskRequest({
+    id: `task-${taskType}`,
+    session: signedSession(),
+    taskType,
+    createdAt: "2026-05-14T12:10:00.000Z",
+  });
+
+  return {
+    ...base,
+    ...overrides,
+    input: {
+      ...base.input,
+      ...overrides.input,
+    },
+  };
+}
+
+describe("videoProcessingMockProvider", () => {
+  it("returns completed transcription artifacts for skincare_routine", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("transcription"),
+      options: { scenario: "skincare_routine", completedAt: "2026-05-14T12:20:00.000Z" },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.transcript?.fullText).toBe(
+      "Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.",
+    );
+    expect(result.artifacts.transcript?.provider).toBe("manual");
+  });
+
+  it("returns visual summary artifacts for backstage_process", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("visual_summary"),
+      options: { scenario: "backstage_process" },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.visualSummary).toBe("Pessoa em reunião mostrando bastidores de trabalho e processo de criação.");
+  });
+
+  it("returns frames for brand_ocr frame extraction", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("frame_extraction"),
+      options: { scenario: "brand_ocr" },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.frames).toHaveLength(3);
+    expect(result.artifacts.frames?.[0]?.description).toContain("skincare");
+  });
+
+  it("returns OCR for brand_ocr", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("ocr"),
+      options: { scenario: "brand_ocr" },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.ocr?.map((item) => item.text)).toEqual(["Rotina da manhã", "Autocuidado real"]);
+  });
+
+  it("returns opening density signal for hook_improvement", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("technical_signals"),
+      options: { scenario: "hook_improvement" },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.artifacts.technicalSignals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "opening_density",
+          value: "baixo nos primeiros segundos",
+        }),
+      ]),
+    );
+  });
+
+  it("returns completed empty artifacts for empty scenario", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("visual_summary"),
+      options: { scenario: "empty" },
+    });
+
+    expect(result).toMatchObject({
+      status: "completed",
+      artifacts: {},
+      message: "Processamento simulado concluído.",
+    });
+  });
+
+  it("returns failed result for failure scenario", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("transcription"),
+      options: { scenario: "failure" },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.message).toBe("Processamento simulado indisponível para esta tarefa.");
+  });
+
+  it("allows failTasks to force a specific task failure", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("ocr"),
+      options: { scenario: "brand_ocr", failTasks: ["ocr"] },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.message).toBe("Processamento simulado indisponível para esta tarefa.");
+  });
+
+  it("returns failed result for invalid request without throwing", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("transcription", {
+        id: "",
+        sessionId: "",
+        storageObjectId: "",
+        input: {
+          storageObjectId: "",
+          signedUrl: null,
+        },
+      }),
+      options: { scenario: "skincare_routine" },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Tarefa sem identificador.");
+    expect(result.message).toContain("URL temporária necessária para este processamento.");
+  });
+
+  it("processes a batch of requests in order", () => {
+    const requests = [request("transcription"), request("visual_summary"), request("ocr")];
+    const results = runVideoProcessingMockProviderBatch({
+      requests,
+      options: { scenario: "skincare_routine" },
+    });
+
+    expect(results.map((result) => result.taskType)).toEqual(["transcription", "visual_summary", "ocr"]);
+  });
+
+  it("uses provided completedAt instead of runtime time", () => {
+    const result = runVideoProcessingMockProvider({
+      request: request("transcription"),
+      options: {
+        scenario: "skincare_routine",
+        completedAt: "2026-05-14T13:00:00.000Z",
+      },
+    });
+
+    expect(result.completedAt).toBe("2026-05-14T13:00:00.000Z");
+  });
+
+  it("merges mock provider outputs into useful processing artifacts", () => {
+    const results = runVideoProcessingMockProviderBatch({
+      requests: [request("transcription"), request("frame_extraction"), request("ocr")],
+      options: { scenario: "skincare_routine" },
+    });
+    const artifacts = mergeVideoProcessingTaskResults(results);
+
+    expect(artifacts.status).toBe("completed");
+    expect(artifacts.transcript.fullText).toBe("Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.");
+    expect(artifacts.frames).toHaveLength(3);
+    expect(artifacts.ocr).toHaveLength(2);
+  });
+
+  it("supports a pipeline smoke with transcript and visual summary results", () => {
+    const results = runVideoProcessingMockProviderBatch({
+      requests: [request("transcription"), request("visual_summary")],
+      options: { scenario: "backstage_process" },
+    });
+    const artifacts = mergeVideoProcessingTaskResults(results);
+
+    expect(artifacts.transcript.fullText).toBe("Mostro os bastidores de uma reunião e explico meu processo de criação.");
+    expect(artifacts.visualSummary).toBe("Pessoa em reunião mostrando bastidores de trabalho e processo de criação.");
+  });
+
+  it("keeps result messages, artifacts, and notes language safe", () => {
+    const results = [
+      runVideoProcessingMockProvider({
+        request: request("transcription"),
+        options: { scenario: "skincare_routine" },
+      }),
+      runVideoProcessingMockProvider({
+        request: request("ocr"),
+        options: { scenario: "failure" },
+      }),
+    ];
+    const artifacts = mergeVideoProcessingTaskResults(results);
+    const text = JSON.stringify({
+      messages: results.map((result) => result.message),
+      artifacts,
+      processingNotes: artifacts.processingNotes,
+    }).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, services, real providers, SDKs, fetch, ffmpeg, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoProcessingMockProvider.ts"), "utf8");
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "))
+      .join("\n");
+
+    expect(imports).not.toContain("React");
+    expect(imports).not.toContain("BoardShell");
+    expect(imports).not.toContain("PostCreationFunnelBoardShell");
+    expect(imports).not.toContain("OpenAI");
+    expect(imports).not.toContain("fetch");
+    expect(imports).not.toContain("Prisma");
+    expect(imports).not.toContain("banco");
+    expect(imports).not.toContain("components/");
+    expect(imports).not.toContain("hooks/");
+    expect(imports).not.toContain("endpoint");
+    expect(imports).not.toContain("upload service real");
+    expect(imports).not.toContain("storage provider SDK");
+    expect(imports).not.toContain("S3");
+    expect(imports).not.toContain("Blob");
+    expect(imports).not.toContain("R2");
+    expect(imports).not.toContain("GCS");
+    expect(imports).not.toContain("ffmpeg");
+    expect(imports).not.toContain("Whisper SDK");
+    expect(imports).not.toContain("OCR SDK");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.ts
+++ b/src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.ts
@@ -1,0 +1,348 @@
+import {
+  VideoProcessingArtifacts,
+  VideoTechnicalSignal,
+} from "./videoProcessingArtifacts";
+import {
+  VideoProcessingTaskRequest,
+  VideoProcessingTaskResult,
+  VideoProcessingTaskType,
+  buildMockVideoProcessingProviderCapabilities,
+  createEmptyVideoProcessingTaskResult,
+  markVideoProcessingTaskCompleted,
+  markVideoProcessingTaskFailed,
+  validateVideoProcessingTaskRequest,
+} from "./videoProcessingProviderContracts";
+
+export type VideoProcessingMockProviderScenario =
+  | "skincare_routine"
+  | "backstage_process"
+  | "brand_ocr"
+  | "hook_improvement"
+  | "empty"
+  | "failure";
+
+export type VideoProcessingMockProviderOptions = {
+  scenario?: VideoProcessingMockProviderScenario;
+  completedAt?: string;
+  failTasks?: VideoProcessingTaskType[];
+};
+
+const COMPLETED_MESSAGE = "Processamento simulado concluído.";
+const FAILED_MESSAGE = "Processamento simulado indisponível para esta tarefa.";
+const INSUFFICIENT_DATA_MESSAGE = "Solicitação simulada sem dados suficientes.";
+
+function completedAtFor(request: VideoProcessingTaskRequest, options?: VideoProcessingMockProviderOptions): string {
+  return options?.completedAt || request.createdAt;
+}
+
+function failedResult(params: {
+  request: VideoProcessingTaskRequest;
+  message: string;
+  options?: VideoProcessingMockProviderOptions;
+}): VideoProcessingTaskResult {
+  return markVideoProcessingTaskFailed({
+    result: createEmptyVideoProcessingTaskResult({ request: params.request }),
+    message: params.message,
+    completedAt: completedAtFor(params.request, params.options),
+  });
+}
+
+function buildIssueMessage(request: VideoProcessingTaskRequest): string {
+  const validation = validateVideoProcessingTaskRequest({
+    request,
+    capabilities: buildMockVideoProcessingProviderCapabilities(),
+  });
+
+  if (validation.issues.length === 0) return INSUFFICIENT_DATA_MESSAGE;
+
+  return validation.issues.map((issue) => issue.message).join(" ");
+}
+
+function technicalSignal(type: VideoTechnicalSignal["type"], value: string, confidence: number | null): VideoTechnicalSignal {
+  return {
+    type,
+    value,
+    confidence,
+  };
+}
+
+function artifactsForTask(
+  taskType: VideoProcessingTaskType,
+  scenario: VideoProcessingMockProviderScenario,
+): Partial<VideoProcessingArtifacts> {
+  if (scenario === "empty") return {};
+
+  if (scenario === "skincare_routine") {
+    if (taskType === "transcription") {
+      return {
+        transcript: {
+          fullText: "Mostro minha rotina de skincare pela manhã e falo sobre autocuidado.",
+          language: "pt-BR",
+          segments: [
+            {
+              startSeconds: 0,
+              endSeconds: 5,
+              text: "Mostro minha rotina de skincare pela manhã.",
+              confidence: 0.92,
+            },
+            {
+              startSeconds: 5,
+              endSeconds: 9,
+              text: "Falo sobre autocuidado.",
+              confidence: 0.9,
+            },
+          ],
+          provider: "manual",
+        },
+      };
+    }
+
+    if (taskType === "visual_summary") {
+      return {
+        visualSummary: "Pessoa apresenta uma rotina de autocuidado com produtos de skincare.",
+      };
+    }
+
+    if (taskType === "frame_extraction") {
+      return {
+        frames: [
+          {
+            id: "mock-skincare-opening",
+            timestampSeconds: 1,
+            label: "opening",
+            description: "Produtos de skincare organizados na bancada.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-skincare-middle",
+            timestampSeconds: 8,
+            label: "middle",
+            description: "Pessoa aplica produto no rosto durante a rotina.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-skincare-closing",
+            timestampSeconds: 18,
+            label: "closing",
+            description: "Fechamento com produtos de autocuidado em destaque.",
+            imageStorageKey: null,
+          },
+        ],
+      };
+    }
+
+    if (taskType === "ocr") {
+      return {
+        ocr: [
+          { timestampSeconds: 2, text: "Rotina da manhã", confidence: 0.82 },
+          { timestampSeconds: 7, text: "Autocuidado real", confidence: 0.8 },
+        ],
+      };
+    }
+
+    if (taskType === "technical_signals") {
+      return {
+        technicalSignals: [
+          technicalSignal("duration", "45 segundos", 1),
+          technicalSignal("text_overlay", "texto na tela sobre rotina e autocuidado", 0.82),
+        ],
+      };
+    }
+  }
+
+  if (scenario === "backstage_process") {
+    if (taskType === "transcription") {
+      return {
+        transcript: {
+          fullText: "Mostro os bastidores de uma reunião e explico meu processo de criação.",
+          language: "pt-BR",
+          segments: [],
+          provider: "manual",
+        },
+      };
+    }
+
+    if (taskType === "visual_summary") {
+      return {
+        visualSummary: "Pessoa em reunião mostrando bastidores de trabalho e processo de criação.",
+      };
+    }
+
+    if (taskType === "frame_extraction") {
+      return {
+        frames: [
+          {
+            id: "mock-backstage-meeting",
+            timestampSeconds: 2,
+            label: "opening",
+            description: "Pessoa em reunião com tela aberta.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-backstage-screen",
+            timestampSeconds: 9,
+            label: "middle",
+            description: "Tela mostra planejamento de conteúdo.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-backstage-note",
+            timestampSeconds: 16,
+            label: "scene_change",
+            description: "Anotação do processo de criação aparece na mesa.",
+            imageStorageKey: null,
+          },
+        ],
+      };
+    }
+
+    if (taskType === "ocr") {
+      return {
+        ocr: [
+          { timestampSeconds: 6, text: "Planejamento", confidence: 0.78 },
+          { timestampSeconds: 13, text: "Bastidores", confidence: 0.76 },
+        ],
+      };
+    }
+
+    if (taskType === "technical_signals") {
+      return {
+        technicalSignals: [
+          technicalSignal("scene_change", "mudança de reunião para anotação de processo", 0.74),
+          technicalSignal("audio_presence", "fala explicando processo de criação", 0.86),
+        ],
+      };
+    }
+  }
+
+  if (scenario === "brand_ocr") {
+    if (taskType === "visual_summary") {
+      return {
+        visualSummary: "Produtos de skincare aparecem em destaque durante a rotina.",
+      };
+    }
+
+    if (taskType === "frame_extraction") {
+      return {
+        frames: [
+          {
+            id: "mock-brand-product",
+            timestampSeconds: 1,
+            label: "opening",
+            description: "Produto de skincare aparece sobre a bancada.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-brand-application",
+            timestampSeconds: 8,
+            label: "middle",
+            description: "Pessoa aplica o produto no rosto.",
+            imageStorageKey: null,
+          },
+          {
+            id: "mock-brand-closing",
+            timestampSeconds: 20,
+            label: "closing",
+            description: "Fechamento mostra o produto em contexto de rotina.",
+            imageStorageKey: null,
+          },
+        ],
+      };
+    }
+
+    if (taskType === "ocr") {
+      return {
+        ocr: [
+          { timestampSeconds: 3, text: "Rotina da manhã", confidence: 0.83 },
+          { timestampSeconds: 10, text: "Autocuidado real", confidence: 0.81 },
+        ],
+      };
+    }
+
+    if (taskType === "technical_signals") {
+      return {
+        technicalSignals: [
+          technicalSignal("text_overlay", "texto na tela reforça rotina e autocuidado", 0.81),
+          technicalSignal("duration", "45 segundos", 1),
+        ],
+      };
+    }
+  }
+
+  if (scenario === "hook_improvement") {
+    if (taskType === "transcription") {
+      return {
+        transcript: {
+          fullText: "O vídeo começa devagar, depois mostra bastidores mais interessantes do processo.",
+          language: "pt-BR",
+          segments: [],
+          provider: "manual",
+        },
+      };
+    }
+
+    if (taskType === "visual_summary") {
+      return {
+        visualSummary: "A abertura parece lenta antes de mostrar o ponto mais interessante.",
+      };
+    }
+
+    if (taskType === "technical_signals") {
+      return {
+        technicalSignals: [
+          technicalSignal("opening_density", "baixo nos primeiros segundos", 0.7),
+          technicalSignal("scene_change", "melhora quando o bastidor aparece", 0.72),
+        ],
+      };
+    }
+  }
+
+  return {};
+}
+
+export function runVideoProcessingMockProvider(params: {
+  request: VideoProcessingTaskRequest;
+  options?: VideoProcessingMockProviderOptions;
+}): VideoProcessingTaskResult {
+  const validation = validateVideoProcessingTaskRequest({
+    request: params.request,
+    capabilities: buildMockVideoProcessingProviderCapabilities(),
+  });
+
+  if (!validation.ok) {
+    return failedResult({
+      request: params.request,
+      message: buildIssueMessage(params.request),
+      options: params.options,
+    });
+  }
+
+  const scenario = params.options?.scenario || "empty";
+
+  if (scenario === "failure" || params.options?.failTasks?.includes(params.request.taskType)) {
+    return failedResult({
+      request: params.request,
+      message: FAILED_MESSAGE,
+      options: params.options,
+    });
+  }
+
+  return markVideoProcessingTaskCompleted({
+    result: createEmptyVideoProcessingTaskResult({ request: params.request }),
+    artifacts: artifactsForTask(params.request.taskType, scenario),
+    completedAt: completedAtFor(params.request, params.options),
+    message: COMPLETED_MESSAGE,
+  });
+}
+
+export function runVideoProcessingMockProviderBatch(params: {
+  requests: VideoProcessingTaskRequest[];
+  options?: VideoProcessingMockProviderOptions;
+}): VideoProcessingTaskResult[] {
+  return params.requests.map((request) =>
+    runVideoProcessingMockProvider({
+      request,
+      options: params.options,
+    }),
+  );
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #795. Adiciona a fase PROVIDER1: provider mock in-memory para processamento de vídeo.

## Inclui

- `videoProcessingMockProvider.ts`
- `videoProcessingMockProvider.test.ts`
- atualização do README de `videoUpload`
- atualização do rollout de providers

## Mock provider

Provider local, determinístico, síncrono e em memória.

Recebe `VideoProcessingTaskRequest`, valida com `validateVideoProcessingTaskRequest` e retorna `VideoProcessingTaskResult` completed/failed sem rede, SDK, arquivo, random ou `Date.now`.

## Cenários suportados

- `skincare_routine`
- `backstage_process`
- `brand_ocr`
- `hook_improvement`
- `empty`
- `failure`

## Helpers

- `runVideoProcessingMockProvider`
- `runVideoProcessingMockProviderBatch`

## Fora de escopo

Não há provider real, SDK, OpenAI, Whisper, OCR real, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell, fetch ou navegação/menu.

## QA relatada

- `videoProcessingMockProvider.test.ts` passou
- regressões obrigatórias passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.