### PR TITLE
feat: add Gemini video narrative real run harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "audit:video-postdates": "node ./scripts/auditVideoPostDates.mjs",
     "sales:tutorial": "tsx --env-file=.env.local ./scripts/createSalesTutorial.ts",
     "sales:tutorial:auth": "tsx --env-file=.env.local ./scripts/createTutorialStorageState.ts",
+    "video:narrative:real-run": "tsx --env-file=.env.local ./scripts/video-narrative-real-run.ts",
     "smoke:types": "tsc -p tsconfig.smoke.json",
     "compliance:whatsapp": "node scripts/compliance-whatsapp.mjs"
   },

--- a/scripts/video-narrative-real-run.ts
+++ b/scripts/video-narrative-real-run.ts
@@ -1,0 +1,27 @@
+import { pathToFileURL } from "node:url";
+import {
+  buildGeminiVideoNarrativeRealRunInputFromEnv,
+  formatGeminiVideoNarrativeRealRunResult,
+  runGeminiVideoNarrativeRealRun,
+} from "../src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness";
+
+export async function runVideoNarrativeRealRunScript(): Promise<void> {
+  const input = buildGeminiVideoNarrativeRealRunInputFromEnv(process.env);
+  const result = await runGeminiVideoNarrativeRealRun({
+    input,
+    env: {
+      apiKey: process.env.GEMINI_API_KEY || process.env.GOOGLE_GENAI_API_KEY || null,
+      enabled: process.env.VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED || null,
+      model: process.env.VIDEO_NARRATIVE_GEMINI_MODEL || null,
+    },
+  });
+
+  console.log(formatGeminiVideoNarrativeRealRunResult(result));
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (isDirectRun) {
+  void runVideoNarrativeRealRunScript();
+}

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -223,6 +223,42 @@ O que não faz:
 - não inicia fluxo automático;
 - não conecta no board real nem em navegação.
 
+### MM11 — Harness manual de execução real
+
+Status: concluído.
+
+Arquivos principais:
+
+- `geminiVideoNarrativeRealRunHarness.ts`
+- `geminiVideoNarrativeRealRunHarness.test.ts`
+- `../../../../../scripts/video-narrative-real-run.ts`
+
+O que faz:
+
+- expõe um harness manual para avaliar uma execução real controlada do provider Gemini;
+- resume `VideoNarrativeAnalysis` e `PostCreationVideoSeed` sem imprimir o texto bruto completo;
+- pode ser executado localmente com `npm run video:narrative:real-run`.
+
+Variáveis necessárias para uso manual:
+
+- `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`
+- `GEMINI_API_KEY` ou `GOOGLE_GENAI_API_KEY`
+- `VIDEO_NARRATIVE_VIDEO_URI` ou `VIDEO_NARRATIVE_INLINE_BASE64` + `VIDEO_NARRATIVE_MIME_TYPE`
+- `VIDEO_NARRATIVE_CREATOR_QUESTION`
+
+Cuidados:
+
+- não commitar API key;
+- não commitar vídeo nem base64 de vídeo;
+- usar apenas em ambiente local/admin;
+- não usar ainda com usuário real.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria upload real;
+- não integra o harness ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -217,7 +217,8 @@ Exemplos:
 7. MM8 — Gemini Flash real atrás de server flag. Concluído como provider injetável protegido por flag server-side, sem cliente real nesta fase.
 8. MM9 — Factory isolada do cliente Gemini. Concluída como adapter server-side para cliente real, sem integração automática ao fluxo.
 9. MM10 — Composer seguro do provider Gemini. Concluído como composição explícita de config, factory e provider, sem integração automática ao fluxo.
-10. Integração experimental futura no Board de Criação.
+10. MM11 — Harness interno para execução real controlada. Concluído como teste manual explícito, sem endpoint, UI ou upload real.
+11. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -234,3 +235,7 @@ Exemplos:
 ## Frase Norte
 
 > O vídeo não entra na D2C para ser extraído. Ele entra para ser interpretado como narrativa em construção.
+
+## Harness Real Controlado
+
+MM11 adiciona apenas um caminho manual de avaliação para o provider real já composto. Ele continua sem endpoint, sem UI e sem upload real. O objetivo é observar output, latência e issues do parser em ambiente interno antes de qualquer exposição ao fluxo do produto.

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts
@@ -1,0 +1,280 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildGeminiVideoNarrativeRealRunInputFromEnv,
+  formatGeminiVideoNarrativeRealRunResult,
+  runGeminiVideoNarrativeRealRun,
+} from "./geminiVideoNarrativeRealRunHarness";
+import { createEmptyVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+
+const SAFE_LANGUAGE_BLOCKLIST = [
+  "erro",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function buildUsefulAnalysis() {
+  const analysis = createEmptyVideoNarrativeAnalysis({
+    id: "analysis-1",
+    createdAt: "2026-05-15T12:00:00.000Z",
+  });
+
+  return {
+    ...analysis,
+    summary: "Rotina de skincare com direção prática.",
+    hook: {
+      detected: "Começar mostrando o resultado antes da rotina.",
+      strength: "medium" as const,
+      why: "A abertura situa a transformação.",
+    },
+    d2cClassification: {
+      ...analysis.d2cClassification,
+      format: "reel" as const,
+      proposal: "tips" as const,
+      narrative: "rotina de autocuidado com sequência clara",
+    },
+    blueprintSuggestion: {
+      whatToPost: "Reel de rotina de skincare com foco em autocuidado.",
+      whyThisPath: "Organiza a leitura do conteúdo.",
+      howItShouldWork: "Abrir com resultado e seguir por etapas.",
+      scenes: ["resultado", "rotina", "fechamento"],
+    },
+    confidence: "medium" as const,
+  };
+}
+
+function buildFallbackAnalysis() {
+  const analysis = createEmptyVideoNarrativeAnalysis({ id: "fallback-analysis" });
+  return {
+    ...analysis,
+    confidence: "low" as const,
+    diagnosis: {
+      ...analysis.diagnosis,
+      recommendedAdjustments: ["Trazer mais contexto antes de transformar o vídeo em pauta."],
+    },
+  };
+}
+
+describe("geminiVideoNarrativeRealRunHarness", () => {
+  it("monta input mínimo a partir do ambiente", () => {
+    expect(buildGeminiVideoNarrativeRealRunInputFromEnv({} as NodeJS.ProcessEnv)).toEqual({
+      id: "manual-video-narrative-run",
+      creatorQuestion: null,
+      videoUri: null,
+      inlineVideoBase64: null,
+      mimeType: null,
+      creatorContext: null,
+      createdAt: null,
+    });
+  });
+
+  it("lê videoUri", () => {
+    expect(
+      buildGeminiVideoNarrativeRealRunInputFromEnv({
+        VIDEO_NARRATIVE_VIDEO_URI: "gs://bucket/video.mp4",
+      } as NodeJS.ProcessEnv).videoUri,
+    ).toBe("gs://bucket/video.mp4");
+  });
+
+  it("lê vídeo inline e mimeType", () => {
+    const input = buildGeminiVideoNarrativeRealRunInputFromEnv({
+      VIDEO_NARRATIVE_INLINE_BASE64: "YmFzZTY0",
+      VIDEO_NARRATIVE_MIME_TYPE: "video/mp4",
+    } as NodeJS.ProcessEnv);
+
+    expect(input.inlineVideoBase64).toBe("YmFzZTY0");
+    expect(input.mimeType).toBe("video/mp4");
+  });
+
+  it("parseia narrativas conhecidas por vírgula", () => {
+    const input = buildGeminiVideoNarrativeRealRunInputFromEnv({
+      VIDEO_NARRATIVE_CREATOR_HANDLE: "@creator",
+      VIDEO_NARRATIVE_KNOWN_NARRATIVES: "rotina, bastidor , publi",
+    } as NodeJS.ProcessEnv);
+
+    expect(input.creatorContext).toEqual({
+      handle: "@creator",
+      niche: null,
+      knownNarratives: ["rotina", "bastidor", "publi"],
+    });
+  });
+
+  it("resume uma execução válida", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: {
+        id: "run-1",
+        creatorQuestion: "Quero saber se vale postar",
+      },
+      runner: async () => ({
+        ok: true,
+        status: "ready",
+        analysis: buildUsefulAnalysis(),
+        issues: [],
+        rawText: "{\"summary\":\"ok\"}",
+      }),
+    });
+
+    expect(result.analysisSummary).toEqual({
+      confidence: "medium",
+      summary: "Rotina de skincare com direção prática.",
+      hook: "Começar mostrando o resultado antes da rotina.",
+      narrative: "rotina de autocuidado com sequência clara",
+      primaryDirection: "Reel de rotina de skincare com foco em autocuidado.",
+    });
+  });
+
+  it("gera seed útil a partir da análise", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-2", creatorQuestion: null },
+      runner: async () => ({
+        ok: true,
+        status: "ready",
+        analysis: buildUsefulAnalysis(),
+        issues: [],
+        rawText: null,
+      }),
+    });
+
+    expect(result.seedSummary).toEqual({
+      initialIdea: "Reel de rotina de skincare com foco em autocuidado.",
+      detectedNarrative: "rotina de autocuidado com sequência clara",
+      primaryAction: "Transformar a sugestão de blueprint em roteiro.",
+      followUpQuestions: [],
+    });
+  });
+
+  it("mantém resumo de fallback quando o provider não conclui", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-3", creatorQuestion: null },
+      runner: async () => ({
+        ok: false,
+        status: "disabled",
+        analysis: buildFallbackAnalysis(),
+        issues: ["Provider multimodal desativado por configuração."],
+        rawText: null,
+      }),
+    });
+
+    expect(result.analysisSummary.confidence).toBe("low");
+    expect(result.seedSummary?.followUpQuestions.length).toBeGreaterThan(0);
+  });
+
+  it("não retorna rawText completo", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-4", creatorQuestion: null },
+      runner: async () => ({
+        ok: true,
+        status: "ready",
+        analysis: buildUsefulAnalysis(),
+        issues: [],
+        rawText: "texto bruto",
+      }),
+    });
+
+    expect(result.hasRawText).toBe(true);
+    expect(result).not.toHaveProperty("rawText");
+  });
+
+  it("formata status, confiança, ação primária e issues", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-5", creatorQuestion: null },
+      runner: async () => ({
+        ok: false,
+        status: "failed",
+        analysis: buildFallbackAnalysis(),
+        issues: ["Contexto insuficiente para transformar o vídeo em pauta."],
+        rawText: null,
+      }),
+    });
+
+    const formatted = formatGeminiVideoNarrativeRealRunResult(result);
+
+    expect(formatted).toContain("status: failed");
+    expect(formatted).toContain("confidence: low");
+    expect(formatted).toContain("seed.primaryAction:");
+    expect(formatted).toContain("issues:");
+  });
+
+  it("remove a chave do output formatado quando uma issue tenta expô-la", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-6", creatorQuestion: null },
+      env: { apiKey: "secret-key" },
+      runner: async () => ({
+        ok: false,
+        status: "failed",
+        analysis: buildFallbackAnalysis(),
+        issues: ["Chave recebida: secret-key"],
+        rawText: null,
+      }),
+    });
+
+    expect(formatGeminiVideoNarrativeRealRunResult(result)).not.toContain("secret-key");
+  });
+
+  it("mantém linguagem segura no output gerado", async () => {
+    const result = await runGeminiVideoNarrativeRealRun({
+      input: { id: "run-7", creatorQuestion: null },
+      runner: async () => ({
+        ok: true,
+        status: "ready",
+        analysis: buildUsefulAnalysis(),
+        issues: [],
+        rawText: null,
+      }),
+    });
+    const generated = formatGeminiVideoNarrativeRealRunResult(result).toLowerCase();
+
+    SAFE_LANGUAGE_BLOCKLIST.forEach((term) => {
+      expect(generated).not.toContain(term);
+    });
+  });
+
+  it("mantém imports restritos no harness e no script", () => {
+    const harnessSource = fs.readFileSync(path.join(__dirname, "geminiVideoNarrativeRealRunHarness.ts"), "utf8");
+    const scriptSource = fs.readFileSync(
+      path.join(process.cwd(), "scripts/video-narrative-real-run.ts"),
+      "utf8",
+    );
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "component",
+      "hook",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "narrativeSource",
+      "adaptiveV2",
+    ];
+    const harnessImports = harnessSource
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import "))
+      .join("\n");
+    const scriptImports = scriptSource
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import "))
+      .join("\n");
+
+    forbiddenImports.forEach((term) => {
+      expect(harnessImports).not.toContain(term);
+      expect(scriptImports).not.toContain(term);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.ts
@@ -1,0 +1,171 @@
+import type { GeminiVideoNarrativeProviderComposerEnv } from "./geminiVideoNarrativeProviderComposer";
+import { GeminiVideoNarrativeProviderInput } from "./geminiVideoNarrativeProvider";
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  getPostCreationVideoSeedPrimaryAction,
+} from "./videoNarrativePostCreationSeed";
+import {
+  getVideoNarrativePrimaryDirection,
+  sanitizeVideoNarrativeAnalysisText,
+} from "./videoNarrativeAnalysisTypes";
+
+export type GeminiVideoNarrativeRealRunInput = GeminiVideoNarrativeProviderInput;
+
+export type GeminiVideoNarrativeRealRunResult = {
+  ok: boolean;
+  status: string;
+  analysisSummary: {
+    confidence: string;
+    summary: string | null;
+    hook: string | null;
+    narrative: string | null;
+    primaryDirection: string | null;
+  };
+  seedSummary: {
+    initialIdea: string | null;
+    detectedNarrative: string | null;
+    primaryAction: string;
+    followUpQuestions: string[];
+  } | null;
+  issues: string[];
+  hasRawText: boolean;
+};
+
+type GeminiVideoNarrativeRealRunEnv = GeminiVideoNarrativeProviderComposerEnv;
+type GeminiVideoNarrativeRealRunRunner = (params: {
+  input: GeminiVideoNarrativeProviderInput;
+  env?: GeminiVideoNarrativeRealRunEnv;
+}) => ReturnType<
+  typeof import("./geminiVideoNarrativeProviderComposer").runGeminiVideoNarrativeProviderFromEnv
+>;
+
+function normalizedValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseKnownNarratives(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function createCreatorContext(env: NodeJS.ProcessEnv) {
+  const handle = normalizedValue(env.VIDEO_NARRATIVE_CREATOR_HANDLE);
+  const niche = normalizedValue(env.VIDEO_NARRATIVE_CREATOR_NICHE);
+  const knownNarratives = parseKnownNarratives(env.VIDEO_NARRATIVE_KNOWN_NARRATIVES);
+
+  if (!handle && !niche && knownNarratives.length === 0) {
+    return null;
+  }
+
+  return {
+    handle,
+    niche,
+    knownNarratives,
+  };
+}
+
+function sanitizeIssue(value: string, secrets: Array<string | null | undefined>): string {
+  const withoutSecrets = secrets.reduce<string>((current, secret) => {
+    const normalizedSecret = normalizedValue(secret);
+    return normalizedSecret ? current.split(normalizedSecret).join("[redigido]") : current;
+  }, value);
+
+  return sanitizeVideoNarrativeAnalysisText(withoutSecrets);
+}
+
+export function buildGeminiVideoNarrativeRealRunInputFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): GeminiVideoNarrativeRealRunInput {
+  return {
+    id: normalizedValue(env.VIDEO_NARRATIVE_RUN_ID) ?? "manual-video-narrative-run",
+    creatorQuestion: normalizedValue(env.VIDEO_NARRATIVE_CREATOR_QUESTION),
+    videoUri: normalizedValue(env.VIDEO_NARRATIVE_VIDEO_URI),
+    inlineVideoBase64: normalizedValue(env.VIDEO_NARRATIVE_INLINE_BASE64),
+    mimeType: normalizedValue(env.VIDEO_NARRATIVE_MIME_TYPE),
+    creatorContext: createCreatorContext(env),
+    createdAt: normalizedValue(env.VIDEO_NARRATIVE_CREATED_AT),
+  };
+}
+
+export async function runGeminiVideoNarrativeRealRun(params: {
+  input: GeminiVideoNarrativeRealRunInput;
+  env?: GeminiVideoNarrativeRealRunEnv;
+  runner?: GeminiVideoNarrativeRealRunRunner;
+}): Promise<GeminiVideoNarrativeRealRunResult> {
+  const runner =
+    params.runner ??
+    (async (runnerParams) => {
+      const { runGeminiVideoNarrativeProviderFromEnv } = await import("./geminiVideoNarrativeProviderComposer");
+      return runGeminiVideoNarrativeProviderFromEnv(runnerParams);
+    });
+  const providerResult = await runner({
+    input: params.input,
+    env: params.env,
+  });
+  const seed = buildPostCreationVideoSeedFromAnalysis({
+    id: `${providerResult.analysis.id}-seed`,
+    analysis: providerResult.analysis,
+    creatorQuestion: params.input.creatorQuestion,
+    createdAt: params.input.createdAt,
+  });
+
+  return {
+    ok: providerResult.ok,
+    status: providerResult.status,
+    analysisSummary: {
+      confidence: providerResult.analysis.confidence,
+      summary: providerResult.analysis.summary,
+      hook: providerResult.analysis.hook.detected,
+      narrative: providerResult.analysis.d2cClassification.narrative,
+      primaryDirection: getVideoNarrativePrimaryDirection(providerResult.analysis),
+    },
+    seedSummary: {
+      initialIdea: seed.initialIdea,
+      detectedNarrative: seed.detectedNarrative,
+      primaryAction: getPostCreationVideoSeedPrimaryAction(seed),
+      followUpQuestions: seed.followUpQuestions.map((item) => item.question),
+    },
+    issues: providerResult.issues.map((issue) =>
+      sanitizeIssue(issue, [
+        params.env?.apiKey,
+        process.env.GEMINI_API_KEY,
+        process.env.GOOGLE_GENAI_API_KEY,
+      ]),
+    ),
+    hasRawText: Boolean(providerResult.rawText),
+  };
+}
+
+function printableValue(value: string | null): string {
+  return value ?? "não informado";
+}
+
+export function formatGeminiVideoNarrativeRealRunResult(result: GeminiVideoNarrativeRealRunResult): string {
+  const seed = result.seedSummary;
+  const followUpQuestions = seed?.followUpQuestions.length
+    ? seed.followUpQuestions.map((item) => `- ${item}`).join("\n")
+    : "- nenhuma";
+  const issues = result.issues.length ? result.issues.map((item) => `- ${item}`).join("\n") : "- nenhuma";
+
+  return [
+    `ok: ${result.ok}`,
+    `status: ${result.status}`,
+    `confidence: ${result.analysisSummary.confidence}`,
+    `summary: ${printableValue(result.analysisSummary.summary)}`,
+    `hook: ${printableValue(result.analysisSummary.hook)}`,
+    `narrative: ${printableValue(result.analysisSummary.narrative)}`,
+    `primaryDirection: ${printableValue(result.analysisSummary.primaryDirection)}`,
+    `seed.initialIdea: ${printableValue(seed?.initialIdea ?? null)}`,
+    `seed.detectedNarrative: ${printableValue(seed?.detectedNarrative ?? null)}`,
+    `seed.primaryAction: ${seed?.primaryAction ?? "Trazer mais contexto antes de transformar o vídeo em pauta."}`,
+    "seed.followUpQuestions:",
+    followUpQuestions,
+    "issues:",
+    issues,
+    `hasRawText: ${result.hasRawText}`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Contexto

PR stacked sobre #807. Adiciona a fase MM11: harness interno/manual para execução real controlada da análise narrativa com Gemini.

## Inclui

- `geminiVideoNarrativeRealRunHarness.ts`
- `geminiVideoNarrativeRealRunHarness.test.ts`
- `scripts/video-narrative-real-run.ts`
- script manual em `package.json`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## Harness criado

Cria um harness manual que monta input por `process.env`, chama o composer existente sob execução explícita, resume `VideoNarrativeAnalysis`, gera `PostCreationVideoSeed` e imprime somente um resumo seguro.

O harness não devolve `rawText`; expõe apenas `hasRawText`.

Também redige API key de issues antes de formatar saída.

Para manter testes isolados do SDK ESM do Gemini, o composer padrão é carregado com import dinâmico apenas no caminho real de execução.

## Script manual

Adicionado:

`video:narrative:real-run`

Motivo: o projeto já possui `tsx` em devDependencies, então foi possível expor um comando manual explícito sem adicionar dependência nova.

## Variáveis documentadas

- `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`
- `GEMINI_API_KEY` ou `GOOGLE_GENAI_API_KEY`
- `VIDEO_NARRATIVE_VIDEO_URI` ou `VIDEO_NARRATIVE_INLINE_BASE64 + VIDEO_NARRATIVE_MIME_TYPE`
- `VIDEO_NARRATIVE_CREATOR_QUESTION`

## Fora de escopo

Não há endpoint, upload real, UI, banco, BoardShell, fetch direto ou rede real em teste.

Não houve alteração de navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

O harness não foi integrado automaticamente ao fluxo real do produto.

Não foi commitada API key, vídeo real ou base64 real.

## QA relatada

- testes MM11/Gemini passaram
- regressões narrativas passaram
- regressões da linha técnica atual passaram
- regressões VU principais passaram
- guardas/previews passaram
- regressões NSE passaram
- regressões Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou
- `npm run build` passou

## Observação

O primeiro build apontou um tipo amplo no reduce de sanitização; foi corrigido com acumulador string e o build passou em seguida. Permanecem apenas warnings preexistentes fora do escopo em brand-report/[slug]/page.tsx e BrandNarrativeMatchesPanel.tsx.

## Status

Draft. Não fazer merge ainda.