### PR TITLE
feat: add video narrative payload validation contracts

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -71,6 +71,7 @@ Já existe:
 - observabilidade foi formalizada em MM17, mas ainda não foi implementada;
 - endpoint guards foram formalizados em MM18, mas ainda não foram implementados;
 - guard contracts puros foram formalizados em MM19, mas ainda não foram conectados a endpoint real;
+- payload validation contracts foram formalizados em MM20, mas ainda não foram conectados a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -117,6 +118,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contrato formal de observabilidade;
 - contrato formal de guards do endpoint real;
 - contratos puros de guard result/status;
+- contratos puros de payload validation;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -430,6 +430,28 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM20 — Payload validation contracts
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativePayloadValidation.ts`
+- `videoNarrativePayloadValidation.test.ts`
+
+O que faz:
+
+- cria tipos puros para `VideoNarrativeAnalyzePayload` e `VideoNarrativeNormalizedAnalyzePayload`;
+- valida `id`, `creatorQuestion`, `videoUri`, `inlineVideoBase64`, `mimeType`, `source` e `creatorContext`;
+- prepara o futuro `payload_schema` guard e parte do `input_source` guard sem criar rota real.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, storage real, UI, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -226,8 +226,9 @@ Exemplos:
 16. MM17 — Observability contract. Define métricas, eventos, logs seguros, dashboards e alertas futuros.
 17. MM18 — Real endpoint guards contract. Define a ordem dos guards obrigatórios antes de route.ts ou provider real.
 18. MM19 — Pure guard contracts. Define tipos/helpers puros para resultados e resumo dos guards, sem endpoint.
-19. Teste real manual quando houver quota/billing disponível.
-20. Integração experimental futura no Board de Criação.
+19. MM20 — Payload validation contracts. Define validação pura para o futuro payload_schema guard e parte do input_source guard.
+20. Teste real manual quando houver quota/billing disponível.
+21. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -258,6 +259,8 @@ MM12 confirma que a linha está preparada para um teste real futuro sem executar
 MM13 define o formato futuro de acesso interno/admin, payload, resposta e limites antes de existir qualquer rota real. O contrato preserva a separação entre prontidão técnica e exposição de produto.
 
 MM14 separa a decisão de origem do vídeo da implementação de upload. Ele recomenda File API ou inline pequeno para teste manual, `videoUri` primeiro no endpoint interno e storage temporário próprio para beta/produto.
+
+MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePayload` e `validateVideoNarrativeAnalyzePayload` como contratos puros para validar payload futuro sem criar endpoint, route.ts, upload real ou UI.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
@@ -141,6 +141,8 @@ Pode servir apenas para testes muito controlados. Não é recomendada para produ
 
 O futuro endpoint deve aplicar input source guard conforme `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md` antes de chamar o provider.
 
+MM20 formaliza `VIDEO_NARRATIVE_ALLOWED_SOURCES` e `VIDEO_NARRATIVE_ALLOWED_MIME_TYPES` em código puro para preparar o futuro `payload_schema` guard e parte do `input_source` guard. `public_url_restricted` permanece documentado como source possível, mas bloqueado por padrão nesta fase.
+
 ## Limites Iniciais
 
 - vídeo até 60s;
@@ -175,6 +177,7 @@ O futuro endpoint deve aplicar input source guard conforme `VIDEO_NARRATIVE_REAL
 - contrato de limites/custo;
 - real run harness Gemini;
 - contrato de endpoint interno/admin;
+- payload validation contracts;
 - `VideoNarrativeAnalysis`.
 
 ## Critérios Antes De Implementar Upload Real

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -53,6 +53,8 @@ Regras:
 
 - precisa ter `videoUri` ou `inlineVideoBase64` + `mimeType`;
 - `creatorQuestion` é recomendado;
+- `VideoNarrativeAnalyzePayload` representa o payload bruto futuro;
+- `VideoNarrativeNormalizedAnalyzePayload` representa o payload normalizado após validação pura;
 - inline base64 só para testes pequenos/controlados;
 - `videoUri`/File API/storage é preferível para fluxo futuro;
 - a decisão detalhada de origem do vídeo fica no contrato `VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md`;
@@ -158,6 +160,8 @@ Regras:
 - `parseGeminiVideoNarrativeJson`;
 - `VideoNarrativeGuardResult`;
 - `VideoNarrativeGuardPipelineSummary`;
+- `VideoNarrativeAnalyzePayload`;
+- `VideoNarrativeNormalizedAnalyzePayload`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
 - `getPostCreationVideoSeedPrimaryAction`;
@@ -177,6 +181,7 @@ Só implementar depois que:
 - contrato de observabilidade estiver aprovado como bloqueio antes de endpoint real;
 - contrato de guards do endpoint real estiver aprovado antes de criar a rota real;
 - contratos puros de guard result/status estiverem disponíveis;
+- payload validation contracts estiverem disponíveis para `payload_schema` e `input_source`;
 - admin guard server-side estiver definido;
 - rate limit/usage limit tiver contrato;
 - consentimento/retenção estiverem planejados.
@@ -188,6 +193,8 @@ Só implementar depois que:
 - MM16: contrato de limites/custos;
 - MM17: contrato de métricas/observabilidade;
 - MM18: contrato dos guards do endpoint real;
-- MM19: endpoint interno real, se billing existir;
-- MM20: preview interno com chamada real;
-- MM21: integração experimental no board.
+- MM19: contratos puros de guard result/status;
+- MM20: payload validation contracts;
+- MM21: endpoint interno real, se billing existir;
+- MM22: preview interno com chamada real;
+- MM23: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -68,6 +68,8 @@ POST /api/internal/video-narrative/analyze
 - validar source;
 - validar creatorContext.
 
+MM20 adiciona `validateVideoNarrativeAnalyzePayload` como helper puro para preparar este guard futuro sem criar endpoint, route.ts ou chamada real.
+
 ### 8. Input Source Guard
 
 - aceitar sources documentados: gemini_file_api, inline_base64, temporary_storage, gcs, s3, r2, public_url_restricted;
@@ -271,6 +273,8 @@ Este contrato complementa:
 
 MM19 adiciona `VideoNarrativeGuardResult`, `VideoNarrativeGuardPipelineSummary` e `VIDEO_NARRATIVE_GUARD_ORDER` como fundação pura para representar essa ordem de guards, ainda sem endpoint real.
 
+MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePayload` e `validateVideoNarrativeAnalyzePayload` como fundação pura para o futuro payload_schema guard e parte do input_source guard.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -282,6 +286,7 @@ Só criar route.ts depois que:
 - consentimento/retenção estiverem aprovados;
 - usage/quota estiverem implementáveis;
 - observability hooks estiverem definidos;
+- payload validation contracts estiverem disponíveis para `payload_schema`;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -296,6 +301,7 @@ Como ainda não há billing/quota:
 ## Próximas Fases Possíveis
 
 - MM19: contratos puros de guard result/status;
-- MM20: storage cleanup contract;
-- MM21: endpoint real somente depois de billing/teste real;
-- MM22: preview interno com endpoint real.
+- MM20: payload validation contracts;
+- MM21: storage cleanup contract;
+- MM22: endpoint real somente depois de billing/teste real;
+- MM23: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts
@@ -1,0 +1,369 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VIDEO_NARRATIVE_ALLOWED_MIME_TYPES,
+  VIDEO_NARRATIVE_ALLOWED_SOURCES,
+  VIDEO_NARRATIVE_MAX_CREATOR_QUESTION_LENGTH,
+  VIDEO_NARRATIVE_MAX_ID_LENGTH,
+  VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+  VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVE_LENGTH,
+  VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVES,
+  isAllowedVideoNarrativeInputSource,
+  isAllowedVideoNarrativeMimeType,
+  sanitizeVideoNarrativePayloadText,
+  validateVideoNarrativeAnalyzePayload,
+} from "./videoNarrativePayloadValidation";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativePayloadValidation.ts");
+
+function issueCodes(payload: unknown): string[] {
+  return validateVideoNarrativeAnalyzePayload(payload).issues.map((issue) => issue.code);
+}
+
+describe("videoNarrativePayloadValidation", () => {
+  it("retorna missing_payload e guard blocked para payload não objeto", () => {
+    const result = validateVideoNarrativeAnalyzePayload(null);
+
+    expect(result.ok).toBe(false);
+    expect(result.normalized).toBeNull();
+    expect(result.issues).toEqual([
+      {
+        code: "missing_payload",
+        message: "Payload não validado.",
+        guardCode: "invalid_payload",
+      },
+    ]);
+    expect(result.guardResult).toMatchObject({
+      name: "payload_schema",
+      status: "blocked",
+      code: "invalid_payload",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("valida payload mínimo com videoUri e source gemini_file_api", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.normalized).toMatchObject({
+      id: "manual-video-narrative-run",
+      videoUri: "file-uri",
+      inlineVideoBase64: null,
+      mimeType: null,
+      source: "gemini_file_api",
+    });
+  });
+
+  it("valida payload mínimo com inlineVideoBase64, mimeType e source inline_base64", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      inlineVideoBase64: "abcd1234",
+      mimeType: "video/mp4",
+      source: "inline_base64",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.normalized).toMatchObject({
+      videoUri: null,
+      inlineVideoBase64: "abcd1234",
+      mimeType: "video/mp4",
+      source: "inline_base64",
+    });
+  });
+
+  it("retorna missing_video_input quando não há vídeo", () => {
+    expect(issueCodes({ source: "gemini_file_api" })).toContain("missing_video_input");
+  });
+
+  it("retorna conflicting_video_input quando videoUri e inlineVideoBase64 vêm juntos", () => {
+    expect(
+      issueCodes({
+        videoUri: "file-uri",
+        inlineVideoBase64: "abcd1234",
+        mimeType: "video/mp4",
+        source: "inline_base64",
+      }),
+    ).toContain("conflicting_video_input");
+  });
+
+  it("retorna inline_base64_too_large quando inline passa do limite", () => {
+    expect(
+      issueCodes({
+        inlineVideoBase64: "a".repeat(VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST + 1),
+        mimeType: "video/mp4",
+        source: "inline_base64",
+      }),
+    ).toContain("inline_base64_too_large");
+  });
+
+  it("retorna missing_mime_type quando inline não informa mimeType", () => {
+    expect(issueCodes({ inlineVideoBase64: "abcd1234", source: "inline_base64" })).toContain(
+      "missing_mime_type",
+    );
+  });
+
+  it("retorna invalid_mime_type para mimeType inválido", () => {
+    expect(
+      issueCodes({
+        inlineVideoBase64: "abcd1234",
+        mimeType: "video/avi",
+        source: "inline_base64",
+      }),
+    ).toContain("invalid_mime_type");
+  });
+
+  it("retorna invalid_source quando source está ausente", () => {
+    expect(issueCodes({ videoUri: "file-uri" })).toContain("invalid_source");
+  });
+
+  it("retorna invalid_source quando source é desconhecido", () => {
+    expect(issueCodes({ videoUri: "file-uri", source: "unknown" })).toContain("invalid_source");
+  });
+
+  it("bloqueia public_url_restricted por padrão", () => {
+    expect(issueCodes({ videoUri: "https://example.test/video.mp4", source: "public_url_restricted" })).toContain(
+      "source_not_allowed",
+    );
+  });
+
+  it("retorna missing_video_input para source inline_base64 sem inlineVideoBase64", () => {
+    expect(issueCodes({ source: "inline_base64" })).toContain("missing_video_input");
+  });
+
+  it("retorna missing_video_input para source gemini_file_api sem videoUri", () => {
+    expect(issueCodes({ source: "gemini_file_api" })).toContain("missing_video_input");
+  });
+
+  it("usa id default quando id está ausente", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+    });
+
+    expect(result.normalized?.id).toBe("manual-video-narrative-run");
+  });
+
+  it("retorna invalid_id quando id passa do limite", () => {
+    expect(
+      issueCodes({
+        id: "a".repeat(VIDEO_NARRATIVE_MAX_ID_LENGTH + 1),
+        videoUri: "file-uri",
+        source: "gemini_file_api",
+      }),
+    ).toContain("invalid_id");
+  });
+
+  it("trima creatorQuestion string", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      creatorQuestion: "  Quero saber se vale postar  ",
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+    });
+
+    expect(result.normalized?.creatorQuestion).toBe("Quero saber se vale postar");
+  });
+
+  it("retorna invalid_creator_question quando creatorQuestion passa do limite", () => {
+    expect(
+      issueCodes({
+        creatorQuestion: "a".repeat(VIDEO_NARRATIVE_MAX_CREATOR_QUESTION_LENGTH + 1),
+        videoUri: "file-uri",
+        source: "gemini_file_api",
+      }),
+    ).toContain("invalid_creator_question");
+  });
+
+  it("redige API key dentro de creatorQuestion", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      creatorQuestion: "usar GEMINI_API_KEY=secret",
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+    });
+
+    expect(result.normalized?.creatorQuestion).toBe("usar [redigido]");
+  });
+
+  it("normaliza creatorContext válido", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+      creatorContext: {
+        handle: "  @criador  ",
+        niche: "  beleza  ",
+        knownNarratives: [" rotina ", "", " transformação "],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.normalized?.creatorContext).toEqual({
+      handle: "@criador",
+      niche: "beleza",
+      knownNarratives: ["rotina", "transformação"],
+    });
+  });
+
+  it("retorna invalid_creator_context para creatorContext inválido", () => {
+    expect(
+      issueCodes({
+        videoUri: "file-uri",
+        source: "gemini_file_api",
+        creatorContext: "contexto",
+      }),
+    ).toContain("invalid_creator_context");
+  });
+
+  it("retorna creator_context_too_large quando knownNarratives passa do limite", () => {
+    expect(
+      issueCodes({
+        videoUri: "file-uri",
+        source: "gemini_file_api",
+        creatorContext: {
+          knownNarratives: Array.from({ length: VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVES + 1 }, (_, index) =>
+            `narrativa ${index}`,
+          ),
+        },
+      }),
+    ).toContain("creator_context_too_large");
+  });
+
+  it("remove knownNarratives vazias e corta texto longo", () => {
+    const longNarrative = Array.from({ length: 40 }, () => "narrativa").join(" ");
+    const result = validateVideoNarrativeAnalyzePayload({
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+      creatorContext: {
+        knownNarratives: ["", "   ", longNarrative],
+      },
+    });
+
+    expect(result.normalized?.creatorContext?.knownNarratives).toEqual([
+      longNarrative.slice(0, VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVE_LENGTH).trim(),
+    ]);
+  });
+
+  it("retorna guardResult passed quando ok", () => {
+    const result = validateVideoNarrativeAnalyzePayload({
+      videoUri: "file-uri",
+      source: "gemini_file_api",
+    });
+
+    expect(result.guardResult).toMatchObject({
+      name: "payload_schema",
+      status: "passed",
+      code: null,
+      shouldCallProvider: true,
+    });
+  });
+
+  it("retorna guardResult blocked quando inválido", () => {
+    const result = validateVideoNarrativeAnalyzePayload({});
+
+    expect(result.guardResult).toMatchObject({
+      name: "payload_schema",
+      status: "blocked",
+      code: "invalid_payload",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("isAllowedVideoNarrativeInputSource cobre todos os sources permitidos", () => {
+    VIDEO_NARRATIVE_ALLOWED_SOURCES.forEach((source) => {
+      expect(isAllowedVideoNarrativeInputSource(source)).toBe(true);
+    });
+    expect(isAllowedVideoNarrativeInputSource("source_desconhecida")).toBe(false);
+  });
+
+  it("isAllowedVideoNarrativeMimeType cobre todos os mimeTypes permitidos", () => {
+    VIDEO_NARRATIVE_ALLOWED_MIME_TYPES.forEach((mimeType) => {
+      expect(isAllowedVideoNarrativeMimeType(mimeType)).toBe(true);
+    });
+    expect(isAllowedVideoNarrativeMimeType("video/avi")).toBe(false);
+  });
+
+  it("redige AIza, GEMINI_API_KEY e GOOGLE_GENAI_API_KEY", () => {
+    expect(
+      sanitizeVideoNarrativePayloadText(
+        "AIza1234567890abcdefghi GEMINI_API_KEY=abc GOOGLE_GENAI_API_KEY=def",
+      ),
+    ).toBe("[redigido] [redigido] [redigido]");
+  });
+
+  it("redige base64 longo", () => {
+    expect(sanitizeVideoNarrativePayloadText(`payload ${"a".repeat(140)}`)).toBe("payload [redigido]");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const outputs = [
+      validateVideoNarrativeAnalyzePayload(null).issues.map((issue) => issue.message),
+      validateVideoNarrativeAnalyzePayload({}).issues.map((issue) => issue.message),
+      sanitizeVideoNarrativePayloadText(
+        "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      ),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.ts
@@ -1,0 +1,389 @@
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  sanitizeVideoNarrativeGuardMessage,
+  type VideoNarrativeGuardBlockCode,
+  type VideoNarrativeGuardResult,
+} from "./videoNarrativeGuardContracts";
+
+export type VideoNarrativeInputSource =
+  | "gemini_file_api"
+  | "inline_base64"
+  | "temporary_storage"
+  | "gcs"
+  | "s3"
+  | "r2"
+  | "public_url_restricted";
+
+export type VideoNarrativePayloadMimeType = "video/mp4" | "video/quicktime" | "video/webm";
+
+export interface VideoNarrativeAnalyzePayload {
+  id?: unknown;
+  creatorQuestion?: unknown;
+  videoUri?: unknown;
+  inlineVideoBase64?: unknown;
+  mimeType?: unknown;
+  source?: unknown;
+  creatorContext?: unknown;
+}
+
+export interface VideoNarrativeCreatorContextPayload {
+  handle?: string | null;
+  niche?: string | null;
+  knownNarratives?: string[];
+}
+
+export interface VideoNarrativeNormalizedAnalyzePayload {
+  id: string;
+  creatorQuestion: string | null;
+  videoUri: string | null;
+  inlineVideoBase64: string | null;
+  mimeType: VideoNarrativePayloadMimeType | null;
+  source: VideoNarrativeInputSource;
+  creatorContext: VideoNarrativeCreatorContextPayload | null;
+}
+
+export interface VideoNarrativePayloadValidationIssue {
+  code:
+    | "missing_payload"
+    | "invalid_id"
+    | "invalid_creator_question"
+    | "missing_video_input"
+    | "conflicting_video_input"
+    | "invalid_video_uri"
+    | "invalid_inline_base64"
+    | "inline_base64_too_large"
+    | "invalid_mime_type"
+    | "missing_mime_type"
+    | "invalid_source"
+    | "source_not_allowed"
+    | "invalid_creator_context"
+    | "creator_context_too_large";
+  message: string;
+  guardCode: VideoNarrativeGuardBlockCode;
+}
+
+export interface VideoNarrativePayloadValidationResult {
+  ok: boolean;
+  normalized: VideoNarrativeNormalizedAnalyzePayload | null;
+  issues: VideoNarrativePayloadValidationIssue[];
+  guardResult: VideoNarrativeGuardResult;
+}
+
+export const VIDEO_NARRATIVE_ALLOWED_SOURCES: VideoNarrativeInputSource[] = [
+  "gemini_file_api",
+  "inline_base64",
+  "temporary_storage",
+  "gcs",
+  "s3",
+  "r2",
+  "public_url_restricted",
+];
+
+export const VIDEO_NARRATIVE_ALLOWED_MIME_TYPES: VideoNarrativePayloadMimeType[] = [
+  "video/mp4",
+  "video/quicktime",
+  "video/webm",
+];
+
+export const VIDEO_NARRATIVE_MAX_CREATOR_QUESTION_LENGTH = 500;
+export const VIDEO_NARRATIVE_MAX_ID_LENGTH = 120;
+export const VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVES = 10;
+export const VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVE_LENGTH = 160;
+export const VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST = 1_500_000;
+
+const DEFAULT_VIDEO_NARRATIVE_ID = "manual-video-narrative-run";
+const URI_SOURCES: VideoNarrativeInputSource[] = [
+  "gemini_file_api",
+  "temporary_storage",
+  "gcs",
+  "s3",
+  "r2",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripControlCharacters(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f]/g, "");
+}
+
+function trimAndSanitize(value: string): string {
+  const stripped = stripControlCharacters(value).trim();
+  return stripped ? sanitizeVideoNarrativePayloadText(stripped).trim() : "";
+}
+
+function createIssue(
+  code: VideoNarrativePayloadValidationIssue["code"],
+  message: string,
+  guardCode: VideoNarrativeGuardBlockCode = "invalid_payload",
+): VideoNarrativePayloadValidationIssue {
+  return {
+    code,
+    message: trimAndSanitize(message),
+    guardCode,
+  };
+}
+
+function normalizeOptionalText(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const sanitized = trimAndSanitize(value);
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+function normalizeInlineBase64(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = stripControlCharacters(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function sanitizeVideoNarrativePayloadText(value: string): string {
+  return sanitizeVideoNarrativeGuardMessage(stripControlCharacters(value));
+}
+
+export function isAllowedVideoNarrativeInputSource(value: unknown): value is VideoNarrativeInputSource {
+  return (
+    typeof value === "string" &&
+    VIDEO_NARRATIVE_ALLOWED_SOURCES.includes(value as VideoNarrativeInputSource)
+  );
+}
+
+export function isAllowedVideoNarrativeMimeType(value: unknown): value is VideoNarrativePayloadMimeType {
+  return (
+    typeof value === "string" &&
+    VIDEO_NARRATIVE_ALLOWED_MIME_TYPES.includes(value as VideoNarrativePayloadMimeType)
+  );
+}
+
+export function normalizeVideoNarrativeCreatorQuestion(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const stripped = stripControlCharacters(value).trim();
+  if (!stripped || stripped.length > VIDEO_NARRATIVE_MAX_CREATOR_QUESTION_LENGTH) {
+    return null;
+  }
+
+  return trimAndSanitize(stripped);
+}
+
+export function normalizeVideoNarrativeId(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return DEFAULT_VIDEO_NARRATIVE_ID;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const stripped = stripControlCharacters(value).trim();
+  if (!stripped) {
+    return DEFAULT_VIDEO_NARRATIVE_ID;
+  }
+
+  if (stripped.length > VIDEO_NARRATIVE_MAX_ID_LENGTH) {
+    return null;
+  }
+
+  return trimAndSanitize(stripped);
+}
+
+export function normalizeVideoNarrativeCreatorContext(
+  value: unknown,
+): VideoNarrativeCreatorContextPayload | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const handle = normalizeOptionalText(value.handle);
+  const niche = normalizeOptionalText(value.niche);
+  const knownNarratives = Array.isArray(value.knownNarratives)
+    ? value.knownNarratives
+        .filter((item): item is string => typeof item === "string")
+        .map((item) =>
+          trimAndSanitize(item.slice(0, VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVE_LENGTH)),
+        )
+        .filter(Boolean)
+    : undefined;
+
+  const context: VideoNarrativeCreatorContextPayload = {
+    handle,
+    niche,
+  };
+
+  if (knownNarratives) {
+    context.knownNarratives = knownNarratives.slice(0, VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVES);
+  }
+
+  return context;
+}
+
+export function validateVideoNarrativeAnalyzePayload(
+  payload: unknown,
+): VideoNarrativePayloadValidationResult {
+  const issues: VideoNarrativePayloadValidationIssue[] = [];
+
+  if (!isRecord(payload)) {
+    issues.push(createIssue("missing_payload", "Payload não validado."));
+
+    return {
+      ok: false,
+      normalized: null,
+      issues,
+      guardResult: createBlockedVideoNarrativeGuardResult({
+        name: "payload_schema",
+        code: "invalid_payload",
+        message: "Payload não validado.",
+      }),
+    };
+  }
+
+  const id = normalizeVideoNarrativeId(payload.id);
+  if (id === null) {
+    issues.push(createIssue("invalid_id", "Identificador não validado."));
+  }
+
+  const creatorQuestion =
+    payload.creatorQuestion === undefined || payload.creatorQuestion === null
+      ? null
+      : normalizeVideoNarrativeCreatorQuestion(payload.creatorQuestion);
+  if (
+    payload.creatorQuestion !== undefined &&
+    payload.creatorQuestion !== null &&
+    (typeof payload.creatorQuestion !== "string" ||
+      stripControlCharacters(payload.creatorQuestion).trim().length >
+        VIDEO_NARRATIVE_MAX_CREATOR_QUESTION_LENGTH)
+  ) {
+    issues.push(createIssue("invalid_creator_question", "Pergunta do criador não validada."));
+  }
+
+  const source = isAllowedVideoNarrativeInputSource(payload.source) ? payload.source : null;
+  if (!source) {
+    issues.push(createIssue("invalid_source", "Origem do vídeo não validada.", "invalid_source"));
+  } else if (source === "public_url_restricted") {
+    issues.push(createIssue("source_not_allowed", "Origem pública restrita não habilitada.", "invalid_source"));
+  }
+
+  const videoUri = normalizeOptionalText(payload.videoUri);
+  const inlineVideoBase64 = normalizeInlineBase64(payload.inlineVideoBase64);
+
+  if (payload.videoUri !== undefined && payload.videoUri !== null && !videoUri) {
+    issues.push(createIssue("invalid_video_uri", "URI do vídeo não validada."));
+  }
+
+  if (payload.inlineVideoBase64 !== undefined && payload.inlineVideoBase64 !== null && !inlineVideoBase64) {
+    issues.push(createIssue("invalid_inline_base64", "Vídeo inline não validado."));
+  }
+
+  if (inlineVideoBase64 && inlineVideoBase64.length > VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST) {
+    issues.push(createIssue("inline_base64_too_large", "Vídeo inline acima do limite.", "payload_too_large"));
+  }
+
+  if (!videoUri && !inlineVideoBase64) {
+    issues.push(createIssue("missing_video_input", "Vídeo não informado."));
+  }
+
+  if (videoUri && inlineVideoBase64) {
+    issues.push(createIssue("conflicting_video_input", "Informe apenas uma origem de vídeo."));
+  }
+
+  let mimeType: VideoNarrativePayloadMimeType | null = null;
+  if (inlineVideoBase64 && payload.mimeType === undefined) {
+    issues.push(createIssue("missing_mime_type", "Formato de vídeo não informado.", "invalid_mime_type"));
+  } else if (payload.mimeType !== undefined && payload.mimeType !== null) {
+    if (isAllowedVideoNarrativeMimeType(payload.mimeType)) {
+      mimeType = payload.mimeType;
+    } else {
+      issues.push(createIssue("invalid_mime_type", "Formato de vídeo não aceito.", "invalid_mime_type"));
+    }
+  }
+
+  if (source === "inline_base64" && !inlineVideoBase64) {
+    issues.push(createIssue("missing_video_input", "Vídeo inline não informado."));
+  }
+
+  if (source && URI_SOURCES.includes(source) && !videoUri) {
+    issues.push(createIssue("missing_video_input", "URI do vídeo não informada."));
+  }
+
+  if (inlineVideoBase64 && source && source !== "inline_base64") {
+    issues.push(createIssue("invalid_source", "Origem do vídeo não combina com o payload.", "invalid_source"));
+  }
+
+  if (videoUri && source === "inline_base64") {
+    issues.push(createIssue("invalid_source", "Origem do vídeo não combina com o payload.", "invalid_source"));
+  }
+
+  let creatorContext: VideoNarrativeCreatorContextPayload | null = null;
+  if (payload.creatorContext !== undefined && payload.creatorContext !== null) {
+    if (!isRecord(payload.creatorContext)) {
+      issues.push(createIssue("invalid_creator_context", "Contexto do criador não validado."));
+    } else {
+      const rawContext = payload.creatorContext;
+      const hasInvalidTextField =
+        (rawContext.handle !== undefined && rawContext.handle !== null && typeof rawContext.handle !== "string") ||
+        (rawContext.niche !== undefined && rawContext.niche !== null && typeof rawContext.niche !== "string");
+      const hasInvalidNarratives =
+        rawContext.knownNarratives !== undefined && !Array.isArray(rawContext.knownNarratives);
+
+      if (hasInvalidTextField || hasInvalidNarratives) {
+        issues.push(createIssue("invalid_creator_context", "Contexto do criador não validado."));
+      }
+
+      if (
+        Array.isArray(rawContext.knownNarratives) &&
+        rawContext.knownNarratives.length > VIDEO_NARRATIVE_MAX_KNOWN_NARRATIVES
+      ) {
+        issues.push(createIssue("creator_context_too_large", "Contexto do criador acima do limite."));
+      }
+
+      creatorContext = normalizeVideoNarrativeCreatorContext(rawContext);
+    }
+  }
+
+  const ok = issues.length === 0;
+
+  return {
+    ok,
+    normalized:
+      ok && id && source
+        ? {
+            id,
+            creatorQuestion,
+            videoUri,
+            inlineVideoBase64,
+            mimeType,
+            source,
+            creatorContext,
+          }
+        : null,
+    issues,
+    guardResult: ok
+      ? createPassedVideoNarrativeGuardResult("payload_schema")
+      : createBlockedVideoNarrativeGuardResult({
+          name: "payload_schema",
+          code: "invalid_payload",
+          message: "Payload não validado.",
+        }),
+  };
+}


### PR DESCRIPTION
## Summary

Stacked sobre #816.

Este PR adiciona a fase MM20 com contratos puros de validação do payload futuro do endpoint interno/admin de análise narrativa de vídeo.

Inclui:
- `VideoNarrativeAnalyzePayload` e `VideoNarrativeNormalizedAnalyzePayload`;
- sources e mime types permitidos;
- `validateVideoNarrativeAnalyzePayload`;
- normalização de `id`, `creatorQuestion`, `videoUri`, `inlineVideoBase64`, `mimeType`, `source` e `creatorContext`;
- issues determinísticas e `VideoNarrativeGuardResult` para o futuro `payload_schema` guard;
- sanitização de API key/base64 em texto humano.

## Non-goals

- Não cria endpoint real.
- Não cria `route.ts`.
- Não cria upload real.
- Não cria UI.
- Não cria banco/tabela.
- Não cria analytics real.
- Não conecta no BoardShell.
- Não altera `PostCreationFunnelState` real.
- Não chama Gemini real.
- Não faz `fetch`.
- Não adiciona dependência nova.
- Não integra billing/Stripe/cobrança real.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath 'src/app/api/brand-narratives/reports/[slug]/route.test.ts'`
- `npm run typecheck`
- `git diff --check`
- `npm run build`