### PR TITLE
feat: add video narrative analysis contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -27,6 +27,28 @@ O que não faz:
 - não cria provider real;
 - não conecta nada ao fluxo real do produto.
 
+### MM2 — Contratos de VideoNarrativeAnalysis
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeAnalysisTypes.ts`
+- `videoNarrativeAnalysisTypes.test.ts`
+
+O que faz:
+
+- define o contrato puro de `VideoNarrativeAnalysis`;
+- modela hook, cenas, classificação D2C, diagnóstico, blueprint, brand match, evidências e sinais futuros de perfil;
+- cria helpers para reconhecer análise útil, direção principal, próximo passo sugerido e sanitização de texto.
+
+O que não faz:
+
+- não implementa provider real;
+- não usa Gemini;
+- não cria endpoint, UI ou persistência;
+- não conecta o contrato ao board real.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -48,6 +48,8 @@ O vídeo deve ser interpretado como peça de conteúdo em construção. A análi
 
 `VideoNarrativeAnalysis` será o principal objeto de saída da análise.
 
+MM2 formaliza esse conceito em contratos puros no arquivo `videoNarrativeAnalysisTypes.ts`, ainda sem provider real e sem integração com o board.
+
 Campos conceituais esperados:
 
 - `hook`;

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts
@@ -1,0 +1,342 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VideoNarrativeAnalysis,
+  createEmptyVideoNarrativeAnalysis,
+  getVideoNarrativePrimaryDirection,
+  getVideoNarrativeSuggestedNextStep,
+  hasUsefulVideoNarrativeAnalysis,
+  sanitizeVideoNarrativeAnalysisText,
+} from "./videoNarrativeAnalysisTypes";
+
+const forbiddenUserFacingTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function emptyAnalysis(overrides: Partial<VideoNarrativeAnalysis> = {}): VideoNarrativeAnalysis {
+  return {
+    ...createEmptyVideoNarrativeAnalysis({ id: "analysis-1" }),
+    ...overrides,
+  };
+}
+
+describe("videoNarrativeAnalysisTypes", () => {
+  it("creates an empty narrative analysis with safe defaults", () => {
+    expect(createEmptyVideoNarrativeAnalysis({ id: "analysis-empty" })).toEqual({
+      id: "analysis-empty",
+      sourceType: "video_narrative_analysis",
+      summary: null,
+      hook: {
+        detected: null,
+        strength: "unknown",
+        why: null,
+      },
+      spokenTopics: [],
+      onScreenText: [],
+      visualElements: [],
+      sceneStructure: [],
+      d2cClassification: {
+        format: "unknown",
+        proposal: "unknown",
+        context: null,
+        tone: null,
+        reference: null,
+        intent: null,
+        narrative: null,
+      },
+      diagnosis: {
+        strengths: [],
+        weaknesses: [],
+        recommendedAdjustments: [],
+      },
+      blueprintSuggestion: {
+        whatToPost: null,
+        whyThisPath: null,
+        howItShouldWork: null,
+        scenes: [],
+      },
+      brandMatch: {
+        enabled: false,
+        territories: [],
+        whyBrandsWouldFit: null,
+      },
+      evidence: {
+        transcript: null,
+        ocr: [],
+        frames: [],
+        technicalSignals: [],
+      },
+      profileSignals: [],
+      confidence: "unknown",
+      createdAt: null,
+    });
+  });
+
+  it("preserves id and createdAt when creating an empty analysis", () => {
+    expect(
+      createEmptyVideoNarrativeAnalysis({
+        id: "analysis-2",
+        createdAt: "2026-05-15T10:00:00.000Z",
+      }),
+    ).toMatchObject({
+      id: "analysis-2",
+      createdAt: "2026-05-15T10:00:00.000Z",
+    });
+  });
+
+  it("returns false for empty analysis", () => {
+    expect(hasUsefulVideoNarrativeAnalysis(emptyAnalysis())).toBe(false);
+  });
+
+  it("returns true when summary is present", () => {
+    expect(hasUsefulVideoNarrativeAnalysis(emptyAnalysis({ summary: "Resumo narrativo." }))).toBe(true);
+  });
+
+  it("returns true when hook is detected", () => {
+    expect(hasUsefulVideoNarrativeAnalysis(emptyAnalysis({ hook: { detected: "Abertura direta.", strength: "medium", why: null } }))).toBe(
+      true,
+    );
+  });
+
+  it("returns true when scene structure has a description", () => {
+    expect(
+      hasUsefulVideoNarrativeAnalysis(
+        emptyAnalysis({
+          sceneStructure: [
+            {
+              id: "scene-1",
+              timestampLabel: "00:00",
+              role: "hook",
+              description: "Abertura apresenta o problema.",
+              suggestedAdjustment: null,
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when narrative classification is present", () => {
+    expect(
+      hasUsefulVideoNarrativeAnalysis(
+        emptyAnalysis({
+          d2cClassification: {
+            ...emptyAnalysis().d2cClassification,
+            narrative: "comentário -> insight -> pauta",
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when diagnosis includes recommendations", () => {
+    expect(
+      hasUsefulVideoNarrativeAnalysis(
+        emptyAnalysis({
+          diagnosis: {
+            strengths: [],
+            weaknesses: [],
+            recommendedAdjustments: ["Abrir com a transformação antes do contexto."],
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when blueprint suggestion is present", () => {
+    expect(
+      hasUsefulVideoNarrativeAnalysis(
+        emptyAnalysis({
+          blueprintSuggestion: {
+            ...emptyAnalysis().blueprintSuggestion,
+            whatToPost: "Um reel de bastidor com virada prática.",
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when transcript evidence is present", () => {
+    expect(
+      hasUsefulVideoNarrativeAnalysis(
+        emptyAnalysis({
+          evidence: {
+            ...emptyAnalysis().evidence,
+            transcript: "Mostro o processo de criação.",
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("prioritizes blueprint suggestion as primary direction", () => {
+    expect(
+      getVideoNarrativePrimaryDirection(
+        emptyAnalysis({
+          summary: "Resumo secundário.",
+          d2cClassification: {
+            ...emptyAnalysis().d2cClassification,
+            narrative: "narrativa secundária",
+          },
+          blueprintSuggestion: {
+            ...emptyAnalysis().blueprintSuggestion,
+            whatToPost: "Reel de bastidor com virada prática.",
+          },
+        }),
+      ),
+    ).toBe("Reel de bastidor com virada prática.");
+  });
+
+  it("uses narrative when blueprint is absent", () => {
+    expect(
+      getVideoNarrativePrimaryDirection(
+        emptyAnalysis({
+          d2cClassification: {
+            ...emptyAnalysis().d2cClassification,
+            narrative: "processo -> insight -> pauta",
+          },
+        }),
+      ),
+    ).toBe("processo -> insight -> pauta");
+  });
+
+  it("uses summary when blueprint and narrative are absent", () => {
+    expect(getVideoNarrativePrimaryDirection(emptyAnalysis({ summary: "Resumo útil." }))).toBe("Resumo útil.");
+  });
+
+  it("uses hook when no broader direction exists", () => {
+    expect(
+      getVideoNarrativePrimaryDirection(
+        emptyAnalysis({
+          hook: {
+            detected: "Começa pela dúvida do criador.",
+            strength: "medium",
+            why: null,
+          },
+        }),
+      ),
+    ).toBe("Começa pela dúvida do criador.");
+  });
+
+  it("returns null for empty primary direction", () => {
+    expect(getVideoNarrativePrimaryDirection(emptyAnalysis())).toBeNull();
+  });
+
+  it("asks for more context when analysis is empty", () => {
+    expect(getVideoNarrativeSuggestedNextStep(emptyAnalysis())).toBe(
+      "Trazer mais contexto antes de transformar o vídeo em pauta.",
+    );
+  });
+
+  it("recommends strengthening the hook when it is weak", () => {
+    expect(
+      getVideoNarrativeSuggestedNextStep(
+        emptyAnalysis({
+          summary: "Há contexto suficiente.",
+          hook: {
+            detected: "Começo lento.",
+            strength: "weak",
+            why: "A abertura demora a mostrar a proposta.",
+          },
+        }),
+      ),
+    ).toBe("Reforçar o gancho antes de transformar o vídeo em roteiro.");
+  });
+
+  it("recommends blueprint when whatToPost exists", () => {
+    expect(
+      getVideoNarrativeSuggestedNextStep(
+        emptyAnalysis({
+          blueprintSuggestion: {
+            ...emptyAnalysis().blueprintSuggestion,
+            whatToPost: "Reel explicando o bastidor em três cenas.",
+          },
+        }),
+      ),
+    ).toBe("Usar a sugestão de blueprint como ponto de partida.");
+  });
+
+  it("recommends evaluating brand fit when brand matching is enabled without blueprint", () => {
+    expect(
+      getVideoNarrativeSuggestedNextStep(
+        emptyAnalysis({
+          summary: "Rotina com território claro.",
+          brandMatch: {
+            enabled: true,
+            territories: ["autocuidado"],
+            whyBrandsWouldFit: "A narrativa conversa com autocuidado.",
+          },
+        }),
+      ),
+    ).toBe("Avaliar o encaixe da narrativa com territórios de marca.");
+  });
+
+  it("sanitizes absolute promise terms", () => {
+    expect(
+      sanitizeVideoNarrativeAnalysisText(
+        "Resultado garantido, com certeza comprovado, viralizar garantido e sempre performa.",
+      ),
+    ).toBe("Resultado indicado, com leitura observado, ampliar chance de clareza e tende a funcionar melhor.");
+  });
+
+  it("keeps generated language conservative", () => {
+    const analysis = emptyAnalysis({
+      summary: sanitizeVideoNarrativeAnalysisText("Caminho comprovado para viralizar garantido."),
+      blueprintSuggestion: {
+        ...emptyAnalysis().blueprintSuggestion,
+        whatToPost: "Reel de bastidor com direção mais clara.",
+      },
+    });
+    const text = JSON.stringify({
+      analysis,
+      emptyNextStep: getVideoNarrativeSuggestedNextStep(emptyAnalysis()),
+      weakHookNextStep: getVideoNarrativeSuggestedNextStep(
+        emptyAnalysis({
+          summary: "Leitura disponível.",
+          hook: {
+            detected: "Abertura lenta.",
+            strength: "weak",
+            why: null,
+          },
+        }),
+      ),
+      primaryDirection: getVideoNarrativePrimaryDirection(analysis),
+    }).toLowerCase();
+
+    for (const term of forbiddenUserFacingTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, providers, storage, or product integrations", () => {
+    const sourcePath = path.join(__dirname, "videoNarrativeAnalysisTypes.ts");
+    const source = fs.readFileSync(sourcePath, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).toBe("");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("Gemini");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.ts
@@ -1,0 +1,229 @@
+export type VideoNarrativeHookStrength = "weak" | "medium" | "strong" | "unknown";
+
+export type VideoNarrativeConfidence = "low" | "medium" | "high" | "unknown";
+
+export type VideoNarrativeSceneRole =
+  | "hook"
+  | "context"
+  | "development"
+  | "proof"
+  | "turning_point"
+  | "call_to_action"
+  | "closing"
+  | "unknown";
+
+export type VideoNarrativeD2CFormat = "reel" | "photo" | "carousel" | "long_video" | "unknown";
+
+export type VideoNarrativeD2CProposal =
+  | "tips"
+  | "review"
+  | "humor_scene"
+  | "positioning_authority"
+  | "behind_the_scenes"
+  | "comparison"
+  | "announcement"
+  | "comment_to_post"
+  | "ad_adaptation"
+  | "collab_narrative"
+  | "unknown";
+
+export type VideoNarrativeHook = {
+  detected: string | null;
+  strength: VideoNarrativeHookStrength;
+  why: string | null;
+};
+
+export type VideoNarrativeScene = {
+  id: string;
+  timestampLabel: string | null;
+  role: VideoNarrativeSceneRole;
+  description: string;
+  suggestedAdjustment: string | null;
+};
+
+export type VideoNarrativeD2CClassification = {
+  format: VideoNarrativeD2CFormat;
+  proposal: VideoNarrativeD2CProposal;
+  context: string | null;
+  tone: string | null;
+  reference: string | null;
+  intent: string | null;
+  narrative: string | null;
+};
+
+export type VideoNarrativeDiagnosis = {
+  strengths: string[];
+  weaknesses: string[];
+  recommendedAdjustments: string[];
+};
+
+export type VideoNarrativeBlueprintSuggestion = {
+  whatToPost: string | null;
+  whyThisPath: string | null;
+  howItShouldWork: string | null;
+  scenes: string[];
+};
+
+export type VideoNarrativeBrandMatch = {
+  enabled: boolean;
+  territories: string[];
+  whyBrandsWouldFit: string | null;
+};
+
+export type VideoNarrativeEvidence = {
+  transcript: string | null;
+  ocr: string[];
+  frames: string[];
+  technicalSignals: string[];
+};
+
+export type VideoNarrativeProfileSignal = {
+  type:
+    | "recurring_theme"
+    | "content_strength"
+    | "brand_territory"
+    | "audience_goal"
+    | "positioning_signal"
+    | "creative_gap"
+    | "unknown";
+  value: string;
+  confidence: VideoNarrativeConfidence;
+  shouldPersistLater: boolean;
+};
+
+export type VideoNarrativeAnalysis = {
+  id: string;
+  sourceType: "video_narrative_analysis";
+  summary: string | null;
+  hook: VideoNarrativeHook;
+  spokenTopics: string[];
+  onScreenText: string[];
+  visualElements: string[];
+  sceneStructure: VideoNarrativeScene[];
+  d2cClassification: VideoNarrativeD2CClassification;
+  diagnosis: VideoNarrativeDiagnosis;
+  blueprintSuggestion: VideoNarrativeBlueprintSuggestion;
+  brandMatch: VideoNarrativeBrandMatch;
+  evidence: VideoNarrativeEvidence;
+  profileSignals: VideoNarrativeProfileSignal[];
+  confidence: VideoNarrativeConfidence;
+  createdAt: string | null;
+};
+
+export function createEmptyVideoNarrativeAnalysis(params: {
+  id: string;
+  createdAt?: string | null;
+}): VideoNarrativeAnalysis {
+  return {
+    id: params.id,
+    sourceType: "video_narrative_analysis",
+    summary: null,
+    hook: {
+      detected: null,
+      strength: "unknown",
+      why: null,
+    },
+    spokenTopics: [],
+    onScreenText: [],
+    visualElements: [],
+    sceneStructure: [],
+    d2cClassification: {
+      format: "unknown",
+      proposal: "unknown",
+      context: null,
+      tone: null,
+      reference: null,
+      intent: null,
+      narrative: null,
+    },
+    diagnosis: {
+      strengths: [],
+      weaknesses: [],
+      recommendedAdjustments: [],
+    },
+    blueprintSuggestion: {
+      whatToPost: null,
+      whyThisPath: null,
+      howItShouldWork: null,
+      scenes: [],
+    },
+    brandMatch: {
+      enabled: false,
+      territories: [],
+      whyBrandsWouldFit: null,
+    },
+    evidence: {
+      transcript: null,
+      ocr: [],
+      frames: [],
+      technicalSignals: [],
+    },
+    profileSignals: [],
+    confidence: "unknown",
+    createdAt: params.createdAt ?? null,
+  };
+}
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function hasTextIn(values: string[]): boolean {
+  return values.some((value) => hasText(value));
+}
+
+export function hasUsefulVideoNarrativeAnalysis(analysis: VideoNarrativeAnalysis): boolean {
+  return Boolean(
+    hasText(analysis.summary) ||
+      hasText(analysis.hook.detected) ||
+      analysis.sceneStructure.some((scene) => hasText(scene.description)) ||
+      hasText(analysis.d2cClassification.narrative) ||
+      hasTextIn(analysis.diagnosis.strengths) ||
+      hasTextIn(analysis.diagnosis.weaknesses) ||
+      hasTextIn(analysis.diagnosis.recommendedAdjustments) ||
+      hasText(analysis.blueprintSuggestion.whatToPost) ||
+      hasText(analysis.evidence.transcript) ||
+      hasTextIn(analysis.visualElements) ||
+      hasTextIn(analysis.spokenTopics),
+  );
+}
+
+export function getVideoNarrativePrimaryDirection(analysis: VideoNarrativeAnalysis): string | null {
+  return (
+    analysis.blueprintSuggestion.whatToPost?.trim() ||
+    analysis.d2cClassification.narrative?.trim() ||
+    analysis.summary?.trim() ||
+    analysis.hook.detected?.trim() ||
+    null
+  );
+}
+
+export function getVideoNarrativeSuggestedNextStep(analysis: VideoNarrativeAnalysis): string {
+  if (!hasUsefulVideoNarrativeAnalysis(analysis)) {
+    return "Trazer mais contexto antes de transformar o vídeo em pauta.";
+  }
+
+  if (analysis.hook.strength === "weak") {
+    return "Reforçar o gancho antes de transformar o vídeo em roteiro.";
+  }
+
+  if (hasText(analysis.blueprintSuggestion.whatToPost)) {
+    return "Usar a sugestão de blueprint como ponto de partida.";
+  }
+
+  if (analysis.brandMatch.enabled) {
+    return "Avaliar o encaixe da narrativa com territórios de marca.";
+  }
+
+  return "Transformar a leitura narrativa em uma pauta mais clara.";
+}
+
+export function sanitizeVideoNarrativeAnalysisText(value: string): string {
+  return value
+    .replace(/viralizar garantido/gi, "ampliar chance de clareza")
+    .replace(/sempre performa/gi, "tende a funcionar melhor")
+    .replace(/garantido/gi, "indicado")
+    .replace(/certeza/gi, "leitura")
+    .replace(/comprovado/gi, "observado")
+    .trim();
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #798. Adiciona a fase MM2: contratos puros de `VideoNarrativeAnalysis`.

## Inclui

- `videoNarrativeAnalysisTypes.ts`
- `videoNarrativeAnalysisTypes.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## O que foi criado

Define `VideoNarrativeAnalysis` como contrato principal futuro da leitura multimodal de vídeo.

Inclui tipos para:

- hook;
- confiança;
- cenas;
- classificação D2C;
- diagnóstico;
- sugestão de blueprint;
- brand match;
- evidências;
- sinais futuros de perfil.

## Helpers

- `createEmptyVideoNarrativeAnalysis`
- `hasUsefulVideoNarrativeAnalysis`
- `getVideoNarrativePrimaryDirection`
- `getVideoNarrativeSuggestedNextStep`
- `sanitizeVideoNarrativeAnalysisText`

## Fora de escopo

Não há provider real, Gemini, OpenAI, SDK, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell ou navegação/menu.

## QA relatada

- `videoNarrativeAnalysisTypes.test.ts` passou
- regressões Provider/Storage/VU/Guard/Previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.