### PR TITLE
feat: add video narrative preview harness

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativePreviewScenario.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativePreviewScenario.ts
@@ -1,0 +1,108 @@
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  getPostCreationVideoSeedPrimaryAction,
+  hasUsefulPostCreationVideoSeed,
+} from "../../videoUpload/videoNarrativePostCreationSeed";
+import {
+  VideoNarrativeMockProviderScenario,
+  runVideoNarrativeMockProvider,
+} from "../../videoUpload/videoNarrativeMockProvider";
+import {
+  getVideoNarrativeSuggestedNextStep,
+  hasUsefulVideoNarrativeAnalysis,
+} from "../../videoUpload/videoNarrativeAnalysisTypes";
+
+export type VideoNarrativePreviewScenario = {
+  id: string;
+  label: string;
+  creatorQuestion: string;
+  mockScenario: VideoNarrativeMockProviderScenario;
+};
+
+export const VIDEO_NARRATIVE_PREVIEW_SCENARIOS: VideoNarrativePreviewScenario[] = [
+  {
+    id: "skincare",
+    label: "Narrativa: rotina de skincare",
+    creatorQuestion: "Quero saber se vale postar",
+    mockScenario: "skincare_routine",
+  },
+  {
+    id: "backstage",
+    label: "Narrativa: bastidor de criação",
+    creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+    mockScenario: "backstage_process",
+  },
+  {
+    id: "brand",
+    label: "Narrativa: potencial de marca",
+    creatorQuestion: "Quero saber se esse vídeo tem potencial para atrair marcas",
+    mockScenario: "brand_potential",
+  },
+  {
+    id: "weak-hook",
+    label: "Narrativa: gancho fraco",
+    creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+    mockScenario: "weak_hook",
+  },
+  {
+    id: "collab",
+    label: "Narrativa: potencial de collab",
+    creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+    mockScenario: "collab_potential",
+  },
+  {
+    id: "ad-adaptation",
+    label: "Narrativa: adaptação para publi",
+    creatorQuestion: "Quero transformar esse vídeo em uma publi sem parecer forçado",
+    mockScenario: "ad_adaptation",
+  },
+  {
+    id: "unclear",
+    label: "Narrativa: contexto insuficiente",
+    creatorQuestion: "Me ajuda com esse vídeo",
+    mockScenario: "unclear_content",
+  },
+];
+
+export const DEFAULT_VIDEO_NARRATIVE_PREVIEW_SCENARIO_ID = "skincare";
+
+function normalizeScenarioId(value?: string | string[] | null) {
+  if (Array.isArray(value)) return value[0] || DEFAULT_VIDEO_NARRATIVE_PREVIEW_SCENARIO_ID;
+  return value || DEFAULT_VIDEO_NARRATIVE_PREVIEW_SCENARIO_ID;
+}
+
+export function getVideoNarrativePreviewScenario(value?: string | string[] | null) {
+  const scenarioId = normalizeScenarioId(value);
+  return (
+    VIDEO_NARRATIVE_PREVIEW_SCENARIOS.find((scenario) => scenario.id === scenarioId) ||
+    VIDEO_NARRATIVE_PREVIEW_SCENARIOS[0]!
+  );
+}
+
+export function buildVideoNarrativePreviewScenario(value?: string | string[] | null) {
+  const scenario = getVideoNarrativePreviewScenario(value);
+  const analysis = runVideoNarrativeMockProvider({
+    input: {
+      id: `video-narrative-preview-${scenario.id}`,
+      creatorQuestion: scenario.creatorQuestion,
+      createdAt: "2026-05-15T10:00:00.000Z",
+    },
+    options: { scenario: scenario.mockScenario },
+  });
+  const seed = buildPostCreationVideoSeedFromAnalysis({
+    id: `video-narrative-preview-${scenario.id}-seed`,
+    analysis,
+    creatorQuestion: scenario.creatorQuestion,
+    createdAt: analysis.createdAt,
+  });
+
+  return {
+    scenario,
+    analysis,
+    hasUsefulAnalysis: hasUsefulVideoNarrativeAnalysis(analysis),
+    seed,
+    hasUsefulSeed: hasUsefulPostCreationVideoSeed(seed),
+    primaryAction: getPostCreationVideoSeedPrimaryAction(seed),
+    suggestedNextStep: getVideoNarrativeSuggestedNextStep(analysis),
+  };
+}

--- a/src/app/dashboard/boards/video-narrative-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-narrative-preview/page.test.tsx
@@ -1,0 +1,184 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import VideoNarrativePreviewPage from "./page";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED;
+const adminViewer = { role: "admin" };
+const commonViewer = { role: "user" };
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = originalEnvValue;
+});
+
+describe("VideoNarrativePreviewPage", () => {
+  it("renders blocked state without mounting the scenario when flag is off", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "0";
+
+    render(await VideoNarrativePreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Narrativa de Vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota.")).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Narrativa de Vídeo")).not.toBeInTheDocument();
+    expect(screen.queryByText("PostCreationVideoSeed")).not.toBeInTheDocument();
+  });
+
+  it("blocks common users when the flag is on", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Narrativa de Vídeo")).not.toBeInTheDocument();
+  });
+
+  it("renders skincare as the default scenario for admin", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Preview interno — Narrativa de Vídeo")).toBeInTheDocument();
+    expect(screen.getAllByText("Narrativa: rotina de skincare").length).toBeGreaterThan(0);
+    expect(screen.getByText("VideoNarrativeAnalysis")).toBeInTheDocument();
+    expect(screen.getByText("PostCreationVideoSeed")).toBeInTheDocument();
+    expect(screen.getAllByText("Ação primária").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Transformar a sugestão de blueprint em roteiro.").length).toBeGreaterThan(0);
+  });
+
+  it("renders the brand scenario", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "brand" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: potencial de marca").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("autocuidado").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/publi orgânica/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/collab em dois atos/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the backstage scenario", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "backstage" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: bastidor de criação").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/behind_the_scenes/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/bastidor/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the weak hook scenario", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "weak-hook" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: gancho fraco").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("weak").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Abrir com uma pergunta/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Direção de abertura/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the collab scenario", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "collab" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: potencial de collab").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/collab_narrative/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/collab/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the ad adaptation scenario", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "ad-adaptation" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: adaptação para publi").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/ad_adaptation/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/beleza/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/publi/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the unclear scenario with refinement questions", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "unclear" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: contexto insuficiente").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("low").length).toBeGreaterThan(0);
+    expect(screen.getByText("Perguntas de refinamento")).toBeInTheDocument();
+    expect(screen.getAllByText("Responder às perguntas de refinamento antes de avançar.").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/plano definitivo/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to skincare for invalid scenarios", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativePreviewPage({ searchParams: { scenario: "missing" }, viewer: adminViewer }));
+
+    expect(screen.getAllByText("Narrativa: rotina de skincare").length).toBeGreaterThan(0);
+  });
+
+  it("keeps rendered language conservative", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+    const { container } = render(
+      await VideoNarrativePreviewPage({ searchParams: { scenario: "unclear" }, viewer: adminViewer }),
+    );
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "erro",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "salvo",
+      "treinado",
+      "definitivo",
+      "aprendido permanentemente",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import product shell, external services, NSE, or Adaptive V2", () => {
+    const pageSource = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+    const scenarioSource = fs.readFileSync(
+      path.join(__dirname, "../components/videoUpload/buildVideoNarrativePreviewScenario.ts"),
+      "utf8",
+    );
+    const source = `${pageSource}\n${scenarioSource}`;
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).not.toMatch(/PostCreationFunnelBoardShell/);
+    expect(importLines).not.toMatch(/BoardShell/);
+    expect(importLines).not.toMatch(/\bfetch\s*\(/);
+    expect(importLines).not.toMatch(/OpenAI/);
+    expect(importLines).not.toMatch(/Gemini/);
+    expect(importLines).not.toMatch(/openai/);
+    expect(importLines).not.toMatch(/prisma/);
+    expect(importLines).not.toMatch(/storage real/i);
+    expect(importLines).not.toMatch(/ffmpeg/i);
+    expect(importLines).not.toMatch(/sdk externo/i);
+    expect(importLines).not.toMatch(/upload service/i);
+    expect(importLines).not.toMatch(/file picker/i);
+    expect(importLines).not.toMatch(/narrativeSource/);
+    expect(importLines).not.toMatch(/postCreationAdaptive/);
+  });
+});

--- a/src/app/dashboard/boards/video-narrative-preview/page.tsx
+++ b/src/app/dashboard/boards/video-narrative-preview/page.tsx
@@ -1,0 +1,208 @@
+import {
+  buildVideoNarrativePreviewScenario,
+  VIDEO_NARRATIVE_PREVIEW_SCENARIOS,
+} from "../components/videoUpload/buildVideoNarrativePreviewScenario";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
+import { isVideoNarrativePreviewEnabled } from "../videoUpload/videoNarrativePreviewFeatureFlag";
+
+type VideoNarrativePreviewPageProps = {
+  searchParams?: { scenario?: string | string[] };
+  viewer?: InternalPreviewUser | null;
+};
+
+function CompactBlock({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-lg bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
+    </div>
+  );
+}
+
+function TextList({ items }: { items: string[] }) {
+  if (items.length === 0) return <p className="mt-3 text-sm text-zinc-700">Sem sinais para este cenário.</p>;
+
+  return (
+    <ul className="mt-3 space-y-1 text-sm leading-6 text-zinc-700">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna bloqueada</p>
+        <h1 className="mt-2 text-2xl font-semibold">Narrativa de Vídeo</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview interno bloqueado. Ative a flag correspondente para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function VideoNarrativePreviewPage({
+  searchParams,
+  viewer,
+}: VideoNarrativePreviewPageProps = {}) {
+  if (!isVideoNarrativePreviewEnabled()) {
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
+  }
+
+  const preview = buildVideoNarrativePreviewScenario(searchParams?.scenario);
+  const { scenario, analysis, seed } = preview;
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Prévia interna</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interno — Narrativa de Vídeo</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Esta tela usa cenários controlados com análise narrativa mockada. Não há upload real, Gemini,
+            processamento real, rede ou conexão com o fluxo do produto.
+          </p>
+        </header>
+
+        <section className="mb-5 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap gap-2">
+            {VIDEO_NARRATIVE_PREVIEW_SCENARIOS.map((candidate) => (
+              <a
+                key={candidate.id}
+                href={`/dashboard/boards/video-narrative-preview?scenario=${candidate.id}`}
+                className={
+                  candidate.id === scenario.id
+                    ? "rounded-full bg-zinc-950 px-3 py-1.5 text-sm font-semibold text-white"
+                    : "rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700"
+                }
+              >
+                {candidate.label}
+              </a>
+            ))}
+          </div>
+          <dl className="mt-4 grid gap-3 text-sm md:grid-cols-4">
+            <CompactBlock label="Cenário ativo" value={scenario.label} />
+            <CompactBlock label="Pergunta do criador" value={scenario.creatorQuestion} />
+            <CompactBlock label="Confiança" value={analysis.confidence} />
+            <CompactBlock label="Ação primária" value={preview.primaryAction} />
+          </dl>
+        </section>
+
+        <section className="mb-5 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase text-zinc-500">VideoNarrativeAnalysis</p>
+            <h2 className="mt-1 text-lg font-semibold">Leitura narrativa</h2>
+            <dl className="mt-4 grid gap-3">
+              <CompactBlock label="Resumo" value={analysis.summary} />
+              <CompactBlock label="Hook" value={analysis.hook.detected} />
+              <CompactBlock label="Força do hook" value={analysis.hook.strength} />
+              <CompactBlock label="Classificação D2C" value={`${analysis.d2cClassification.proposal} · ${analysis.d2cClassification.narrative || "sem narrativa"}`} />
+              <CompactBlock label="Próximo passo sugerido" value={preview.suggestedNextStep} />
+            </dl>
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Diagnóstico</p>
+            <h2 className="mt-1 text-lg font-semibold">Sinais da análise</h2>
+            <TextList
+              items={[
+                ...analysis.diagnosis.strengths,
+                ...analysis.diagnosis.weaknesses,
+                ...analysis.diagnosis.recommendedAdjustments,
+              ]}
+            />
+          </div>
+        </section>
+
+        <section className="mb-5 grid gap-4 lg:grid-cols-3">
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Tópicos falados</h2>
+            <TextList items={analysis.spokenTopics} />
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Elementos visuais</h2>
+            <TextList items={analysis.visualElements} />
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Cenas</h2>
+            <TextList items={analysis.sceneStructure.map((scene) => `${scene.role}: ${scene.description}`)} />
+          </div>
+        </section>
+
+        <section className="mb-5 grid gap-4 lg:grid-cols-3">
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Blueprint</h2>
+            <dl className="mt-4 grid gap-3">
+              <CompactBlock label="O que postar" value={analysis.blueprintSuggestion.whatToPost} />
+              <CompactBlock label="Por que seguir" value={analysis.blueprintSuggestion.whyThisPath} />
+              <CompactBlock label="Como funcionar" value={analysis.blueprintSuggestion.howItShouldWork} />
+            </dl>
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Brand match</h2>
+            <TextList
+              items={[
+                ...(analysis.brandMatch.enabled ? analysis.brandMatch.territories : []),
+                ...(analysis.brandMatch.whyBrandsWouldFit ? [analysis.brandMatch.whyBrandsWouldFit] : []),
+              ]}
+            />
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Evidências</h2>
+            <TextList
+              items={[
+                ...(analysis.evidence.transcript ? [analysis.evidence.transcript] : []),
+                ...analysis.evidence.ocr,
+                ...analysis.evidence.frames,
+                ...analysis.evidence.technicalSignals,
+              ]}
+            />
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">PostCreationVideoSeed</p>
+          <h2 className="mt-1 text-lg font-semibold">Entrada futura do board</h2>
+          <dl className="mt-4 grid gap-3 md:grid-cols-2">
+            <CompactBlock label="Ideia inicial" value={seed.initialIdea} />
+            <CompactBlock label="Narrativa detectada" value={seed.detectedNarrative} />
+            <CompactBlock label="Proposta sugerida" value={seed.suggestedProposal} />
+            <CompactBlock label="Diagnóstico estratégico" value={seed.strategicDiagnosis} />
+            <CompactBlock label="Direção de abertura" value={seed.scriptDirection.opening} />
+            <CompactBlock label="Resumo de evidências" value={seed.evidenceSummary} />
+          </dl>
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <h3 className="text-sm font-semibold">Hints de marca</h3>
+              <TextList items={seed.brandMatchHints} />
+            </div>
+            <div className="rounded-lg bg-zinc-50 p-3">
+              <h3 className="text-sm font-semibold">Perguntas de refinamento</h3>
+              <TextList items={seed.followUpQuestions.map((item) => `${item.question} ${item.reason}`)} />
+            </div>
+          </div>
+          <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-white">
+            <p className="text-xs font-semibold uppercase text-zinc-300">Ação primária</p>
+            <p className="mt-1 text-sm leading-6">{preview.primaryAction}</p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -111,6 +111,30 @@ O que não faz:
 - não integra o seed ao board real;
 - não usa provider externo.
 
+### MM6 — Preview interno narrativo multimodal
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../video-narrative-preview/page.tsx`
+- `../video-narrative-preview/page.test.tsx`
+- `../components/videoUpload/buildVideoNarrativePreviewScenario.ts`
+- `videoNarrativePreviewFeatureFlag.ts`
+- `videoNarrativePreviewFeatureFlag.test.ts`
+
+O que faz:
+
+- cria a rota interna `/dashboard/boards/video-narrative-preview`;
+- mostra cenários controlados de `VideoNarrativeAnalysis` → `PostCreationVideoSeed`;
+- protege o harness com `NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED=1` e sessão admin/dev.
+
+O que não faz:
+
+- não aceita input livre;
+- não usa provider real;
+- não conecta no board real nem em navegação.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -212,7 +212,7 @@ Exemplos:
 2. MM3 — Adapter `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
 3. MM4 — Mock provider narrativo multimodal. Concluído como provider local determinístico.
 4. MM5 — Pipeline QA multimodal. Concluído como validação de `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
-5. MM6 — Preview interno narrativo.
+5. MM6 — Preview interno narrativo. Concluído como harness isolado por flag e sessão admin/dev.
 6. MM7 — Prompt/schema Gemini.
 7. MM8 — Gemini Flash real atrás de server flag.
 8. MM9 — Integração experimental no Board de Criação.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.test.ts
@@ -1,0 +1,28 @@
+import { isVideoNarrativePreviewEnabled } from "./videoNarrativePreviewFeatureFlag";
+
+const originalEnvValue = process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = originalEnvValue;
+});
+
+describe("videoNarrativePreviewFeatureFlag", () => {
+  it("enables the video narrative preview when env flag is 1", () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "1";
+
+    expect(isVideoNarrativePreviewEnabled()).toBe(true);
+  });
+
+  it("keeps the video narrative preview disabled when env flag is absent or off", () => {
+    delete process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED;
+    expect(isVideoNarrativePreviewEnabled()).toBe(false);
+
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED = "0";
+    expect(isVideoNarrativePreviewEnabled()).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.ts
@@ -1,0 +1,5 @@
+const VIDEO_NARRATIVE_PREVIEW_ENV_FLAG = "NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED";
+
+export function isVideoNarrativePreviewEnabled(): boolean {
+  return process.env[VIDEO_NARRATIVE_PREVIEW_ENV_FLAG] === "1";
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #802. Adiciona a fase MM6: preview interno narrativo multimodal.

## Inclui

- `src/app/dashboard/boards/video-narrative-preview/page.tsx`
- `src/app/dashboard/boards/video-narrative-preview/page.test.tsx`
- `src/app/dashboard/boards/components/videoUpload/buildVideoNarrativePreviewScenario.ts`
- `videoNarrativePreviewFeatureFlag.ts`
- `videoNarrativePreviewFeatureFlag.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## Preview criado

Nova rota interna:

`/dashboard/boards/video-narrative-preview`

Mostra o fluxo:

`VideoNarrativeAnalysis → PostCreationVideoSeed → ação primária`

Exibe leitura narrativa, hook, classificação D2C, diagnóstico, blueprint, brand match, evidências, seed e perguntas de refinamento.

## Cenários disponíveis

- `skincare`
- `backstage`
- `brand`
- `weak-hook`
- `collab`
- `ad-adaptation`
- `unclear`

## Proteção

- flag: `NEXT_PUBLIC_VIDEO_NARRATIVE_PREVIEW_ENABLED=1`
- guarda admin/dev via `canAccessInternalPreview`

Com flag off ou sem permissão, a rota renderiza estado bloqueado e não mostra conteúdo do preview.

## Fora de escopo

Não há provider real, Gemini, OpenAI, SDK, ffmpeg, storage real, upload real, endpoint, UI real, banco, BoardShell, fetch ou navegação/menu.

O `PostCreationFunnelState` real não foi alterado.

NSE/Adaptive não foram importados no novo helper nem na nova page.

## QA relatada

- novos testes do preview + flag passaram
- regressões narrativas passaram
- regressões da linha técnica atual passaram
- regressões VU principais passaram
- regressões guard/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.