### PR TITLE
docs: add Gemini video narrative readiness audit

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -1,0 +1,109 @@
+# Gemini Video Narrative Readiness Audit
+
+## Objetivo
+
+Esta auditoria valida a prontidão técnica da linha Gemini multimodal sem chamada real. O teste real ainda depende de API key com billing/quota disponível, então esta fase confirma apenas contratos, isolamento e guardas antes de qualquer execução externa futura.
+
+## Estado Atual
+
+Já existe:
+
+- `VideoNarrativeAnalysis`;
+- `PostCreationVideoSeed`;
+- mock provider narrativo;
+- preview interno narrativo;
+- prompt/schema Gemini;
+- provider com flag server-side;
+- client factory com `@google/genai`;
+- composer `env/config -> factory -> provider`;
+- harness manual de execução real.
+
+## O Que Ainda Não Foi Validado
+
+- qualidade real da resposta Gemini;
+- latência real;
+- custo real por vídeo;
+- aderência real ao JSON;
+- interpretação real de vídeo curto;
+- comportamento real com vídeo sem contexto.
+
+## Checklist De Segurança
+
+- o provider real é server-side;
+- a flag server-side é obrigatória;
+- o provider real não usa `NEXT_PUBLIC`;
+- a API key vem de env;
+- a API key não é retornada;
+- `rawText` não é exposto no harness;
+- o harness retorna apenas `hasRawText`;
+- sem endpoint público;
+- sem UI pública;
+- sem upload real;
+- sem integração automática no board;
+- sem persistência;
+- sem chamada real em teste automatizado;
+- sem navegação/menu.
+
+## Checklist De Arquitetura
+
+- `VideoNarrativeAnalysis` é o output principal;
+- `VideoProcessingArtifacts` é evidência auxiliar;
+- `PostCreationVideoSeed` é a ponte segura;
+- o provider Gemini é injetável;
+- a factory é isolada;
+- o composer não roda sozinho;
+- o harness é manual;
+- existe fallback;
+- o schema normaliza resposta inválida;
+- o prompt pede JSON válido;
+- a linguagem evita promessa absoluta.
+
+## Riscos Pendentes
+
+- billing/quota não validado;
+- modelo default ainda não validado em execução real;
+- prompt pode precisar de ajuste após resposta real;
+- schema pode precisar tolerar variações;
+- File API/upload ainda não existe;
+- origem real do `videoUri` ainda precisa ser definida;
+- consentimento/retenção ainda não foram implementados;
+- limite por plano ainda não existe;
+- custo real ainda desconhecido.
+
+## Critérios Para Liberar Teste Real Manual
+
+Antes de rodar real:
+
+- API key nova e segura;
+- quota/billing disponível;
+- vídeo curto e não sensível;
+- flag ligada localmente;
+- comando manual com env;
+- não commitar vídeo/base64;
+- não commitar API key;
+- output sanitizado salvo fora do repositório, se necessário.
+
+## Critérios Para Criar Endpoint Interno Depois
+
+Só criar endpoint depois que:
+
+- teste real manual rodar pelo menos 3 vídeos curtos;
+- schema parsear respostas úteis ou ajustes forem feitos;
+- custo/latência forem anotados;
+- fallback for validado;
+- decisão de input de vídeo for tomada: File API, inline ou storage;
+- autenticação admin/dev for definida.
+
+## Decisão Recomendada
+
+Como não há billing agora, seguir sem teste real e avançar apenas em:
+
+- auditoria;
+- docs;
+- preview/fallback;
+- planejamento de endpoint/storage;
+- sem expor para usuário.
+
+## Frase Norte
+
+> O sistema pode estar pronto para testar Gemini real sem ainda estar pronto para lançar vídeo no produto.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -259,6 +259,27 @@ O que não faz:
 - não cria upload real;
 - não integra o harness ao fluxo real do produto.
 
+### MM12 — Auditoria de prontidão sem chamada real
+
+Status: concluído.
+
+Arquivos principais:
+
+- `GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md`
+- `geminiVideoNarrativeReadinessAudit.test.ts`
+
+O que faz:
+
+- consolida a prontidão técnica da linha Gemini sem chamar a API real;
+- verifica guardas, isolamento e pendências antes de qualquer teste externo;
+- registra que a API real só deve ser testada depois de billing/quota disponível.
+
+O que não faz:
+
+- não substitui teste real com vídeo curto;
+- não cria endpoint, upload real ou UI;
+- não integra nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -218,7 +218,9 @@ Exemplos:
 8. MM9 — Factory isolada do cliente Gemini. Concluída como adapter server-side para cliente real, sem integração automática ao fluxo.
 9. MM10 — Composer seguro do provider Gemini. Concluído como composição explícita de config, factory e provider, sem integração automática ao fluxo.
 10. MM11 — Harness interno para execução real controlada. Concluído como teste manual explícito, sem endpoint, UI ou upload real.
-11. Integração experimental futura no Board de Criação.
+11. MM12 — Readiness audit sem chamada real. Concluído como auditoria documental e estática antes de qualquer teste externo.
+12. Teste real manual quando houver quota/billing disponível.
+13. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -239,3 +241,7 @@ Exemplos:
 ## Harness Real Controlado
 
 MM11 adiciona apenas um caminho manual de avaliação para o provider real já composto. Ele continua sem endpoint, sem UI e sem upload real. O objetivo é observar output, latência e issues do parser em ambiente interno antes de qualquer exposição ao fluxo do produto.
+
+## Readiness Audit
+
+MM12 confirma que a linha está preparada para um teste real futuro sem executar rede nesta fase. O próximo passo prático deixa de ser nova implementação e passa a ser um teste manual curto quando houver quota/billing disponível.

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts
@@ -1,0 +1,117 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const ROOT_DIR = process.cwd();
+
+function readVideoUploadFile(fileName: string): string {
+  return fs.readFileSync(path.join(VIDEO_UPLOAD_DIR, fileName), "utf8");
+}
+
+function readRootFile(filePath: string): string {
+  return fs.readFileSync(path.join(ROOT_DIR, filePath), "utf8");
+}
+
+describe("geminiVideoNarrativeReadinessAudit", () => {
+  it("mantém a auditoria documental presente", () => {
+    expect(fs.existsSync(path.join(VIDEO_UPLOAD_DIR, "GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md"))).toBe(true);
+  });
+
+  it("documenta os contratos, guardas e riscos pendentes", () => {
+    const audit = readVideoUploadFile("GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md");
+    const expectedTerms = [
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "flag server-side",
+      "API key",
+      "rawText",
+      "hasRawText",
+      "sem endpoint público",
+      "sem UI pública",
+      "sem upload real",
+      "billing/quota",
+      "custo real",
+      "latência real",
+      "File API",
+      "consentimento",
+      "retenção",
+      "limite por plano",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(audit).toContain(term);
+    });
+  });
+
+  it("mantém a flag real fora de NEXT_PUBLIC", () => {
+    const featureFlag = readVideoUploadFile("geminiVideoNarrativeFeatureFlag.ts");
+    expect(featureFlag).not.toContain("NEXT_PUBLIC");
+  });
+
+  it("mantém o composer lendo somente configuração server-side esperada", () => {
+    const composer = readVideoUploadFile("geminiVideoNarrativeProviderComposer.ts");
+    expect(composer).toContain("GEMINI_API_KEY");
+    expect(composer).toContain("GOOGLE_GENAI_API_KEY");
+    expect(composer).toContain("VIDEO_NARRATIVE_GEMINI_MODEL");
+  });
+
+  it("mantém o harness retornando apenas hasRawText no contrato público", () => {
+    const harness = readVideoUploadFile("geminiVideoNarrativeRealRunHarness.ts");
+    const resultType = harness.match(/export type GeminiVideoNarrativeRealRunResult = \{[\s\S]*?\n\};/)?.[0];
+
+    expect(resultType).toContain("hasRawText: boolean;");
+    expect(resultType).not.toContain("rawText:");
+  });
+
+  it("mantém o script sem segredos ou base64 embutidos", () => {
+    const script = readRootFile("scripts/video-narrative-real-run.ts");
+    expect(script).not.toMatch(/AIza[0-9A-Za-z_-]{20,}/);
+    expect(script).not.toMatch(/[A-Za-z0-9+/]{80,}={0,2}/);
+  });
+
+  it("mantém os novos arquivos livres de integrações proibidas", () => {
+    const sources = [
+      readVideoUploadFile("GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md"),
+      readVideoUploadFile("geminiVideoNarrativeReadinessAudit.test.ts"),
+    ].join("\n");
+    const forbiddenImports = [
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "Prisma",
+      "OpenAI",
+      "fetch",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(sources).not.toContain(`from "${term}`);
+      expect(sources).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("mantém linguagem consultiva na auditoria", () => {
+    const audit = readVideoUploadFile("GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md").toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(audit).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+});


### PR DESCRIPTION
## Contexto

PR stacked sobre #808. Adiciona a fase MM12: auditoria de prontidão da linha Gemini/multimodal sem chamada real.

## Inclui

- `GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md`
- `geminiVideoNarrativeReadinessAudit.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first

## O que foi documentado

A auditoria registra:

- estado atual da linha Gemini/multimodal;
- o que já existe;
- o que ainda não foi validado;
- checklist de segurança;
- checklist de arquitetura;
- riscos pendentes;
- critérios para teste real manual futuro;
- critérios antes de endpoint interno.

## Principais conclusões

A linha está pronta para teste real futuro, mas não para lançamento de produto.

A arquitetura já está protegida por flag server-side, fallback, schema defensivo, composer explícito e harness manual.

O bloqueio atual é operacional, não estrutural: ainda faltam billing/quota, medição real de custo/latência, validação do modelo default e decisão sobre origem real do vídeo.

## Teste estático

O novo teste confirma:

- flag real sem `NEXT_PUBLIC`;
- composer lendo apenas envs esperadas;
- harness expondo `hasRawText`, não `rawText`;
- script sem API key/base64 embutidos;
- ausência de imports proibidos nos novos arquivos;
- linguagem consultiva na auditoria.

## Fora de escopo

Não há endpoint, upload real, UI, banco, BoardShell, fetch ou rede real em teste.

Não houve navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

Não houve chamada Gemini real.

Não houve dependência nova.

## QA relatada

- `geminiVideoNarrativeReadinessAudit.test.ts` passou
- bloco Gemini passou
- regressões narrativas passaram
- regressões principais de video upload passaram
- guard/previews, NSE e Adaptive V2 passaram
- `npm run typecheck` passou
- `git diff --check` passou
- `npm run build` passou

## Status

Draft. Não fazer merge ainda.