### PR TITLE
feat: add video narrative guard contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -70,6 +70,7 @@ Já existe:
 - limites/custo foram formalizados em MM16, mas ainda não foram implementados;
 - observabilidade foi formalizada em MM17, mas ainda não foi implementada;
 - endpoint guards foram formalizados em MM18, mas ainda não foram implementados;
+- guard contracts puros foram formalizados em MM19, mas ainda não foram conectados a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -115,6 +116,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contrato formal de limites/custo;
 - contrato formal de observabilidade;
 - contrato formal de guards do endpoint real;
+- contratos puros de guard result/status;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -408,6 +408,28 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM19 — Contratos puros de guard result/status
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeGuardContracts.ts`
+- `videoNarrativeGuardContracts.test.ts`
+
+O que faz:
+
+- cria tipos puros para nomes, status, códigos, severidade, resultado e resumo dos guards;
+- define `VIDEO_NARRATIVE_GUARD_ORDER` na mesma ordem do contrato MM18;
+- adiciona helpers determinísticos para resultado passed/blocked/skipped, resumo do pipeline, decisão de provider/quota e sanitização de mensagens.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, storage real, UI, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -225,8 +225,9 @@ Exemplos:
 15. MM16 — Usage limits and cost contract. Define limite, quota, custo, retry, cooldown e regras comerciais futuras.
 16. MM17 — Observability contract. Define métricas, eventos, logs seguros, dashboards e alertas futuros.
 17. MM18 — Real endpoint guards contract. Define a ordem dos guards obrigatórios antes de route.ts ou provider real.
-18. Teste real manual quando houver quota/billing disponível.
-19. Integração experimental futura no Board de Criação.
+18. MM19 — Pure guard contracts. Define tipos/helpers puros para resultados e resumo dos guards, sem endpoint.
+19. Teste real manual quando houver quota/billing disponível.
+20. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -265,3 +266,5 @@ MM16 formaliza limites e custo antes de billing real, endpoint real ou beta. Ele
 MM17 formaliza observabilidade antes de analytics real, endpoint real ou beta. Ele exige medir custo, latência, falha, fallback e utilidade sem logar vídeo, base64, API key, rawText completo ou URL assinada com token.
 
 MM18 formaliza a ordem de guards do futuro endpoint real/admin. Ele bloqueia `route.ts` e provider real até que método, sessão, admin/dev, flag, payload, origem, consentimento, retenção, usage/quota e observabilidade estejam resolvidos.
+
+MM19 começa a transformar a ordem de guards em fundação de código puro. Ele cria `VideoNarrativeGuardResult`, `VideoNarrativeGuardPipelineSummary` e helpers determinísticos para decidir provider/quota sem endpoint real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -156,6 +156,8 @@ Regras:
 - `runGeminiVideoNarrativeProviderFromEnv`;
 - `createGeminiVideoNarrativeClient`;
 - `parseGeminiVideoNarrativeJson`;
+- `VideoNarrativeGuardResult`;
+- `VideoNarrativeGuardPipelineSummary`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
 - `getPostCreationVideoSeedPrimaryAction`;
@@ -174,6 +176,7 @@ Só implementar depois que:
 - contrato de limites/custo estiver aprovado como bloqueio antes de endpoint real ou beta;
 - contrato de observabilidade estiver aprovado como bloqueio antes de endpoint real;
 - contrato de guards do endpoint real estiver aprovado antes de criar a rota real;
+- contratos puros de guard result/status estiverem disponíveis;
 - admin guard server-side estiver definido;
 - rate limit/usage limit tiver contrato;
 - consentimento/retenção estiverem planejados.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
@@ -216,6 +216,8 @@ Só implementar endpoint real quando:
 
 O futuro endpoint deve seguir `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md` para acionar observability start/completion hook somente depois dos guards corretos.
 
+Os eventos e logs futuros podem usar `VideoNarrativeGuardResult` e `VideoNarrativeGuardPipelineSummary` para registrar qual guard bloqueou sem expor payload sensível.
+
 ## Decisão Recomendada Agora
 
 Como ainda não há billing/quota:

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -269,6 +269,8 @@ Este contrato complementa:
 - `VideoNarrativeAnalysis`;
 - `PostCreationVideoSeed`.
 
+MM19 adiciona `VideoNarrativeGuardResult`, `VideoNarrativeGuardPipelineSummary` e `VIDEO_NARRATIVE_GUARD_ORDER` como fundação pura para representar essa ordem de guards, ainda sem endpoint real.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts
@@ -1,0 +1,335 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VIDEO_NARRATIVE_GUARD_ORDER,
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  createSkippedVideoNarrativeGuardResult,
+  isVideoNarrativeGuardBlocking,
+  sanitizeVideoNarrativeGuardMessage,
+  shouldVideoNarrativeGuardAllowProviderCall,
+  shouldVideoNarrativeGuardAllowQuotaConsumption,
+  summarizeVideoNarrativeGuardResults,
+  type VideoNarrativeGuardName,
+  type VideoNarrativeGuardResult,
+} from "./videoNarrativeGuardContracts";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeGuardContracts.ts");
+
+function passed(name: VideoNarrativeGuardName): VideoNarrativeGuardResult {
+  return createPassedVideoNarrativeGuardResult(name);
+}
+
+function buildPassingThroughSafeResponse(): VideoNarrativeGuardResult[] {
+  return VIDEO_NARRATIVE_GUARD_ORDER.map((name) => passed(name));
+}
+
+function buildPassingBeforeProvider(): VideoNarrativeGuardResult[] {
+  return VIDEO_NARRATIVE_GUARD_ORDER.slice(0, VIDEO_NARRATIVE_GUARD_ORDER.indexOf("provider")).map((name) =>
+    passed(name),
+  );
+}
+
+describe("videoNarrativeGuardContracts", () => {
+  it("mantém a ordem oficial dos 19 guards do contrato MM18", () => {
+    expect(VIDEO_NARRATIVE_GUARD_ORDER).toEqual([
+      "method",
+      "session",
+      "admin_dev",
+      "feature_flag",
+      "content_type",
+      "payload_size",
+      "payload_schema",
+      "input_source",
+      "mime_duration_size",
+      "consent",
+      "retention",
+      "usage_quota",
+      "observability_start",
+      "provider",
+      "parse_fallback",
+      "seed_generation",
+      "usage_consumption",
+      "observability_completion",
+      "safe_response",
+    ]);
+  });
+
+  it("cria resultado passed seguro", () => {
+    expect(createPassedVideoNarrativeGuardResult("method")).toEqual({
+      name: "method",
+      status: "passed",
+      code: null,
+      severity: "info",
+      message: "Método validado.",
+      shouldCallProvider: true,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("cria resultado blocked sem provider e sem quota", () => {
+    const result = createBlockedVideoNarrativeGuardResult({
+      name: "payload_schema",
+      code: "invalid_payload",
+      message: "Payload não validado.",
+    });
+
+    expect(result.status).toBe("blocked");
+    expect(result.severity).toBe("blocking");
+    expect(result.shouldCallProvider).toBe(false);
+    expect(result.shouldConsumeQuota).toBe(false);
+  });
+
+  it("cria resultado skipped", () => {
+    expect(createSkippedVideoNarrativeGuardResult({ name: "provider" })).toMatchObject({
+      name: "provider",
+      status: "skipped",
+      code: null,
+      severity: "info",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("identifica bloqueio apenas quando status blocked e severity blocking", () => {
+    expect(
+      isVideoNarrativeGuardBlocking(
+        createBlockedVideoNarrativeGuardResult({
+          name: "method",
+          code: "method_not_allowed",
+          message: "Método bloqueado.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isVideoNarrativeGuardBlocking(
+        createBlockedVideoNarrativeGuardResult({
+          name: "method",
+          code: "method_not_allowed",
+          message: "Método observado.",
+          severity: "warning",
+        }),
+      ),
+    ).toBe(false);
+    expect(isVideoNarrativeGuardBlocking(createPassedVideoNarrativeGuardResult("method"))).toBe(false);
+  });
+
+  it("usa o primeiro blockedBy conforme ordem oficial, não ordem recebida", () => {
+    const summary = summarizeVideoNarrativeGuardResults([
+      createBlockedVideoNarrativeGuardResult({
+        name: "retention",
+        code: "retention_expired",
+        message: "Retenção expirada.",
+      }),
+      createBlockedVideoNarrativeGuardResult({
+        name: "method",
+        code: "method_not_allowed",
+        message: "Método bloqueado.",
+      }),
+    ]);
+
+    expect(summary.blockedBy?.name).toBe("method");
+  });
+
+  it.each<VideoNarrativeGuardName>([
+    "method",
+    "session",
+    "admin_dev",
+    "feature_flag",
+    "payload_schema",
+    "input_source",
+    "consent",
+    "retention",
+    "usage_quota",
+  ])("bloqueia provider quando %s falha antes do provider", (name) => {
+    const summary = summarizeVideoNarrativeGuardResults([
+      ...buildPassingBeforeProvider(),
+      createBlockedVideoNarrativeGuardResult({
+        name,
+        code: name === "method" ? "method_not_allowed" : "invalid_payload",
+        message: "Guard não validado.",
+      }),
+    ]);
+
+    expect(summary.canCallProvider).toBe(false);
+  });
+
+  it("permite provider quando todos os guards anteriores passam", () => {
+    expect(summarizeVideoNarrativeGuardResults(buildPassingBeforeProvider()).canCallProvider).toBe(true);
+  });
+
+  it("não consome quota quando há falha antes do provider", () => {
+    const summary = summarizeVideoNarrativeGuardResults([
+      createBlockedVideoNarrativeGuardResult({
+        name: "payload_schema",
+        code: "invalid_payload",
+        message: "Payload não validado.",
+      }),
+      ...buildPassingThroughSafeResponse(),
+    ]);
+
+    expect(summary.canConsumeQuota).toBe(false);
+  });
+
+  it("não consome quota quando provider está indisponível", () => {
+    const results = buildPassingThroughSafeResponse().map((result) =>
+      result.name === "provider"
+        ? createBlockedVideoNarrativeGuardResult({
+            name: "provider",
+            code: "provider_unavailable",
+            message: "Provider não disponível.",
+          })
+        : result,
+    );
+
+    expect(summarizeVideoNarrativeGuardResults(results).canConsumeQuota).toBe(false);
+  });
+
+  it("não consome quota quando parse_failed bloqueia", () => {
+    const results = buildPassingThroughSafeResponse().map((result) =>
+      result.name === "parse_fallback"
+        ? createBlockedVideoNarrativeGuardResult({
+            name: "parse_fallback",
+            code: "parse_failed",
+            message: "Parse não validado.",
+          })
+        : result,
+    );
+
+    expect(summarizeVideoNarrativeGuardResults(results).canConsumeQuota).toBe(false);
+  });
+
+  it("consome quota apenas quando usage_consumption e safe_response passam", () => {
+    expect(summarizeVideoNarrativeGuardResults(buildPassingThroughSafeResponse()).canConsumeQuota).toBe(true);
+
+    const withoutUsage = buildPassingThroughSafeResponse().filter(
+      (result) => result.name !== "usage_consumption",
+    );
+    expect(summarizeVideoNarrativeGuardResults(withoutUsage).canConsumeQuota).toBe(false);
+
+    const unsafeResponse = buildPassingThroughSafeResponse().map((result) =>
+      result.name === "safe_response"
+        ? createBlockedVideoNarrativeGuardResult({
+            name: "safe_response",
+            code: "unsafe_response",
+            message: "Resposta não validada.",
+          })
+        : result,
+    );
+    expect(summarizeVideoNarrativeGuardResults(unsafeResponse).canConsumeQuota).toBe(false);
+  });
+
+  it("shouldVideoNarrativeGuardAllowProviderCall respeita resumo", () => {
+    expect(shouldVideoNarrativeGuardAllowProviderCall(buildPassingBeforeProvider())).toBe(true);
+    expect(
+      shouldVideoNarrativeGuardAllowProviderCall([
+        createBlockedVideoNarrativeGuardResult({
+          name: "session",
+          code: "unauthorized",
+          message: "Sessão ausente.",
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("shouldVideoNarrativeGuardAllowQuotaConsumption respeita resumo", () => {
+    expect(shouldVideoNarrativeGuardAllowQuotaConsumption(buildPassingThroughSafeResponse())).toBe(true);
+    expect(
+      shouldVideoNarrativeGuardAllowQuotaConsumption([
+        createBlockedVideoNarrativeGuardResult({
+          name: "consent",
+          code: "consent_missing",
+          message: "Consentimento ausente.",
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("redige API key iniciando com AIza", () => {
+    expect(sanitizeVideoNarrativeGuardMessage("chave AIza1234567890abcdefghi")).toBe("chave [redigido]");
+  });
+
+  it("redige GEMINI_API_KEY e GOOGLE_GENAI_API_KEY", () => {
+    expect(sanitizeVideoNarrativeGuardMessage("GEMINI_API_KEY=abc GOOGLE_GENAI_API_KEY=def")).toBe(
+      "[redigido] [redigido]",
+    );
+  });
+
+  it("redige base64 longo", () => {
+    const longBase64 = "a".repeat(140);
+    expect(sanitizeVideoNarrativeGuardMessage(`payload ${longBase64}`)).toBe("payload [redigido]");
+  });
+
+  it("mantém linguagem segura nas mensagens default e outputs dos helpers", () => {
+    const outputs = [
+      ...VIDEO_NARRATIVE_GUARD_ORDER.map((name) => createPassedVideoNarrativeGuardResult(name).message),
+      createBlockedVideoNarrativeGuardResult({
+        name: "method",
+        code: "method_not_allowed",
+        message: "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      }).message,
+      createSkippedVideoNarrativeGuardResult({
+        name: "provider",
+        message: "Guard não executado.",
+      }).message,
+    ].join(" ").toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.ts
@@ -1,0 +1,256 @@
+export type VideoNarrativeGuardName =
+  | "method"
+  | "session"
+  | "admin_dev"
+  | "feature_flag"
+  | "content_type"
+  | "payload_size"
+  | "payload_schema"
+  | "input_source"
+  | "mime_duration_size"
+  | "consent"
+  | "retention"
+  | "usage_quota"
+  | "observability_start"
+  | "provider"
+  | "parse_fallback"
+  | "seed_generation"
+  | "usage_consumption"
+  | "observability_completion"
+  | "safe_response";
+
+export type VideoNarrativeGuardStatus = "passed" | "blocked" | "skipped";
+
+export type VideoNarrativeGuardBlockCode =
+  | "method_not_allowed"
+  | "unauthorized"
+  | "forbidden"
+  | "disabled"
+  | "invalid_content_type"
+  | "payload_too_large"
+  | "invalid_payload"
+  | "invalid_source"
+  | "invalid_mime_type"
+  | "invalid_duration"
+  | "invalid_size"
+  | "consent_missing"
+  | "retention_expired"
+  | "usage_limited"
+  | "quota_exceeded"
+  | "cooldown_active"
+  | "observability_unavailable"
+  | "provider_unavailable"
+  | "parse_failed"
+  | "seed_unavailable"
+  | "usage_not_consumed"
+  | "unsafe_response";
+
+export type VideoNarrativeGuardSeverity = "info" | "warning" | "blocking";
+
+export interface VideoNarrativeGuardResult {
+  name: VideoNarrativeGuardName;
+  status: VideoNarrativeGuardStatus;
+  code: VideoNarrativeGuardBlockCode | null;
+  severity: VideoNarrativeGuardSeverity;
+  message: string;
+  shouldCallProvider: boolean;
+  shouldConsumeQuota: boolean;
+}
+
+export interface VideoNarrativeGuardPipelineSummary {
+  canCallProvider: boolean;
+  canConsumeQuota: boolean;
+  blockedBy: VideoNarrativeGuardResult | null;
+  results: VideoNarrativeGuardResult[];
+}
+
+export const VIDEO_NARRATIVE_GUARD_ORDER: VideoNarrativeGuardName[] = [
+  "method",
+  "session",
+  "admin_dev",
+  "feature_flag",
+  "content_type",
+  "payload_size",
+  "payload_schema",
+  "input_source",
+  "mime_duration_size",
+  "consent",
+  "retention",
+  "usage_quota",
+  "observability_start",
+  "provider",
+  "parse_fallback",
+  "seed_generation",
+  "usage_consumption",
+  "observability_completion",
+  "safe_response",
+];
+
+const PROVIDER_GUARD_INDEX = VIDEO_NARRATIVE_GUARD_ORDER.indexOf("provider");
+const QUOTA_DECISION_GUARDS: VideoNarrativeGuardName[] = [
+  "provider",
+  "parse_fallback",
+  "seed_generation",
+  "usage_consumption",
+  "safe_response",
+];
+
+const SAFE_DEFAULT_MESSAGES: Record<VideoNarrativeGuardName, string> = {
+  method: "Método validado.",
+  session: "Sessão validada.",
+  admin_dev: "Acesso interno validado.",
+  feature_flag: "Flag server-side validada.",
+  content_type: "Content-type validado.",
+  payload_size: "Tamanho do payload validado.",
+  payload_schema: "Payload validado.",
+  input_source: "Origem do vídeo validada.",
+  mime_duration_size: "Formato, duração e tamanho validados.",
+  consent: "Consentimento validado.",
+  retention: "Retenção validada.",
+  usage_quota: "Uso e quota validados.",
+  observability_start: "Observabilidade inicial validada.",
+  provider: "Provider validado.",
+  parse_fallback: "Parse e fallback validados.",
+  seed_generation: "Seed validado.",
+  usage_consumption: "Consumo de quota validado.",
+  observability_completion: "Observabilidade final validada.",
+  safe_response: "Resposta segura validada.",
+};
+
+const BLOCKED_TERMS = [
+  "viralizar garantido",
+  "treinado permanentemente",
+  "resposta correta",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "venceu",
+  "perdeu",
+];
+
+function getGuardOrderIndex(name: VideoNarrativeGuardName): number {
+  return VIDEO_NARRATIVE_GUARD_ORDER.indexOf(name);
+}
+
+function getResultForGuard(
+  results: VideoNarrativeGuardResult[],
+  name: VideoNarrativeGuardName,
+): VideoNarrativeGuardResult | undefined {
+  return results.find((result) => result.name === name);
+}
+
+export function sanitizeVideoNarrativeGuardMessage(message: string): string {
+  let sanitized = message;
+
+  sanitized = sanitized.replace(/AIza[0-9A-Za-z_-]{8,}/g, "[redigido]");
+  sanitized = sanitized.replace(/\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+/g, "[redigido]");
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/]{120,}={0,2}\b/g, "[redigido]");
+
+  BLOCKED_TERMS.forEach((term) => {
+    sanitized = sanitized.replace(new RegExp(term.replace(/\s+/g, "\\s+"), "gi"), "[redigido]");
+  });
+
+  return sanitized.trim() || "Guard avaliado.";
+}
+
+export function createPassedVideoNarrativeGuardResult(
+  name: VideoNarrativeGuardName,
+): VideoNarrativeGuardResult {
+  return {
+    name,
+    status: "passed",
+    code: null,
+    severity: "info",
+    message: sanitizeVideoNarrativeGuardMessage(SAFE_DEFAULT_MESSAGES[name]),
+    shouldCallProvider: true,
+    shouldConsumeQuota: false,
+  };
+}
+
+export function createBlockedVideoNarrativeGuardResult(params: {
+  name: VideoNarrativeGuardName;
+  code: VideoNarrativeGuardBlockCode;
+  message: string;
+  severity?: VideoNarrativeGuardSeverity;
+}): VideoNarrativeGuardResult {
+  return {
+    name: params.name,
+    status: "blocked",
+    code: params.code,
+    severity: params.severity ?? "blocking",
+    message: sanitizeVideoNarrativeGuardMessage(params.message),
+    shouldCallProvider: false,
+    shouldConsumeQuota: false,
+  };
+}
+
+export function createSkippedVideoNarrativeGuardResult(params: {
+  name: VideoNarrativeGuardName;
+  message?: string;
+}): VideoNarrativeGuardResult {
+  return {
+    name: params.name,
+    status: "skipped",
+    code: null,
+    severity: "info",
+    message: sanitizeVideoNarrativeGuardMessage(params.message ?? "Guard não executado."),
+    shouldCallProvider: false,
+    shouldConsumeQuota: false,
+  };
+}
+
+export function isVideoNarrativeGuardBlocking(result: VideoNarrativeGuardResult): boolean {
+  return result.status === "blocked" && result.severity === "blocking";
+}
+
+export function summarizeVideoNarrativeGuardResults(
+  results: VideoNarrativeGuardResult[],
+): VideoNarrativeGuardPipelineSummary {
+  const blockingResults = results.filter(isVideoNarrativeGuardBlocking);
+  const blockedBy =
+    blockingResults.sort((left, right) => getGuardOrderIndex(left.name) - getGuardOrderIndex(right.name))[0] ??
+    null;
+
+  const hasBlockingBeforeProvider = blockingResults.some(
+    (result) => getGuardOrderIndex(result.name) < PROVIDER_GUARD_INDEX,
+  );
+
+  const canCallProvider = !hasBlockingBeforeProvider;
+  const quotaRelevantBlocked = blockingResults.some((result) =>
+    QUOTA_DECISION_GUARDS.includes(result.name),
+  );
+  const usageConsumption = getResultForGuard(results, "usage_consumption");
+  const safeResponse = getResultForGuard(results, "safe_response");
+  const provider = getResultForGuard(results, "provider");
+
+  const canConsumeQuota =
+    canCallProvider &&
+    provider?.status === "passed" &&
+    usageConsumption?.status === "passed" &&
+    safeResponse?.status === "passed" &&
+    !quotaRelevantBlocked;
+
+  return {
+    canCallProvider,
+    canConsumeQuota,
+    blockedBy,
+    results,
+  };
+}
+
+export function shouldVideoNarrativeGuardAllowProviderCall(
+  results: VideoNarrativeGuardResult[],
+): boolean {
+  return summarizeVideoNarrativeGuardResults(results).canCallProvider;
+}
+
+export function shouldVideoNarrativeGuardAllowQuotaConsumption(
+  results: VideoNarrativeGuardResult[],
+): boolean {
+  return summarizeVideoNarrativeGuardResults(results).canConsumeQuota;
+}


### PR DESCRIPTION
Stacked sobre #815. Base: `feat/video-narrative-real-endpoint-guards-contract`.

## Summary
- Adds pure `VideoNarrativeGuardResult` / status contracts for the future real/admin video narrative endpoint guards.
- Defines `VIDEO_NARRATIVE_GUARD_ORDER` in the exact MM18 order.
- Adds deterministic helpers for passed/blocked/skipped guard results, pipeline summaries, provider/quota decisions, and safe message sanitization.
- Updates README, architecture, endpoint guards contract, endpoint contract, observability contract, and readiness audit to reference MM19.

## Non-goals
- No real endpoint or `route.ts`.
- No real upload, storage, UI, BoardShell connection, PostCreationFunnelState change, fetch, Gemini call, database/table, analytics provider, billing, Stripe, charge flow, cron/job, or new dependency.

## Validation
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath src/app/api/brand-narratives/reports/[slug]/route.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`