### PR TITLE
feat: add video narrative post creation seed adapter

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -49,6 +49,27 @@ O que não faz:
 - não cria endpoint, UI ou persistência;
 - não conecta o contrato ao board real.
 
+### MM3 — Adapter para PostCreationVideoSeed
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativePostCreationSeed.ts`
+- `videoNarrativePostCreationSeed.test.ts`
+
+O que faz:
+
+- define `PostCreationVideoSeed` como ponte intermediária entre análise multimodal e board futuro;
+- converte `VideoNarrativeAnalysis` em ideia inicial, narrativa detectada, diagnóstico, blueprint draft, direção de roteiro, hints de marca e perguntas de refinamento;
+- mantém sanitização dos textos oriundos da análise.
+
+O que não faz:
+
+- não altera `PostCreationFunnelState`;
+- não conecta no `BoardShell`;
+- não cria provider, endpoint ou UI real.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -150,6 +150,8 @@ A abstração de produto deve ser `Multimodal Narrative Provider`.
 
 `PostCreationVideoSeed`
 
+MM3 formaliza esse intermediário no adapter puro `videoNarrativePostCreationSeed.ts`, sem alterar o `PostCreationFunnelState` real.
+
 Esse seed deve carregar:
 
 - `initialIdea`;

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts
@@ -1,0 +1,383 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VideoNarrativeAnalysis,
+  createEmptyVideoNarrativeAnalysis,
+} from "./videoNarrativeAnalysisTypes";
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  createEmptyPostCreationVideoSeed,
+  getPostCreationVideoSeedPrimaryAction,
+  hasUsefulPostCreationVideoSeed,
+} from "./videoNarrativePostCreationSeed";
+
+const forbiddenTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function analysis(overrides: Partial<VideoNarrativeAnalysis> = {}): VideoNarrativeAnalysis {
+  return {
+    ...createEmptyVideoNarrativeAnalysis({ id: "analysis-1", createdAt: "2026-05-15T10:00:00.000Z" }),
+    ...overrides,
+  };
+}
+
+function seedFrom(value: VideoNarrativeAnalysis) {
+  return buildPostCreationVideoSeedFromAnalysis({
+    id: "seed-1",
+    analysis: value,
+    creatorQuestion: "Quero entender esse vídeo.",
+  });
+}
+
+describe("videoNarrativePostCreationSeed", () => {
+  it("creates an empty seed with safe defaults", () => {
+    expect(createEmptyPostCreationVideoSeed({ id: "seed-empty", analysisId: "analysis-empty" })).toEqual({
+      id: "seed-empty",
+      source: "video_narrative_analysis",
+      analysisId: "analysis-empty",
+      creatorQuestion: null,
+      initialIdea: null,
+      detectedNarrative: null,
+      suggestedFormat: null,
+      suggestedProposal: null,
+      strategicDiagnosis: null,
+      blueprintDraft: { whatToPost: null, whyThisPath: null, howItShouldWork: null, scenes: [] },
+      scriptDirection: { opening: null, development: [], closing: null, tone: null },
+      brandMatchHints: [],
+      followUpQuestions: [],
+      evidenceSummary: null,
+      confidence: "unknown",
+      createdAt: null,
+    });
+  });
+
+  it("preserves id, analysisId, and createdAt for empty seed", () => {
+    expect(
+      createEmptyPostCreationVideoSeed({
+        id: "seed-2",
+        analysisId: "analysis-2",
+        createdAt: "2026-05-15T11:00:00.000Z",
+      }),
+    ).toMatchObject({ id: "seed-2", analysisId: "analysis-2", createdAt: "2026-05-15T11:00:00.000Z" });
+  });
+
+  it("uses blueprint whatToPost as initial idea", () => {
+    expect(
+      seedFrom(analysis({ blueprintSuggestion: { ...analysis().blueprintSuggestion, whatToPost: "Reel de bastidor." } }))
+        .initialIdea,
+    ).toBe("Reel de bastidor.");
+  });
+
+  it("uses summary as initial idea without blueprint", () => {
+    expect(seedFrom(analysis({ summary: "Resumo do vídeo." })).initialIdea).toBe("Resumo do vídeo.");
+  });
+
+  it("uses hook as initial idea without blueprint or summary", () => {
+    expect(
+      seedFrom(analysis({ hook: { detected: "Começa pela dúvida.", strength: "medium", why: null } })).initialIdea,
+    ).toBe("Começa pela dúvida.");
+  });
+
+  it("maps narrative classification to detected narrative", () => {
+    expect(
+      seedFrom(
+        analysis({
+          d2cClassification: { ...analysis().d2cClassification, narrative: "comentário -> insight -> pauta" },
+        }),
+      ).detectedNarrative,
+    ).toBe("comentário -> insight -> pauta");
+  });
+
+  it("turns unknown format into null", () => {
+    expect(seedFrom(analysis()).suggestedFormat).toBeNull();
+  });
+
+  it("turns unknown proposal into null", () => {
+    expect(seedFrom(analysis()).suggestedProposal).toBeNull();
+  });
+
+  it("combines strength and adjustment in strategic diagnosis", () => {
+    expect(
+      seedFrom(
+        analysis({
+          diagnosis: {
+            strengths: ["Boa clareza visual"],
+            weaknesses: [],
+            recommendedAdjustments: ["Abrir com a transformação"],
+          },
+        }),
+      ).strategicDiagnosis,
+    ).toBe("Ponto forte: Boa clareza visual. Ajuste sugerido: Abrir com a transformação.");
+  });
+
+  it("copies blueprint suggestion into blueprint draft", () => {
+    expect(
+      seedFrom(
+        analysis({
+          blueprintSuggestion: {
+            whatToPost: "Reel em três cenas.",
+            whyThisPath: "A leitura já está clara.",
+            howItShouldWork: "Abrir, provar, fechar.",
+            scenes: ["Abertura", "Prova", "Fechamento"],
+          },
+        }),
+      ).blueprintDraft,
+    ).toEqual({
+      whatToPost: "Reel em três cenas.",
+      whyThisPath: "A leitura já está clara.",
+      howItShouldWork: "Abrir, provar, fechar.",
+      scenes: ["Abertura", "Prova", "Fechamento"],
+    });
+  });
+
+  it("uses hook as script opening", () => {
+    expect(
+      seedFrom(analysis({ hook: { detected: "Gancho direto.", strength: "strong", why: null } })).scriptDirection.opening,
+    ).toBe("Gancho direto.");
+  });
+
+  it("uses recommended adjustment as opening when hook is weak", () => {
+    expect(
+      seedFrom(
+        analysis({
+          hook: { detected: "Começo lento.", strength: "weak", why: null },
+          diagnosis: { strengths: [], weaknesses: [], recommendedAdjustments: ["Abrir pela transformação."] },
+        }),
+      ).scriptDirection.opening,
+    ).toBe("Abrir pela transformação.");
+  });
+
+  it("uses blueprint scenes as development", () => {
+    expect(
+      seedFrom(
+        analysis({
+          blueprintSuggestion: { ...analysis().blueprintSuggestion, scenes: ["Cena 1", "Cena 2"] },
+        }),
+      ).scriptDirection.development,
+    ).toEqual(["Cena 1", "Cena 2"]);
+  });
+
+  it("uses scene descriptions as development when blueprint scenes are empty", () => {
+    expect(
+      seedFrom(
+        analysis({
+          sceneStructure: [
+            { id: "scene-1", timestampLabel: null, role: "context", description: "Contexto", suggestedAdjustment: null },
+            { id: "scene-2", timestampLabel: null, role: "development", description: "Desenvolvimento", suggestedAdjustment: null },
+          ],
+        }),
+      ).scriptDirection.development,
+    ).toEqual(["Contexto", "Desenvolvimento"]);
+  });
+
+  it("uses closing or call to action scene as closing", () => {
+    expect(
+      seedFrom(
+        analysis({
+          sceneStructure: [
+            { id: "scene-1", timestampLabel: null, role: "closing", description: "Fechar com convite.", suggestedAdjustment: null },
+          ],
+        }),
+      ).scriptDirection.closing,
+    ).toBe("Fechar com convite.");
+  });
+
+  it("keeps brand hints empty when brand match is disabled", () => {
+    expect(seedFrom(analysis()).brandMatchHints).toEqual([]);
+  });
+
+  it("includes territories and reason when brand match is enabled", () => {
+    expect(
+      seedFrom(
+        analysis({
+          brandMatch: {
+            enabled: true,
+            territories: ["autocuidado"],
+            whyBrandsWouldFit: "A narrativa conversa com rotina.",
+          },
+        }),
+      ).brandMatchHints,
+    ).toEqual(["autocuidado", "A narrativa conversa com rotina."]);
+  });
+
+  it("adds hook follow-up when hook is missing", () => {
+    expect(seedFrom(analysis()).followUpQuestions).toContainEqual({
+      id: "hook",
+      question: "Qual é a primeira frase ou cena que abre esse vídeo?",
+      reason: "Ajuda a entender a força do gancho.",
+    });
+  });
+
+  it("adds narrative follow-up when narrative is missing", () => {
+    expect(seedFrom(analysis()).followUpQuestions).toContainEqual({
+      id: "narrative",
+      question: "Qual narrativa você quer que esse vídeo comunique?",
+      reason: "Ajuda a transformar o vídeo em uma pauta mais clara.",
+    });
+  });
+
+  it("adds blueprint follow-up when whatToPost is missing", () => {
+    expect(seedFrom(analysis()).followUpQuestions).toContainEqual({
+      id: "blueprint",
+      question: "Que tipo de post você imagina criar a partir desse vídeo?",
+      reason: "Ajuda a escolher o caminho do blueprint.",
+    });
+  });
+
+  it("limits follow-up questions to three", () => {
+    expect(seedFrom(analysis()).followUpQuestions).toHaveLength(3);
+  });
+
+  it("summarizes transcript, OCR, frames, and technical signals", () => {
+    expect(
+      seedFrom(
+        analysis({
+          evidence: {
+            transcript: "Fala disponível.",
+            ocr: ["Texto na tela"],
+            frames: ["Cena inicial"],
+            technicalSignals: ["opening_density baixo"],
+          },
+        }),
+      ).evidenceSummary,
+    ).toBe(
+      "Há fala/transcrição disponível. Há texto na tela identificado. Há contexto visual por cenas/frames. Há sinais técnicos auxiliares.",
+    );
+  });
+
+  it("returns false for empty useful seed", () => {
+    expect(hasUsefulPostCreationVideoSeed(createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }))).toBe(
+      false,
+    );
+  });
+
+  it("returns true for seed with initial idea", () => {
+    expect(
+      hasUsefulPostCreationVideoSeed({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        initialIdea: "Reel de rotina.",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for seed with follow-up questions", () => {
+    expect(
+      hasUsefulPostCreationVideoSeed({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        followUpQuestions: [{ id: "hook", question: "Qual abertura?", reason: "Ajuda a refinar." }],
+      }),
+    ).toBe(true);
+  });
+
+  it("prioritizes blueprint in primary action", () => {
+    expect(
+      getPostCreationVideoSeedPrimaryAction({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        blueprintDraft: { whatToPost: "Reel", whyThisPath: null, howItShouldWork: null, scenes: [] },
+      }),
+    ).toBe("Transformar a sugestão de blueprint em roteiro.");
+  });
+
+  it("uses opening in primary action without blueprint", () => {
+    expect(
+      getPostCreationVideoSeedPrimaryAction({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        scriptDirection: { opening: "Abrir pela dúvida.", development: [], closing: null, tone: null },
+      }),
+    ).toBe("Usar a direção de abertura para construir o roteiro.");
+  });
+
+  it("uses detected narrative in primary action without blueprint or opening", () => {
+    expect(
+      getPostCreationVideoSeedPrimaryAction({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        detectedNarrative: "processo -> insight",
+      }),
+    ).toBe("Refinar a narrativa detectada antes de gerar o roteiro.");
+  });
+
+  it("uses follow-ups in primary action when main fields are absent", () => {
+    expect(
+      getPostCreationVideoSeedPrimaryAction({
+        ...createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }),
+        followUpQuestions: [{ id: "hook", question: "Qual abertura?", reason: "Ajuda a refinar." }],
+      }),
+    ).toBe("Responder às perguntas de refinamento antes de avançar.");
+  });
+
+  it("returns fallback action for empty seed", () => {
+    expect(getPostCreationVideoSeedPrimaryAction(createEmptyPostCreationVideoSeed({ id: "seed", analysisId: "analysis" }))).toBe(
+      "Trazer mais contexto antes de transformar o vídeo em pauta.",
+    );
+  });
+
+  it("sanitizes texts that come from analysis", () => {
+    const seed = seedFrom(
+      analysis({
+        summary: "Certeza comprovada.",
+        blueprintSuggestion: {
+          whatToPost: "Plano garantido.",
+          whyThisPath: "Pode viralizar garantido.",
+          howItShouldWork: "Sempre performa.",
+          scenes: ["Cena comprovada."],
+        },
+        brandMatch: {
+          enabled: true,
+          territories: ["território garantido"],
+          whyBrandsWouldFit: "Certeza de encaixe.",
+        },
+      }),
+    );
+    const text = JSON.stringify(seed).toLowerCase();
+
+    for (const term of ["garantido", "certeza", "comprovado", "viralizar garantido"]) {
+      expect(text).not.toContain(term);
+    }
+  });
+
+  it("keeps generated language conservative", () => {
+    const seed = seedFrom(analysis());
+    const text = JSON.stringify({
+      seed,
+      action: getPostCreationVideoSeedPrimaryAction(seed),
+    }).toLowerCase();
+
+    for (const term of forbiddenTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, providers, storage, or product integrations", () => {
+    const sourcePath = path.join(__dirname, "videoNarrativePostCreationSeed.ts");
+    const source = fs.readFileSync(sourcePath, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(source).toContain("./videoNarrativeAnalysisTypes");
+    expect(importLines).not.toContain("React");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("Gemini");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.ts
@@ -1,0 +1,240 @@
+import {
+  VideoNarrativeAnalysis,
+  VideoNarrativeConfidence,
+  sanitizeVideoNarrativeAnalysisText,
+} from "./videoNarrativeAnalysisTypes";
+
+export type PostCreationVideoSeedSource = "video_narrative_analysis";
+
+export type PostCreationVideoSeedConfidence = VideoNarrativeConfidence;
+
+export type PostCreationVideoSeedBlueprintDraft = {
+  whatToPost: string | null;
+  whyThisPath: string | null;
+  howItShouldWork: string | null;
+  scenes: string[];
+};
+
+export type PostCreationVideoSeedScriptDirection = {
+  opening: string | null;
+  development: string[];
+  closing: string | null;
+  tone: string | null;
+};
+
+export type PostCreationVideoSeedFollowUpQuestion = {
+  id: string;
+  question: string;
+  reason: string;
+};
+
+export type PostCreationVideoSeed = {
+  id: string;
+  source: "video_narrative_analysis";
+  analysisId: string;
+  creatorQuestion: string | null;
+  initialIdea: string | null;
+  detectedNarrative: string | null;
+  suggestedFormat: string | null;
+  suggestedProposal: string | null;
+  strategicDiagnosis: string | null;
+  blueprintDraft: PostCreationVideoSeedBlueprintDraft;
+  scriptDirection: PostCreationVideoSeedScriptDirection;
+  brandMatchHints: string[];
+  followUpQuestions: PostCreationVideoSeedFollowUpQuestion[];
+  evidenceSummary: string | null;
+  confidence: PostCreationVideoSeedConfidence;
+  createdAt: string | null;
+};
+
+function cleanText(value: string | null | undefined): string | null {
+  if (!value?.trim()) return null;
+  return sanitizeVideoNarrativeAnalysisText(value);
+}
+
+function cleanTexts(values: string[]): string[] {
+  return values.map((value) => cleanText(value)).filter((value): value is string => Boolean(value));
+}
+
+export function createEmptyPostCreationVideoSeed(params: {
+  id: string;
+  analysisId: string;
+  createdAt?: string | null;
+}): PostCreationVideoSeed {
+  return {
+    id: params.id,
+    source: "video_narrative_analysis",
+    analysisId: params.analysisId,
+    creatorQuestion: null,
+    initialIdea: null,
+    detectedNarrative: null,
+    suggestedFormat: null,
+    suggestedProposal: null,
+    strategicDiagnosis: null,
+    blueprintDraft: {
+      whatToPost: null,
+      whyThisPath: null,
+      howItShouldWork: null,
+      scenes: [],
+    },
+    scriptDirection: {
+      opening: null,
+      development: [],
+      closing: null,
+      tone: null,
+    },
+    brandMatchHints: [],
+    followUpQuestions: [],
+    evidenceSummary: null,
+    confidence: "unknown",
+    createdAt: params.createdAt ?? null,
+  };
+}
+
+function buildStrategicDiagnosis(analysis: VideoNarrativeAnalysis): string | null {
+  const strength = cleanText(analysis.diagnosis.strengths[0]);
+  const weakness = cleanText(analysis.diagnosis.weaknesses[0]);
+  const adjustment = cleanText(analysis.diagnosis.recommendedAdjustments[0]);
+  const parts: string[] = [];
+
+  if (strength) parts.push(`Ponto forte: ${strength}.`);
+  if (weakness) parts.push(`Ponto de atenção: ${weakness}.`);
+  if (adjustment) parts.push(`Ajuste sugerido: ${adjustment}.`);
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+function buildScriptDirection(analysis: VideoNarrativeAnalysis): PostCreationVideoSeedScriptDirection {
+  const recommendedAdjustment = cleanText(analysis.diagnosis.recommendedAdjustments[0]);
+  const detectedHook = cleanText(analysis.hook.detected);
+  const closingScene = analysis.sceneStructure.find(
+    (scene) => scene.role === "call_to_action" || scene.role === "closing",
+  );
+  const blueprintScenes = cleanTexts(analysis.blueprintSuggestion.scenes);
+  const fallbackScenes = cleanTexts(analysis.sceneStructure.map((scene) => scene.description));
+
+  return {
+    opening: analysis.hook.strength === "weak" && recommendedAdjustment ? recommendedAdjustment : detectedHook,
+    development: blueprintScenes.length > 0 ? blueprintScenes : fallbackScenes,
+    closing: cleanText(closingScene?.description),
+    tone: cleanText(analysis.d2cClassification.tone),
+  };
+}
+
+function buildBrandMatchHints(analysis: VideoNarrativeAnalysis): string[] {
+  if (!analysis.brandMatch.enabled) return [];
+
+  const hints = cleanTexts(analysis.brandMatch.territories);
+  const reason = cleanText(analysis.brandMatch.whyBrandsWouldFit);
+  return reason ? [...hints, reason] : hints;
+}
+
+function buildFollowUpQuestions(analysis: VideoNarrativeAnalysis): PostCreationVideoSeedFollowUpQuestion[] {
+  const questions: PostCreationVideoSeedFollowUpQuestion[] = [];
+
+  if (!cleanText(analysis.hook.detected)) {
+    questions.push({
+      id: "hook",
+      question: "Qual é a primeira frase ou cena que abre esse vídeo?",
+      reason: "Ajuda a entender a força do gancho.",
+    });
+  }
+
+  if (!cleanText(analysis.d2cClassification.narrative)) {
+    questions.push({
+      id: "narrative",
+      question: "Qual narrativa você quer que esse vídeo comunique?",
+      reason: "Ajuda a transformar o vídeo em uma pauta mais clara.",
+    });
+  }
+
+  if (!cleanText(analysis.blueprintSuggestion.whatToPost)) {
+    questions.push({
+      id: "blueprint",
+      question: "Que tipo de post você imagina criar a partir desse vídeo?",
+      reason: "Ajuda a escolher o caminho do blueprint.",
+    });
+  }
+
+  return questions.slice(0, 3);
+}
+
+function buildEvidenceSummary(analysis: VideoNarrativeAnalysis): string | null {
+  const parts: string[] = [];
+
+  if (cleanText(analysis.evidence.transcript)) parts.push("Há fala/transcrição disponível.");
+  if (cleanTexts(analysis.evidence.ocr).length > 0) parts.push("Há texto na tela identificado.");
+  if (cleanTexts(analysis.evidence.frames).length > 0) parts.push("Há contexto visual por cenas/frames.");
+  if (cleanTexts(analysis.evidence.technicalSignals).length > 0) parts.push("Há sinais técnicos auxiliares.");
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+export function buildPostCreationVideoSeedFromAnalysis(params: {
+  id: string;
+  analysis: VideoNarrativeAnalysis;
+  creatorQuestion?: string | null;
+  createdAt?: string | null;
+}): PostCreationVideoSeed {
+  const { analysis } = params;
+
+  return {
+    id: params.id,
+    source: "video_narrative_analysis",
+    analysisId: analysis.id,
+    creatorQuestion: params.creatorQuestion?.trim() || null,
+    initialIdea:
+      cleanText(analysis.blueprintSuggestion.whatToPost) ||
+      cleanText(analysis.summary) ||
+      cleanText(analysis.hook.detected),
+    detectedNarrative: cleanText(analysis.d2cClassification.narrative) || cleanText(analysis.summary),
+    suggestedFormat: analysis.d2cClassification.format === "unknown" ? null : analysis.d2cClassification.format,
+    suggestedProposal: analysis.d2cClassification.proposal === "unknown" ? null : analysis.d2cClassification.proposal,
+    strategicDiagnosis: buildStrategicDiagnosis(analysis),
+    blueprintDraft: {
+      whatToPost: cleanText(analysis.blueprintSuggestion.whatToPost),
+      whyThisPath: cleanText(analysis.blueprintSuggestion.whyThisPath),
+      howItShouldWork: cleanText(analysis.blueprintSuggestion.howItShouldWork),
+      scenes: cleanTexts(analysis.blueprintSuggestion.scenes),
+    },
+    scriptDirection: buildScriptDirection(analysis),
+    brandMatchHints: buildBrandMatchHints(analysis),
+    followUpQuestions: buildFollowUpQuestions(analysis),
+    evidenceSummary: buildEvidenceSummary(analysis),
+    confidence: analysis.confidence,
+    createdAt: params.createdAt ?? analysis.createdAt ?? null,
+  };
+}
+
+export function hasUsefulPostCreationVideoSeed(seed: PostCreationVideoSeed): boolean {
+  return Boolean(
+    cleanText(seed.initialIdea) ||
+      cleanText(seed.detectedNarrative) ||
+      cleanText(seed.strategicDiagnosis) ||
+      cleanText(seed.blueprintDraft.whatToPost) ||
+      cleanText(seed.scriptDirection.opening) ||
+      seed.scriptDirection.development.length > 0 ||
+      seed.brandMatchHints.length > 0 ||
+      seed.followUpQuestions.length > 0,
+  );
+}
+
+export function getPostCreationVideoSeedPrimaryAction(seed: PostCreationVideoSeed): string {
+  if (cleanText(seed.blueprintDraft.whatToPost)) {
+    return "Transformar a sugestão de blueprint em roteiro.";
+  }
+
+  if (cleanText(seed.scriptDirection.opening)) {
+    return "Usar a direção de abertura para construir o roteiro.";
+  }
+
+  if (cleanText(seed.detectedNarrative)) {
+    return "Refinar a narrativa detectada antes de gerar o roteiro.";
+  }
+
+  if (seed.followUpQuestions.length > 0) {
+    return "Responder às perguntas de refinamento antes de avançar.";
+  }
+
+  return "Trazer mais contexto antes de transformar o vídeo em pauta.";
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #799. Adiciona a fase MM3: adapter puro de `VideoNarrativeAnalysis` para `PostCreationVideoSeed`.

## Inclui

- `videoNarrativePostCreationSeed.ts`
- `videoNarrativePostCreationSeed.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## O que foi criado

Define `PostCreationVideoSeed` como camada intermediária segura entre a análise narrativa multimodal e o futuro funil de criação.

O adapter mapeia:

- ideia inicial;
- narrativa detectada;
- formato/proposta sugeridos;
- diagnóstico estratégico;
- blueprint draft;
- direção de roteiro;
- hints de marca;
- perguntas de refinamento;
- resumo de evidências.

## Helpers

- `createEmptyPostCreationVideoSeed`
- `buildPostCreationVideoSeedFromAnalysis`
- `hasUsefulPostCreationVideoSeed`
- `getPostCreationVideoSeedPrimaryAction`

## Fora de escopo

Não há provider real, Gemini, OpenAI, SDK, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell ou navegação/menu.

O `PostCreationFunnelState` real não foi alterado.

## QA relatada

- `videoNarrativePostCreationSeed.test.ts` passou
- `videoNarrativeAnalysisTypes.test.ts` passou
- regressões Provider/Storage/VU/Guard/Previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.