### PR TITLE
docs: document multimodal-first video narrative architecture

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,27 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM1 — Arquitetura narrativa multimodal-first
+
+Status: concluído.
+
+Arquivo principal:
+
+- `VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md`
+
+O que faz:
+
+- redefine a direção de produto para uma experiência `multimodal-first`;
+- posiciona `VideoNarrativeAnalysis` como saída principal da análise futura;
+- trata transcrição, OCR, frames e sinais técnicos como evidências auxiliares;
+- introduz `PostCreationVideoSeed` como ponte conceitual para o board de criação.
+
+O que não faz:
+
+- não altera contratos existentes;
+- não cria provider real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -1,0 +1,230 @@
+# Video Multimodal Narrative Architecture
+
+## Objetivo
+
+Este documento redefine a arquitetura de análise de vídeo para o board de criação.
+
+A feature não existe para apenas extrair texto de vídeo. Ela existe para transformar vídeo em direção estratégica de conteúdo. OCR, transcrição, frames e sinais técnicos continuam úteis, mas devem funcionar como evidências auxiliares. O output principal passa a ser `VideoNarrativeAnalysis`, e essa análise deve alimentar o post em construção.
+
+## Problema Da Abordagem OCR-First
+
+OCR sozinho:
+
+- lê texto na tela;
+- não entende fala;
+- não entende gancho;
+- não entende ritmo;
+- não entende intenção narrativa;
+- não entende tom;
+- não entende contexto visual completo;
+- não entende presença de produto ou marca de forma estratégica;
+- não transforma o conteúdo em blueprint.
+
+## Nova Abordagem Multimodal-First
+
+```text
+VideoUploadDraft
++
+creatorQuestion
++
+video file future
+↓
+Multimodal Narrative Provider
+↓
+VideoNarrativeAnalysis
+↓
+PostCreationVideoSeed
+↓
+Board de Criação
+↓
+Blueprint
+↓
+Roteiro
+```
+
+O vídeo deve ser interpretado como peça de conteúdo em construção. A análise precisa combinar o que é dito, o que aparece, como a abertura funciona, qual narrativa emerge e como isso pode virar direção prática dentro do board.
+
+## Conceito De VideoNarrativeAnalysis
+
+`VideoNarrativeAnalysis` será o principal objeto de saída da análise.
+
+Campos conceituais esperados:
+
+- `hook`;
+- `summary`;
+- `spokenTopics`;
+- `onScreenText`;
+- `visualElements`;
+- `sceneStructure`;
+- `d2cClassification`;
+- `diagnosis`;
+- `blueprintSuggestion`;
+- `brandMatch`;
+- `evidence`.
+
+Exemplo conceitual:
+
+```json
+{
+  "hook": {
+    "detected": "...",
+    "strength": "weak | medium | strong | unknown",
+    "why": "..."
+  },
+  "summary": "...",
+  "spokenTopics": [],
+  "onScreenText": [],
+  "visualElements": [],
+  "sceneStructure": [],
+  "d2cClassification": {
+    "format": "reel",
+    "proposal": "tips",
+    "context": "planning",
+    "tone": "educational",
+    "reference": null,
+    "intent": "educar",
+    "narrative": "comentário -> insight -> pauta"
+  },
+  "diagnosis": {
+    "strengths": [],
+    "weaknesses": [],
+    "recommendedAdjustments": []
+  },
+  "blueprintSuggestion": {
+    "whatToPost": "...",
+    "whyThisPath": "...",
+    "howItShouldWork": "...",
+    "scenes": []
+  },
+  "brandMatch": {
+    "enabled": true,
+    "territories": [],
+    "whyBrandsWouldFit": "..."
+  },
+  "evidence": {
+    "transcript": null,
+    "ocr": [],
+    "frames": [],
+    "technicalSignals": []
+  }
+}
+```
+
+## Relação Com Artifacts Atuais
+
+`VideoProcessingArtifacts` continua útil, mas muda de papel.
+
+Antes:
+
+```text
+VideoProcessingArtifacts
+↓
+quase o centro do pipeline
+```
+
+Agora:
+
+```text
+VideoProcessingArtifacts
+↓
+evidence
+↓
+VideoNarrativeAnalysis
+```
+
+Transcrição, OCR, frames e sinais técnicos passam a sustentar a leitura narrativa em vez de definir sozinhos a experiência.
+
+## Relação Com Gemini Flash
+
+A abstração de produto deve ser `Multimodal Narrative Provider`.
+
+`Gemini Flash` é o candidato inicial mais provável para a primeira implementação real porque a experiência precisa combinar vídeo, áudio e contexto visual em uma leitura única. O nome do provider não deve contaminar o contrato de produto.
+
+`Gemini Pro` pode ficar reservado para análises premium ou futuras, se custo e qualidade justificarem.
+
+## Relação Com PostCreationFunnelState
+
+`VideoNarrativeAnalysis` não deve ser despejado diretamente no estado real do funil. O board precisa receber um intermediário orientado à jornada:
+
+`PostCreationVideoSeed`
+
+Esse seed deve carregar:
+
+- `initialIdea`;
+- `creatorQuestion`;
+- `detectedNarrative`;
+- `suggestedFormat`;
+- `suggestedProposal`;
+- `strategicDiagnosis`;
+- `blueprintDraft`;
+- `scriptDirection`;
+- `brandMatchHints`;
+- `followUpQuestions`.
+
+O board deve consumir esse seed para continuar a jornada com contexto suficiente, sem acoplar o funil inteiro ao schema bruto do provider.
+
+## Experiência Esperada Para O Usuário
+
+1. Criador escolhe “Analisar um vídeo”.
+2. Sobe vídeo.
+3. Responde: “O que você quer descobrir com esse vídeo?”
+4. A D2C analisa narrativa, gancho, cenas, intenção e potencial.
+5. A D2C entrega diagnóstico.
+6. A D2C transforma em blueprint.
+7. O criador refina.
+8. A D2C gera roteiro ou post em construção.
+
+## Pergunta Do Criador
+
+O campo de texto não deve ser genérico.
+
+Pergunta recomendada:
+
+> O que você quer descobrir com esse vídeo?
+
+Exemplos:
+
+- Quero saber se vale postar.
+- Quero melhorar o gancho.
+- Quero entender qual narrativa esse vídeo comunica.
+- Quero adaptar para publi.
+- Quero saber que marca combina.
+- Quero transformar em roteiro.
+
+## O Que Fica Fora Do MVP
+
+- vídeos longos;
+- `Gemini Pro` automático;
+- reprocessamento ilimitado;
+- persistência automática no perfil narrativo;
+- comparação entre vídeos;
+- múltiplos vídeos;
+- brand matching avançado com banco real de marcas;
+- collab automática.
+
+## Ordem Recomendada A Partir Desta Virada
+
+1. MM2 — Contratos `VideoNarrativeAnalysis`.
+2. MM3 — Adapter `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
+3. MM4 — Mock provider narrativo multimodal.
+4. MM5 — Pipeline QA multimodal.
+5. MM6 — Preview interno narrativo.
+6. MM7 — Prompt/schema Gemini.
+7. MM8 — Gemini Flash real atrás de server flag.
+8. MM9 — Integração experimental no Board de Criação.
+
+## Critérios Antes De Provider Real
+
+- schema definido;
+- mock provider validado;
+- preview interno aprovado;
+- custo estimado;
+- consentimento definido;
+- limite por plano definido;
+- server-side flag;
+- fallback seguro;
+- nenhum sinal persistido automaticamente.
+
+## Frase Norte
+
+> O vídeo não entra na D2C para ser extraído. Ele entra para ser interpretado como narrativa em construção.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_PROCESSING_PROVIDER_ROLLOUT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_PROCESSING_PROVIDER_ROLLOUT.md
@@ -1,5 +1,9 @@
 # Video Processing Providers — Rollout Plan
 
+## Direção De Produto
+
+Esta matriz continua útil como infraestrutura para providers e artifacts. A direção principal do produto, porém, passa a ser `VideoNarrativeAnalysis` em arquitetura `multimodal-first`: transcrição, OCR, frames e sinais técnicos funcionam como evidências auxiliares, não como centro da experiência.
+
 ## Objetivo
 
 Este documento orienta a escolha futura de providers para transformar vídeo em artifacts narrativos úteis para a D2C.


### PR DESCRIPTION
## Contexto

PR stacked sobre #797. Adiciona a fase MM1: documentação da arquitetura multimodal-first para análise narrativa de vídeo.

## Inclui

- `VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md`
- atualização do README de `videoUpload`
- atualização do rollout de providers

## Direção de produto

Reposiciona a experiência de vídeo no board de criação:

- o vídeo não entra para ser apenas extraído/processado;
- o vídeo entra para ser interpretado como narrativa em construção;
- `VideoNarrativeAnalysis` passa a ser o output principal futuro;
- OCR, transcrição, frames e sinais técnicos passam a ser evidências auxiliares;
- `PostCreationVideoSeed` é definido como ponte conceitual para o board.

## Fora de escopo

Não houve alteração de código ou testes. Não há provider real, Gemini, OpenAI, SDK, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell ou navegação/menu.

## QA relatada

- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.