### PR TITLE
docs: add video narrative input source contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -97,6 +97,7 @@ Só criar endpoint depois que:
 Próximo passo documental:
 
 - revisar `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md` antes de qualquer implementação de rota.
+- revisar `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md` antes de qualquer implementação de upload real.
 
 ## Decisão Recomendada
 
@@ -106,6 +107,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - docs;
 - preview/fallback;
 - planejamento de endpoint/storage;
+- contrato formal de origem do vídeo;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -301,6 +301,26 @@ O que não faz:
 - não cria upload real ou UI;
 - não conecta nada ao fluxo real do produto.
 
+### MM14 — Contrato de origem do vídeo
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`
+- `videoNarrativeInputSourceContract.test.ts`
+
+O que faz:
+
+- compara Gemini File API, inline base64, storage temporário próprio, GCS/S3/R2 e URL pública restrita;
+- define recomendação por fase para teste manual, endpoint interno/admin e beta/produto;
+- separa a decisão de origem do vídeo de qualquer implementação de upload real.
+
+O que não faz:
+
+- não cria endpoint, upload real, storage real ou UI;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -220,6 +220,7 @@ Exemplos:
 10. MM11 — Harness interno para execução real controlada. Concluído como teste manual explícito, sem endpoint, UI ou upload real.
 11. MM12 — Readiness audit sem chamada real. Concluído como auditoria documental e estática antes de qualquer teste externo.
 12. MM13 — Internal endpoint contract. Concluído como contrato interno/admin, ainda sem endpoint real.
+13. MM14 — Input source contract. Define a origem futura do vídeo por fase, ainda sem upload ou storage real.
 13. Teste real manual quando houver quota/billing disponível.
 14. Integração experimental futura no Board de Criação.
 
@@ -250,3 +251,5 @@ MM12 confirma que a linha está preparada para um teste real futuro sem executar
 ## Internal Endpoint Contract
 
 MM13 define o formato futuro de acesso interno/admin, payload, resposta e limites antes de existir qualquer rota real. O contrato preserva a separação entre prontidão técnica e exposição de produto.
+
+MM14 separa a decisão de origem do vídeo da implementação de upload. Ele recomenda File API ou inline pequeno para teste manual, `videoUri` primeiro no endpoint interno e storage temporário próprio para beta/produto.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
@@ -1,0 +1,201 @@
+# Video Narrative Input Source Contract
+
+## Objetivo
+
+Este documento define como o vídeo poderá chegar ao futuro endpoint interno/admin de análise narrativa antes de qualquer upload real.
+
+## Escopo
+
+- é contrato, não implementação;
+- não existe upload real nesta fase;
+- não existe endpoint real nesta fase;
+- não existe storage real nesta fase;
+- não existe UI nesta fase.
+
+## Problema
+
+O futuro endpoint precisa receber uma referência segura ao vídeo, mas há caminhos diferentes:
+
+- `videoUri` vindo da Gemini File API;
+- `inlineVideoBase64` para testes pequenos;
+- storage temporário próprio;
+- GCS/S3/R2;
+- URL pública restrita.
+
+## Comparação De Opções
+
+### Opção A — Gemini File API
+
+Um arquivo local/admin é enviado para a Gemini File API, a Gemini retorna `file.uri`, e o endpoint recebe `videoUri`.
+
+Prós:
+
+- alinhado ao SDK Gemini;
+- melhor para arquivos maiores que inline;
+- bom para harness/admin.
+
+Contras:
+
+- acopla a origem ao provider;
+- não resolve storage próprio do produto;
+- depende de billing/quota;
+- precisa decidir retenção, limpeza e expiração conforme a política do provider.
+
+### Opção B — inlineVideoBase64
+
+Um vídeo pequeno é convertido para base64, e o endpoint recebe `inlineVideoBase64` + `mimeType`.
+
+Prós:
+
+- simples;
+- sem storage;
+- bom para vídeos muito curtos.
+
+Contras:
+
+- payload grande;
+- risco de log acidental;
+- ruim para UX;
+- não serve como fluxo principal.
+
+### Opção C — Storage Temporário Próprio
+
+A D2C recebe o upload, salva temporariamente em um storage escolhido, gera URI ou signed URL, e o endpoint usa esse input.
+
+Prós:
+
+- controle de retenção;
+- controle de expiração;
+- melhor para UX futura;
+- permite auditoria e limites.
+
+Contras:
+
+- exige provider de storage;
+- exige upload real;
+- exige cleanup;
+- exige consentimento;
+- exige mais segurança.
+
+### Opção D — GCS/S3/R2
+
+São variações possíveis de storage temporário próprio:
+
+- GCS pode conversar melhor com o ecossistema Google;
+- S3/R2 podem ser adequados por custo e ecossistema;
+- a decisão depende da infraestrutura real do projeto.
+
+### Opção E — URL Pública Restrita
+
+Pode servir apenas para testes muito controlados. Não é recomendada para produto por risco de privacidade, disponibilidade e expiração.
+
+## Recomendação Inicial
+
+### Fase De Teste Real Manual
+
+- usar Gemini File API ou inline base64 pequeno;
+- não commitar vídeo;
+- não commitar API key.
+
+### Fase De Endpoint Interno/Admin
+
+- aceitar `videoUri` primeiro;
+- manter inline base64 apenas como fallback controlado.
+
+### Fase De Beta/Produto
+
+- usar storage temporário próprio ou provider escolhido;
+- nunca depender de base64 como fluxo principal;
+- a File API pode existir como etapa intermediária/admin, mas não precisa ser a origem de produto.
+
+## Contrato De Input Recomendado Para O Endpoint Futuro
+
+```json
+{
+  "id": "manual-video-narrative-run",
+  "creatorQuestion": "Quero saber se vale postar",
+  "videoUri": "file-or-storage-uri",
+  "inlineVideoBase64": null,
+  "mimeType": "video/mp4",
+  "source": "gemini_file_api | inline_base64 | temporary_storage | gcs | s3 | r2 | public_url_restricted",
+  "creatorContext": {
+    "handle": "...",
+    "niche": "...",
+    "knownNarratives": []
+  }
+}
+```
+
+## Validações Recomendadas
+
+- exigir `videoUri` ou `inlineVideoBase64` + `mimeType`;
+- bloquear payload sem vídeo;
+- limitar `creatorQuestion`;
+- limitar `knownNarratives`;
+- permitir apenas `mimeType` aceito;
+- bloquear base64 acima de limite pequeno;
+- exigir `source`;
+- rejeitar URL pública em beta/produto, exceto se explicitamente permitido;
+- nunca logar base64;
+- nunca retornar raw video data.
+
+## Limites Iniciais
+
+- vídeo até 60s;
+- até 100MB quando houver upload/storage;
+- inline base64 apenas para teste pequeno;
+- 1 vídeo por análise;
+- 1 análise por execução interna;
+- beta futuro com 5 análises/mês;
+- timeout server-side;
+- expiração obrigatória para storage temporário.
+
+## Privacidade E Segurança
+
+- não salvar vídeo permanentemente;
+- não persistir sinais no perfil sem decisão posterior;
+- consentimento antes de beta;
+- retenção documentada;
+- cleanup obrigatório;
+- logs sem vídeo/base64/API key;
+- resposta sem `rawText` completo;
+- apenas `hasRawText`.
+
+## Relação Com Contratos Existentes
+
+- `VideoUploadDraft`;
+- `VideoUploadSession`;
+- `VideoTemporaryStorageObject`;
+- `VideoStorageRetention`;
+- real run harness Gemini;
+- contrato de endpoint interno/admin;
+- `VideoNarrativeAnalysis`.
+
+## Critérios Antes De Implementar Upload Real
+
+- escolher provider de storage;
+- definir política de retenção;
+- definir consentimento;
+- definir limites por plano;
+- definir cleanup;
+- definir quem pode acessar;
+- validar Gemini real com 3 vídeos curtos;
+- medir latência/custo;
+- decidir se a File API entra como etapa intermediária.
+
+## Decisão Recomendada Agora
+
+Como ainda não há billing/quota:
+
+- não implementar upload real;
+- manter inline/base64 apenas como caminho manual teórico;
+- documentar File API como candidata para teste real;
+- preparar o contrato para `videoUri`;
+- só implementar storage quando houver integração real com produto.
+
+## Próximas Fases Possíveis
+
+- MM15: contrato de consentimento/retenção;
+- MM16: contrato de limites/custos;
+- MM17: endpoint interno real, somente se billing existir;
+- MM18: upload/storage real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -55,6 +55,7 @@ Regras:
 - `creatorQuestion` é recomendado;
 - inline base64 só para testes pequenos/controlados;
 - `videoUri`/File API/storage é preferível para fluxo futuro;
+- a decisão detalhada de origem do vídeo fica no contrato `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`;
 - não aceitar arquivo multipart neste contrato inicial;
 - não aceitar input livre sem limites;
 - não aceitar usuário comum.
@@ -165,7 +166,7 @@ Só implementar depois que:
 
 ## Próximas Fases Possíveis
 
-- MM14: contrato de upload/File API;
+- MM14: contrato de origem do vídeo;
 - MM15: endpoint interno real, se billing existir;
 - MM16: preview interno com chamada real;
 - MM17: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts
@@ -1,0 +1,118 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md");
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+describe("videoNarrativeInputSourceContract", () => {
+  it("mantém o contrato documental presente", () => {
+    expect(fs.existsSync(CONTRACT_PATH)).toBe(true);
+  });
+
+  it("documenta fontes, limites, privacidade e contratos relacionados", () => {
+    const contract = readContract();
+    const expectedTerms = [
+      "Gemini File API",
+      "inlineVideoBase64",
+      "mimeType",
+      "videoUri",
+      "storage temporário próprio",
+      "GCS",
+      "S3",
+      "R2",
+      "URL Pública Restrita",
+      "60s",
+      "100MB",
+      "5 análises/mês",
+      "consentimento",
+      "retenção",
+      "cleanup",
+      "hasRawText",
+      "resposta sem `rawText` completo",
+      "nunca logar base64",
+      "não commitar vídeo",
+      "não commitar API key",
+      "VideoUploadDraft",
+      "VideoUploadSession",
+      "VideoTemporaryStorageObject",
+      "VideoNarrativeAnalysis",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(contract).toContain(term);
+    });
+  });
+
+  it("recomenda uma origem diferente por fase", () => {
+    const contract = readContract();
+    expect(contract).toContain("usar Gemini File API ou inline base64 pequeno");
+    expect(contract).toContain("aceitar `videoUri` primeiro");
+    expect(contract).toContain("usar storage temporário próprio ou provider escolhido");
+    expect(contract).toContain("nunca depender de base64 como fluxo principal");
+  });
+
+  it("não inclui instrução de implementação de rota", () => {
+    expect(readContract()).not.toContain("route.ts");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+
+  it("mantém linguagem consultiva no documento", () => {
+    const contract = readContract().toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(contract).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém os novos arquivos sem imports proibidos", () => {
+    const testSource = fs.readFileSync(__filename, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "component",
+      "hook",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "UI",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(testSource).not.toContain(`from "${term}`);
+      expect(testSource).not.toContain(`from '${term}`);
+    });
+  });
+});


### PR DESCRIPTION
## Contexto

PR stacked sobre #810. Adiciona a fase MM14: contrato documental/testável da origem do vídeo para análise narrativa.

## Inclui

- `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`
- `videoNarrativeInputSourceContract.test.ts`
- atualização do README de `videoUpload`
- atualização da arquitetura multimodal-first
- atualização do contrato de endpoint interno
- atualização da readiness audit

## Contrato criado

O documento separa a decisão de entrada do vídeo da futura implementação de upload.

Compara:

- Gemini File API;
- inline base64 pequeno;
- storage temporário próprio;
- GCS/S3/R2;
- URL pública restrita.

Também formaliza validações, limites, privacidade, relação com os contratos já existentes e critérios antes de qualquer upload real.

## Recomendação por fase

- Teste manual real: Gemini File API ou inline pequeno.
- Endpoint interno/admin: `videoUri` primeiro, inline apenas como fallback controlado.
- Beta/produto: storage temporário próprio ou provider escolhido.
- Base64 não deve virar fluxo principal.

## Fora de escopo

Não há endpoint, `route.ts`, upload real, UI, banco, BoardShell, fetch ou rede real em teste.

Não houve alteração de navegação/menu real.

O `PostCreationFunnelState` real não foi alterado.

Não houve chamada Gemini real.

## QA relatada

- teste novo MM14 passou
- teste MM13 passou
- bloco Gemini/docs completo passou
- regressões narrativas passaram
- regressões principais de videoUpload passaram
- guards/previews passaram
- NSE passou
- Adaptive V2 passou
- `npm run typecheck` passou
- `git diff --check` passou
- `npm run build` passou

## Status

Draft. Não fazer merge ainda.