### PR TITLE
feat: add Gemini video narrative provider composer

### DIFF
--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -202,6 +202,27 @@ O que não faz:
 - não integra automaticamente a factory ao fluxo real;
 - não cria endpoint nem navegação.
 
+### MM10 — Composer seguro do provider Gemini
+
+Status: concluído.
+
+Arquivos principais:
+
+- `geminiVideoNarrativeProviderComposer.ts`
+- `geminiVideoNarrativeProviderComposer.test.ts`
+
+O que faz:
+
+- resolve chave e modelo a partir de configuração server-side;
+- compõe explicitamente a factory real com o provider injetável já existente;
+- mantém a chamada isolada e sob a flag server-side existente.
+
+O que não faz:
+
+- não cria endpoint;
+- não inicia fluxo automático;
+- não conecta no board real nem em navegação.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -216,7 +216,8 @@ Exemplos:
 6. MM7 — Prompt/schema Gemini. Concluído como contratos puros de prompt, normalização e fallback seguro.
 7. MM8 — Gemini Flash real atrás de server flag. Concluído como provider injetável protegido por flag server-side, sem cliente real nesta fase.
 8. MM9 — Factory isolada do cliente Gemini. Concluída como adapter server-side para cliente real, sem integração automática ao fluxo.
-9. Integração experimental futura no Board de Criação.
+9. MM10 — Composer seguro do provider Gemini. Concluído como composição explícita de config, factory e provider, sem integração automática ao fluxo.
+10. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts
@@ -1,0 +1,279 @@
+import fs from "fs";
+import path from "path";
+
+jest.mock("./geminiVideoNarrativeClientFactory", () => ({
+  DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL: "gemini-3-flash-preview",
+  createGeminiVideoNarrativeClient: jest.fn(),
+}));
+
+import { DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL } from "./geminiVideoNarrativeClientFactory";
+import {
+  getGeminiVideoNarrativeApiKey,
+  getGeminiVideoNarrativeModel,
+  runGeminiVideoNarrativeProviderFromEnv,
+} from "./geminiVideoNarrativeProviderComposer";
+import { GeminiVideoNarrativeClient } from "./geminiVideoNarrativeProvider";
+
+const originalEnv = {
+  geminiApiKey: process.env.GEMINI_API_KEY,
+  googleGenAiApiKey: process.env.GOOGLE_GENAI_API_KEY,
+  model: process.env.VIDEO_NARRATIVE_GEMINI_MODEL,
+  enabled: process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED,
+};
+const forbiddenTerms = [
+  "erro",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function restoreEnvValue(name: keyof NodeJS.ProcessEnv, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function input(overrides = {}) {
+  return {
+    id: "analysis-1",
+    creatorQuestion: "Quero entender este vídeo.",
+    videoUri: "gs://bucket/video.mp4",
+    createdAt: "2026-05-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function validClient(): GeminiVideoNarrativeClient {
+  return {
+    async generateContent() {
+      return {
+        text: JSON.stringify({
+          summary: "Rotina de autocuidado.",
+          blueprintSuggestion: { whatToPost: "Reel de rotina com virada prática." },
+        }),
+      };
+    },
+  };
+}
+
+afterEach(() => {
+  restoreEnvValue("GEMINI_API_KEY", originalEnv.geminiApiKey);
+  restoreEnvValue("GOOGLE_GENAI_API_KEY", originalEnv.googleGenAiApiKey);
+  restoreEnvValue("VIDEO_NARRATIVE_GEMINI_MODEL", originalEnv.model);
+  restoreEnvValue("VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED", originalEnv.enabled);
+});
+
+describe("geminiVideoNarrativeProviderComposer", () => {
+  it("uses env apiKey first", () => {
+    expect(getGeminiVideoNarrativeApiKey({ apiKey: "env-key" })).toBe("env-key");
+  });
+
+  it("uses GEMINI_API_KEY as fallback", () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+    delete process.env.GOOGLE_GENAI_API_KEY;
+
+    expect(getGeminiVideoNarrativeApiKey()).toBe("gemini-key");
+  });
+
+  it("uses GOOGLE_GENAI_API_KEY as second fallback", () => {
+    delete process.env.GEMINI_API_KEY;
+    process.env.GOOGLE_GENAI_API_KEY = "google-key";
+
+    expect(getGeminiVideoNarrativeApiKey()).toBe("google-key");
+  });
+
+  it("returns null when no api key exists", () => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_GENAI_API_KEY;
+
+    expect(getGeminiVideoNarrativeApiKey()).toBeNull();
+  });
+
+  it("uses env model first", () => {
+    expect(getGeminiVideoNarrativeModel({ model: "model-a" })).toBe("model-a");
+  });
+
+  it("uses VIDEO_NARRATIVE_GEMINI_MODEL as fallback", () => {
+    process.env.VIDEO_NARRATIVE_GEMINI_MODEL = "model-b";
+
+    expect(getGeminiVideoNarrativeModel()).toBe("model-b");
+  });
+
+  it("uses the default model as fallback", () => {
+    delete process.env.VIDEO_NARRATIVE_GEMINI_MODEL;
+
+    expect(getGeminiVideoNarrativeModel()).toBe(DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL);
+  });
+
+  it("does not call createClient when explicitly disabled", async () => {
+    const createClient = jest.fn();
+    const result = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "false", apiKey: "secret-key" },
+      createClient,
+    });
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(result.status).toBe("disabled");
+  });
+
+  it("returns missing_api_key without calling createClient", async () => {
+    const createClient = jest.fn();
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_GENAI_API_KEY;
+    const result = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true" },
+      createClient,
+    });
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(result.status).toBe("missing_api_key");
+  });
+
+  it("creates a client with apiKey and model when enabled", async () => {
+    const createClient = jest.fn(() => ({ ok: true, client: validClient(), issue: null }));
+    await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key", model: "gemini-model" },
+      createClient,
+    });
+
+    expect(createClient).toHaveBeenCalledWith({ apiKey: "secret-key", model: "gemini-model" });
+  });
+
+  it("returns missing_client when the factory has no client", async () => {
+    const result = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({ ok: false, client: null, issue: "sem cliente" }),
+    });
+
+    expect(result.status).toBe("missing_client");
+  });
+
+  it("uses the injected client and returns a useful analysis", async () => {
+    const result = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({ ok: true, client: validClient(), issue: null }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("ready");
+    expect(result.analysis.blueprintSuggestion.whatToPost).toBe("Reel de rotina com virada prática.");
+  });
+
+  it("uses only mock clients during tests", async () => {
+    const generateContent = jest.fn().mockResolvedValue({
+      text: JSON.stringify({ summary: "Resumo útil." }),
+    });
+    await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({ ok: true, client: { generateContent }, issue: null }),
+    });
+
+    expect(generateContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose api keys in provider results", async () => {
+    const result = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({ ok: true, client: validClient(), issue: null }),
+    });
+
+    expect(JSON.stringify(result)).not.toContain("secret-key");
+  });
+
+  it("accepts videoUri", async () => {
+    let receivedVideoUri: string | null | undefined;
+    await runGeminiVideoNarrativeProviderFromEnv({
+      input: input({ videoUri: "gs://bucket/video.mp4" }),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({
+        ok: true,
+        issue: null,
+        client: {
+          async generateContent(params) {
+            receivedVideoUri = params.videoUri;
+            return { text: JSON.stringify({ summary: "Resumo útil." }) };
+          },
+        },
+      }),
+    });
+
+    expect(receivedVideoUri).toBe("gs://bucket/video.mp4");
+  });
+
+  it("accepts inline video payloads", async () => {
+    let receivedInline: string | null | undefined;
+    let receivedMimeType: string | null | undefined;
+    await runGeminiVideoNarrativeProviderFromEnv({
+      input: input({ videoUri: null, inlineVideoBase64: "ZmFrZQ==", mimeType: "video/mp4" }),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({
+        ok: true,
+        issue: null,
+        client: {
+          async generateContent(params) {
+            receivedInline = params.inlineVideoBase64;
+            receivedMimeType = params.mimeType;
+            return { text: JSON.stringify({ summary: "Resumo útil." }) };
+          },
+        },
+      }),
+    });
+
+    expect(receivedInline).toBe("ZmFrZQ==");
+    expect(receivedMimeType).toBe("video/mp4");
+  });
+
+  it("keeps returned language conservative", async () => {
+    const disabled = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "false" },
+    });
+    const ready = await runGeminiVideoNarrativeProviderFromEnv({
+      input: input(),
+      env: { enabled: "true", apiKey: "secret-key" },
+      createClient: () => ({ ok: true, client: validClient(), issue: null }),
+    });
+    const content = JSON.stringify({ disabled, ready }).toLowerCase();
+
+    forbiddenTerms.forEach((term) => expect(content).not.toContain(term));
+  });
+
+  it("keeps composer imports isolated from forbidden integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativeProviderComposer.ts"), "utf8");
+    [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch(",
+      "Prisma",
+      "banco",
+      "components/",
+      "hooks/",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+    ].forEach((blocked) => expect(source).not.toContain(blocked));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.ts
@@ -1,0 +1,108 @@
+import {
+  GeminiVideoNarrativeProviderInput,
+  GeminiVideoNarrativeProviderResult,
+  runGeminiVideoNarrativeProvider,
+} from "./geminiVideoNarrativeProvider";
+import {
+  DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL,
+  createGeminiVideoNarrativeClient,
+} from "./geminiVideoNarrativeClientFactory";
+import { isGeminiVideoNarrativeEnabled } from "./geminiVideoNarrativeFeatureFlag";
+
+export type GeminiVideoNarrativeProviderComposerEnv = {
+  apiKey?: string | null;
+  enabled?: string | null;
+  model?: string | null;
+};
+
+export type GeminiVideoNarrativeProviderComposerOptions = {
+  env?: GeminiVideoNarrativeProviderComposerEnv;
+  createClient?: typeof createGeminiVideoNarrativeClient;
+};
+
+const VIDEO_NARRATIVE_GEMINI_FLAG = "VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED";
+
+function normalizedValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isComposerEnabled(env?: GeminiVideoNarrativeProviderComposerEnv): boolean {
+  if (env?.enabled === "true") return true;
+  if (env?.enabled === "false") return false;
+  return isGeminiVideoNarrativeEnabled();
+}
+
+async function withProviderFlag<T>(enabled: boolean, run: () => Promise<T>): Promise<T> {
+  const previous = process.env[VIDEO_NARRATIVE_GEMINI_FLAG];
+  process.env[VIDEO_NARRATIVE_GEMINI_FLAG] = enabled ? "true" : "false";
+
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[VIDEO_NARRATIVE_GEMINI_FLAG];
+    } else {
+      process.env[VIDEO_NARRATIVE_GEMINI_FLAG] = previous;
+    }
+  }
+}
+
+export function getGeminiVideoNarrativeApiKey(env?: GeminiVideoNarrativeProviderComposerEnv): string | null {
+  return (
+    normalizedValue(env?.apiKey) ??
+    normalizedValue(process.env.GEMINI_API_KEY) ??
+    normalizedValue(process.env.GOOGLE_GENAI_API_KEY)
+  );
+}
+
+export function getGeminiVideoNarrativeModel(env?: GeminiVideoNarrativeProviderComposerEnv): string {
+  return (
+    normalizedValue(env?.model) ??
+    normalizedValue(process.env.VIDEO_NARRATIVE_GEMINI_MODEL) ??
+    DEFAULT_GEMINI_VIDEO_NARRATIVE_MODEL
+  );
+}
+
+export async function runGeminiVideoNarrativeProviderFromEnv(params: {
+  input: GeminiVideoNarrativeProviderInput;
+  env?: GeminiVideoNarrativeProviderComposerEnv;
+  createClient?: typeof createGeminiVideoNarrativeClient;
+}): Promise<GeminiVideoNarrativeProviderResult> {
+  const enabled = isComposerEnabled(params.env);
+
+  if (!enabled) {
+    return withProviderFlag(false, () =>
+      runGeminiVideoNarrativeProvider({
+        input: params.input,
+        client: null,
+        apiKey: null,
+      }),
+    );
+  }
+
+  const apiKey = getGeminiVideoNarrativeApiKey(params.env);
+  if (!apiKey) {
+    return withProviderFlag(true, () =>
+      runGeminiVideoNarrativeProvider({
+        input: params.input,
+        client: null,
+        apiKey: null,
+      }),
+    );
+  }
+
+  const createClient = params.createClient ?? createGeminiVideoNarrativeClient;
+  const factoryResult = createClient({
+    apiKey,
+    model: getGeminiVideoNarrativeModel(params.env),
+  });
+
+  return withProviderFlag(true, () =>
+    runGeminiVideoNarrativeProvider({
+      input: params.input,
+      client: factoryResult.client,
+      apiKey,
+    }),
+  );
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #806. Adiciona a fase MM10: composer server-side seguro para juntar configuração, factory do cliente Gemini e provider de análise narrativa.

## Inclui

- `geminiVideoNarrativeProviderComposer.ts`
- `geminiVideoNarrativeProviderComposer.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## Composer criado

Resolve configuração server-side para:

- chave: `env.apiKey → GEMINI_API_KEY → GOOGLE_GENAI_API_KEY`
- modelo: `env.model → VIDEO_NARRATIVE_GEMINI_MODEL → default`

Compõe explicitamente:

`createGeminiVideoNarrativeClient → runGeminiVideoNarrativeProvider`

Mantém a flag server-side existente e permite override controlado em teste sem alterar o provider global.

## Helpers

- `getGeminiVideoNarrativeApiKey`
- `getGeminiVideoNarrativeModel`
- `runGeminiVideoNarrativeProviderFromEnv`

## Fora de escopo

Não há endpoint, upload real, UI, banco, BoardShell, fetch direto ou rede real em teste.

Não houve navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

O composer não foi integrado automaticamente ao fluxo real do produto.

## QA relatada

- `geminiVideoNarrativeProviderComposer.test.ts` passou
- bloco Gemini atual passou
- regressões narrativas passaram
- regressões da linha técnica passaram
- regressões VU principais passaram
- regressões guard/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou
- `npm run build` passou

## Status

Draft. Não fazer merge ainda.