### PR TITLE
docs: add video narrative usage limits cost contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -67,7 +67,8 @@ Já existe:
 - File API/upload ainda não existe;
 - origem real do `videoUri` ainda precisa ser definida;
 - consentimento/retenção foram formalizados em MM15, mas ainda não foram implementados;
-- limite por plano ainda não existe;
+- limites/custo foram formalizados em MM16, mas ainda não foram implementados;
+- limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
 ## Critérios Para Liberar Teste Real Manual
@@ -109,6 +110,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - planejamento de endpoint/storage;
 - contrato formal de origem do vídeo;
 - contrato formal de consentimento/retenção;
+- contrato formal de limites/custo;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -342,6 +342,28 @@ O que não faz:
 - não cria endpoint, upload real, storage real, UI ou rota;
 - não conecta nada ao fluxo real do produto.
 
+### MM16 — Contrato de limites e custo
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md`
+- `videoNarrativeUsageLimitsCostContract.test.ts`
+
+O que faz:
+
+- define limites, custo, quota, retry, cooldown, rate limit e regras comerciais futuras;
+- registra 5 análises/mês como hipótese de beta, não promessa pública;
+- condiciona 10 análises/mês à medição de custo real.
+
+O que não faz:
+
+- não cria billing real;
+- não cria cobrança;
+- não cria endpoint, upload real, storage real, UI ou rota;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -222,8 +222,9 @@ Exemplos:
 12. MM13 — Internal endpoint contract. Concluído como contrato interno/admin, ainda sem endpoint real.
 13. MM14 — Input source contract. Define a origem futura do vídeo por fase, ainda sem upload ou storage real.
 14. MM15 — Consent and retention contract. Define consentimento, retenção, expiração e uso de sinais antes de upload real ou beta.
-15. Teste real manual quando houver quota/billing disponível.
-16. Integração experimental futura no Board de Criação.
+15. MM16 — Usage limits and cost contract. Define limite, quota, custo, retry, cooldown e regras comerciais futuras.
+16. Teste real manual quando houver quota/billing disponível.
+17. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -256,3 +257,5 @@ MM13 define o formato futuro de acesso interno/admin, payload, resposta e limite
 MM14 separa a decisão de origem do vídeo da implementação de upload. Ele recomenda File API ou inline pequeno para teste manual, `videoUri` primeiro no endpoint interno e storage temporário próprio para beta/produto.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
+
+MM16 formaliza limites e custo antes de billing real, endpoint real ou beta. Ele usa 5 análises/mês como hipótese inicial de beta e só considera 10 análises/mês depois de medir custo real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
@@ -141,6 +141,7 @@ Antes de qualquer beta com usuário real:
 
 - consentimento aprovado;
 - retenção definida;
+- limites/custo definidos;
 - cleanup implementado;
 - limite por plano definido;
 - storage definido;
@@ -156,11 +157,12 @@ Como não há billing/quota e ainda não há upload real:
 - não implementar consentimento em UI ainda;
 - não implementar retenção real ainda;
 - documentar contrato;
+- tratar o contrato de limites/custo como dependência antes de beta;
 - usar o contrato como bloqueio antes de qualquer beta.
 
 ## Próximas Fases Possíveis
 
 - MM16: contrato de custo/limites de uso;
 - MM17: contrato de cleanup/storage retention real;
-- MM18: endpoint interno real, somente depois de billing;
-- MM19: UI copy de consentimento, antes de beta.
+- MM18: endpoint interno real com usage guard, somente depois de billing;
+- MM19: UI copy de consentimento e limites, antes de beta.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
@@ -147,6 +147,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - 1 vídeo por análise;
 - 1 análise por execução interna;
 - beta futuro com 5 análises/mês;
+- limites de tamanho/duração devem considerar custo real por análise;
 - timeout server-side;
 - expiração obrigatória para storage temporário.
 
@@ -169,6 +170,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - `VideoTemporaryStorageObject`;
 - `VideoStorageRetention`;
 - contrato de consentimento/retenção;
+- contrato de limites/custo;
 - real run harness Gemini;
 - contrato de endpoint interno/admin;
 - `VideoNarrativeAnalysis`.
@@ -180,6 +182,7 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 - definir consentimento;
 - aprovar o contrato de consentimento/retenção;
 - definir limites por plano;
+- definir regra de custo/usage limit por tamanho/duração;
 - definir cleanup;
 - definir quem pode acessar;
 - validar Gemini real com 3 vídeos curtos;

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -57,6 +57,7 @@ Regras:
 - `videoUri`/File API/storage é preferível para fluxo futuro;
 - a decisão detalhada de origem do vídeo fica no contrato `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`;
 - consentimento e retenção ficam no contrato `VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md`;
+- limites, quota e cooldown ficam no contrato `VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md`;
 - não aceitar arquivo multipart neste contrato inicial;
 - não aceitar input livre sem limites;
 - não aceitar usuário comum.
@@ -97,7 +98,10 @@ Regras:
 - `insufficient_context`;
 - `blocked_unauthorized`;
 - `blocked_forbidden`;
-- `usage_limited`.
+- `usage_limited`;
+- `quota_exceeded`;
+- `cooldown_active`;
+- `provider_unavailable`.
 
 ## Validações Futuras
 
@@ -141,6 +145,7 @@ Regras:
 - custo real ainda não medido;
 - não liberar sem quota/billing conhecido;
 - registrar latência/custo futuramente;
+- aplicar usage guard, quota e cooldown antes de endpoint real ou beta;
 - feature flag deve permitir desligamento rápido.
 
 ## Relação Com Código Atual
@@ -163,6 +168,7 @@ Só implementar depois que:
 - prompt/schema forem ajustados se necessário;
 - decisão de input de vídeo for tomada;
 - contrato de consentimento/retenção estiver aprovado como bloqueio antes de endpoint real ou beta;
+- contrato de limites/custo estiver aprovado como bloqueio antes de endpoint real ou beta;
 - admin guard server-side estiver definido;
 - rate limit/usage limit tiver contrato;
 - consentimento/retenção estiverem planejados.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
@@ -1,0 +1,193 @@
+# Video Narrative Usage Limits and Cost Contract
+
+## Objetivo
+
+Este documento define limites, custo, quota, consumo, retry, cooldown e regras comerciais futuras para análise narrativa de vídeo antes de qualquer endpoint real, upload real ou beta.
+
+Ele existe para separar decisões comerciais e operacionais de qualquer implementação real de billing, cobrança, endpoint, upload ou UI.
+
+## Escopo
+
+- é contrato, não implementação;
+- não existe billing real nesta fase;
+- não existe cobrança nesta fase;
+- não existe endpoint real nesta fase;
+- não existe upload real nesta fase;
+- não existe UI nesta fase.
+
+## Princípio Central
+
+A análise de vídeo deve ser útil para o criador sem abrir um custo imprevisível para a D2C.
+
+## O Que Conta Como Análise Consumida
+
+Regra conceitual para consumo de quota:
+
+- análise deve contar quando o provider real é chamado com sucesso suficiente para retornar `VideoNarrativeAnalysis` útil;
+- falha antes de chamar provider não deve consumir quota;
+- payload inválido não deve consumir quota;
+- falta de API key/configuração não deve consumir quota;
+- falha total do provider pode não consumir quota na fase beta;
+- resposta parcial com análise útil pode consumir quota;
+- reprocessamento manual deve consumir nova análise, salvo exceção admin/dev.
+
+## Limites Recomendados Por Fase
+
+### Fase Admin/Manual
+
+- sem limite comercial;
+- uso apenas por admin/dev;
+- registrar manualmente custo/latência fora do produto;
+- não usar vídeo de usuário real.
+
+### Fase Endpoint Interno
+
+- limite baixo por admin/dev;
+- 1 vídeo por request;
+- 1 análise por request;
+- timeout server-side;
+- sem retry automático ilimitado.
+
+### Fase Beta Fechado
+
+- sugestão inicial: 5 análises/mês por usuário;
+- vídeo até 60s;
+- tamanho até 100MB quando houver upload/storage;
+- retry manual controlado;
+- limite diário opcional;
+- feature flag para desligamento rápido.
+
+### Fase Produto
+
+- plano atual pode começar com 5 a 10 análises/mês;
+- pacotes extras ou upgrade apenas depois de custo real conhecido;
+- controle por plano;
+- cooldown contra abuso;
+- rate limit por usuário/conta;
+- limite por tamanho/duração.
+
+## Recomendação Inicial
+
+Como ainda não há custo real medido:
+
+- usar 5 análises/mês no beta como hipótese de beta, não promessa pública;
+- não prometer 10 análises/mês até medir custo;
+- considerar 10 análises/mês apenas depois de medir custo real por vídeo curto e confirmar que o custo é seguro;
+- deixar possibilidade de pacote extra futura;
+- não implementar cobrança agora.
+
+## Métricas Obrigatórias Antes De Lançamento
+
+Antes de lançar análise de vídeo para usuários, devemos medir:
+
+- custo por análise;
+- latência por análise;
+- taxa de falha;
+- taxa de fallback;
+- taxa de schema parse ok;
+- tamanho/duração do vídeo;
+- provider status;
+- quantidade de retries;
+- uso por usuário;
+- seed útil gerado ou não;
+- conversão para blueprint/roteiro.
+
+## Retry E Cooldown
+
+- retry automático deve ser limitado;
+- retry por falha de configuração não deve acontecer;
+- retry por payload inválido não deve acontecer;
+- retry por falha transitória pode existir com limite futuro;
+- usuário não deve conseguir disparar loops;
+- cooldown pode ser aplicado por usuário se houver falhas repetidas;
+- admin/dev pode ter bypass controlado em ambiente interno.
+
+## Rate Limit Futuro
+
+O rate limit futuro deve considerar:
+
+- por usuário;
+- por conta;
+- por IP se aplicável;
+- por plano;
+- por janela de tempo;
+- por tamanho/duração;
+- por endpoint interno.
+
+## Feature Flags
+
+- `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED` controla provider real;
+- uma futura flag pode controlar endpoint interno;
+- uma futura flag pode controlar beta para usuários;
+- flag deve permitir desligamento rápido;
+- nunca usar `NEXT_PUBLIC` para habilitar custo real.
+
+## Falhas E Quota
+
+Status conceituais futuros:
+
+- `usage_limited`;
+- `quota_exceeded`;
+- `cooldown_active`;
+- `provider_unavailable`;
+- `invalid_payload`;
+- `disabled`;
+- `ready`;
+- `failed`.
+
+## UX Futura Para Limite
+
+Cópias conceituais em português para limite, falha sem consumo e indisponibilidade:
+
+- “Você atingiu o limite de análises de vídeo deste período.”
+- “Não consumimos uma análise porque o vídeo não pôde ser validado.”
+- “A análise de vídeo está temporariamente indisponível.”
+- “Tente novamente mais tarde ou use um vídeo menor.”
+
+Essas mensagens devem manter tom humano, sem promessa de resultado e sem pressionar reenvio.
+
+## Relação Com Contratos Existentes
+
+Este contrato complementa:
+
+- `VideoNarrativeAnalysis`;
+- `PostCreationVideoSeed`;
+- `VideoNarrativeInternalEndpointContract`;
+- `VideoNarrativeInputSourceContract`;
+- `VideoNarrativeConsentRetentionContract`;
+- Gemini readiness audit;
+- real run harness.
+
+Ele depende das decisões de consentimento, retenção e storage/input antes de qualquer beta.
+
+## Critérios Antes De Implementar Limite Real
+
+Só implementar limite real depois que houver:
+
+- billing/quota Gemini disponível;
+- pelo menos 3 vídeos curtos testados;
+- custo médio estimado;
+- latência média estimada;
+- política de beta definida;
+- consentimento/retenção definidos;
+- storage/input definido;
+- endpoint interno implementado;
+- logs seguros definidos;
+- decisão sobre plano atual e pacotes extras.
+
+## Decisão Recomendada Agora
+
+Como não há billing/quota:
+
+- não implementar cobrança;
+- não implementar quota real;
+- documentar contrato;
+- usar 5 análises/mês como hipótese de beta, não promessa pública;
+- revisitar depois do teste real manual.
+
+## Próximas Fases Possíveis
+
+- MM17: contrato de métricas/observabilidade;
+- MM18: contrato de endpoint real com usage guard;
+- MM19: contrato de UI copy para limites;
+- MM20: implementação de limite real depois de billing e endpoint interno.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts
@@ -1,0 +1,144 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md");
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+describe("videoNarrativeUsageLimitsCostContract", () => {
+  it("mantém o contrato documental presente", () => {
+    expect(fs.existsSync(CONTRACT_PATH)).toBe(true);
+  });
+
+  it("documenta custo, quota, limites e contratos relacionados", () => {
+    const contract = readContract();
+    const expectedTerms = [
+      "custo",
+      "quota",
+      "limite",
+      "5 análises/mês",
+      "10 análises/mês",
+      "beta",
+      "plano",
+      "pacote extra",
+      "upgrade",
+      "retry",
+      "cooldown",
+      "rate limit",
+      "feature flag",
+      "VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED",
+      "NEXT_PUBLIC",
+      "billing",
+      "latência",
+      "taxa de falha",
+      "taxa de fallback",
+      "schema parse",
+      "usage_limited",
+      "quota_exceeded",
+      "provider_unavailable",
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "consentimento",
+      "retenção",
+      "storage/input",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(contract).toContain(term);
+    });
+  });
+
+  it("mantém o princípio central de custo previsível", () => {
+    expect(readContract()).toContain(
+      "A análise de vídeo deve ser útil para o criador sem abrir um custo imprevisível para a D2C.",
+    );
+  });
+
+  it("trata 5 análises/mês como hipótese de beta, não promessa pública", () => {
+    expect(readContract()).toContain("usar 5 análises/mês como hipótese de beta, não promessa pública");
+  });
+
+  it("condiciona 10 análises/mês à medição de custo real", () => {
+    expect(readContract()).toContain(
+      "considerar 10 análises/mês apenas depois de medir custo real por vídeo curto",
+    );
+  });
+
+  it("bloqueia cobrança nesta fase", () => {
+    expect(readContract()).toContain("não existe cobrança nesta fase");
+    expect(readContract()).toContain("não implementar cobrança");
+  });
+
+  it("inclui cópias futuras de UX em português para limite e indisponibilidade", () => {
+    const contract = readContract();
+
+    expect(contract).toContain("Você atingiu o limite de análises de vídeo deste período.");
+    expect(contract).toContain("Não consumimos uma análise porque o vídeo não pôde ser validado.");
+    expect(contract).toContain("A análise de vídeo está temporariamente indisponível.");
+    expect(contract).toContain("Tente novamente mais tarde ou use um vídeo menor.");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+
+  it("mantém os novos arquivos sem imports proibidos", () => {
+    const testSource = fs.readFileSync(__filename, "utf8");
+    const contract = readContract();
+    const combinedSource = `${testSource}\n${contract}`;
+    const forbiddenImports = [
+      "Stripe",
+      "billing",
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "ffmpeg",
+      "UI",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(combinedSource).not.toContain(`from "${term}`);
+      expect(combinedSource).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("mantém linguagem consultiva no documento", () => {
+    const contract = readContract().toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(contract).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+});


### PR DESCRIPTION
Stacked sobre #812. Base: `feat/video-narrative-consent-retention-contract`.

## Summary
- Adds MM16 documentation for video narrative usage limits, cost, quota, retry, cooldown, rate limit, feature flags, and future commercial rules.
- Adds a static contract test that verifies required terms, safe language, route absence, UX copy, and forbidden integration imports.
- Updates the video upload README, multimodal architecture, consent/retention contract, input source contract, internal endpoint contract, and readiness audit to reference MM16 as a blocker before beta/real implementation.

## Non-goals
- No real endpoint or `route.ts`.
- No real upload, storage, UI, BoardShell connection, PostCreationFunnelState change, fetch, Gemini call, database, billing, Stripe, charge flow, cron/job, or new dependency.

## Validation
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath src/app/api/brand-narratives/reports/[slug]/route.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`