### PR TITLE
feat: add Gemini video narrative provider flag

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -158,6 +158,29 @@ O que não faz:
 - não usa SDK;
 - não conecta no board real nem em navegação.
 
+### MM8 — Provider multimodal atrás de flag server-side
+
+Status: concluído.
+
+Arquivos principais:
+
+- `geminiVideoNarrativeFeatureFlag.ts`
+- `geminiVideoNarrativeFeatureFlag.test.ts`
+- `geminiVideoNarrativeProvider.ts`
+- `geminiVideoNarrativeProvider.test.ts`
+
+O que faz:
+
+- protege a futura execução multimodal com `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`;
+- expõe um provider server-side injetável, com fallback seguro e sem rede nos testes;
+- mantém a dependência de cliente externa fora desta fase.
+
+O que não faz:
+
+- não cria endpoint;
+- não adiciona cliente real;
+- não conecta no board real nem em navegação.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -214,7 +214,7 @@ Exemplos:
 4. MM5 — Pipeline QA multimodal. Concluído como validação de `VideoNarrativeAnalysis` → `PostCreationVideoSeed`.
 5. MM6 — Preview interno narrativo. Concluído como harness isolado por flag e sessão admin/dev.
 6. MM7 — Prompt/schema Gemini. Concluído como contratos puros de prompt, normalização e fallback seguro.
-7. MM8 — Gemini Flash real atrás de server flag.
+7. MM8 — Gemini Flash real atrás de server flag. Concluído como provider injetável protegido por flag server-side, sem cliente real nesta fase.
 8. MM9 — Integração experimental no Board de Criação.
 
 ## Critérios Antes De Provider Real

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts
@@ -1,0 +1,32 @@
+import { isGeminiVideoNarrativeEnabled } from "./geminiVideoNarrativeFeatureFlag";
+
+const originalEnvValue = process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+    return;
+  }
+
+  process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED = originalEnvValue;
+});
+
+describe("geminiVideoNarrativeFeatureFlag", () => {
+  it("returns false when the env flag is absent", () => {
+    delete process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+
+    expect(isGeminiVideoNarrativeEnabled()).toBe(false);
+  });
+
+  it("returns false when the env flag is false", () => {
+    process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED = "false";
+
+    expect(isGeminiVideoNarrativeEnabled()).toBe(false);
+  });
+
+  it("returns true only when the env flag is true", () => {
+    process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED = "true";
+
+    expect(isGeminiVideoNarrativeEnabled()).toBe(true);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.ts
@@ -1,0 +1,5 @@
+const GEMINI_VIDEO_NARRATIVE_ENV_FLAG = "VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED";
+
+export function isGeminiVideoNarrativeEnabled(): boolean {
+  return process.env[GEMINI_VIDEO_NARRATIVE_ENV_FLAG] === "true";
+}

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts
@@ -1,0 +1,309 @@
+import fs from "fs";
+import path from "path";
+
+import { buildPostCreationVideoSeedFromAnalysis } from "./videoNarrativePostCreationSeed";
+import { hasUsefulVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import {
+  GeminiVideoNarrativeClient,
+  createUnavailableGeminiVideoNarrativeResult,
+  runGeminiVideoNarrativeProvider,
+} from "./geminiVideoNarrativeProvider";
+
+const originalEnvValue = process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+const forbiddenTerms = [
+  "erro",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function enableProvider() {
+  process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED = "true";
+}
+
+function input(overrides = {}) {
+  return {
+    id: "analysis-1",
+    creatorQuestion: "Quero entender este vídeo.",
+    videoUri: "gs://bucket/video.mp4",
+    createdAt: "2026-05-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function validJson() {
+  return JSON.stringify({
+    summary: "Rotina de autocuidado.",
+    blueprintSuggestion: { whatToPost: "Reel de rotina com virada prática." },
+  });
+}
+
+function clientReturning(text: string | null): GeminiVideoNarrativeClient {
+  return {
+    async generateContent() {
+      return { text };
+    },
+  };
+}
+
+afterEach(() => {
+  if (originalEnvValue === undefined) {
+    delete process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+    return;
+  }
+
+  process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED = originalEnvValue;
+});
+
+describe("geminiVideoNarrativeProvider", () => {
+  it("returns disabled and fallback when the flag is off", async () => {
+    delete process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED;
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(validJson()),
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "disabled" });
+    expect(result.analysis.confidence).toBe("low");
+  });
+
+  it("returns missing_api_key when the flag is on without apiKey", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      client: clientReturning(validJson()),
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "missing_api_key" });
+  });
+
+  it("returns missing_client when the flag is on without client", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "missing_client" });
+  });
+
+  it("returns failed when no video source is provided", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input({ videoUri: null }),
+      apiKey: "secret",
+      client: clientReturning(validJson()),
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "failed" });
+    expect(result.issues).toContain("Vídeo não informado para análise.");
+  });
+
+  it("returns a ready useful analysis with valid JSON", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(validJson()),
+    });
+
+    expect(result).toMatchObject({ ok: true, status: "ready" });
+    expect(hasUsefulVideoNarrativeAnalysis(result.analysis)).toBe(true);
+  });
+
+  it("returns failed and fallback for invalid JSON", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning("{"),
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "failed" });
+    expect(result.analysis.confidence).toBe("low");
+  });
+
+  it("returns failed and fallback when client returns null text", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(null),
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "failed" });
+    expect(result.analysis.confidence).toBe("low");
+  });
+
+  it("returns a safe issue when the client throws", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: {
+        async generateContent() {
+          throw new Error("network");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, status: "failed" });
+    expect(result.issues).toEqual(["Análise multimodal indisponível nesta execução."]);
+  });
+
+  it("passes creator question and context into the prompt", async () => {
+    enableProvider();
+    let receivedUserInstruction = "";
+    await runGeminiVideoNarrativeProvider({
+      input: input({
+        creatorQuestion: "Quero melhorar o gancho.",
+        creatorContext: { handle: "@criadora", niche: "beleza", knownNarratives: ["rotina"] },
+      }),
+      apiKey: "secret",
+      client: {
+        async generateContent(params) {
+          receivedUserInstruction = params.userInstruction;
+          return { text: validJson() };
+        },
+      },
+    });
+
+    expect(receivedUserInstruction).toContain("Quero melhorar o gancho.");
+    expect(receivedUserInstruction).toContain("@criadora");
+    expect(receivedUserInstruction).toContain("beleza");
+    expect(receivedUserInstruction).toContain("rotina");
+  });
+
+  it("accepts videoUri", async () => {
+    enableProvider();
+    let receivedVideoUri: string | null | undefined;
+    await runGeminiVideoNarrativeProvider({
+      input: input({ videoUri: "gs://bucket/video.mp4" }),
+      apiKey: "secret",
+      client: {
+        async generateContent(params) {
+          receivedVideoUri = params.videoUri;
+          return { text: validJson() };
+        },
+      },
+    });
+
+    expect(receivedVideoUri).toBe("gs://bucket/video.mp4");
+  });
+
+  it("accepts inlineVideoBase64 and mimeType", async () => {
+    enableProvider();
+    let receivedInline: string | null | undefined;
+    let receivedMimeType: string | null | undefined;
+    await runGeminiVideoNarrativeProvider({
+      input: input({ videoUri: null, inlineVideoBase64: "ZmFrZQ==", mimeType: "video/mp4" }),
+      apiKey: "secret",
+      client: {
+        async generateContent(params) {
+          receivedInline = params.inlineVideoBase64;
+          receivedMimeType = params.mimeType;
+          return { text: validJson() };
+        },
+      },
+    });
+
+    expect(receivedInline).toBe("ZmFrZQ==");
+    expect(receivedMimeType).toBe("video/mp4");
+  });
+
+  it("does not expose apiKey in issues or raw text", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret-key",
+      client: clientReturning("{"),
+    });
+    const content = JSON.stringify(result);
+
+    expect(content).not.toContain("secret-key");
+  });
+
+  it("keeps parser issue text free of blocked language", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(
+        JSON.stringify({
+          summary: "Plano garantido.",
+        }),
+      ),
+    });
+    const content = result.issues.join(" ").toLowerCase();
+
+    forbiddenTerms.forEach((term) => expect(content).not.toContain(term));
+  });
+
+  it("feeds a valid analysis into the post creation seed adapter", async () => {
+    enableProvider();
+    const result = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(validJson()),
+    });
+    const seed = buildPostCreationVideoSeedFromAnalysis({
+      id: "seed-1",
+      analysis: result.analysis,
+      creatorQuestion: result.analysis.summary,
+    });
+
+    expect(seed.initialIdea).toBe("Reel de rotina com virada prática.");
+  });
+
+  it("keeps generated provider outputs free of blocked language", async () => {
+    enableProvider();
+    const disabled = createUnavailableGeminiVideoNarrativeResult({
+      id: "disabled",
+      status: "disabled",
+      issue: "Provider multimodal desativado por configuração.",
+    });
+    const ready = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning(validJson()),
+    });
+    const failed = await runGeminiVideoNarrativeProvider({
+      input: input(),
+      apiKey: "secret",
+      client: clientReturning("{"),
+    });
+    const content = JSON.stringify({ disabled, ready, failed }).toLowerCase();
+
+    forbiddenTerms.forEach((term) => expect(content).not.toContain(term));
+  });
+
+  it("keeps provider imports isolated from forbidden integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativeProvider.ts"), "utf8");
+    [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "fetch(",
+      "Prisma",
+      "banco",
+      "components/",
+      "hooks/",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "OpenAI",
+    ].forEach((blocked) => expect(source).not.toContain(blocked));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.ts
@@ -1,0 +1,149 @@
+import { buildGeminiVideoNarrativePrompt } from "./geminiVideoNarrativePrompt";
+import {
+  buildFallbackVideoNarrativeAnalysis,
+  parseGeminiVideoNarrativeJson,
+} from "./geminiVideoNarrativeSchema";
+import { isGeminiVideoNarrativeEnabled } from "./geminiVideoNarrativeFeatureFlag";
+import { VideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+
+export type GeminiVideoNarrativeProviderStatus =
+  | "disabled"
+  | "missing_api_key"
+  | "missing_client"
+  | "ready"
+  | "failed";
+
+export type GeminiVideoNarrativeProviderInput = {
+  id: string;
+  creatorQuestion: string | null;
+  videoUri?: string | null;
+  inlineVideoBase64?: string | null;
+  mimeType?: string | null;
+  creatorContext?: {
+    handle?: string | null;
+    niche?: string | null;
+    knownNarratives?: string[];
+  } | null;
+  createdAt?: string | null;
+};
+
+export type GeminiVideoNarrativeProviderResult = {
+  ok: boolean;
+  status: GeminiVideoNarrativeProviderStatus;
+  analysis: VideoNarrativeAnalysis;
+  issues: string[];
+  rawText: string | null;
+};
+
+export type GeminiVideoNarrativeClient = {
+  generateContent(params: {
+    systemInstruction: string;
+    userInstruction: string;
+    responseFormatInstruction: string;
+    videoUri?: string | null;
+    inlineVideoBase64?: string | null;
+    mimeType?: string | null;
+  }): Promise<{ text: string | null }>;
+};
+
+export function createUnavailableGeminiVideoNarrativeResult(params: {
+  id: string;
+  createdAt?: string | null;
+  status: GeminiVideoNarrativeProviderStatus;
+  issue: string;
+}): GeminiVideoNarrativeProviderResult {
+  return {
+    ok: false,
+    status: params.status,
+    analysis: buildFallbackVideoNarrativeAnalysis({
+      id: params.id,
+      createdAt: params.createdAt,
+    }),
+    issues: [params.issue],
+    rawText: null,
+  };
+}
+
+export async function runGeminiVideoNarrativeProvider(params: {
+  input: GeminiVideoNarrativeProviderInput;
+  client?: GeminiVideoNarrativeClient | null;
+  apiKey?: string | null;
+}): Promise<GeminiVideoNarrativeProviderResult> {
+  const { input } = params;
+
+  if (!isGeminiVideoNarrativeEnabled()) {
+    return createUnavailableGeminiVideoNarrativeResult({
+      id: input.id,
+      createdAt: input.createdAt,
+      status: "disabled",
+      issue: "Provider multimodal desativado por configuração.",
+    });
+  }
+
+  if (!params.apiKey) {
+    return createUnavailableGeminiVideoNarrativeResult({
+      id: input.id,
+      createdAt: input.createdAt,
+      status: "missing_api_key",
+      issue: "Chave do provider multimodal ausente.",
+    });
+  }
+
+  if (!params.client) {
+    return createUnavailableGeminiVideoNarrativeResult({
+      id: input.id,
+      createdAt: input.createdAt,
+      status: "missing_client",
+      issue: "Cliente multimodal não configurado.",
+    });
+  }
+
+  if (!input.videoUri && !input.inlineVideoBase64) {
+    return createUnavailableGeminiVideoNarrativeResult({
+      id: input.id,
+      createdAt: input.createdAt,
+      status: "failed",
+      issue: "Vídeo não informado para análise.",
+    });
+  }
+
+  try {
+    const prompt = buildGeminiVideoNarrativePrompt({
+      creatorQuestion: input.creatorQuestion,
+      creatorContext: input.creatorContext,
+    });
+    const response = await params.client.generateContent({
+      ...prompt,
+      videoUri: input.videoUri,
+      inlineVideoBase64: input.inlineVideoBase64,
+      mimeType: input.mimeType,
+    });
+    const rawText = response.text;
+    const parsed = parseGeminiVideoNarrativeJson({
+      id: input.id,
+      rawText: rawText ?? "",
+      createdAt: input.createdAt,
+    });
+    const analysis =
+      parsed.analysis ??
+      buildFallbackVideoNarrativeAnalysis({
+        id: input.id,
+        createdAt: input.createdAt,
+      });
+
+    return {
+      ok: parsed.ok,
+      status: parsed.ok ? "ready" : "failed",
+      analysis,
+      issues: parsed.issues.map((item) => item.message),
+      rawText,
+    };
+  } catch {
+    return createUnavailableGeminiVideoNarrativeResult({
+      id: input.id,
+      createdAt: input.createdAt,
+      status: "failed",
+      issue: "Análise multimodal indisponível nesta execução.",
+    });
+  }
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #804. Adiciona a fase MM8: provider Gemini Flash preparado atrás de flag server-side, sem cliente real acoplado.

## Inclui

- `geminiVideoNarrativeFeatureFlag.ts`
- `geminiVideoNarrativeFeatureFlag.test.ts`
- `geminiVideoNarrativeProvider.ts`
- `geminiVideoNarrativeProvider.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## SDK Gemini

O `package.json` não contém SDK Gemini/Google AI generativo instalado. Existe `google-auth-library`, mas não um cliente Gemini/GenAI.

Por isso, não foi instalada dependência nova e não foi criada factory real de cliente Gemini nesta fase.

## Provider / flag

Nova flag server-side:

`VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`

O provider é injetável por interface local, sem cliente real acoplado.

Fluxos cobertos:

- disabled
- missing_api_key
- missing_client
- ausência de vídeo
- resposta válida
- resposta inválida
- resposta nula
- exceção do cliente

## Helpers

- `isGeminiVideoNarrativeEnabled`
- `createUnavailableGeminiVideoNarrativeResult`
- `runGeminiVideoNarrativeProvider`

## Fora de escopo

Não há endpoint, upload real, UI, banco, BoardShell, storage real, fetch direto ou rede real em teste.

Não houve navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

Factory real de cliente Gemini não foi criada.

## QA relatada

- `geminiVideoNarrativeFeatureFlag.test.ts` passou
- `geminiVideoNarrativeProvider.test.ts` passou
- `geminiVideoNarrativeSchema.test.ts` passou
- `geminiVideoNarrativePrompt.test.ts` passou
- regressões narrativas passaram
- regressões da linha técnica passaram
- regressões VU principais passaram
- regressões guard/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.