### PR TITLE
feat: add video narrative mock provider

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -70,6 +70,27 @@ O que não faz:
 - não conecta no `BoardShell`;
 - não cria provider, endpoint ou UI real.
 
+### MM4 — Mock provider narrativo multimodal
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeMockProvider.ts`
+- `videoNarrativeMockProvider.test.ts`
+
+O que faz:
+
+- simula leituras narrativas multimodais determinísticas;
+- retorna `VideoNarrativeAnalysis` diretamente, sem usar artifacts técnicos como saída principal;
+- cobre rotina de skincare, bastidor, potencial de marca, gancho fraco, collab, conteúdo pouco claro e adaptação para publi.
+
+O que não faz:
+
+- não usa provider real;
+- não usa Gemini;
+- não cria endpoint, UI ou integração com o board real.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -210,7 +210,7 @@ Exemplos:
 
 1. MM2 — Contratos `VideoNarrativeAnalysis`.
 2. MM3 — Adapter `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
-3. MM4 — Mock provider narrativo multimodal.
+3. MM4 — Mock provider narrativo multimodal. Concluído como provider local determinístico.
 4. MM5 — Pipeline QA multimodal.
 5. MM6 — Preview interno narrativo.
 6. MM7 — Prompt/schema Gemini.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts
@@ -1,0 +1,194 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  hasUsefulPostCreationVideoSeed,
+} from "./videoNarrativePostCreationSeed";
+import {
+  getVideoNarrativeSuggestedNextStep,
+  hasUsefulVideoNarrativeAnalysis,
+} from "./videoNarrativeAnalysisTypes";
+import {
+  VideoNarrativeMockProviderScenario,
+  runVideoNarrativeMockProvider,
+  runVideoNarrativeMockProviderBatch,
+} from "./videoNarrativeMockProvider";
+
+const forbiddenTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function run(scenario: VideoNarrativeMockProviderScenario, id = "analysis-1") {
+  return runVideoNarrativeMockProvider({
+    input: { id, creatorQuestion: "Quero entender esse vídeo.", createdAt: "2026-05-15T10:00:00.000Z" },
+    options: { scenario },
+  });
+}
+
+describe("videoNarrativeMockProvider", () => {
+  it("returns useful skincare routine analysis", () => {
+    const result = run("skincare_routine");
+
+    expect(hasUsefulVideoNarrativeAnalysis(result)).toBe(true);
+    expect(result.summary).toContain("skincare");
+    expect(result.spokenTopics).toEqual(expect.arrayContaining(["skincare", "autocuidado"]));
+    expect(result.visualElements).toContain("produtos de skincare");
+    expect(result.onScreenText).toContain("Rotina da manhã");
+    expect(result.d2cClassification).toMatchObject({
+      format: "reel",
+      proposal: "tips",
+      context: "autocuidado",
+      tone: "educational",
+    });
+  });
+
+  it("fills brand match and evidence for skincare routine", () => {
+    const result = run("skincare_routine");
+
+    expect(result.brandMatch.enabled).toBe(true);
+    expect(result.brandMatch.territories).toEqual(expect.arrayContaining(["autocuidado", "skincare"]));
+    expect(result.evidence.transcript).toContain("rotina de skincare");
+    expect(result.evidence.ocr).toContain("Rotina da manhã");
+    expect(result.evidence.frames.length).toBeGreaterThan(0);
+  });
+
+  it("returns backstage process proposal and process signal", () => {
+    const result = run("backstage_process");
+
+    expect(result.d2cClassification.proposal).toBe("behind_the_scenes");
+    expect(result.d2cClassification.narrative).toContain("bastidor");
+    expect(result.profileSignals).toContainEqual(
+      expect.objectContaining({ type: "content_strength", value: "bastidor e processo" }),
+    );
+  });
+
+  it("returns brand potential with organic ad blueprint", () => {
+    const result = run("brand_potential");
+
+    expect(result.brandMatch.enabled).toBe(true);
+    expect(result.brandMatch.territories).toEqual(expect.arrayContaining(["beleza", "autocuidado"]));
+    expect(result.blueprintSuggestion.whatToPost).toContain("publi orgânica");
+  });
+
+  it("returns weak hook with recommendations", () => {
+    const result = run("weak_hook");
+
+    expect(result.hook.strength).toBe("weak");
+    expect(result.diagnosis.weaknesses.join(" ")).toContain("abertura");
+    expect(result.diagnosis.recommendedAdjustments.join(" ")).toContain("Abrir com");
+  });
+
+  it("suggests strengthening hook for weak hook scenario", () => {
+    expect(getVideoNarrativeSuggestedNextStep(run("weak_hook"))).toBe(
+      "Reforçar o gancho antes de transformar o vídeo em roteiro.",
+    );
+  });
+
+  it("returns collab proposal and blueprint", () => {
+    const result = run("collab_potential");
+
+    expect(result.d2cClassification.proposal).toBe("collab_narrative");
+    expect(result.d2cClassification.narrative).toContain("troca entre comunidades");
+    expect(result.blueprintSuggestion.whatToPost).toContain("collab");
+  });
+
+  it("returns low-confidence unclear content that can generate seed follow-ups", () => {
+    const result = run("unclear_content");
+    const seed = buildPostCreationVideoSeedFromAnalysis({ id: "seed-1", analysis: result });
+
+    expect(result.confidence).toBe("low");
+    expect(result.hook.strength).toBe("unknown");
+    expect(result.blueprintSuggestion.whatToPost).toBeNull();
+    expect(seed.followUpQuestions.length).toBeGreaterThan(0);
+  });
+
+  it("returns ad adaptation and seed brand hints", () => {
+    const result = run("ad_adaptation");
+    const seed = buildPostCreationVideoSeedFromAnalysis({ id: "seed-1", analysis: result });
+
+    expect(result.d2cClassification.proposal).toBe("ad_adaptation");
+    expect(result.brandMatch.enabled).toBe(true);
+    expect(seed.brandMatchHints.length).toBeGreaterThan(0);
+  });
+
+  it("uses safe fallback id for empty input id", () => {
+    expect(run("skincare_routine", "").id).toBe("mock-video-narrative-analysis");
+  });
+
+  it("preserves createdAt from input", () => {
+    expect(run("skincare_routine").createdAt).toBe("2026-05-15T10:00:00.000Z");
+  });
+
+  it("lets confidence option override default", () => {
+    expect(
+      runVideoNarrativeMockProvider({
+        input: { id: "analysis-1", creatorQuestion: null },
+        options: { scenario: "skincare_routine", confidence: "high" },
+      }).confidence,
+    ).toBe("high");
+  });
+
+  it("preserves input order in batch", () => {
+    const results = runVideoNarrativeMockProviderBatch({
+      inputs: [
+        { id: "analysis-a", creatorQuestion: null },
+        { id: "analysis-b", creatorQuestion: null },
+      ],
+      options: { scenario: "backstage_process" },
+    });
+
+    expect(results.map((result) => result.id)).toEqual(["analysis-a", "analysis-b"]);
+  });
+
+  it("builds a useful seed from mock analysis", () => {
+    const seed = buildPostCreationVideoSeedFromAnalysis({ id: "seed-1", analysis: run("skincare_routine") });
+
+    expect(hasUsefulPostCreationVideoSeed(seed)).toBe(true);
+    expect(seed.initialIdea || seed.followUpQuestions.length > 0).toBeTruthy();
+  });
+
+  it("keeps scenario language conservative", () => {
+    const text = JSON.stringify(
+      [
+        "skincare_routine",
+        "backstage_process",
+        "brand_potential",
+        "weak_hook",
+        "collab_potential",
+        "unclear_content",
+        "ad_adaptation",
+      ].map((scenario) => run(scenario as VideoNarrativeMockProviderScenario)),
+    ).toLowerCase();
+
+    for (const term of forbiddenTerms) {
+      expect(text).not.toContain(term);
+    }
+    expect(text).not.toContain("erro");
+  });
+
+  it("does not import UI, providers, storage, or product integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "videoNarrativeMockProvider.ts"), "utf8");
+
+    expect(source).toContain("./videoNarrativeAnalysisTypes");
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("OpenAI");
+    expect(source).not.toContain("Gemini");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("Prisma");
+    expect(source).not.toContain("storage");
+    expect(source).not.toContain("ffmpeg");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.ts
@@ -1,0 +1,322 @@
+import {
+  VideoNarrativeAnalysis,
+  VideoNarrativeConfidence,
+  createEmptyVideoNarrativeAnalysis,
+  sanitizeVideoNarrativeAnalysisText,
+} from "./videoNarrativeAnalysisTypes";
+
+export type VideoNarrativeMockProviderScenario =
+  | "skincare_routine"
+  | "backstage_process"
+  | "brand_potential"
+  | "weak_hook"
+  | "collab_potential"
+  | "unclear_content"
+  | "ad_adaptation";
+
+export type VideoNarrativeMockProviderInput = {
+  id: string;
+  creatorQuestion: string | null;
+  createdAt?: string | null;
+};
+
+export type VideoNarrativeMockProviderOptions = {
+  scenario?: VideoNarrativeMockProviderScenario;
+  confidence?: VideoNarrativeConfidence;
+};
+
+const fallbackId = "mock-video-narrative-analysis";
+
+function clean(value: string): string {
+  return sanitizeVideoNarrativeAnalysisText(value);
+}
+
+function buildBase(input: VideoNarrativeMockProviderInput, confidence: VideoNarrativeConfidence): VideoNarrativeAnalysis {
+  return {
+    ...createEmptyVideoNarrativeAnalysis({
+      id: input.id.trim() || fallbackId,
+      createdAt: input.createdAt ?? null,
+    }),
+    confidence,
+  };
+}
+
+function buildScenario(
+  input: VideoNarrativeMockProviderInput,
+  scenario: VideoNarrativeMockProviderScenario,
+  confidence: VideoNarrativeConfidence,
+): VideoNarrativeAnalysis {
+  const base = buildBase(input, confidence);
+
+  switch (scenario) {
+    case "backstage_process":
+      return {
+        ...base,
+        summary: clean("Vídeo de bastidor mostrando processo de criação em andamento."),
+        hook: {
+          detected: clean("Abre com a rotina real antes da entrega final."),
+          strength: "medium",
+          why: clean("A abertura cria contexto para acompanhar o processo."),
+        },
+        spokenTopics: [clean("processo de criação"), clean("bastidores")],
+        visualElements: [clean("reunião"), clean("tela de trabalho"), clean("rascunhos")],
+        sceneStructure: [
+          { id: "context", timestampLabel: "00:00", role: "context", description: clean("Mostra a reunião inicial."), suggestedAdjustment: null },
+          { id: "development", timestampLabel: "00:08", role: "development", description: clean("Desenvolve o raciocínio no processo."), suggestedAdjustment: null },
+          { id: "closing", timestampLabel: "00:24", role: "closing", description: clean("Fecha com a entrega tomando forma."), suggestedAdjustment: null },
+        ],
+        d2cClassification: {
+          format: "reel",
+          proposal: "behind_the_scenes",
+          context: clean("processo"),
+          tone: clean("observational"),
+          reference: null,
+          intent: clean("mostrar processo"),
+          narrative: clean("bastidor -> processo -> pauta"),
+        },
+        diagnosis: {
+          strengths: [clean("O processo aparece de forma concreta.")],
+          weaknesses: [],
+          recommendedAdjustments: [clean("Explicitar a virada prática do bastidor.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: clean("Um reel de bastidor que transforma processo em pauta."),
+          whyThisPath: clean("O material já mostra contexto real e progressão."),
+          howItShouldWork: clean("Abrir no bastidor, revelar decisão e fechar com aprendizado."),
+          scenes: [clean("Reunião"), clean("Decisão"), clean("Aprendizado")],
+        },
+        brandMatch: { enabled: false, territories: [], whyBrandsWouldFit: null },
+        evidence: {
+          transcript: clean("Mostro como a ideia sai da reunião e vira pauta."),
+          ocr: [clean("Planejamento")],
+          frames: [clean("Reunião"), clean("Tela"), clean("Rascunhos")],
+          technicalSignals: [],
+        },
+        profileSignals: [
+          { type: "content_strength", value: clean("bastidor e processo"), confidence: "medium", shouldPersistLater: false },
+        ],
+      };
+    case "brand_potential":
+      return {
+        ...base,
+        summary: clean("Vídeo com narrativa de autocuidado que pode receber adaptação orgânica para marca."),
+        hook: {
+          detected: clean("Abre pelo ritual antes de citar qualquer produto."),
+          strength: "strong",
+          why: clean("A narrativa já existe sem depender da publi."),
+        },
+        spokenTopics: [clean("autocuidado"), clean("rotina")],
+        visualElements: [clean("produtos de beleza"), clean("bancada"), clean("aplicação no rosto")],
+        sceneStructure: [
+          { id: "hook", timestampLabel: "00:00", role: "hook", description: clean("Começa pelo ritual diário."), suggestedAdjustment: null },
+          { id: "proof", timestampLabel: "00:10", role: "proof", description: clean("Mostra o uso no contexto real."), suggestedAdjustment: null },
+        ],
+        d2cClassification: {
+          format: "reel",
+          proposal: "ad_adaptation",
+          context: clean("autocuidado"),
+          tone: clean("natural"),
+          reference: null,
+          intent: clean("adaptar para publi orgânica"),
+          narrative: clean("rotina orgânica -> produto -> continuidade"),
+        },
+        diagnosis: {
+          strengths: [clean("A presença de produto conversa com uma rotina já existente.")],
+          weaknesses: [],
+          recommendedAdjustments: [clean("Manter o produto dentro da história, sem quebrar o fluxo.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: clean("Adaptar a rotina para uma publi orgânica com produto integrado."),
+          whyThisPath: clean("O vídeo já sustenta contexto antes da marca entrar."),
+          howItShouldWork: clean("Preservar rotina, inserir benefício e fechar com uso real."),
+          scenes: [clean("Ritual"), clean("Produto em uso"), clean("Resultado percebido")],
+        },
+        brandMatch: {
+          enabled: true,
+          territories: [clean("beleza"), clean("autocuidado"), clean("creator economy")],
+          whyBrandsWouldFit: clean("A narrativa encaixa produto em hábito real."),
+        },
+        evidence: { transcript: clean("Essa é minha rotina de autocuidado."), ocr: [], frames: [clean("Produto na bancada")], technicalSignals: [] },
+        profileSignals: [{ type: "brand_territory", value: clean("autocuidado"), confidence: "high", shouldPersistLater: false }],
+      };
+    case "weak_hook":
+      return {
+        ...base,
+        summary: clean("Vídeo com boa matéria-prima, mas abertura lenta."),
+        hook: {
+          detected: clean("Começa contextualizando antes de mostrar o ponto mais forte."),
+          strength: "weak",
+          why: clean("A tensão aparece tarde demais para orientar a leitura."),
+        },
+        spokenTopics: [clean("processo de criação")],
+        visualElements: [clean("mesa de trabalho")],
+        sceneStructure: [
+          { id: "hook", timestampLabel: "00:00", role: "hook", description: clean("Abertura longa antes do conflito."), suggestedAdjustment: clean("Abrir pela pergunta central.") },
+        ],
+        d2cClassification: {
+          format: "reel",
+          proposal: "tips",
+          context: clean("planejamento"),
+          tone: clean("educational"),
+          reference: null,
+          intent: clean("ensinar"),
+          narrative: clean("dúvida -> ajuste -> pauta"),
+        },
+        diagnosis: {
+          strengths: [clean("O desenvolvimento tem material útil.")],
+          weaknesses: [clean("A abertura demora para revelar o gancho.")],
+          recommendedAdjustments: [clean("Abrir com uma pergunta ou situação mais clara.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: clean("Reestruturar o vídeo em torno da dúvida principal."),
+          whyThisPath: clean("O conteúdo melhora quando a tensão aparece cedo."),
+          howItShouldWork: clean("Abrir com conflito, desenvolver exemplo e fechar com direção."),
+          scenes: [clean("Pergunta"), clean("Exemplo"), clean("Direção")],
+        },
+        brandMatch: { enabled: false, territories: [], whyBrandsWouldFit: null },
+        evidence: { transcript: clean("Antes de mostrar o ponto principal, explico todo o contexto."), ocr: [], frames: [], technicalSignals: [clean("opening_density: low")] },
+        profileSignals: [{ type: "creative_gap", value: clean("gancho de abertura"), confidence: "medium", shouldPersistLater: false }],
+      };
+    case "collab_potential":
+      return {
+        ...base,
+        summary: clean("Vídeo com espaço para troca entre criadores e comunidades."),
+        hook: { detected: clean("Abre com uma pergunta que convida contraponto."), strength: "medium", why: clean("A estrutura deixa espaço para outra voz.") },
+        spokenTopics: [clean("troca entre comunidades")],
+        visualElements: [clean("creator em câmera")],
+        sceneStructure: [
+          { id: "hook", timestampLabel: "00:00", role: "hook", description: clean("Pergunta inicial abre conversa."), suggestedAdjustment: null },
+          { id: "development", timestampLabel: "00:07", role: "development", description: clean("Tema permite resposta complementar."), suggestedAdjustment: null },
+        ],
+        d2cClassification: {
+          format: "reel",
+          proposal: "collab_narrative",
+          context: clean("comunidade"),
+          tone: clean("conversational"),
+          reference: null,
+          intent: clean("estimular troca"),
+          narrative: clean("pergunta -> contraponto -> troca entre comunidades"),
+        },
+        diagnosis: { strengths: [clean("A pauta admite dois pontos de vista.")], weaknesses: [], recommendedAdjustments: [clean("Definir o papel de cada creator na conversa.")] },
+        blueprintSuggestion: {
+          whatToPost: clean("Uma collab em dois atos, com pergunta e resposta."),
+          whyThisPath: clean("A narrativa ganha força com contraponto."),
+          howItShouldWork: clean("Um creator abre a tensão e o outro amplia a leitura."),
+          scenes: [clean("Pergunta"), clean("Contraponto"), clean("Síntese")],
+        },
+        brandMatch: { enabled: false, territories: [], whyBrandsWouldFit: null },
+        evidence: { transcript: clean("Quero ouvir como outros criadores lidam com isso."), ocr: [], frames: [], technicalSignals: [] },
+        profileSignals: [{ type: "audience_goal", value: clean("troca entre comunidades"), confidence: "medium", shouldPersistLater: false }],
+      };
+    case "unclear_content":
+      return {
+        ...base,
+        summary: clean("Leitura inicial disponível, mas ainda sem contexto suficiente para definir a pauta."),
+        hook: { detected: null, strength: "unknown", why: null },
+        d2cClassification: {
+          ...base.d2cClassification,
+          format: "unknown",
+          proposal: "unknown",
+        },
+        diagnosis: {
+          strengths: [],
+          weaknesses: [],
+          recommendedAdjustments: [clean("Trazer mais contexto sobre intenção, abertura e caminho desejado.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: null,
+          whyThisPath: null,
+          howItShouldWork: null,
+          scenes: [],
+        },
+      };
+    case "ad_adaptation":
+      return {
+        ...buildScenario(input, "brand_potential", confidence),
+        summary: clean("Vídeo orgânico com espaço para adaptação de publi sem perder a narrativa."),
+        d2cClassification: {
+          format: "reel",
+          proposal: "ad_adaptation",
+          context: clean("rotina"),
+          tone: clean("organic"),
+          reference: null,
+          intent: clean("adaptar para publi"),
+          narrative: clean("rotina orgânica -> encaixe de produto -> continuidade"),
+        },
+        diagnosis: {
+          strengths: [clean("A história orgânica já sustenta o produto.")],
+          weaknesses: [],
+          recommendedAdjustments: [clean("Preservar a coerência do conteúdo ao inserir a marca.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: clean("Uma adaptação de publi que mantém a rotina como centro."),
+          whyThisPath: clean("A narrativa orgânica permite inserir produto sem quebrar o fluxo."),
+          howItShouldWork: clean("Manter contexto, mostrar uso e fechar com continuidade."),
+          scenes: [clean("Rotina"), clean("Produto integrado"), clean("Fechamento orgânico")],
+        },
+      };
+    case "skincare_routine":
+    default:
+      return {
+        ...base,
+        summary: clean("Rotina de skincare pela manhã com foco em autocuidado."),
+        hook: { detected: clean("Começa mostrando a primeira etapa da rotina."), strength: "medium", why: clean("A abertura situa rapidamente o ritual.") },
+        spokenTopics: [clean("skincare"), clean("autocuidado")],
+        onScreenText: [clean("Rotina da manhã")],
+        visualElements: [clean("produtos de skincare"), clean("aplicação no rosto")],
+        sceneStructure: [
+          { id: "hook", timestampLabel: "00:00", role: "hook", description: clean("Mostra o início da rotina."), suggestedAdjustment: null },
+          { id: "development", timestampLabel: "00:06", role: "development", description: clean("Explica as etapas do autocuidado."), suggestedAdjustment: null },
+          { id: "closing", timestampLabel: "00:24", role: "closing", description: clean("Fecha com continuidade da rotina."), suggestedAdjustment: null },
+        ],
+        d2cClassification: {
+          format: "reel",
+          proposal: "tips",
+          context: clean("autocuidado"),
+          tone: clean("educational"),
+          reference: null,
+          intent: clean("educar"),
+          narrative: clean("rotina de autocuidado -> dica -> continuidade"),
+        },
+        diagnosis: {
+          strengths: [clean("A rotina é fácil de acompanhar.")],
+          weaknesses: [],
+          recommendedAdjustments: [clean("Destacar uma dica prática logo no início.")],
+        },
+        blueprintSuggestion: {
+          whatToPost: clean("Um reel de rotina de skincare com dica prática."),
+          whyThisPath: clean("O vídeo já combina ritual visual e assunto claro."),
+          howItShouldWork: clean("Abrir na rotina, explicar uma dica e fechar com continuidade."),
+          scenes: [clean("Início da rotina"), clean("Dica prática"), clean("Fechamento")],
+        },
+        brandMatch: {
+          enabled: true,
+          territories: [clean("autocuidado"), clean("skincare")],
+          whyBrandsWouldFit: clean("A narrativa conecta produto com hábito real."),
+        },
+        evidence: {
+          transcript: clean("Mostro minha rotina de skincare pela manhã e falo sobre autocuidado."),
+          ocr: [clean("Rotina da manhã")],
+          frames: [clean("Produtos na bancada"), clean("Aplicação no rosto")],
+          technicalSignals: [],
+        },
+        profileSignals: [{ type: "brand_territory", value: clean("autocuidado"), confidence: "high", shouldPersistLater: false }],
+      };
+  }
+}
+
+export function runVideoNarrativeMockProvider(params: {
+  input: VideoNarrativeMockProviderInput;
+  options?: VideoNarrativeMockProviderOptions;
+}): VideoNarrativeAnalysis {
+  const scenario = params.options?.scenario ?? "skincare_routine";
+  const confidence = params.options?.confidence ?? (scenario === "unclear_content" ? "low" : "medium");
+  return buildScenario(params.input, scenario, confidence);
+}
+
+export function runVideoNarrativeMockProviderBatch(params: {
+  inputs: VideoNarrativeMockProviderInput[];
+  options?: VideoNarrativeMockProviderOptions;
+}): VideoNarrativeAnalysis[] {
+  return params.inputs.map((input) => runVideoNarrativeMockProvider({ input, options: params.options }));
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #800. Adiciona a fase MM4: mock provider narrativo multimodal.

## Inclui

- `videoNarrativeMockProvider.ts`
- `videoNarrativeMockProvider.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## O que foi criado

Provider local, síncrono, determinístico e em memória que retorna `VideoNarrativeAnalysis` diretamente como produto principal.

Diferente da linha técnica anterior, este mock não usa `VideoProcessingArtifacts` como saída central. Ele simula a nova direção de produto: vídeo + pergunta do criador → leitura narrativa → diagnóstico → blueprint → seed futuro do board.

## Cenários suportados

- `skincare_routine`
- `backstage_process`
- `brand_potential`
- `weak_hook`
- `collab_potential`
- `unclear_content`
- `ad_adaptation`

## Helpers

- `runVideoNarrativeMockProvider`
- `runVideoNarrativeMockProviderBatch`

## Fora de escopo

Não há provider real, Gemini, OpenAI, SDK, ffmpeg, storage real, upload real, endpoint, UI, banco, BoardShell, fetch ou navegação/menu.

O `PostCreationFunnelState` real não foi alterado.

## QA relatada

- testes MM4 + MM3 + MM2 passaram
- regressões Provider/Storage/VU/Guard/Previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.