### PR TITLE
docs: add video narrative consent retention contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -66,7 +66,7 @@ Já existe:
 - schema pode precisar tolerar variações;
 - File API/upload ainda não existe;
 - origem real do `videoUri` ainda precisa ser definida;
-- consentimento/retenção ainda não foram implementados;
+- consentimento/retenção foram formalizados em MM15, mas ainda não foram implementados;
 - limite por plano ainda não existe;
 - custo real ainda desconhecido.
 
@@ -108,6 +108,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - preview/fallback;
 - planejamento de endpoint/storage;
 - contrato formal de origem do vídeo;
+- contrato formal de consentimento/retenção;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -321,6 +321,27 @@ O que não faz:
 - não cria endpoint, upload real, storage real ou UI;
 - não conecta nada ao fluxo real do produto.
 
+### MM15 — Contrato de consentimento e retenção
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md`
+- `videoNarrativeConsentRetentionContract.test.ts`
+
+O que faz:
+
+- define consentimento, retenção, privacidade, logs, expiração e uso de sinais narrativos antes de qualquer beta;
+- trata vídeo como dado temporário de análise, não como ativo permanente da conta;
+- formaliza que `profileSignals` não devem ser persistidos automaticamente no perfil.
+
+O que não faz:
+
+- não cria implementação real;
+- não cria endpoint, upload real, storage real, UI ou rota;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -221,8 +221,9 @@ Exemplos:
 11. MM12 — Readiness audit sem chamada real. Concluído como auditoria documental e estática antes de qualquer teste externo.
 12. MM13 — Internal endpoint contract. Concluído como contrato interno/admin, ainda sem endpoint real.
 13. MM14 — Input source contract. Define a origem futura do vídeo por fase, ainda sem upload ou storage real.
-13. Teste real manual quando houver quota/billing disponível.
-14. Integração experimental futura no Board de Criação.
+14. MM15 — Consent and retention contract. Define consentimento, retenção, expiração e uso de sinais antes de upload real ou beta.
+15. Teste real manual quando houver quota/billing disponível.
+16. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -253,3 +254,5 @@ MM12 confirma que a linha está preparada para um teste real futuro sem executar
 MM13 define o formato futuro de acesso interno/admin, payload, resposta e limites antes de existir qualquer rota real. O contrato preserva a separação entre prontidão técnica e exposição de produto.
 
 MM14 separa a decisão de origem do vídeo da implementação de upload. Ele recomenda File API ou inline pequeno para teste manual, `videoUri` primeiro no endpoint interno e storage temporário próprio para beta/produto.
+
+MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
@@ -1,0 +1,166 @@
+# Video Narrative Consent and Retention Contract
+
+## Objetivo
+
+Este documento define regras de consentimento, retenção e privacidade para a futura análise narrativa de vídeo, antes de qualquer experiência real com usuário.
+
+Ele existe para deixar claras as decisões mínimas de segurança, expiração, logs e uso de sinais narrativos antes de qualquer upload real, endpoint real ou storage real.
+
+## Escopo
+
+- é contrato, não implementação;
+- não existe upload real nesta fase;
+- não existe endpoint real nesta fase;
+- não existe UI nesta fase;
+- não existe storage real nesta fase.
+
+## Princípio Central
+
+O vídeo deve ser tratado como dado temporário de análise, não como ativo permanente da conta.
+
+## O Que O Usuário Deve Consentir No Futuro
+
+Antes de enviar um vídeo para análise narrativa, o usuário precisa entender:
+
+- que o vídeo será enviado para análise por IA;
+- que o vídeo pode conter imagem, voz, rosto, ambiente, texto na tela e dados pessoais;
+- que a análise retorna diagnóstico narrativo, blueprint e possíveis sinais estratégicos;
+- que o arquivo de vídeo não deve ser salvo permanentemente por padrão;
+- que sinais narrativos só devem alimentar perfil/conta se houver regra clara;
+- que a análise pode falhar ou pedir mais contexto;
+- que o vídeo deve ser dele ou autorizado.
+
+## Texto Conceitual De Consentimento Futuro
+
+Texto curto em português para uso futuro em uma interface de consentimento:
+
+> Ao enviar este vídeo, você autoriza a D2C a analisá-lo com IA para gerar uma leitura narrativa, sugestões de pauta e direção de roteiro. O vídeo será tratado como arquivo temporário de análise. A D2C não deve salvar o arquivo permanentemente sem uma regra clara de retenção. Evite enviar vídeos com dados sensíveis ou pessoas que não autorizaram o uso.
+
+## Retenção Recomendada Por Fase
+
+### Fase Admin/Manual
+
+- não salvar vídeo no produto;
+- usar apenas URI/payload temporário;
+- não registrar base64;
+- não registrar rawText completo;
+- output pode ser salvo manualmente fora do repo apenas se sanitizado.
+
+### Fase Endpoint Interno
+
+- vídeo temporário;
+- expiração curta;
+- logs sem vídeo/base64/API key;
+- guardar apenas status, issues seguras e timestamps se necessário.
+
+### Fase Beta
+
+- retenção máxima sugerida: 24h a 72h para arquivo de vídeo;
+- análise textual pode ficar associada à sessão/board se o usuário confirmar;
+- sinais narrativos não devem ser persistidos automaticamente sem decisão de produto.
+
+### Fase Produto
+
+- política explícita de retenção;
+- exclusão/expiração documentada;
+- opção de apagar análise/vídeo;
+- logs auditáveis sem conteúdo sensível.
+
+## Dados Que Não Devem Ser Salvos Por Padrão
+
+- vídeo bruto;
+- base64;
+- rawText completo do provider;
+- API key;
+- arquivos temporários após expiração;
+- sinais narrativos permanentes sem consentimento específico;
+- rostos/voz como atributos biométricos.
+
+O rawText completo não deve ser retornado/salvo por padrão.
+
+## Dados Que Podem Ser Salvos Com Cuidado
+
+- status da análise;
+- createdAt;
+- expiresAt;
+- provider status;
+- issues sanitizadas;
+- `VideoNarrativeAnalysis` sanitizado;
+- `PostCreationVideoSeed`;
+- decisão do usuário de transformar em pauta/roteiro;
+- sinais narrativos somente se houver regra futura.
+
+## Sinais Narrativos E Perfil Do Usuário
+
+`VideoNarrativeAnalysis` pode gerar `profileSignals` para indicar aprendizados úteis sobre narrativa, formato, tom, marca, pauta ou direção de roteiro.
+
+Esses `profileSignals` não devem ser automaticamente persistidos no perfil do usuário.
+
+No futuro, pode haver uma confirmação explícita como:
+
+> Usar esse aprendizado para melhorar minhas próximas sugestões.
+
+Até lá, sinais narrativos devem ficar no contexto da análise/sessão e não devem alimentar perfil/conta de forma automática.
+
+## Remoção E Expiração
+
+Requisitos futuros:
+
+- todo arquivo temporário deve ter `expiresAt`;
+- cleanup deve ser idempotente;
+- falha de cleanup deve ser auditável;
+- usuário/admin deve poder ver status de expiração em beta/produto;
+- arquivos expirados não devem ser usados para nova análise.
+
+## Logs
+
+Regras para logs:
+
+- não logar vídeo;
+- não logar base64;
+- não logar API key;
+- não logar rawText completo;
+- logs podem conter ids, status, duração, tamanho, provider status, timestamps e issues seguras;
+- logs de custo/latência devem ser agregados quando possível.
+
+## Relação Com Contratos Existentes
+
+Este contrato depende e complementa:
+
+- `VideoTemporaryStorageObject`;
+- `VideoStorageRetention`;
+- `VideoUploadSession`;
+- `VideoNarrativeInputSourceContract`;
+- `VideoNarrativeInternalEndpointContract`;
+- `VideoNarrativeAnalysis`;
+- `PostCreationVideoSeed`.
+
+## Critérios Antes De Beta
+
+Antes de qualquer beta com usuário real:
+
+- consentimento aprovado;
+- retenção definida;
+- cleanup implementado;
+- limite por plano definido;
+- storage definido;
+- endpoint interno testado;
+- Gemini real testado com vídeos curtos;
+- UI deixando claro que é análise temporária;
+- opção de não persistir sinais no perfil.
+
+## Decisão Recomendada Agora
+
+Como não há billing/quota e ainda não há upload real:
+
+- não implementar consentimento em UI ainda;
+- não implementar retenção real ainda;
+- documentar contrato;
+- usar o contrato como bloqueio antes de qualquer beta.
+
+## Próximas Fases Possíveis
+
+- MM16: contrato de custo/limites de uso;
+- MM17: contrato de cleanup/storage retention real;
+- MM18: endpoint interno real, somente depois de billing;
+- MM19: UI copy de consentimento, antes de beta.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
@@ -156,6 +156,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - não persistir sinais no perfil sem decisão posterior;
 - consentimento antes de beta;
 - retenção documentada;
+- seguir `VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md` antes de qualquer upload real;
 - cleanup obrigatório;
 - logs sem vídeo/base64/API key;
 - resposta sem `rawText` completo;
@@ -167,6 +168,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - `VideoUploadSession`;
 - `VideoTemporaryStorageObject`;
 - `VideoStorageRetention`;
+- contrato de consentimento/retenção;
 - real run harness Gemini;
 - contrato de endpoint interno/admin;
 - `VideoNarrativeAnalysis`.
@@ -176,6 +178,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - escolher provider de storage;
 - definir política de retenção;
 - definir consentimento;
+- aprovar o contrato de consentimento/retenção;
 - definir limites por plano;
 - definir cleanup;
 - definir quem pode acessar;

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -56,6 +56,7 @@ Regras:
 - inline base64 só para testes pequenos/controlados;
 - `videoUri`/File API/storage é preferível para fluxo futuro;
 - a decisão detalhada de origem do vídeo fica no contrato `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`;
+- consentimento e retenção ficam no contrato `VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md`;
 - não aceitar arquivo multipart neste contrato inicial;
 - não aceitar input livre sem limites;
 - não aceitar usuário comum.
@@ -131,6 +132,7 @@ Regras:
 - não logar vídeo;
 - redigir issues;
 - expiração futura do arquivo;
+- seguir o contrato de consentimento/retenção antes de endpoint real ou beta;
 - consentimento obrigatório antes de beta.
 
 ## Custo
@@ -160,6 +162,7 @@ Só implementar depois que:
 - harness manual rodar pelo menos 3 vídeos curtos;
 - prompt/schema forem ajustados se necessário;
 - decisão de input de vídeo for tomada;
+- contrato de consentimento/retenção estiver aprovado como bloqueio antes de endpoint real ou beta;
 - admin guard server-side estiver definido;
 - rate limit/usage limit tiver contrato;
 - consentimento/retenção estiverem planejados.
@@ -167,6 +170,8 @@ Só implementar depois que:
 ## Próximas Fases Possíveis
 
 - MM14: contrato de origem do vídeo;
-- MM15: endpoint interno real, se billing existir;
-- MM16: preview interno com chamada real;
-- MM17: integração experimental no board.
+- MM15: contrato de consentimento/retenção;
+- MM16: contrato de limites/custos;
+- MM17: endpoint interno real, se billing existir;
+- MM18: preview interno com chamada real;
+- MM19: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts
@@ -1,0 +1,136 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md");
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+describe("videoNarrativeConsentRetentionContract", () => {
+  it("mantém o contrato documental presente", () => {
+    expect(fs.existsSync(CONTRACT_PATH)).toBe(true);
+  });
+
+  it("documenta consentimento, retenção, privacidade e contratos relacionados", () => {
+    const contract = readContract();
+    const expectedTerms = [
+      "consentimento",
+      "retenção",
+      "privacidade",
+      "vídeo temporário",
+      "IA",
+      "voz",
+      "rosto",
+      "texto na tela",
+      "dados pessoais",
+      "não deve ser salvo permanentemente",
+      "profileSignals",
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "VideoTemporaryStorageObject",
+      "VideoStorageRetention",
+      "VideoUploadSession",
+      "expiresAt",
+      "cleanup",
+      "logs",
+      "API key",
+      "base64",
+      "rawText",
+      "24h",
+      "72h",
+      "limite por plano",
+      "beta",
+      "apagar análise/vídeo",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(contract).toContain(term);
+    });
+  });
+
+  it("mantém o princípio central de dado temporário", () => {
+    expect(readContract()).toContain(
+      "O vídeo deve ser tratado como dado temporário de análise, não como ativo permanente da conta.",
+    );
+  });
+
+  it("inclui texto conceitual de consentimento futuro em português", () => {
+    const contract = readContract();
+
+    expect(contract).toContain("Ao enviar este vídeo, você autoriza a D2C");
+    expect(contract).toContain("analisá-lo com IA");
+    expect(contract).toContain("arquivo temporário de análise");
+    expect(contract).toContain("Evite enviar vídeos com dados sensíveis");
+  });
+
+  it("bloqueia persistência automática de profileSignals", () => {
+    expect(readContract()).toContain(
+      "Esses `profileSignals` não devem ser automaticamente persistidos no perfil do usuário.",
+    );
+  });
+
+  it("bloqueia retorno ou salvamento padrão de rawText completo", () => {
+    expect(readContract()).toContain("O rawText completo não deve ser retornado/salvo por padrão.");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+
+  it("mantém linguagem consultiva no documento", () => {
+    const contract = readContract().toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(contract).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém os novos arquivos sem imports proibidos", () => {
+    const testSource = fs.readFileSync(__filename, "utf8");
+    const contract = readContract();
+    const combinedSource = `${testSource}\n${contract}`;
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "UI",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(combinedSource).not.toContain(`from "${term}`);
+      expect(combinedSource).not.toContain(`from '${term}`);
+    });
+  });
+});


### PR DESCRIPTION
Stacked sobre #811. Base: `feat/video-narrative-input-source-contract`.

## Summary
- Adds MM15 documentation for video narrative consent, retention, privacy, logs, cleanup, expiration, and profile signal handling.
- Adds a static contract test that verifies required terms, safe language, route absence, and forbidden integration imports.
- Updates the video upload README, multimodal architecture, input source contract, internal endpoint contract, and readiness audit to reference MM15 as a blocker before beta/real implementation.

## Non-goals
- No real endpoint or `route.ts`.
- No real upload, storage, UI, BoardShell connection, PostCreationFunnelState change, fetch, Gemini call, database, cron/job, or new dependency.

## Validation
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath src/app/api/brand-narratives/reports/[slug]/route.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`