### PR TITLE
feat: add Gemini video narrative prompt and schema contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -135,6 +135,29 @@ O que não faz:
 - não usa provider real;
 - não conecta no board real nem em navegação.
 
+### MM7 — Prompt e schema para análise narrativa multimodal
+
+Status: concluído.
+
+Arquivos principais:
+
+- `geminiVideoNarrativePrompt.ts`
+- `geminiVideoNarrativePrompt.test.ts`
+- `geminiVideoNarrativeSchema.ts`
+- `geminiVideoNarrativeSchema.test.ts`
+
+O que faz:
+
+- define o prompt textual base da futura análise narrativa multimodal;
+- normaliza a resposta estruturada esperada para `VideoNarrativeAnalysis`;
+- aplica sanitização e fallback seguro antes de qualquer integração real.
+
+O que não faz:
+
+- não chama provider externo;
+- não usa SDK;
+- não conecta no board real nem em navegação.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -213,7 +213,7 @@ Exemplos:
 3. MM4 — Mock provider narrativo multimodal. Concluído como provider local determinístico.
 4. MM5 — Pipeline QA multimodal. Concluído como validação de `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
 5. MM6 — Preview interno narrativo. Concluído como harness isolado por flag e sessão admin/dev.
-6. MM7 — Prompt/schema Gemini.
+6. MM7 — Prompt/schema Gemini. Concluído como contratos puros de prompt, normalização e fallback seguro.
 7. MM8 — Gemini Flash real atrás de server flag.
 8. MM9 — Integração experimental no Board de Criação.
 

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts
@@ -1,0 +1,142 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildGeminiVideoNarrativePrompt,
+  buildGeminiVideoNarrativeResponseFormatInstruction,
+  buildGeminiVideoNarrativeSystemInstruction,
+  buildGeminiVideoNarrativeUserInstruction,
+} from "./geminiVideoNarrativePrompt";
+
+const forbiddenTerms = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "erro",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+describe("geminiVideoNarrativePrompt", () => {
+  it("positions the model as a content strategist without promising performance", () => {
+    const instruction = buildGeminiVideoNarrativeSystemInstruction();
+
+    expect(instruction).toContain("estrategista de conteúdo da D2C");
+    expect(instruction).toContain("Evite prometer performance");
+  });
+
+  it("includes creatorQuestion when provided", () => {
+    expect(buildGeminiVideoNarrativeUserInstruction({ creatorQuestion: "Quero melhorar o gancho." })).toContain(
+      "Quero melhorar o gancho.",
+    );
+  });
+
+  it("works without creatorQuestion", () => {
+    expect(buildGeminiVideoNarrativeUserInstruction({ creatorQuestion: null })).toContain(
+      "Pergunta do criador: não informada.",
+    );
+  });
+
+  it("includes creator context when provided", () => {
+    const instruction = buildGeminiVideoNarrativeUserInstruction({
+      creatorQuestion: null,
+      creatorContext: {
+        handle: "@criadora",
+        niche: "beleza",
+        knownNarratives: ["rotina", "bastidor"],
+      },
+    });
+
+    expect(instruction).toContain("@criadora");
+    expect(instruction).toContain("beleza");
+    expect(instruction).toContain("rotina, bastidor");
+  });
+
+  it("requires valid JSON and blocks markdown or outer text", () => {
+    const instruction = buildGeminiVideoNarrativeResponseFormatInstruction();
+
+    expect(instruction).toContain("Retorne apenas JSON válido.");
+    expect(instruction).toContain("Não use markdown.");
+    expect(instruction).toContain("Não escreva texto fora do JSON.");
+  });
+
+  it("contains the central response fields", () => {
+    const instruction = buildGeminiVideoNarrativeResponseFormatInstruction();
+
+    [
+      "hook",
+      "summary",
+      "sceneStructure",
+      "d2cClassification",
+      "diagnosis",
+      "blueprintSuggestion",
+      "brandMatch",
+      "evidence",
+    ].forEach((field) => expect(instruction).toContain(field));
+  });
+
+  it("states that the video is a content piece in progress", () => {
+    expect(buildGeminiVideoNarrativeSystemInstruction()).toContain("peça de conteúdo em construção");
+  });
+
+  it("asks for low confidence when context is missing", () => {
+    const prompt = buildGeminiVideoNarrativePrompt({ creatorQuestion: null });
+
+    expect(`${prompt.systemInstruction} ${prompt.userInstruction}`).toContain("baixa confiança");
+  });
+
+  it("does not mention permanent saving or training", () => {
+    const prompt = buildGeminiVideoNarrativePrompt({ creatorQuestion: null });
+    const content = JSON.stringify(prompt).toLowerCase();
+
+    expect(content).not.toContain("salvar");
+    expect(content).not.toContain("treinar");
+    expect(content).not.toContain("permanente");
+  });
+
+  it("does not mention credentials, SDKs, or provider calls", () => {
+    const prompt = buildGeminiVideoNarrativePrompt({ creatorQuestion: null });
+    const content = JSON.stringify(prompt).toLowerCase();
+
+    ["api key", "sdk", "fetch", "gemini", "openai"].forEach((blocked) => expect(content).not.toContain(blocked));
+  });
+
+  it("keeps generated prompt text free of blocked terms", () => {
+    const prompt = buildGeminiVideoNarrativePrompt({
+      creatorQuestion: "Quero adaptar este vídeo.",
+      creatorContext: { handle: "@criadora", niche: "beleza", knownNarratives: ["rotina"] },
+    });
+    const content = JSON.stringify(prompt).toLowerCase();
+
+    forbiddenTerms.forEach((term) => {
+      expect(content).not.toContain(term);
+    });
+  });
+
+  it("keeps prompt imports isolated from runtime integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativePrompt.ts"), "utf8");
+    [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "Gemini SDK",
+      "fetch(",
+      "Prisma",
+      "banco",
+      "components/",
+      "hooks/",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+    ].forEach((blocked) => expect(source).not.toContain(blocked));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.ts
@@ -1,0 +1,73 @@
+export type GeminiVideoNarrativePromptInput = {
+  creatorQuestion: string | null;
+  creatorContext?: {
+    handle?: string | null;
+    niche?: string | null;
+    knownNarratives?: string[];
+  } | null;
+  language?: "pt-BR";
+};
+
+export type GeminiVideoNarrativePrompt = {
+  systemInstruction: string;
+  userInstruction: string;
+  responseFormatInstruction: string;
+};
+
+export function buildGeminiVideoNarrativeSystemInstruction(): string {
+  return [
+    "Você atua como estrategista de conteúdo da D2C.",
+    "Analise o vídeo como uma peça de conteúdo em construção, não como simples extração técnica.",
+    "Avalie gancho, resumo, tópicos falados, textos na tela, elementos visuais, estrutura de cenas, classificação D2C, diagnóstico, blueprint, brand match, evidências e sinais futuros de perfil.",
+    "Evite prometer performance e evite linguagem absoluta.",
+    "Quando faltar contexto, reduza a confiança, deixe lacunas explícitas e proponha ajustes em vez de inventar.",
+  ].join(" ");
+}
+
+export function buildGeminiVideoNarrativeUserInstruction(input: GeminiVideoNarrativePromptInput): string {
+  const parts = [
+    "Analise este vídeo como narrativa em construção para orientar um post futuro.",
+    "Use português do Brasil.",
+  ];
+
+  if (input.creatorQuestion) {
+    parts.push(`Pergunta do criador: ${input.creatorQuestion}`);
+  } else {
+    parts.push("Pergunta do criador: não informada.");
+  }
+
+  if (input.creatorContext?.handle) {
+    parts.push(`Handle do criador: ${input.creatorContext.handle}`);
+  }
+  if (input.creatorContext?.niche) {
+    parts.push(`Nicho: ${input.creatorContext.niche}`);
+  }
+  if (input.creatorContext?.knownNarratives?.length) {
+    parts.push(`Narrativas já conhecidas: ${input.creatorContext.knownNarratives.join(", ")}.`);
+  }
+
+  parts.push(
+    "Taxonomia conceitual de formato: reel, photo, carousel, long_video, unknown.",
+    "Taxonomia conceitual de proposta: tips, review, humor_scene, positioning_authority, behind_the_scenes, comparison, announcement, comment_to_post, ad_adaptation, collab_narrative, unknown.",
+    "Se o contexto visual ou sonoro for insuficiente, retorne baixa confiança e ajustes úteis.",
+  );
+
+  return parts.join(" ");
+}
+
+export function buildGeminiVideoNarrativeResponseFormatInstruction(): string {
+  return [
+    "Retorne apenas JSON válido.",
+    "Não use markdown.",
+    "Não escreva texto fora do JSON.",
+    'Use o shape: {"hook":{"detected":null,"strength":"unknown","why":null},"summary":null,"spokenTopics":[],"onScreenText":[],"visualElements":[],"sceneStructure":[],"d2cClassification":{"format":"unknown","proposal":"unknown","context":null,"tone":null,"reference":null,"intent":null,"narrative":null},"diagnosis":{"strengths":[],"weaknesses":[],"recommendedAdjustments":[]},"blueprintSuggestion":{"whatToPost":null,"whyThisPath":null,"howItShouldWork":null,"scenes":[]},"brandMatch":{"enabled":false,"territories":[],"whyBrandsWouldFit":null},"evidence":{"transcript":null,"ocr":[],"frames":[],"technicalSignals":[]},"profileSignals":[],"confidence":"unknown"}.',
+  ].join(" ");
+}
+
+export function buildGeminiVideoNarrativePrompt(input: GeminiVideoNarrativePromptInput): GeminiVideoNarrativePrompt {
+  return {
+    systemInstruction: buildGeminiVideoNarrativeSystemInstruction(),
+    userInstruction: buildGeminiVideoNarrativeUserInstruction(input),
+    responseFormatInstruction: buildGeminiVideoNarrativeResponseFormatInstruction(),
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts
@@ -1,0 +1,226 @@
+import fs from "fs";
+import path from "path";
+
+import { buildPostCreationVideoSeedFromAnalysis } from "./videoNarrativePostCreationSeed";
+import { hasUsefulVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import {
+  buildFallbackVideoNarrativeAnalysis,
+  normalizeGeminiVideoNarrativeResponse,
+  parseGeminiVideoNarrativeJson,
+} from "./geminiVideoNarrativeSchema";
+
+const forbiddenTerms = [
+  "erro",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+];
+
+function normalize(raw: unknown) {
+  return normalizeGeminiVideoNarrativeResponse({ id: "analysis-1", raw, createdAt: "2026-05-15T12:00:00.000Z" });
+}
+
+describe("geminiVideoNarrativeSchema", () => {
+  it("returns invalid_json and fallback for malformed JSON", () => {
+    const result = parseGeminiVideoNarrativeJson({ id: "analysis-1", rawText: "{" });
+    expect(result.ok).toBe(false);
+    expect(result.analysis?.confidence).toBe("low");
+    expect(result.issues).toContainEqual({ code: "invalid_json", message: "Resposta de análise em formato inválido." });
+  });
+
+  it("returns missing_object and fallback for non-object payload", () => {
+    const result = normalize("texto");
+    expect(result.ok).toBe(false);
+    expect(result.analysis?.confidence).toBe("low");
+    expect(result.issues).toContainEqual({
+      code: "missing_object",
+      message: "Resposta de análise sem objeto estruturado.",
+    });
+  });
+
+  it("normalizes a minimally useful summary response", () => {
+    const result = normalize({ summary: "Resumo útil." });
+    expect(result.ok).toBe(true);
+    expect(result.analysis?.summary).toBe("Resumo útil.");
+  });
+
+  it("normalizes a valid hook", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      hook: { detected: "Abertura clara.", strength: "strong", why: "Vai direto ao ponto." },
+    });
+    expect(result.analysis?.hook).toEqual({
+      detected: "Abertura clara.",
+      strength: "strong",
+      why: "Vai direto ao ponto.",
+    });
+  });
+
+  it("adds invalid_hook without breaking normalization", () => {
+    const result = normalize({ summary: "Resumo útil.", hook: { strength: "loud" } });
+    expect(result.analysis?.hook.strength).toBe("unknown");
+    expect(result.issues.map((item) => item.code)).toContain("invalid_hook");
+  });
+
+  it("normalizes a valid classification", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      d2cClassification: { format: "reel", proposal: "tips", narrative: "rotina -> insight -> pauta" },
+    });
+    expect(result.analysis?.d2cClassification).toMatchObject({
+      format: "reel",
+      proposal: "tips",
+      narrative: "rotina -> insight -> pauta",
+    });
+  });
+
+  it("adds invalid_classification for invalid enum values", () => {
+    const result = normalize({ summary: "Resumo útil.", d2cClassification: { format: "story", proposal: "viral" } });
+    expect(result.analysis?.d2cClassification).toMatchObject({ format: "unknown", proposal: "unknown" });
+    expect(result.issues.map((item) => item.code)).toContain("invalid_classification");
+  });
+
+  it("normalizes a valid diagnosis", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      diagnosis: { strengths: ["Boa leitura visual"], weaknesses: [], recommendedAdjustments: ["Abrir mais rápido."] },
+    });
+    expect(result.analysis?.diagnosis).toEqual({
+      strengths: ["Boa leitura visual"],
+      weaknesses: [],
+      recommendedAdjustments: ["Abrir mais rápido."],
+    });
+  });
+
+  it("adds invalid_diagnosis for invalid diagnosis shape", () => {
+    const result = normalize({ summary: "Resumo útil.", diagnosis: { strengths: "boa" } });
+    expect(result.analysis?.diagnosis.strengths).toEqual([]);
+    expect(result.issues.map((item) => item.code)).toContain("invalid_diagnosis");
+  });
+
+  it("normalizes a valid blueprint", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      blueprintSuggestion: {
+        whatToPost: "Reel de rotina.",
+        whyThisPath: "A narrativa já está clara.",
+        howItShouldWork: "Abrir, provar, fechar.",
+        scenes: ["Abertura"],
+      },
+    });
+    expect(result.analysis?.blueprintSuggestion).toEqual({
+      whatToPost: "Reel de rotina.",
+      whyThisPath: "A narrativa já está clara.",
+      howItShouldWork: "Abrir, provar, fechar.",
+      scenes: ["Abertura"],
+    });
+  });
+
+  it("adds invalid_blueprint for invalid blueprint shape", () => {
+    const result = normalize({ summary: "Resumo útil.", blueprintSuggestion: { scenes: "Cena 1" } });
+    expect(result.analysis?.blueprintSuggestion.scenes).toEqual([]);
+    expect(result.issues.map((item) => item.code)).toContain("invalid_blueprint");
+  });
+
+  it("turns invalid arrays into empty arrays", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      spokenTopics: "tema",
+      onScreenText: "texto",
+      visualElements: "produto",
+      sceneStructure: "cena",
+    });
+    expect(result.analysis).toMatchObject({ spokenTopics: [], onScreenText: [], visualElements: [], sceneStructure: [] });
+  });
+
+  it("turns invalid enums into unknown", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      hook: { detected: "Abertura.", strength: "fast" },
+      d2cClassification: { format: "story", proposal: "series" },
+      confidence: "certain",
+    });
+    expect(result.analysis).toMatchObject({
+      hook: { strength: "unknown" },
+      d2cClassification: { format: "unknown", proposal: "unknown" },
+      confidence: "unknown",
+    });
+  });
+
+  it("sanitizes unsafe language and records the adjustment", () => {
+    const result = normalize({ summary: "Resultado garantido com certeza e caminho comprovado." });
+    expect(result.analysis?.summary).toBe("Resultado indicado com leitura e caminho observado.");
+    expect(result.issues).toContainEqual({
+      code: "unsafe_language",
+      message: "Ajustamos termos absolutos para manter a análise consultiva.",
+    });
+  });
+
+  it("returns insufficient_context and fallback when no useful content exists", () => {
+    const result = normalize({});
+    expect(result.ok).toBe(false);
+    expect(result.analysis?.confidence).toBe("low");
+    expect(result.issues.map((item) => item.code)).toContain("insufficient_context");
+  });
+
+  it("builds a low-confidence fallback with a safe adjustment", () => {
+    const fallback = buildFallbackVideoNarrativeAnalysis({ id: "fallback-1" });
+    expect(fallback.confidence).toBe("low");
+    expect(fallback.diagnosis.recommendedAdjustments).toEqual([
+      "Trazer mais contexto antes de transformar o vídeo em pauta.",
+    ]);
+  });
+
+  it("returns a useful analysis when parsed content is useful", () => {
+    const result = parseGeminiVideoNarrativeJson({ id: "analysis-1", rawText: JSON.stringify({ summary: "Resumo útil." }) });
+    expect(result.analysis && hasUsefulVideoNarrativeAnalysis(result.analysis)).toBe(true);
+  });
+
+  it("can feed the post creation seed adapter in a smoke test", () => {
+    const result = normalize({ summary: "Resumo útil.", blueprintSuggestion: { whatToPost: "Reel de rotina." } });
+    const seed = buildPostCreationVideoSeedFromAnalysis({
+      id: "seed-1",
+      analysis: result.analysis!,
+      creatorQuestion: "O que fazer com este vídeo?",
+    });
+    expect(seed.initialIdea).toBe("Reel de rotina.");
+  });
+
+  it("keeps issue and fallback strings free of blocked terms", () => {
+    const fallback = buildFallbackVideoNarrativeAnalysis({ id: "fallback-1", reason: "Contexto sem detalhe suficiente." });
+    const invalidJson = parseGeminiVideoNarrativeJson({ id: "analysis-1", rawText: "{" });
+    const unsafe = normalize({ summary: "Leitura garantido." });
+    const content = JSON.stringify({ fallback, issues: [...invalidJson.issues, ...unsafe.issues] }).toLowerCase();
+
+    forbiddenTerms.forEach((term) => expect(content).not.toContain(term));
+  });
+
+  it("keeps schema imports isolated from runtime integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativeSchema.ts"), "utf8");
+    [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "Gemini SDK",
+      "fetch(",
+      "Prisma",
+      "banco",
+      "components/",
+      "hooks/",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+    ].forEach((blocked) => expect(source).not.toContain(blocked));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.ts
@@ -1,0 +1,347 @@
+import {
+  VideoNarrativeAnalysis,
+  VideoNarrativeConfidence,
+  VideoNarrativeD2CFormat,
+  VideoNarrativeD2CProposal,
+  VideoNarrativeHookStrength,
+  VideoNarrativeSceneRole,
+  createEmptyVideoNarrativeAnalysis,
+  hasUsefulVideoNarrativeAnalysis,
+  sanitizeVideoNarrativeAnalysisText,
+} from "./videoNarrativeAnalysisTypes";
+
+export type GeminiVideoNarrativeRawResponse = {
+  hook?: { detected?: unknown; strength?: unknown; why?: unknown };
+  summary?: unknown;
+  spokenTopics?: unknown;
+  onScreenText?: unknown;
+  visualElements?: unknown;
+  sceneStructure?: unknown;
+  d2cClassification?: unknown;
+  diagnosis?: unknown;
+  blueprintSuggestion?: unknown;
+  brandMatch?: unknown;
+  evidence?: unknown;
+  profileSignals?: unknown;
+  confidence?: unknown;
+};
+
+export type GeminiVideoNarrativeSchemaIssueCode =
+  | "invalid_json"
+  | "missing_object"
+  | "invalid_hook"
+  | "invalid_classification"
+  | "invalid_diagnosis"
+  | "invalid_blueprint"
+  | "unsafe_language"
+  | "insufficient_context";
+
+export type GeminiVideoNarrativeSchemaIssue = {
+  code: GeminiVideoNarrativeSchemaIssueCode;
+  message: string;
+};
+
+export type GeminiVideoNarrativeParseResult = {
+  ok: boolean;
+  analysis: VideoNarrativeAnalysis | null;
+  issues: GeminiVideoNarrativeSchemaIssue[];
+};
+
+const hookStrengths = new Set<VideoNarrativeHookStrength>(["weak", "medium", "strong", "unknown"]);
+const confidenceValues = new Set<VideoNarrativeConfidence>(["low", "medium", "high", "unknown"]);
+const sceneRoles = new Set<VideoNarrativeSceneRole>([
+  "hook",
+  "context",
+  "development",
+  "proof",
+  "turning_point",
+  "call_to_action",
+  "closing",
+  "unknown",
+]);
+const d2cFormats = new Set<VideoNarrativeD2CFormat>(["reel", "photo", "carousel", "long_video", "unknown"]);
+const d2cProposals = new Set<VideoNarrativeD2CProposal>([
+  "tips",
+  "review",
+  "humor_scene",
+  "positioning_authority",
+  "behind_the_scenes",
+  "comparison",
+  "announcement",
+  "comment_to_post",
+  "ad_adaptation",
+  "collab_narrative",
+  "unknown",
+]);
+const profileSignalTypes = new Set([
+  "recurring_theme",
+  "content_strength",
+  "brand_territory",
+  "audience_goal",
+  "positioning_signal",
+  "creative_gap",
+  "unknown",
+]);
+const unsafeLanguageTerms = ["viralizar garantido", "sempre performa", "garantido", "certeza", "comprovado"];
+
+function issue(code: GeminiVideoNarrativeSchemaIssueCode, message: string): GeminiVideoNarrativeSchemaIssue {
+  return { code, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const sanitized = sanitizeVideoNarrativeAnalysisText(value);
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(readString).filter((item): item is string => Boolean(item));
+}
+
+function containsUnsafeLanguage(value: unknown): boolean {
+  if (typeof value === "string") {
+    const lower = value.toLowerCase();
+    return unsafeLanguageTerms.some((term) => lower.includes(term));
+  }
+  if (Array.isArray(value)) return value.some(containsUnsafeLanguage);
+  if (isRecord(value)) return Object.values(value).some(containsUnsafeLanguage);
+  return false;
+}
+
+function normalizeSceneStructure(value: unknown): VideoNarrativeAnalysis["sceneStructure"] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter(isRecord)
+    .map((scene, index) => ({
+      id: readString(scene.id) ?? `scene-${index + 1}`,
+      timestampLabel: readString(scene.timestampLabel),
+      role:
+        typeof scene.role === "string" && sceneRoles.has(scene.role as VideoNarrativeSceneRole)
+          ? (scene.role as VideoNarrativeSceneRole)
+          : "unknown",
+      description: readString(scene.description) ?? "",
+      suggestedAdjustment: readString(scene.suggestedAdjustment),
+    }))
+    .filter((scene) => scene.description.length > 0);
+}
+
+function normalizeProfileSignals(value: unknown): VideoNarrativeAnalysis["profileSignals"] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter(isRecord)
+    .map((signal) => ({
+      type:
+        typeof signal.type === "string" && profileSignalTypes.has(signal.type)
+          ? (signal.type as VideoNarrativeAnalysis["profileSignals"][number]["type"])
+          : "unknown",
+      value: readString(signal.value) ?? "",
+      confidence:
+        typeof signal.confidence === "string" && confidenceValues.has(signal.confidence as VideoNarrativeConfidence)
+          ? (signal.confidence as VideoNarrativeConfidence)
+          : "unknown",
+      shouldPersistLater: typeof signal.shouldPersistLater === "boolean" ? signal.shouldPersistLater : false,
+    }))
+    .filter((signal) => signal.value.length > 0);
+}
+
+export function buildFallbackVideoNarrativeAnalysis(params: {
+  id: string;
+  createdAt?: string | null;
+  reason?: string | null;
+}): VideoNarrativeAnalysis {
+  const fallback = createEmptyVideoNarrativeAnalysis({
+    id: params.id,
+    createdAt: params.createdAt ?? null,
+  });
+
+  return {
+    ...fallback,
+    summary: params.reason ? readString(params.reason) : null,
+    diagnosis: {
+      ...fallback.diagnosis,
+      recommendedAdjustments: ["Trazer mais contexto antes de transformar o vídeo em pauta."],
+    },
+    confidence: "low",
+  };
+}
+
+export function parseGeminiVideoNarrativeJson(params: {
+  id: string;
+  rawText: string;
+  createdAt?: string | null;
+}): GeminiVideoNarrativeParseResult {
+  try {
+    return normalizeGeminiVideoNarrativeResponse({
+      id: params.id,
+      raw: JSON.parse(params.rawText),
+      createdAt: params.createdAt,
+    });
+  } catch {
+    return {
+      ok: false,
+      analysis: buildFallbackVideoNarrativeAnalysis({ id: params.id, createdAt: params.createdAt }),
+      issues: [issue("invalid_json", "Resposta de análise em formato inválido.")],
+    };
+  }
+}
+
+export function normalizeGeminiVideoNarrativeResponse(params: {
+  id: string;
+  raw: unknown;
+  createdAt?: string | null;
+}): GeminiVideoNarrativeParseResult {
+  if (!isRecord(params.raw)) {
+    return {
+      ok: false,
+      analysis: buildFallbackVideoNarrativeAnalysis({ id: params.id, createdAt: params.createdAt }),
+      issues: [issue("missing_object", "Resposta de análise sem objeto estruturado.")],
+    };
+  }
+
+  const raw = params.raw as GeminiVideoNarrativeRawResponse;
+  const issues: GeminiVideoNarrativeSchemaIssue[] = [];
+  const base = createEmptyVideoNarrativeAnalysis({ id: params.id, createdAt: params.createdAt ?? null });
+
+  if (containsUnsafeLanguage(raw)) {
+    issues.push(issue("unsafe_language", "Ajustamos termos absolutos para manter a análise consultiva."));
+  }
+
+  if (raw.hook !== undefined && !isRecord(raw.hook)) {
+    issues.push(issue("invalid_hook", "Leitura de gancho incompleta."));
+  }
+  const hook = isRecord(raw.hook) ? raw.hook : {};
+  const normalizedHook = {
+    detected: readString(hook.detected),
+    strength:
+      typeof hook.strength === "string" && hookStrengths.has(hook.strength as VideoNarrativeHookStrength)
+        ? (hook.strength as VideoNarrativeHookStrength)
+        : "unknown",
+    why: readString(hook.why),
+  };
+  if (
+    isRecord(raw.hook) &&
+    hook.strength !== undefined &&
+    (typeof hook.strength !== "string" || !hookStrengths.has(hook.strength as VideoNarrativeHookStrength))
+  ) {
+    issues.push(issue("invalid_hook", "Leitura de gancho incompleta."));
+  }
+
+  const rawClassification = raw.d2cClassification;
+  if (rawClassification !== undefined && !isRecord(rawClassification)) {
+    issues.push(issue("invalid_classification", "Classificação narrativa incompleta."));
+  }
+  const classification = isRecord(rawClassification) ? rawClassification : {};
+  const normalizedClassification = {
+    format:
+      typeof classification.format === "string" && d2cFormats.has(classification.format as VideoNarrativeD2CFormat)
+        ? (classification.format as VideoNarrativeD2CFormat)
+        : "unknown",
+    proposal:
+      typeof classification.proposal === "string" &&
+      d2cProposals.has(classification.proposal as VideoNarrativeD2CProposal)
+        ? (classification.proposal as VideoNarrativeD2CProposal)
+        : "unknown",
+    context: readString(classification.context),
+    tone: readString(classification.tone),
+    reference: readString(classification.reference),
+    intent: readString(classification.intent),
+    narrative: readString(classification.narrative),
+  };
+  if (
+    isRecord(rawClassification) &&
+    ((classification.format !== undefined &&
+      (typeof classification.format !== "string" ||
+        !d2cFormats.has(classification.format as VideoNarrativeD2CFormat))) ||
+      (classification.proposal !== undefined &&
+        (typeof classification.proposal !== "string" ||
+          !d2cProposals.has(classification.proposal as VideoNarrativeD2CProposal))))
+  ) {
+    issues.push(issue("invalid_classification", "Classificação narrativa incompleta."));
+  }
+
+  const rawDiagnosis = raw.diagnosis;
+  if (rawDiagnosis !== undefined && !isRecord(rawDiagnosis)) {
+    issues.push(issue("invalid_diagnosis", "Diagnóstico narrativo incompleto."));
+  }
+  const diagnosis = isRecord(rawDiagnosis) ? rawDiagnosis : {};
+  const normalizedDiagnosis = {
+    strengths: readStringArray(diagnosis.strengths),
+    weaknesses: readStringArray(diagnosis.weaknesses),
+    recommendedAdjustments: readStringArray(diagnosis.recommendedAdjustments),
+  };
+  if (
+    isRecord(rawDiagnosis) &&
+    [diagnosis.strengths, diagnosis.weaknesses, diagnosis.recommendedAdjustments].some(
+      (value) => value !== undefined && !Array.isArray(value),
+    )
+  ) {
+    issues.push(issue("invalid_diagnosis", "Diagnóstico narrativo incompleto."));
+  }
+
+  const rawBlueprint = raw.blueprintSuggestion;
+  if (rawBlueprint !== undefined && !isRecord(rawBlueprint)) {
+    issues.push(issue("invalid_blueprint", "Sugestão de blueprint incompleta."));
+  }
+  const blueprint = isRecord(rawBlueprint) ? rawBlueprint : {};
+  const normalizedBlueprint = {
+    whatToPost: readString(blueprint.whatToPost),
+    whyThisPath: readString(blueprint.whyThisPath),
+    howItShouldWork: readString(blueprint.howItShouldWork),
+    scenes: readStringArray(blueprint.scenes),
+  };
+  if (isRecord(rawBlueprint) && blueprint.scenes !== undefined && !Array.isArray(blueprint.scenes)) {
+    issues.push(issue("invalid_blueprint", "Sugestão de blueprint incompleta."));
+  }
+
+  const brandMatch = isRecord(raw.brandMatch) ? raw.brandMatch : {};
+  const evidence = isRecord(raw.evidence) ? raw.evidence : {};
+  const analysis: VideoNarrativeAnalysis = {
+    ...base,
+    summary: readString(raw.summary),
+    hook: normalizedHook,
+    spokenTopics: readStringArray(raw.spokenTopics),
+    onScreenText: readStringArray(raw.onScreenText),
+    visualElements: readStringArray(raw.visualElements),
+    sceneStructure: normalizeSceneStructure(raw.sceneStructure),
+    d2cClassification: normalizedClassification,
+    diagnosis: normalizedDiagnosis,
+    blueprintSuggestion: normalizedBlueprint,
+    brandMatch: {
+      enabled: typeof brandMatch.enabled === "boolean" ? brandMatch.enabled : false,
+      territories: readStringArray(brandMatch.territories),
+      whyBrandsWouldFit: readString(brandMatch.whyBrandsWouldFit),
+    },
+    evidence: {
+      transcript: readString(evidence.transcript),
+      ocr: readStringArray(evidence.ocr),
+      frames: readStringArray(evidence.frames),
+      technicalSignals: readStringArray(evidence.technicalSignals),
+    },
+    profileSignals: normalizeProfileSignals(raw.profileSignals),
+    confidence:
+      typeof raw.confidence === "string" && confidenceValues.has(raw.confidence as VideoNarrativeConfidence)
+        ? (raw.confidence as VideoNarrativeConfidence)
+        : "unknown",
+  };
+
+  if (!hasUsefulVideoNarrativeAnalysis(analysis)) {
+    return {
+      ok: false,
+      analysis: buildFallbackVideoNarrativeAnalysis({ id: params.id, createdAt: params.createdAt }),
+      issues: [...issues, issue("insufficient_context", "Contexto insuficiente para transformar o vídeo em pauta.")],
+    };
+  }
+
+  return {
+    ok: issues.length === 0 || issues.every((item) => item.code === "unsafe_language"),
+    analysis,
+    issues,
+  };
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #803. Adiciona a fase MM7: contratos puros de prompt e schema para futura análise narrativa multimodal com Gemini.

## Inclui

- `geminiVideoNarrativeSchema.ts`
- `geminiVideoNarrativeSchema.test.ts`
- `geminiVideoNarrativePrompt.ts`
- `geminiVideoNarrativePrompt.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## O que foi criado

Schema puro para futura resposta multimodal:

- parse de JSON;
- normalização defensiva;
- sanitização de linguagem;
- fallback seguro;
- issues estruturadas.

Prompt puro provider-agnostic:

- instrução de sistema;
- instrução do usuário;
- instrução de formato de resposta em JSON compatível com `VideoNarrativeAnalysis`.

## Helpers

- `parseGeminiVideoNarrativeJson`
- `normalizeGeminiVideoNarrativeResponse`
- `buildFallbackVideoNarrativeAnalysis`
- `buildGeminiVideoNarrativePrompt`
- `buildGeminiVideoNarrativeSystemInstruction`
- `buildGeminiVideoNarrativeUserInstruction`
- `buildGeminiVideoNarrativeResponseFormatInstruction`

## Fora de escopo

Não há provider real, Gemini SDK, OpenAI, SDK externo, fetch, ffmpeg, storage real, upload real, endpoint, UI de produto, banco, BoardShell ou navegação/menu.

O `PostCreationFunnelState` real não foi alterado.

## QA relatada

- `geminiVideoNarrativeSchema.test.ts` passou
- `geminiVideoNarrativePrompt.test.ts` passou
- regressões narrativas passaram
- regressões da linha técnica passaram
- regressões VU principais passaram
- regressões guard/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.