### PR TITLE
feat: add Gemini video narrative client factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "d2c-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@google/genai": "^2.3.0",
         "@headlessui/react": "^2.2.2",
         "@heroicons/react": "^2.2.0",
         "@sentry/nextjs": "^10.0.0",
@@ -1285,6 +1286,124 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@google/genai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.3.0.tgz",
+      "integrity": "sha512-rXDhXUBj31gZafcwQFbXvt8jMrMxZoK7ECjQpk88UfA/OkZls3PtZDprT9lM3jjqRtwRjQoNLoPoNq6MlV8qLw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/@headlessui/react": {
       "version": "2.2.7",
@@ -2909,6 +3028,70 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.0",
@@ -7297,6 +7480,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -8856,6 +9048,38 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -9053,6 +9277,18 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded-parse": {
@@ -12564,6 +12800,12 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13629,6 +13871,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -14286,6 +14547,30 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -17643,7 +17928,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "compliance:whatsapp": "node scripts/compliance-whatsapp.mjs"
   },
   "dependencies": {
+    "@google/genai": "^2.3.0",
     "@headlessui/react": "^2.2.2",
     "@heroicons/react": "^2.2.0",
     "@sentry/nextjs": "^10.0.0",

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -181,6 +181,27 @@ O que não faz:
 - não adiciona cliente real;
 - não conecta no board real nem em navegação.
 
+### MM9 — Factory isolada do cliente Gemini
+
+Status: concluído.
+
+Arquivos principais:
+
+- `geminiVideoNarrativeClientFactory.ts`
+- `geminiVideoNarrativeClientFactory.test.ts`
+
+O que faz:
+
+- adiciona o SDK oficial `@google/genai`;
+- cria uma factory server-side isolada que adapta URI existente ou vídeo inline à interface local do provider;
+- centraliza o modelo inicial em `DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL`.
+
+O que não faz:
+
+- não cria upload via File API;
+- não integra automaticamente a factory ao fluxo real;
+- não cria endpoint nem navegação.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -215,7 +215,8 @@ Exemplos:
 5. MM6 — Preview interno narrativo. Concluído como harness isolado por flag e sessão admin/dev.
 6. MM7 — Prompt/schema Gemini. Concluído como contratos puros de prompt, normalização e fallback seguro.
 7. MM8 — Gemini Flash real atrás de server flag. Concluído como provider injetável protegido por flag server-side, sem cliente real nesta fase.
-8. MM9 — Integração experimental no Board de Criação.
+8. MM9 — Factory isolada do cliente Gemini. Concluída como adapter server-side para cliente real, sem integração automática ao fluxo.
+9. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts
@@ -1,0 +1,217 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  GoogleGenAI,
+  createPartFromBase64,
+  createPartFromUri,
+  createUserContent,
+} from "@google/genai";
+import {
+  DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL,
+  createGeminiVideoNarrativeClient,
+} from "./geminiVideoNarrativeClientFactory";
+
+jest.mock("@google/genai", () => ({
+  GoogleGenAI: jest.fn(),
+  createUserContent: jest.fn((parts) => ({ role: "user", parts })),
+  createPartFromUri: jest.fn((uri, mimeType) => ({ fileData: { fileUri: uri, mimeType } })),
+  createPartFromBase64: jest.fn((data, mimeType) => ({ inlineData: { data, mimeType } })),
+}));
+
+const generateContent = jest.fn();
+const mockedGoogleGenAI = GoogleGenAI as jest.MockedClass<typeof GoogleGenAI>;
+const mockedCreateUserContent = createUserContent as jest.MockedFunction<typeof createUserContent>;
+const mockedCreatePartFromUri = createPartFromUri as jest.MockedFunction<typeof createPartFromUri>;
+const mockedCreatePartFromBase64 = createPartFromBase64 as jest.MockedFunction<typeof createPartFromBase64>;
+
+const forbiddenTerms = [
+  "erro",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function buildClient(model?: string) {
+  return createGeminiVideoNarrativeClient({
+    apiKey: "secret-key",
+    model,
+  }).client!;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  generateContent.mockResolvedValue({ text: "texto útil" });
+  mockedGoogleGenAI.mockImplementation(
+    () =>
+      ({
+        models: { generateContent },
+      }) as unknown as GoogleGenAI,
+  );
+});
+
+describe("geminiVideoNarrativeClientFactory", () => {
+  it("returns false without apiKey", () => {
+    expect(createGeminiVideoNarrativeClient({ apiKey: "" })).toEqual({
+      ok: false,
+      client: null,
+      issue: "Chave do provider multimodal ausente.",
+    });
+  });
+
+  it("returns true with apiKey", () => {
+    expect(createGeminiVideoNarrativeClient({ apiKey: "secret-key" })).toMatchObject({
+      ok: true,
+      issue: null,
+    });
+  });
+
+  it("creates a client with generateContent", () => {
+    expect(buildClient().generateContent).toEqual(expect.any(Function));
+  });
+
+  it("uses uri parts when videoUri is provided", async () => {
+    const client = buildClient();
+    await client.generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      videoUri: "gs://bucket/video.mp4",
+      mimeType: "video/mp4",
+    });
+
+    expect(mockedCreatePartFromUri).toHaveBeenCalledWith("gs://bucket/video.mp4", "video/mp4");
+    expect(generateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          parts: expect.arrayContaining([{ fileData: { fileUri: "gs://bucket/video.mp4", mimeType: "video/mp4" } }]),
+        }),
+      }),
+    );
+  });
+
+  it("uses inline data when inlineVideoBase64 is provided", async () => {
+    const client = buildClient();
+    await client.generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      inlineVideoBase64: "ZmFrZQ==",
+      mimeType: "video/mp4",
+    });
+
+    expect(mockedCreatePartFromBase64).toHaveBeenCalledWith("ZmFrZQ==", "video/mp4");
+    expect(generateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          parts: expect.arrayContaining([{ inlineData: { data: "ZmFrZQ==", mimeType: "video/mp4" } }]),
+        }),
+      }),
+    );
+  });
+
+  it("returns text from the sdk response", async () => {
+    generateContent.mockResolvedValueOnce({ text: "resposta" });
+    const result = await buildClient().generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      videoUri: "gs://bucket/video.mp4",
+    });
+
+    expect(result).toEqual({ text: "resposta" });
+  });
+
+  it("returns null when the sdk response has no text", async () => {
+    generateContent.mockResolvedValueOnce({});
+    const result = await buildClient().generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      videoUri: "gs://bucket/video.mp4",
+    });
+
+    expect(result).toEqual({ text: null });
+  });
+
+  it("returns null without media and does not call the model", async () => {
+    const result = await buildClient().generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+    });
+
+    expect(result).toEqual({ text: null });
+    expect(generateContent).not.toHaveBeenCalled();
+  });
+
+  it("uses the default model", async () => {
+    await buildClient().generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      videoUri: "gs://bucket/video.mp4",
+    });
+
+    expect(generateContent).toHaveBeenCalledWith(
+      expect.objectContaining({ model: DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL }),
+    );
+  });
+
+  it("respects a custom model", async () => {
+    await buildClient("gemini-custom").generateContent({
+      systemInstruction: "sistema",
+      userInstruction: "usuário",
+      responseFormatInstruction: "json",
+      videoUri: "gs://bucket/video.mp4",
+    });
+
+    expect(generateContent).toHaveBeenCalledWith(expect.objectContaining({ model: "gemini-custom" }));
+  });
+
+  it("does not expose the api key in issues or generated text", () => {
+    const missing = createGeminiVideoNarrativeClient({ apiKey: "" });
+    const ready = createGeminiVideoNarrativeClient({ apiKey: "secret-key" });
+    const content = JSON.stringify({ missing, ready });
+
+    expect(content).not.toContain("secret-key");
+  });
+
+  it("keeps exported strings free of blocked language", () => {
+    const content = JSON.stringify({
+      issue: createGeminiVideoNarrativeClient({ apiKey: "" }).issue,
+      model: DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL,
+    }).toLowerCase();
+
+    forbiddenTerms.forEach((term) => expect(content).not.toContain(term));
+  });
+
+  it("keeps factory imports isolated from forbidden integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativeClientFactory.ts"), "utf8");
+    [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch(",
+      "Prisma",
+      "banco",
+      "components/",
+      "hooks/",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+    ].forEach((blocked) => expect(source).not.toContain(blocked));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
@@ -1,5 +1,6 @@
 import {
   GoogleGenAI,
+  Part,
   createPartFromBase64,
   createPartFromUri,
   createUserContent,
@@ -50,7 +51,7 @@ export function createGeminiVideoNarrativeClient(
           return { text: null };
         }
 
-        const parts = [userInstruction, responseFormatInstruction];
+        const parts: Array<string | Part> = [userInstruction, responseFormatInstruction];
 
         if (videoUri) {
           parts.push(createPartFromUri(videoUri, mimeType ?? "video/mp4"));

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
@@ -1,0 +1,73 @@
+import {
+  GoogleGenAI,
+  createPartFromBase64,
+  createPartFromUri,
+  createUserContent,
+} from "@google/genai";
+
+import { GeminiVideoNarrativeClient } from "./geminiVideoNarrativeProvider";
+
+export type GeminiVideoNarrativeClientFactoryOptions = {
+  apiKey: string;
+  model?: string;
+};
+
+export type GeminiVideoNarrativeClientFactoryResult = {
+  ok: boolean;
+  client: GeminiVideoNarrativeClient | null;
+  issue: string | null;
+};
+
+export const DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL = "gemini-3-flash-preview";
+
+export function createGeminiVideoNarrativeClient(
+  params: GeminiVideoNarrativeClientFactoryOptions,
+): GeminiVideoNarrativeClientFactoryResult {
+  if (!params.apiKey.trim()) {
+    return {
+      ok: false,
+      client: null,
+      issue: "Chave do provider multimodal ausente.",
+    };
+  }
+
+  const ai = new GoogleGenAI({ apiKey: params.apiKey });
+  const model = params.model ?? DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL;
+
+  return {
+    ok: true,
+    issue: null,
+    client: {
+      async generateContent({
+        systemInstruction,
+        userInstruction,
+        responseFormatInstruction,
+        videoUri,
+        inlineVideoBase64,
+        mimeType,
+      }) {
+        if (!videoUri && !inlineVideoBase64) {
+          return { text: null };
+        }
+
+        const parts = [userInstruction, responseFormatInstruction];
+
+        if (videoUri) {
+          parts.push(createPartFromUri(videoUri, mimeType ?? "video/mp4"));
+        } else if (inlineVideoBase64) {
+          parts.push(createPartFromBase64(inlineVideoBase64, mimeType ?? "video/mp4"));
+        }
+
+        const response = await ai.models.generateContent({
+          model,
+          contents: createUserContent(parts),
+          config: { systemInstruction },
+        });
+
+        return {
+          text: response.text ?? null,
+        };
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #805. Adiciona a fase MM9: factory isolada do cliente Gemini para análise narrativa de vídeo.

## Inclui

- `geminiVideoNarrativeClientFactory.ts`
- `geminiVideoNarrativeClientFactory.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first
- `@google/genai` em `package.json`/`package-lock.json`

## Package manager / dependência

Package manager detectado: npm (`package-lock.json`).

Dependência adicionada:

- `@google/genai@^2.3.0`

## Factory

Foi criada uma factory server-side isolada que adapta o SDK real à interface local `GeminiVideoNarrativeClient`.

Suporta:

- `videoUri` via `createPartFromUri`
- `inlineVideoBase64 + mimeType` via `createPartFromBase64`
- `config.systemInstruction`
- modelo centralizado em `DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL`

## Helpers

- `createGeminiVideoNarrativeClient`
- `DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL`

## Fora de escopo

Não há endpoint, upload real, UI, banco, BoardShell, storage real, fetch direto ou rede real em teste.

Não houve navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

A factory não foi integrada automaticamente ao fluxo real do produto.

## QA relatada

- `geminiVideoNarrativeClientFactory.test.ts` passou
- regressões MM7/MM8 passaram
- regressões narrativas passaram
- regressões da linha técnica passaram
- regressões VU principais passaram
- regressões guard/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou

## Status

Draft. Não fazer merge ainda.