### PR TITLE
feat: add video narrative input source guards

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -72,6 +72,7 @@ Já existe:
 - endpoint guards foram formalizados em MM18, mas ainda não foram implementados;
 - guard contracts puros foram formalizados em MM19, mas ainda não foram conectados a endpoint real;
 - payload validation contracts foram formalizados em MM20, mas ainda não foram conectados a endpoint real;
+- input/source guard helpers foram formalizados em MM21, mas ainda não foram conectados a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -119,6 +120,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contrato formal de guards do endpoint real;
 - contratos puros de guard result/status;
 - contratos puros de payload validation;
+- helpers puros de input/source guard;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -452,6 +452,28 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM21 — Input/source guard helpers
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeInputSourceGuards.ts`
+- `videoNarrativeInputSourceGuards.test.ts`
+
+O que faz:
+
+- cria helpers puros para decidir se uma origem de vídeo normalizada pode ser usada em cada fase;
+- define políticas para `manual_real_test`, `internal_endpoint`, `closed_beta` e `production`;
+- prepara o futuro `input_source` guard sem criar endpoint, upload real ou storage real.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, storage real, UI, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -227,8 +227,9 @@ Exemplos:
 17. MM18 — Real endpoint guards contract. Define a ordem dos guards obrigatórios antes de route.ts ou provider real.
 18. MM19 — Pure guard contracts. Define tipos/helpers puros para resultados e resumo dos guards, sem endpoint.
 19. MM20 — Payload validation contracts. Define validação pura para o futuro payload_schema guard e parte do input_source guard.
-20. Teste real manual quando houver quota/billing disponível.
-21. Integração experimental futura no Board de Criação.
+20. MM21 — Input/source guard helpers. Define políticas puras por fase para o futuro input_source guard.
+21. Teste real manual quando houver quota/billing disponível.
+22. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -261,6 +262,8 @@ MM13 define o formato futuro de acesso interno/admin, payload, resposta e limite
 MM14 separa a decisão de origem do vídeo da implementação de upload. Ele recomenda File API ou inline pequeno para teste manual, `videoUri` primeiro no endpoint interno e storage temporário próprio para beta/produto.
 
 MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePayload` e `validateVideoNarrativeAnalyzePayload` como contratos puros para validar payload futuro sem criar endpoint, route.ts, upload real ou UI.
+
+MM21 adiciona `VideoNarrativeInputSourceGuardPolicy` e `validateVideoNarrativeInputSourceForPhase` para aplicar políticas por fase sobre payload já normalizado, ainda sem endpoint, upload real ou storage real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INPUT_SOURCE_CONTRACT.md
@@ -143,6 +143,8 @@ O futuro endpoint deve aplicar input source guard conforme `VIDEO_NARRATIVE_REAL
 
 MM20 formaliza `VIDEO_NARRATIVE_ALLOWED_SOURCES` e `VIDEO_NARRATIVE_ALLOWED_MIME_TYPES` em código puro para preparar o futuro `payload_schema` guard e parte do `input_source` guard. `public_url_restricted` permanece documentado como source possível, mas bloqueado por padrão nesta fase.
 
+MM21 formaliza `VIDEO_NARRATIVE_INPUT_SOURCE_POLICIES` para as fases `manual_real_test`, `internal_endpoint`, `closed_beta` e `production`. As políticas permitem File API e inline pequeno apenas em fases internas/controladas, priorizam storage/URI para beta/produto e mantêm `public_url_restricted` bloqueado por padrão.
+
 ## Limites Iniciais
 
 - vídeo até 60s;
@@ -178,6 +180,7 @@ MM20 formaliza `VIDEO_NARRATIVE_ALLOWED_SOURCES` e `VIDEO_NARRATIVE_ALLOWED_MIME
 - real run harness Gemini;
 - contrato de endpoint interno/admin;
 - payload validation contracts;
+- input/source guard helpers;
 - `VideoNarrativeAnalysis`.
 
 ## Critérios Antes De Implementar Upload Real

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -76,6 +76,8 @@ MM20 adiciona `validateVideoNarrativeAnalyzePayload` como helper puro para prepa
 - restringir public_url_restricted;
 - bloquear base64 como fluxo principal.
 
+MM21 adiciona `validateVideoNarrativeInputSourceForPhase` e políticas puras por fase para preparar este guard futuro sem criar endpoint, route.ts, upload real ou storage real.
+
 ### 9. Mime/Duration/Size Guard
 
 - mimeTypes permitidos;
@@ -275,6 +277,8 @@ MM19 adiciona `VideoNarrativeGuardResult`, `VideoNarrativeGuardPipelineSummary` 
 
 MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePayload` e `validateVideoNarrativeAnalyzePayload` como fundação pura para o futuro payload_schema guard e parte do input_source guard.
 
+MM21 adiciona `VideoNarrativeInputSourceGuardPolicy`, `VideoNarrativeInputSourcePhase` e `validateVideoNarrativeInputSourceForPhase` como fundação pura específica para o input_source guard.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -287,6 +291,7 @@ Só criar route.ts depois que:
 - usage/quota estiverem implementáveis;
 - observability hooks estiverem definidos;
 - payload validation contracts estiverem disponíveis para `payload_schema`;
+- input/source guard helpers estiverem disponíveis para `input_source`;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -302,6 +307,7 @@ Como ainda não há billing/quota:
 
 - MM19: contratos puros de guard result/status;
 - MM20: payload validation contracts;
-- MM21: storage cleanup contract;
-- MM22: endpoint real somente depois de billing/teste real;
-- MM23: preview interno com endpoint real.
+- MM21: input/source guard helpers;
+- MM22: storage cleanup contract;
+- MM23: endpoint real somente depois de billing/teste real;
+- MM24: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts
@@ -1,0 +1,430 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildVideoNarrativeInputSourceGuardResult,
+  getVideoNarrativeInputSourcePolicy,
+  isVideoNarrativeInputSourceAllowedForPhase,
+  requiresVideoNarrativeInlinePayload,
+  requiresVideoNarrativeMimeTypeForSource,
+  requiresVideoNarrativeVideoUri,
+  validateVideoNarrativeInputSourceForPhase,
+  type VideoNarrativeInputSourcePhase,
+} from "./videoNarrativeInputSourceGuards";
+import {
+  VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+  type VideoNarrativeInputSource,
+  type VideoNarrativeNormalizedAnalyzePayload,
+} from "./videoNarrativePayloadValidation";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeInputSourceGuards.ts");
+
+function buildPayload(
+  overrides: Partial<VideoNarrativeNormalizedAnalyzePayload> = {},
+): VideoNarrativeNormalizedAnalyzePayload {
+  return {
+    id: "manual-video-narrative-run",
+    creatorQuestion: null,
+    videoUri: "file-uri",
+    inlineVideoBase64: null,
+    mimeType: null,
+    source: "gemini_file_api",
+    creatorContext: null,
+    ...overrides,
+  };
+}
+
+function codesFor(params: {
+  payload: VideoNarrativeNormalizedAnalyzePayload;
+  phase: VideoNarrativeInputSourcePhase;
+}): string[] {
+  return validateVideoNarrativeInputSourceForPhase(params).issues.map((issue) => issue.code);
+}
+
+describe("videoNarrativeInputSourceGuards", () => {
+  it("retorna política de manual_real_test", () => {
+    expect(getVideoNarrativeInputSourcePolicy("manual_real_test")).toEqual({
+      phase: "manual_real_test",
+      allowGeminiFileApi: true,
+      allowInlineBase64: true,
+      allowTemporaryStorage: false,
+      allowGcs: false,
+      allowS3: false,
+      allowR2: false,
+      allowPublicUrlRestricted: false,
+      requireVideoUriForRemoteSources: true,
+      requireMimeTypeForInline: true,
+      maxInlineBase64Length: VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+    });
+  });
+
+  it("retorna política de internal_endpoint", () => {
+    expect(getVideoNarrativeInputSourcePolicy("internal_endpoint")).toMatchObject({
+      phase: "internal_endpoint",
+      allowGeminiFileApi: true,
+      allowInlineBase64: true,
+      allowTemporaryStorage: true,
+      allowGcs: true,
+      allowS3: true,
+      allowR2: true,
+      allowPublicUrlRestricted: false,
+    });
+  });
+
+  it("retorna política de closed_beta", () => {
+    expect(getVideoNarrativeInputSourcePolicy("closed_beta")).toMatchObject({
+      phase: "closed_beta",
+      allowGeminiFileApi: false,
+      allowInlineBase64: false,
+      allowTemporaryStorage: true,
+      allowGcs: true,
+      allowS3: true,
+      allowR2: true,
+      allowPublicUrlRestricted: false,
+      maxInlineBase64Length: 0,
+    });
+  });
+
+  it("retorna política de production", () => {
+    expect(getVideoNarrativeInputSourcePolicy("production")).toMatchObject({
+      phase: "production",
+      allowGeminiFileApi: false,
+      allowInlineBase64: false,
+      allowTemporaryStorage: true,
+      allowGcs: true,
+      allowS3: true,
+      allowR2: true,
+      allowPublicUrlRestricted: false,
+      maxInlineBase64Length: 0,
+    });
+  });
+
+  it("manual_real_test permite gemini_file_api", () => {
+    expect(
+      isVideoNarrativeInputSourceAllowedForPhase({
+        source: "gemini_file_api",
+        phase: "manual_real_test",
+      }),
+    ).toBe(true);
+  });
+
+  it("manual_real_test permite inline_base64", () => {
+    expect(
+      isVideoNarrativeInputSourceAllowedForPhase({
+        source: "inline_base64",
+        phase: "manual_real_test",
+      }),
+    ).toBe(true);
+  });
+
+  it("manual_real_test bloqueia temporary_storage", () => {
+    expect(
+      isVideoNarrativeInputSourceAllowedForPhase({
+        source: "temporary_storage",
+        phase: "manual_real_test",
+      }),
+    ).toBe(false);
+  });
+
+  it("internal_endpoint permite gemini_file_api", () => {
+    expect(
+      isVideoNarrativeInputSourceAllowedForPhase({
+        source: "gemini_file_api",
+        phase: "internal_endpoint",
+      }),
+    ).toBe(true);
+  });
+
+  it.each<VideoNarrativeInputSource>(["temporary_storage", "gcs", "s3", "r2"])(
+    "internal_endpoint permite %s",
+    (source) => {
+      expect(isVideoNarrativeInputSourceAllowedForPhase({ source, phase: "internal_endpoint" })).toBe(true);
+    },
+  );
+
+  it("closed_beta bloqueia gemini_file_api e inline_base64", () => {
+    expect(isVideoNarrativeInputSourceAllowedForPhase({ source: "gemini_file_api", phase: "closed_beta" })).toBe(
+      false,
+    );
+    expect(isVideoNarrativeInputSourceAllowedForPhase({ source: "inline_base64", phase: "closed_beta" })).toBe(
+      false,
+    );
+  });
+
+  it("production bloqueia gemini_file_api e inline_base64", () => {
+    expect(isVideoNarrativeInputSourceAllowedForPhase({ source: "gemini_file_api", phase: "production" })).toBe(
+      false,
+    );
+    expect(isVideoNarrativeInputSourceAllowedForPhase({ source: "inline_base64", phase: "production" })).toBe(
+      false,
+    );
+  });
+
+  it.each<VideoNarrativeInputSourcePhase>([
+    "manual_real_test",
+    "internal_endpoint",
+    "closed_beta",
+    "production",
+  ])("public_url_restricted bloqueia em %s", (phase) => {
+    expect(
+      validateVideoNarrativeInputSourceForPhase({
+        payload: buildPayload({
+          source: "public_url_restricted",
+          videoUri: "https://example.test/video.mp4",
+        }),
+        phase,
+      }).issues.map((issue) => issue.code),
+    ).toContain("public_url_not_allowed");
+  });
+
+  it("requiresVideoNarrativeVideoUri retorna true para sources remotos", () => {
+    (["gemini_file_api", "temporary_storage", "gcs", "s3", "r2", "public_url_restricted"] as const).forEach(
+      (source) => {
+        expect(requiresVideoNarrativeVideoUri(source)).toBe(true);
+      },
+    );
+    expect(requiresVideoNarrativeVideoUri("inline_base64")).toBe(false);
+  });
+
+  it("requiresVideoNarrativeInlinePayload retorna true só para inline_base64", () => {
+    (["gemini_file_api", "temporary_storage", "gcs", "s3", "r2", "public_url_restricted"] as const).forEach(
+      (source) => {
+        expect(requiresVideoNarrativeInlinePayload(source)).toBe(false);
+      },
+    );
+    expect(requiresVideoNarrativeInlinePayload("inline_base64")).toBe(true);
+  });
+
+  it("requiresVideoNarrativeMimeTypeForSource retorna true para inline_base64", () => {
+    expect(requiresVideoNarrativeMimeTypeForSource("inline_base64")).toBe(true);
+    expect(requiresVideoNarrativeMimeTypeForSource("gemini_file_api")).toBe(false);
+  });
+
+  it("passa para gemini_file_api com videoUri em manual_real_test", () => {
+    const result = validateVideoNarrativeInputSourceForPhase({
+      payload: buildPayload({ source: "gemini_file_api", videoUri: "file-uri" }),
+      phase: "manual_real_test",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.guardResult.status).toBe("passed");
+  });
+
+  it("passa para inline_base64 com mimeType e payload pequeno em manual_real_test", () => {
+    const result = validateVideoNarrativeInputSourceForPhase({
+      payload: buildPayload({
+        source: "inline_base64",
+        videoUri: null,
+        inlineVideoBase64: "abcd1234",
+        mimeType: "video/mp4",
+      }),
+      phase: "manual_real_test",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("bloqueia inline_base64 em production", () => {
+    expect(
+      codesFor({
+        payload: buildPayload({
+          source: "inline_base64",
+          videoUri: null,
+          inlineVideoBase64: "abcd1234",
+          mimeType: "video/mp4",
+        }),
+        phase: "production",
+      }),
+    ).toContain("source_not_allowed_for_phase");
+  });
+
+  it("bloqueia source remoto sem videoUri", () => {
+    expect(
+      codesFor({
+        payload: buildPayload({ source: "gcs", videoUri: null }),
+        phase: "internal_endpoint",
+      }),
+    ).toContain("missing_video_uri_for_source");
+  });
+
+  it("bloqueia inline sem mimeType", () => {
+    expect(
+      codesFor({
+        payload: buildPayload({
+          source: "inline_base64",
+          videoUri: null,
+          inlineVideoBase64: "abcd1234",
+          mimeType: null,
+        }),
+        phase: "manual_real_test",
+      }),
+    ).toContain("missing_mime_type_for_inline");
+  });
+
+  it("bloqueia inline acima do limite da fase", () => {
+    expect(
+      codesFor({
+        payload: buildPayload({
+          source: "inline_base64",
+          videoUri: null,
+          inlineVideoBase64: "a".repeat(VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST + 1),
+          mimeType: "video/mp4",
+        }),
+        phase: "manual_real_test",
+      }),
+    ).toContain("inline_base64_too_large_for_phase");
+  });
+
+  it("bloqueia source/payload mismatch", () => {
+    expect(
+      codesFor({
+        payload: buildPayload({
+          source: "gcs",
+          videoUri: "gcs-uri",
+          inlineVideoBase64: "abcd1234",
+        }),
+        phase: "internal_endpoint",
+      }),
+    ).toContain("source_payload_mismatch");
+
+    expect(
+      codesFor({
+        payload: buildPayload({
+          source: "inline_base64",
+          videoUri: "file-uri",
+          inlineVideoBase64: "abcd1234",
+          mimeType: "video/mp4",
+        }),
+        phase: "manual_real_test",
+      }),
+    ).toContain("source_payload_mismatch");
+  });
+
+  it("buildVideoNarrativeInputSourceGuardResult cria passed guard quando ok", () => {
+    expect(
+      buildVideoNarrativeInputSourceGuardResult({
+        ok: true,
+        source: "gemini_file_api",
+        phase: "manual_real_test",
+      }).guardResult,
+    ).toMatchObject({
+      name: "input_source",
+      status: "passed",
+      code: null,
+      shouldCallProvider: true,
+    });
+  });
+
+  it("buildVideoNarrativeInputSourceGuardResult cria blocked guard quando inválido", () => {
+    expect(
+      buildVideoNarrativeInputSourceGuardResult({
+        ok: false,
+        source: "temporary_storage",
+        phase: "manual_real_test",
+        issues: [{ code: "source_not_allowed_for_phase", message: "Origem não habilitada." }],
+      }).guardResult,
+    ).toMatchObject({
+      name: "input_source",
+      status: "blocked",
+      code: "invalid_source",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("mensagens não incluem base64 mesmo quando payload tem base64 longo", () => {
+    const result = validateVideoNarrativeInputSourceForPhase({
+      payload: buildPayload({
+        source: "inline_base64",
+        videoUri: null,
+        inlineVideoBase64: "a".repeat(VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST + 1),
+        mimeType: "video/mp4",
+      }),
+      phase: "manual_real_test",
+    });
+
+    const text = result.issues.map((issue) => issue.message).join(" ");
+    expect(text).not.toContain("a".repeat(120));
+    expect(text).toContain("Vídeo inline acima do limite desta fase.");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const outputs = [
+      buildVideoNarrativeInputSourceGuardResult({
+        ok: false,
+        source: "temporary_storage",
+        phase: "manual_real_test",
+        issues: [{ code: "source_not_allowed_for_phase", message: "Origem não habilitada." }],
+      }).guardResult.message,
+      validateVideoNarrativeInputSourceForPhase({
+        payload: buildPayload({
+          source: "inline_base64",
+          videoUri: null,
+          inlineVideoBase64: "a".repeat(VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST + 1),
+          mimeType: "video/mp4",
+        }),
+        phase: "manual_real_test",
+      }).issues.map((issue) => issue.message),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.ts
@@ -1,0 +1,279 @@
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  sanitizeVideoNarrativeGuardMessage,
+  type VideoNarrativeGuardResult,
+} from "./videoNarrativeGuardContracts";
+import {
+  VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+  type VideoNarrativeInputSource,
+  type VideoNarrativeNormalizedAnalyzePayload,
+} from "./videoNarrativePayloadValidation";
+
+export type VideoNarrativeInputSourcePhase =
+  | "manual_real_test"
+  | "internal_endpoint"
+  | "closed_beta"
+  | "production";
+
+export interface VideoNarrativeInputSourceGuardPolicy {
+  phase: VideoNarrativeInputSourcePhase;
+  allowGeminiFileApi: boolean;
+  allowInlineBase64: boolean;
+  allowTemporaryStorage: boolean;
+  allowGcs: boolean;
+  allowS3: boolean;
+  allowR2: boolean;
+  allowPublicUrlRestricted: boolean;
+  requireVideoUriForRemoteSources: boolean;
+  requireMimeTypeForInline: boolean;
+  maxInlineBase64Length: number;
+}
+
+export interface VideoNarrativeInputSourceGuardIssue {
+  code:
+    | "source_not_allowed_for_phase"
+    | "missing_video_uri_for_source"
+    | "missing_inline_payload"
+    | "missing_mime_type_for_inline"
+    | "inline_base64_too_large_for_phase"
+    | "public_url_not_allowed"
+    | "source_payload_mismatch";
+  message: string;
+}
+
+export interface VideoNarrativeInputSourceGuardResult {
+  ok: boolean;
+  source: VideoNarrativeInputSource;
+  phase: VideoNarrativeInputSourcePhase;
+  issues: VideoNarrativeInputSourceGuardIssue[];
+  guardResult: VideoNarrativeGuardResult;
+}
+
+export const VIDEO_NARRATIVE_INPUT_SOURCE_POLICIES: Record<
+  VideoNarrativeInputSourcePhase,
+  VideoNarrativeInputSourceGuardPolicy
+> = {
+  manual_real_test: {
+    phase: "manual_real_test",
+    allowGeminiFileApi: true,
+    allowInlineBase64: true,
+    allowTemporaryStorage: false,
+    allowGcs: false,
+    allowS3: false,
+    allowR2: false,
+    allowPublicUrlRestricted: false,
+    requireVideoUriForRemoteSources: true,
+    requireMimeTypeForInline: true,
+    maxInlineBase64Length: VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+  },
+  internal_endpoint: {
+    phase: "internal_endpoint",
+    allowGeminiFileApi: true,
+    allowInlineBase64: true,
+    allowTemporaryStorage: true,
+    allowGcs: true,
+    allowS3: true,
+    allowR2: true,
+    allowPublicUrlRestricted: false,
+    requireVideoUriForRemoteSources: true,
+    requireMimeTypeForInline: true,
+    maxInlineBase64Length: VIDEO_NARRATIVE_MAX_INLINE_BASE64_LENGTH_FOR_INTERNAL_TEST,
+  },
+  closed_beta: {
+    phase: "closed_beta",
+    allowGeminiFileApi: false,
+    allowInlineBase64: false,
+    allowTemporaryStorage: true,
+    allowGcs: true,
+    allowS3: true,
+    allowR2: true,
+    allowPublicUrlRestricted: false,
+    requireVideoUriForRemoteSources: true,
+    requireMimeTypeForInline: true,
+    maxInlineBase64Length: 0,
+  },
+  production: {
+    phase: "production",
+    allowGeminiFileApi: false,
+    allowInlineBase64: false,
+    allowTemporaryStorage: true,
+    allowGcs: true,
+    allowS3: true,
+    allowR2: true,
+    allowPublicUrlRestricted: false,
+    requireVideoUriForRemoteSources: true,
+    requireMimeTypeForInline: true,
+    maxInlineBase64Length: 0,
+  },
+};
+
+const REMOTE_VIDEO_URI_SOURCES: VideoNarrativeInputSource[] = [
+  "gemini_file_api",
+  "temporary_storage",
+  "gcs",
+  "s3",
+  "r2",
+  "public_url_restricted",
+];
+
+function sanitizeIssueMessage(message: string): string {
+  return sanitizeVideoNarrativeGuardMessage(message);
+}
+
+function createInputSourceIssue(
+  code: VideoNarrativeInputSourceGuardIssue["code"],
+  message: string,
+): VideoNarrativeInputSourceGuardIssue {
+  return {
+    code,
+    message: sanitizeIssueMessage(message),
+  };
+}
+
+export function getVideoNarrativeInputSourcePolicy(
+  phase: VideoNarrativeInputSourcePhase,
+): VideoNarrativeInputSourceGuardPolicy {
+  return VIDEO_NARRATIVE_INPUT_SOURCE_POLICIES[phase];
+}
+
+export function isVideoNarrativeInputSourceAllowedForPhase(params: {
+  source: VideoNarrativeInputSource;
+  phase: VideoNarrativeInputSourcePhase;
+}): boolean {
+  const policy = getVideoNarrativeInputSourcePolicy(params.phase);
+
+  switch (params.source) {
+    case "gemini_file_api":
+      return policy.allowGeminiFileApi;
+    case "inline_base64":
+      return policy.allowInlineBase64;
+    case "temporary_storage":
+      return policy.allowTemporaryStorage;
+    case "gcs":
+      return policy.allowGcs;
+    case "s3":
+      return policy.allowS3;
+    case "r2":
+      return policy.allowR2;
+    case "public_url_restricted":
+      return policy.allowPublicUrlRestricted;
+  }
+}
+
+export function requiresVideoNarrativeVideoUri(source: VideoNarrativeInputSource): boolean {
+  return REMOTE_VIDEO_URI_SOURCES.includes(source);
+}
+
+export function requiresVideoNarrativeInlinePayload(source: VideoNarrativeInputSource): boolean {
+  return source === "inline_base64";
+}
+
+export function requiresVideoNarrativeMimeTypeForSource(source: VideoNarrativeInputSource): boolean {
+  return source === "inline_base64";
+}
+
+export function buildVideoNarrativeInputSourceGuardResult(params: {
+  ok: boolean;
+  source: VideoNarrativeInputSource;
+  phase: VideoNarrativeInputSourcePhase;
+  issues?: VideoNarrativeInputSourceGuardResult["issues"];
+}): VideoNarrativeInputSourceGuardResult {
+  const issues = params.issues ?? [];
+
+  return {
+    ok: params.ok,
+    source: params.source,
+    phase: params.phase,
+    issues,
+    guardResult: params.ok
+      ? createPassedVideoNarrativeGuardResult("input_source")
+      : createBlockedVideoNarrativeGuardResult({
+          name: "input_source",
+          code: "invalid_source",
+          message: "Origem do vídeo não validada.",
+        }),
+  };
+}
+
+export function validateVideoNarrativeInputSourceForPhase(params: {
+  payload: VideoNarrativeNormalizedAnalyzePayload;
+  phase: VideoNarrativeInputSourcePhase;
+}): VideoNarrativeInputSourceGuardResult {
+  const { payload, phase } = params;
+  const policy = getVideoNarrativeInputSourcePolicy(phase);
+  const issues: VideoNarrativeInputSourceGuardIssue[] = [];
+
+  if (!isVideoNarrativeInputSourceAllowedForPhase({ source: payload.source, phase })) {
+    issues.push(
+      createInputSourceIssue(
+        "source_not_allowed_for_phase",
+        "Origem do vídeo não habilitada para esta fase.",
+      ),
+    );
+  }
+
+  if (payload.source === "public_url_restricted") {
+    issues.push(
+      createInputSourceIssue("public_url_not_allowed", "URL pública restrita não habilitada."),
+    );
+  }
+
+  if (
+    policy.requireVideoUriForRemoteSources &&
+    requiresVideoNarrativeVideoUri(payload.source) &&
+    !payload.videoUri
+  ) {
+    issues.push(createInputSourceIssue("missing_video_uri_for_source", "URI do vídeo não informada."));
+  }
+
+  if (requiresVideoNarrativeInlinePayload(payload.source) && !payload.inlineVideoBase64) {
+    issues.push(createInputSourceIssue("missing_inline_payload", "Vídeo inline não informado."));
+  }
+
+  if (
+    policy.requireMimeTypeForInline &&
+    requiresVideoNarrativeMimeTypeForSource(payload.source) &&
+    !payload.mimeType
+  ) {
+    issues.push(createInputSourceIssue("missing_mime_type_for_inline", "Formato do vídeo não informado."));
+  }
+
+  if (
+    payload.source === "inline_base64" &&
+    payload.inlineVideoBase64 &&
+    payload.inlineVideoBase64.length > policy.maxInlineBase64Length
+  ) {
+    issues.push(
+      createInputSourceIssue(
+        "inline_base64_too_large_for_phase",
+        "Vídeo inline acima do limite desta fase.",
+      ),
+    );
+  }
+
+  if (requiresVideoNarrativeVideoUri(payload.source) && payload.inlineVideoBase64) {
+    issues.push(
+      createInputSourceIssue(
+        "source_payload_mismatch",
+        "Origem remota não deve receber payload inline.",
+      ),
+    );
+  }
+
+  if (payload.source === "inline_base64" && payload.videoUri) {
+    issues.push(
+      createInputSourceIssue(
+        "source_payload_mismatch",
+        "Origem inline não deve receber URI de vídeo.",
+      ),
+    );
+  }
+
+  return buildVideoNarrativeInputSourceGuardResult({
+    ok: issues.length === 0,
+    source: payload.source,
+    phase,
+    issues,
+  });
+}


### PR DESCRIPTION
## Summary

Stacked sobre #817.

Este PR adiciona a fase MM21 com helpers puros para o futuro `input_source` guard da análise narrativa de vídeo.

Inclui:
- `VideoNarrativeInputSourcePhase`;
- `VideoNarrativeInputSourceGuardPolicy`;
- `VideoNarrativeInputSourceGuardResult`;
- `VIDEO_NARRATIVE_INPUT_SOURCE_POLICIES`;
- helpers para política por fase, exigência de `videoUri`, inline payload e mime type;
- `validateVideoNarrativeInputSourceForPhase` usando payload já normalizado pelo MM20;
- integração com `VideoNarrativeGuardResult` para `input_source`.

## Policies

- `manual_real_test`: permite Gemini File API e inline base64 pequeno.
- `internal_endpoint`: permite Gemini File API, inline controlado e sources remotos/storage.
- `closed_beta`: bloqueia Gemini File API e inline; prioriza storage/URI.
- `production`: bloqueia Gemini File API e inline; prioriza storage/URI.
- `public_url_restricted`: bloqueado em todas as fases por enquanto.

## Non-goals

- Não cria endpoint real.
- Não cria `route.ts`.
- Não cria upload real.
- Não cria UI.
- Não cria banco/tabela.
- Não cria analytics real.
- Não conecta no BoardShell.
- Não altera `PostCreationFunnelState` real.
- Não chama Gemini real.
- Não faz `fetch`.
- Não adiciona dependência nova.
- Não integra billing/Stripe/cobrança real.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath 'src/app/api/brand-narratives/reports/[slug]/route.test.ts'`
- `npm run typecheck`
- `git diff --check`
- `npm run build`