### PR TITLE
docs: add video narrative internal endpoint contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -94,6 +94,10 @@ Só criar endpoint depois que:
 - decisão de input de vídeo for tomada: File API, inline ou storage;
 - autenticação admin/dev for definida.
 
+Próximo passo documental:
+
+- revisar `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md` antes de qualquer implementação de rota.
+
 ## Decisão Recomendada
 
 Como não há billing agora, seguir sem teste real e avançar apenas em:

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -280,6 +280,27 @@ O que não faz:
 - não cria endpoint, upload real ou UI;
 - não integra nada ao fluxo real do produto.
 
+### MM13 — Contrato de endpoint interno/admin
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md`
+- `videoNarrativeInternalEndpointContract.test.ts`
+
+O que faz:
+
+- define antes da implementação o futuro endpoint interno/admin;
+- descreve segurança, payload, resposta, status, limites e privacidade;
+- fixa os critérios que precisam existir antes de qualquer rota real.
+
+O que não faz:
+
+- não cria endpoint real;
+- não cria upload real ou UI;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -219,8 +219,9 @@ Exemplos:
 9. MM10 — Composer seguro do provider Gemini. Concluído como composição explícita de config, factory e provider, sem integração automática ao fluxo.
 10. MM11 — Harness interno para execução real controlada. Concluído como teste manual explícito, sem endpoint, UI ou upload real.
 11. MM12 — Readiness audit sem chamada real. Concluído como auditoria documental e estática antes de qualquer teste externo.
-12. Teste real manual quando houver quota/billing disponível.
-13. Integração experimental futura no Board de Criação.
+12. MM13 — Internal endpoint contract. Concluído como contrato interno/admin, ainda sem endpoint real.
+13. Teste real manual quando houver quota/billing disponível.
+14. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -245,3 +246,7 @@ MM11 adiciona apenas um caminho manual de avaliação para o provider real já c
 ## Readiness Audit
 
 MM12 confirma que a linha está preparada para um teste real futuro sem executar rede nesta fase. O próximo passo prático deixa de ser nova implementação e passa a ser um teste manual curto quando houver quota/billing disponível.
+
+## Internal Endpoint Contract
+
+MM13 define o formato futuro de acesso interno/admin, payload, resposta e limites antes de existir qualquer rota real. O contrato preserva a separação entre prontidão técnica e exposição de produto.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -1,0 +1,171 @@
+# Video Narrative Internal Endpoint Contract
+
+## Objetivo
+
+Este documento define o contrato de um futuro endpoint interno/admin para testar análise narrativa de vídeo com segurança, antes de expor qualquer experiência para usuário.
+
+## Escopo
+
+- é contrato, não implementação;
+- sem endpoint real nesta fase;
+- sem UI;
+- sem upload real;
+- sem `BoardShell`;
+- sem `PostCreationFunnelState` real.
+
+## Caminho Futuro Sugerido
+
+Endpoint futuro sugerido:
+
+```text
+POST /api/internal/video-narrative/analyze
+```
+
+Esse caminho ainda não será criado nesta fase.
+
+## Acesso
+
+- apenas admin/dev;
+- sessão obrigatória;
+- helper recomendado: `canAccessInternalPreview` ou equivalente server-side;
+- flag server-side obrigatória: `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`;
+- nunca usar `NEXT_PUBLIC` para habilitar custo real;
+- bloquear qualquer usuário comum.
+
+## Payload Futuro
+
+```json
+{
+  "id": "manual-video-narrative-run",
+  "creatorQuestion": "Quero saber se vale postar",
+  "videoUri": "file-or-gcs-uri",
+  "inlineVideoBase64": null,
+  "mimeType": "video/mp4",
+  "creatorContext": {
+    "handle": "...",
+    "niche": "...",
+    "knownNarratives": []
+  }
+}
+```
+
+Regras:
+
+- precisa ter `videoUri` ou `inlineVideoBase64` + `mimeType`;
+- `creatorQuestion` é recomendado;
+- inline base64 só para testes pequenos/controlados;
+- `videoUri`/File API/storage é preferível para fluxo futuro;
+- não aceitar arquivo multipart neste contrato inicial;
+- não aceitar input livre sem limites;
+- não aceitar usuário comum.
+
+## Resposta Futura
+
+```json
+{
+  "ok": true,
+  "status": "ready",
+  "analysis": {},
+  "seed": {},
+  "primaryAction": "...",
+  "issues": [],
+  "hasRawText": true
+}
+```
+
+Regras:
+
+- nunca retornar `rawText` completo;
+- retornar apenas `hasRawText`;
+- nunca retornar API key;
+- `analysis` deve ser `VideoNarrativeAnalysis`;
+- `seed` deve ser `PostCreationVideoSeed`;
+- `issues` devem ser sanitizadas;
+- fallback deve retornar `ok false` com analysis segura.
+
+## Status Futuros
+
+- `disabled`;
+- `missing_api_key`;
+- `missing_client`;
+- `missing_video`;
+- `invalid_payload`;
+- `ready`;
+- `failed`;
+- `insufficient_context`;
+- `blocked_unauthorized`;
+- `blocked_forbidden`;
+- `usage_limited`.
+
+## Validações Futuras
+
+- método `POST`;
+- `content-type` JSON;
+- tamanho máximo de payload;
+- `mimeType` permitido;
+- duração máxima futura;
+- `videoUri` obrigatório ou inline completo;
+- `creatorQuestion` com limite de caracteres;
+- `creatorContext` limitado;
+- sem `rawText` no response;
+- sem persistência automática.
+
+## Limites Iniciais Recomendados
+
+- vídeo até 60s;
+- tamanho até 100MB quando houver upload real;
+- `inlineVideoBase64` apenas para teste pequeno;
+- timeout server-side;
+- 1 análise por vez;
+- beta/admin sem limite comercial ainda;
+- futuro plano: 5 análises/mês em beta.
+
+## Segurança E Privacidade
+
+- não salvar vídeo automaticamente;
+- não persistir sinais no perfil sem decisão posterior;
+- não expor `rawText`;
+- não logar API key;
+- não logar base64;
+- não logar vídeo;
+- redigir issues;
+- expiração futura do arquivo;
+- consentimento obrigatório antes de beta.
+
+## Custo
+
+- endpoint deve existir só atrás de flag server-side;
+- custo real ainda não medido;
+- não liberar sem quota/billing conhecido;
+- registrar latência/custo futuramente;
+- feature flag deve permitir desligamento rápido.
+
+## Relação Com Código Atual
+
+- `runGeminiVideoNarrativeProviderFromEnv`;
+- `createGeminiVideoNarrativeClient`;
+- `parseGeminiVideoNarrativeJson`;
+- `VideoNarrativeAnalysis`;
+- `buildPostCreationVideoSeedFromAnalysis`;
+- `getPostCreationVideoSeedPrimaryAction`;
+- real run harness atual.
+
+## Critérios Antes De Implementar Endpoint Real
+
+Só implementar depois que:
+
+- houver API key nova e segura;
+- houver billing/quota;
+- harness manual rodar pelo menos 3 vídeos curtos;
+- prompt/schema forem ajustados se necessário;
+- decisão de input de vídeo for tomada;
+- admin guard server-side estiver definido;
+- rate limit/usage limit tiver contrato;
+- consentimento/retenção estiverem planejados.
+
+## Próximas Fases Possíveis
+
+- MM14: contrato de upload/File API;
+- MM15: endpoint interno real, se billing existir;
+- MM16: preview interno com chamada real;
+- MM17: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts
@@ -1,0 +1,116 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md");
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+describe("videoNarrativeInternalEndpointContract", () => {
+  it("mantém o contrato documental presente", () => {
+    expect(fs.existsSync(CONTRACT_PATH)).toBe(true);
+  });
+
+  it("documenta acesso, payload, resposta, custo e limites", () => {
+    const contract = readContract();
+    const expectedTerms = [
+      "POST /api/internal/video-narrative/analyze",
+      "admin/dev",
+      "sessão",
+      "server-side",
+      "VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED",
+      "nunca usar `NEXT_PUBLIC`",
+      "videoUri",
+      "inlineVideoBase64",
+      "mimeType",
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "hasRawText",
+      "nunca retornar `rawText` completo",
+      "API key",
+      "consentimento",
+      "retenção",
+      "custo",
+      "quota",
+      "limite",
+      "5 análises/mês",
+      "60s",
+      "100MB",
+      "sem upload real",
+      "sem UI",
+      "sem endpoint real nesta fase",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(contract).toContain(term);
+    });
+  });
+
+  it("não inclui implementação real, credencial ou payload bruto extenso", () => {
+    const contract = readContract();
+    expect(contract).not.toContain("route.ts");
+    expect(contract).not.toMatch(/AIza[0-9A-Za-z_-]{20,}/);
+    expect(contract).not.toMatch(/[A-Za-z0-9+/]{120,}={0,2}/);
+    expect(contract).not.toContain("usuário comum pode");
+    expect(contract.toLowerCase()).not.toContain("promessa de performance");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+
+  it("mantém linguagem consultiva no documento", () => {
+    const contract = readContract().toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(contract).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém os novos arquivos sem imports proibidos", () => {
+    const testSource = fs.readFileSync(__filename, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "component",
+      "hook",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "UI",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(testSource).not.toContain(`from "${term}`);
+      expect(testSource).not.toContain(`from '${term}`);
+    });
+  });
+});


### PR DESCRIPTION
## Contexto

PR stacked sobre #809. Adiciona a fase MM13: contrato documental/testável do futuro endpoint interno/admin para análise narrativa de vídeo.

## Inclui

- `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md`
- `videoNarrativeInternalEndpointContract.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first
- atualização da readiness audit

## Contrato criado

Define, sem implementar, o futuro endpoint interno/admin:

`POST /api/internal/video-narrative/analyze`

O contrato cobre:

- acesso apenas para admin/dev com sessão obrigatória;
- flag server-side `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED=true`;
- payload conceitual com `videoUri` ou `inlineVideoBase64 + mimeType`;
- resposta com `VideoNarrativeAnalysis`, `PostCreationVideoSeed`, `primaryAction`, `issues` e apenas `hasRawText`;
- status futuros;
- validações;
- limites;
- privacidade;
- custo;
- vínculos com o código atual;
- critérios antes de implementar a rota real.

## Decisões documentadas

- contrato antes de implementação;
- nada de `rawText` completo no response;
- nada de API key no response/log;
- sem multipart no contrato inicial;
- `videoUri`/File API/storage como caminho futuro preferível;
- limites iniciais sugeridos: até 60s, até 100MB, beta futuro com 5 análises/mês;
- endpoint real só depois de teste manual com billing/quota, decisão de input, admin guard, rate limit e consentimento/retenção definidos.

## Fora de escopo

Não há endpoint real, `route.ts`, upload real, UI real, banco, BoardShell, fetch ou rede real em teste.

Não houve alteração de navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

Não houve chamada Gemini real.

Nenhum arquivo em `app/api/**` foi criado para esta fase.

## QA relatada

- teste novo MM13 passou
- bloco Gemini completo passou
- regressões narrativas passaram
- regressões principais de videoUpload passaram
- guards/previews passaram
- NSE passou
- Adaptive V2 passou
- `npm run typecheck` passou
- `git diff --check` passou
- `npm run build` passou

## Status

Draft. Não fazer merge ainda.