### PR TITLE
docs: add video narrative observability contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -68,6 +68,7 @@ Já existe:
 - origem real do `videoUri` ainda precisa ser definida;
 - consentimento/retenção foram formalizados em MM15, mas ainda não foram implementados;
 - limites/custo foram formalizados em MM16, mas ainda não foram implementados;
+- observabilidade foi formalizada em MM17, mas ainda não foi implementada;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -111,6 +112,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contrato formal de origem do vídeo;
 - contrato formal de consentimento/retenção;
 - contrato formal de limites/custo;
+- contrato formal de observabilidade;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -364,6 +364,28 @@ O que não faz:
 - não cria endpoint, upload real, storage real, UI ou rota;
 - não conecta nada ao fluxo real do produto.
 
+### MM17 — Contrato de métricas e observabilidade
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md`
+- `videoNarrativeObservabilityContract.test.ts`
+
+O que faz:
+
+- define métricas, eventos conceituais, logs seguros, dashboards e alertas futuros;
+- exige visibilidade de custo, latência, falha, fallback e utilidade antes de endpoint real;
+- formaliza que `rawText` completo, base64, vídeo bruto, API key e URL assinada com token não devem ir para logs.
+
+O que não faz:
+
+- não cria analytics real;
+- não cria banco/tabela;
+- não cria endpoint, upload real, storage real, UI ou rota;
+- não conecta provider externo nem fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -223,8 +223,9 @@ Exemplos:
 13. MM14 — Input source contract. Define a origem futura do vídeo por fase, ainda sem upload ou storage real.
 14. MM15 — Consent and retention contract. Define consentimento, retenção, expiração e uso de sinais antes de upload real ou beta.
 15. MM16 — Usage limits and cost contract. Define limite, quota, custo, retry, cooldown e regras comerciais futuras.
-16. Teste real manual quando houver quota/billing disponível.
-17. Integração experimental futura no Board de Criação.
+16. MM17 — Observability contract. Define métricas, eventos, logs seguros, dashboards e alertas futuros.
+17. Teste real manual quando houver quota/billing disponível.
+18. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -259,3 +260,5 @@ MM14 separa a decisão de origem do vídeo da implementação de upload. Ele rec
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 
 MM16 formaliza limites e custo antes de billing real, endpoint real ou beta. Ele usa 5 análises/mês como hipótese inicial de beta e só considera 10 análises/mês depois de medir custo real.
+
+MM17 formaliza observabilidade antes de analytics real, endpoint real ou beta. Ele exige medir custo, latência, falha, fallback e utilidade sem logar vídeo, base64, API key, rawText completo ou URL assinada com token.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
@@ -123,6 +123,8 @@ Regras para logs:
 - logs podem conter ids, status, duração, tamanho, provider status, timestamps e issues seguras;
 - logs de custo/latência devem ser agregados quando possível.
 
+Logs seguros e observabilidade futura devem seguir `VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md` antes de endpoint real ou beta.
+
 ## Relação Com Contratos Existentes
 
 Este contrato depende e complementa:
@@ -142,6 +144,7 @@ Antes de qualquer beta com usuário real:
 - consentimento aprovado;
 - retenção definida;
 - limites/custo definidos;
+- logs seguros e observabilidade definidos;
 - cleanup implementado;
 - limite por plano definido;
 - storage definido;

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -58,6 +58,7 @@ Regras:
 - a decisão detalhada de origem do vídeo fica no contrato `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`;
 - consentimento e retenção ficam no contrato `VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md`;
 - limites, quota e cooldown ficam no contrato `VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md`;
+- métricas, eventos e logs seguros ficam no contrato `VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md`;
 - não aceitar arquivo multipart neste contrato inicial;
 - não aceitar input livre sem limites;
 - não aceitar usuário comum.
@@ -146,6 +147,7 @@ Regras:
 - não liberar sem quota/billing conhecido;
 - registrar latência/custo futuramente;
 - aplicar usage guard, quota e cooldown antes de endpoint real ou beta;
+- planejar observability hooks antes de endpoint real;
 - feature flag deve permitir desligamento rápido.
 
 ## Relação Com Código Atual
@@ -169,6 +171,7 @@ Só implementar depois que:
 - decisão de input de vídeo for tomada;
 - contrato de consentimento/retenção estiver aprovado como bloqueio antes de endpoint real ou beta;
 - contrato de limites/custo estiver aprovado como bloqueio antes de endpoint real ou beta;
+- contrato de observabilidade estiver aprovado como bloqueio antes de endpoint real;
 - admin guard server-side estiver definido;
 - rate limit/usage limit tiver contrato;
 - consentimento/retenção estiverem planejados.
@@ -178,6 +181,7 @@ Só implementar depois que:
 - MM14: contrato de origem do vídeo;
 - MM15: contrato de consentimento/retenção;
 - MM16: contrato de limites/custos;
-- MM17: endpoint interno real, se billing existir;
-- MM18: preview interno com chamada real;
-- MM19: integração experimental no board.
+- MM17: contrato de métricas/observabilidade;
+- MM18: endpoint interno real, se billing existir;
+- MM19: preview interno com chamada real;
+- MM20: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
@@ -1,0 +1,231 @@
+# Video Narrative Observability Contract
+
+## Objetivo
+
+Este documento define métricas, eventos, logs seguros, indicadores de qualidade e critérios de observabilidade antes de qualquer endpoint real, upload real ou beta.
+
+Ele existe para garantir que custo, latência, falha, fallback e utilidade do resultado sejam mensuráveis antes de expor análise narrativa de vídeo para usuários.
+
+## Escopo
+
+- é contrato, não implementação;
+- não existe analytics real nesta fase;
+- não existe banco/tabela nesta fase;
+- não existe endpoint real nesta fase;
+- não existe upload real nesta fase;
+- não existe UI nesta fase.
+
+## Princípio Central
+
+Não lançar análise de vídeo sem conseguir medir custo, latência, falha, fallback e utilidade do resultado.
+
+## Métricas Obrigatórias Do Provider
+
+Devem ser medidas futuramente:
+
+- provider status;
+- model usado;
+- startedAt;
+- completedAt;
+- latencyMs;
+- ok true/false;
+- status final;
+- issues count;
+- rawText presente ou não, apenas como hasRawText;
+- schema parse ok/fail;
+- fallback usado ou não;
+- confidence;
+- missing video/input;
+- disabled by flag;
+- missing api key;
+- missing client;
+- provider unavailable.
+
+## Métricas Obrigatórias Do Vídeo/Input
+
+Devem ser medidas futuramente:
+
+- source: gemini_file_api, inline_base64, temporary_storage, gcs, s3, r2, public_url_restricted;
+- mimeType;
+- durationSeconds;
+- sizeBytes;
+- input type: videoUri ou inlineVideoBase64;
+- has creatorQuestion;
+- creatorQuestion length;
+- creatorContext presence;
+- knownNarratives count;
+- não logar base64;
+- não logar URL sensível se contiver token;
+- não logar vídeo.
+
+## Métricas De Custo
+
+Devem ser medidas futuramente:
+
+- estimatedCost;
+- costCurrency;
+- token/input unit se disponível;
+- video duration bucket;
+- model;
+- quota consumed true/false;
+- usage counted reason;
+- usage not counted reason;
+- quota remaining se disponível;
+- cost by user/account/admin;
+- custo médio por análise;
+- custo p95.
+
+## Métricas De Produto/Qualidade
+
+Devem ser medidas futuramente:
+
+- hasUsefulAnalysis;
+- hasUsefulSeed;
+- primaryAction;
+- blueprint generated;
+- followUpQuestions count;
+- brandMatch enabled;
+- profileSignals count;
+- seed initialIdea present;
+- conversion to blueprint;
+- conversion to script;
+- user accepted suggestion;
+- user edited generated result;
+- user abandoned after analysis.
+
+## Métricas De Falha
+
+Falhas e bloqueios a medir:
+
+- invalid_payload;
+- usage_limited;
+- quota_exceeded;
+- cooldown_active;
+- provider_unavailable;
+- parse_failed;
+- insufficient_context;
+- timeout;
+- blocked_unauthorized;
+- blocked_forbidden;
+- consent_missing;
+- retention_blocked;
+- storage_expired.
+
+## Eventos Futuros Sugeridos
+
+Eventos conceituais, sem implementação nesta fase:
+
+- video_narrative_analysis_requested;
+- video_narrative_analysis_started;
+- video_narrative_analysis_completed;
+- video_narrative_analysis_failed;
+- video_narrative_analysis_fallback_used;
+- video_narrative_seed_created;
+- video_narrative_blueprint_started;
+- video_narrative_script_started;
+- video_narrative_usage_consumed;
+- video_narrative_usage_not_consumed;
+- video_narrative_limit_reached.
+
+## Logs Seguros
+
+Logs podem conter:
+
+- requestId;
+- userId hash ou id interno, se permitido;
+- accountId;
+- status;
+- provider status;
+- model;
+- durationSeconds bucket;
+- sizeBytes bucket;
+- latencyMs;
+- issues sanitized;
+- timestamps;
+- quota consumed true/false.
+
+Logs não podem conter:
+
+- API key;
+- base64;
+- vídeo bruto;
+- rawText completo;
+- texto completo do provider;
+- URL assinada com token;
+- dados sensíveis extraídos do vídeo;
+- rosto/voz como atributo biométrico.
+
+O rawText completo não deve ser logado.
+
+## Dashboards Futuros
+
+Painéis futuros:
+
+- dashboard de custo diário;
+- dashboard de custo por usuário;
+- dashboard de latência média/p95;
+- dashboard de taxa de sucesso;
+- dashboard de taxa de fallback;
+- dashboard de taxa de parse ok;
+- dashboard de taxa de limite atingido;
+- dashboard de vídeos por source;
+- dashboard de análises que viraram blueprint;
+- dashboard de análises que viraram roteiro.
+
+## Alertas Futuros
+
+Alertas futuros:
+
+- alerta de custo acima do esperado;
+- alerta de spike de falhas;
+- alerta de aumento de fallback;
+- alerta de parse fail acima de limite;
+- alerta de latência p95 alta;
+- alerta de quota próxima do limite;
+- alerta de uso anormal por usuário;
+- alerta de provider indisponível;
+- alerta de storage cleanup falhando.
+
+## Relação Com Contratos Existentes
+
+Este contrato complementa:
+
+- `VideoNarrativeUsageLimitsCostContract`;
+- `VideoNarrativeConsentRetentionContract`;
+- `VideoNarrativeInputSourceContract`;
+- `VideoNarrativeInternalEndpointContract`;
+- Gemini readiness audit;
+- real run harness;
+- `VideoNarrativeAnalysis`;
+- `PostCreationVideoSeed`.
+
+## Critérios Antes De Endpoint Real
+
+Só implementar endpoint real quando:
+
+- eventos mínimos estiverem definidos;
+- logs seguros estiverem definidos;
+- métrica de latencyMs estiver planejada;
+- métrica de custo estiver planejada;
+- usage/quota estiver planejado;
+- consentimento/retenção estiverem definidos;
+- input source estiver definido;
+- fallback estiver monitorável.
+
+## Decisão Recomendada Agora
+
+Como ainda não há billing/quota:
+
+- não implementar analytics real;
+- não criar tabela;
+- não criar banco;
+- não conectar provider externo;
+- usar este contrato para guiar futuro endpoint;
+- quando houver teste real manual, registrar resultados manualmente fora do repo.
+
+## Próximas Fases Possíveis
+
+- MM18: contrato de endpoint real com observability hooks;
+- MM19: contrato de storage cleanup observability;
+- MM20: contrato de UI beta com estados observáveis;
+- MM21: implementação real somente depois de billing/teste real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
@@ -92,6 +92,8 @@ Antes de lançar análise de vídeo para usuários, devemos medir:
 - seed útil gerado ou não;
 - conversão para blueprint/roteiro.
 
+As métricas obrigatórias e logs seguros devem seguir `VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md` antes de qualquer uso real.
+
 ## Retry E Cooldown
 
 - retry automático deve ser limitado;
@@ -173,6 +175,7 @@ Só implementar limite real depois que houver:
 - storage/input definido;
 - endpoint interno implementado;
 - logs seguros definidos;
+- observabilidade mínima definida;
 - decisão sobre plano atual e pacotes extras.
 
 ## Decisão Recomendada Agora
@@ -188,6 +191,6 @@ Como não há billing/quota:
 ## Próximas Fases Possíveis
 
 - MM17: contrato de métricas/observabilidade;
-- MM18: contrato de endpoint real com usage guard;
+- MM18: contrato de endpoint real com usage guard e observability hooks;
 - MM19: contrato de UI copy para limites;
 - MM20: implementação de limite real depois de billing e endpoint interno.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts
@@ -1,0 +1,144 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md");
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+describe("videoNarrativeObservabilityContract", () => {
+  it("mantém o contrato documental presente", () => {
+    expect(fs.existsSync(CONTRACT_PATH)).toBe(true);
+  });
+
+  it("documenta métricas, eventos, logs seguros e contratos relacionados", () => {
+    const contract = readContract();
+    const expectedTerms = [
+      "custo",
+      "latência",
+      "latencyMs",
+      "fallback",
+      "schema parse",
+      "provider status",
+      "hasRawText",
+      "estimatedCost",
+      "quota consumed",
+      "usage_limited",
+      "quota_exceeded",
+      "cooldown_active",
+      "provider_unavailable",
+      "parse_failed",
+      "insufficient_context",
+      "consent_missing",
+      "storage_expired",
+      "video_narrative_analysis_requested",
+      "video_narrative_analysis_completed",
+      "video_narrative_analysis_failed",
+      "video_narrative_usage_consumed",
+      "video_narrative_limit_reached",
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "blueprint",
+      "roteiro",
+      "p95",
+      "dashboard",
+      "alerta",
+      "API key",
+      "base64",
+      "rawText completo",
+      "URL assinada",
+      "dados sensíveis",
+    ];
+
+    expectedTerms.forEach((term) => {
+      expect(contract).toContain(term);
+    });
+  });
+
+  it("mantém o princípio central de observabilidade", () => {
+    expect(readContract()).toContain(
+      "Não lançar análise de vídeo sem conseguir medir custo, latência, falha, fallback e utilidade do resultado.",
+    );
+  });
+
+  it("bloqueia analytics real nesta fase", () => {
+    expect(readContract()).toContain("não existe analytics real nesta fase");
+    expect(readContract()).toContain("não implementar analytics real");
+  });
+
+  it("bloqueia tabela e banco nesta fase", () => {
+    const contract = readContract();
+
+    expect(contract).toContain("não existe banco/tabela nesta fase");
+    expect(contract).toContain("não criar tabela");
+    expect(contract).toContain("não criar banco");
+  });
+
+  it("bloqueia log de rawText completo", () => {
+    expect(readContract()).toContain("O rawText completo não deve ser logado.");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+
+  it("mantém os novos arquivos sem imports proibidos", () => {
+    const testSource = fs.readFileSync(__filename, "utf8");
+    const contract = readContract();
+    const combinedSource = `${testSource}\n${contract}`;
+    const forbiddenImports = [
+      "Stripe",
+      "billing",
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(combinedSource).not.toContain(`from "${term}`);
+      expect(combinedSource).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("mantém linguagem consultiva no documento", () => {
+    const contract = readContract().toLowerCase();
+    const blockedTerms = [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ];
+
+    blockedTerms.forEach((term) => {
+      expect(contract).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+});


### PR DESCRIPTION
Stacked sobre #813. Base: `feat/video-narrative-usage-limits-cost-contract`.

## Summary
- Adds MM17 documentation for video narrative observability: provider/input/cost/product/failure metrics, conceptual events, safe logs, dashboards, and future alerts.
- Adds a static contract test that verifies required terms, safe language, route absence, no real analytics/table/database, rawText logging prohibition, and forbidden integration imports.
- Updates the video upload README, multimodal architecture, usage/cost contract, consent/retention contract, internal endpoint contract, and readiness audit to reference MM17 as a blocker before endpoint/beta.

## Non-goals
- No real endpoint or `route.ts`.
- No real upload, storage, UI, BoardShell connection, PostCreationFunnelState change, fetch, Gemini call, database/table, analytics provider, billing, Stripe, charge flow, cron/job, or new dependency.

## Validation
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath src/app/api/brand-narratives/reports/[slug]/route.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`