### PR TITLE
feat: add video narrative consent retention guards

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -73,6 +73,7 @@ Já existe:
 - guard contracts puros foram formalizados em MM19, mas ainda não foram conectados a endpoint real;
 - payload validation contracts foram formalizados em MM20, mas ainda não foram conectados a endpoint real;
 - input/source guard helpers foram formalizados em MM21, mas ainda não foram conectados a endpoint real;
+- consent/retention guard helpers foram formalizados em MM22, mas ainda não foram conectados a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -121,6 +122,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contratos puros de guard result/status;
 - contratos puros de payload validation;
 - helpers puros de input/source guard;
+- helpers puros de consent/retention guard;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -474,6 +474,28 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM22 — Consent/retention guard helpers
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeConsentRetentionGuards.ts`
+- `videoNarrativeConsentRetentionGuards.test.ts`
+
+O que faz:
+
+- cria helpers puros para validar consentimento, retenção e expiração por fase;
+- define políticas para `manual_real_test`, `internal_endpoint`, `closed_beta` e `production`;
+- prepara os futuros guards `consent` e `retention` sem criar endpoint, upload real ou storage real.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, storage real, UI, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -228,8 +228,9 @@ Exemplos:
 18. MM19 — Pure guard contracts. Define tipos/helpers puros para resultados e resumo dos guards, sem endpoint.
 19. MM20 — Payload validation contracts. Define validação pura para o futuro payload_schema guard e parte do input_source guard.
 20. MM21 — Input/source guard helpers. Define políticas puras por fase para o futuro input_source guard.
-21. Teste real manual quando houver quota/billing disponível.
-22. Integração experimental futura no Board de Criação.
+21. MM22 — Consent/retention guard helpers. Define políticas puras por fase para os futuros guards consent e retention.
+22. Teste real manual quando houver quota/billing disponível.
+23. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -264,6 +265,8 @@ MM14 separa a decisão de origem do vídeo da implementação de upload. Ele rec
 MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePayload` e `validateVideoNarrativeAnalyzePayload` como contratos puros para validar payload futuro sem criar endpoint, route.ts, upload real ou UI.
 
 MM21 adiciona `VideoNarrativeInputSourceGuardPolicy` e `validateVideoNarrativeInputSourceForPhase` para aplicar políticas por fase sobre payload já normalizado, ainda sem endpoint, upload real ou storage real.
+
+MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` para preparar consentimento, retenção e expiração sem endpoint, upload real, storage real ou cleanup real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_CONSENT_RETENTION_CONTRACT.md
@@ -114,6 +114,8 @@ Requisitos futuros:
 
 O futuro endpoint deve aplicar consent guard e retention guard conforme `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md` antes de qualquer chamada ao provider.
 
+MM22 formaliza `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` como helpers puros para esses guards futuros. Isso ainda não cria endpoint, upload real, storage real, cleanup real ou UI.
+
 ## Logs
 
 Regras para logs:
@@ -136,6 +138,7 @@ Este contrato depende e complementa:
 - `VideoUploadSession`;
 - `VideoNarrativeInputSourceContract`;
 - `VideoNarrativeInternalEndpointContract`;
+- consent/retention guard helpers;
 - `VideoNarrativeAnalysis`;
 - `PostCreationVideoSeed`.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -89,10 +89,14 @@ MM21 adiciona `validateVideoNarrativeInputSourceForPhase` e políticas puras por
 - exigir confirmação futura de consentimento antes de beta;
 - admin/manual pode ter bypass documentado, mas não para usuário comum.
 
+MM22 adiciona helpers puros para preparar este guard por fase, mantendo bypass apenas para fases internas/admin e exigindo consentimento explícito para beta/produto.
+
 ### 11. Retention Guard
 
 - exigir expiresAt quando houver storage temporário;
 - não aceitar arquivo expirado.
+
+MM22 adiciona helpers puros para validar `expiresAt`, expiração e limite máximo de retenção por fase, sem criar storage real ou cleanup real.
 
 ### 12. Usage/Quota Guard
 
@@ -279,6 +283,8 @@ MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePa
 
 MM21 adiciona `VideoNarrativeInputSourceGuardPolicy`, `VideoNarrativeInputSourcePhase` e `validateVideoNarrativeInputSourceForPhase` como fundação pura específica para o input_source guard.
 
+MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` como fundação pura para os guards consent e retention.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -292,6 +298,7 @@ Só criar route.ts depois que:
 - observability hooks estiverem definidos;
 - payload validation contracts estiverem disponíveis para `payload_schema`;
 - input/source guard helpers estiverem disponíveis para `input_source`;
+- consent/retention guard helpers estiverem disponíveis para `consent` e `retention`;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -308,6 +315,7 @@ Como ainda não há billing/quota:
 - MM19: contratos puros de guard result/status;
 - MM20: payload validation contracts;
 - MM21: input/source guard helpers;
-- MM22: storage cleanup contract;
-- MM23: endpoint real somente depois de billing/teste real;
-- MM24: preview interno com endpoint real.
+- MM22: consent/retention guard helpers;
+- MM23: storage cleanup contract;
+- MM24: endpoint real somente depois de billing/teste real;
+- MM25: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts
@@ -1,0 +1,402 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildVideoNarrativeConsentGuardResult,
+  buildVideoNarrativeRetentionGuardResult,
+  canVideoNarrativeAdminBypassConsent,
+  getVideoNarrativeConsentPolicy,
+  getVideoNarrativeRetentionPolicy,
+  isVideoNarrativeRetentionExpired,
+  isVideoNarrativeRetentionWithinPolicy,
+  requiresVideoNarrativeExpiresAt,
+  requiresVideoNarrativeExplicitConsent,
+  sanitizeVideoNarrativeConsentRetentionMessage,
+  validateVideoNarrativeConsentRetentionForPhase,
+  type VideoNarrativeConsentRetentionIssue,
+  type VideoNarrativeConsentRetentionPhase,
+} from "./videoNarrativeConsentRetentionGuards";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeConsentRetentionGuards.ts");
+const NOW = "2026-05-17T12:00:00.000Z";
+const WITHIN_24H = "2026-05-18T12:00:00.000Z";
+const WITHIN_72H = "2026-05-20T12:00:00.000Z";
+const OVER_72H = "2026-05-20T12:00:01.000Z";
+const PAST = "2026-05-17T11:59:59.000Z";
+
+function issueCodes(input: Parameters<typeof validateVideoNarrativeConsentRetentionForPhase>[0]): string[] {
+  return validateVideoNarrativeConsentRetentionForPhase(input).issues.map((issue) => issue.code);
+}
+
+describe("videoNarrativeConsentRetentionGuards", () => {
+  it("retorna política de consentimento de manual_real_test", () => {
+    expect(getVideoNarrativeConsentPolicy("manual_real_test")).toEqual({
+      phase: "manual_real_test",
+      requiresExplicitConsent: false,
+      allowAdminBypass: true,
+      requiresConsentVersion: false,
+      allowProfileSignalsPersistence: false,
+    });
+  });
+
+  it("retorna política de consentimento de internal_endpoint", () => {
+    expect(getVideoNarrativeConsentPolicy("internal_endpoint")).toEqual({
+      phase: "internal_endpoint",
+      requiresExplicitConsent: false,
+      allowAdminBypass: true,
+      requiresConsentVersion: false,
+      allowProfileSignalsPersistence: false,
+    });
+  });
+
+  it("retorna política de consentimento de closed_beta", () => {
+    expect(getVideoNarrativeConsentPolicy("closed_beta")).toEqual({
+      phase: "closed_beta",
+      requiresExplicitConsent: true,
+      allowAdminBypass: false,
+      requiresConsentVersion: true,
+      allowProfileSignalsPersistence: false,
+    });
+  });
+
+  it("retorna política de consentimento de production", () => {
+    expect(getVideoNarrativeConsentPolicy("production")).toEqual({
+      phase: "production",
+      requiresExplicitConsent: true,
+      allowAdminBypass: false,
+      requiresConsentVersion: true,
+      allowProfileSignalsPersistence: false,
+    });
+  });
+
+  it("retorna maxRetentionHours esperado por fase", () => {
+    expect(getVideoNarrativeRetentionPolicy("manual_real_test").maxRetentionHours).toBeNull();
+    expect(getVideoNarrativeRetentionPolicy("internal_endpoint").maxRetentionHours).toBe(72);
+    expect(getVideoNarrativeRetentionPolicy("closed_beta").maxRetentionHours).toBe(72);
+    expect(getVideoNarrativeRetentionPolicy("production").maxRetentionHours).toBe(72);
+  });
+
+  it("manual_real_test não exige consentimento explícito", () => {
+    expect(requiresVideoNarrativeExplicitConsent("manual_real_test")).toBe(false);
+  });
+
+  it("closed_beta exige consentimento explícito", () => {
+    expect(requiresVideoNarrativeExplicitConsent("closed_beta")).toBe(true);
+  });
+
+  it("production exige consentimento explícito", () => {
+    expect(requiresVideoNarrativeExplicitConsent("production")).toBe(true);
+  });
+
+  it("internal_endpoint permite admin/dev sem consentimento explícito", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "internal_endpoint",
+      isAdminOrDev: true,
+      expiresAt: WITHIN_24H,
+      now: NOW,
+    });
+
+    expect(canVideoNarrativeAdminBypassConsent("internal_endpoint")).toBe(true);
+    expect(result.consentGuardResult.status).toBe("passed");
+  });
+
+  it("closed_beta sem consentimento bloqueia consent guard", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "closed_beta",
+      hasExplicitConsent: false,
+      consentVersion: "v1",
+      expiresAt: WITHIN_24H,
+      now: NOW,
+    });
+
+    expect(result.consentGuardResult).toMatchObject({
+      name: "consent",
+      status: "blocked",
+      code: "consent_missing",
+    });
+    expect(result.issues.map((issue) => issue.code)).toContain("consent_missing");
+  });
+
+  it("production sem consentVersion bloqueia consent guard", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "production",
+      hasExplicitConsent: true,
+      expiresAt: WITHIN_24H,
+      now: NOW,
+    });
+
+    expect(result.consentGuardResult.status).toBe("blocked");
+    expect(result.issues.map((issue) => issue.code)).toContain("consent_version_missing");
+  });
+
+  it("closed_beta com consentimento e consentVersion passa consent guard", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "closed_beta",
+      hasExplicitConsent: true,
+      consentVersion: "v1",
+      expiresAt: WITHIN_24H,
+      now: NOW,
+    });
+
+    expect(result.consentGuardResult.status).toBe("passed");
+  });
+
+  it("fase que exige expiresAt sem expiresAt bloqueia retention guard", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "closed_beta",
+      hasExplicitConsent: true,
+      consentVersion: "v1",
+      now: NOW,
+    });
+
+    expect(requiresVideoNarrativeExpiresAt("closed_beta")).toBe(true);
+    expect(result.retentionGuardResult.status).toBe("blocked");
+    expect(result.issues.map((issue) => issue.code)).toContain("expires_at_missing");
+  });
+
+  it("expiresAt no passado bloqueia retention guard", () => {
+    expect(
+      issueCodes({
+        phase: "closed_beta",
+        hasExplicitConsent: true,
+        consentVersion: "v1",
+        expiresAt: PAST,
+        now: NOW,
+      }),
+    ).toContain("retention_expired");
+  });
+
+  it("expiresAt inválido bloqueia retention guard", () => {
+    expect(
+      issueCodes({
+        phase: "closed_beta",
+        hasExplicitConsent: true,
+        consentVersion: "v1",
+        expiresAt: "sem-data",
+        now: NOW,
+      }),
+    ).toContain("invalid_date");
+  });
+
+  it("expiresAt além de maxRetentionHours bloqueia retention guard", () => {
+    expect(
+      issueCodes({
+        phase: "production",
+        hasExplicitConsent: true,
+        consentVersion: "v1",
+        expiresAt: OVER_72H,
+        now: NOW,
+      }),
+    ).toContain("retention_exceeds_policy");
+  });
+
+  it("expiresAt dentro da política passa retention guard", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "production",
+      hasExplicitConsent: true,
+      consentVersion: "v1",
+      expiresAt: WITHIN_72H,
+      now: NOW,
+    });
+
+    expect(result.retentionGuardResult.status).toBe("passed");
+  });
+
+  it("isVideoNarrativeRetentionExpired funciona com now fixo", () => {
+    expect(isVideoNarrativeRetentionExpired({ expiresAt: PAST, now: NOW })).toBe(true);
+    expect(isVideoNarrativeRetentionExpired({ expiresAt: WITHIN_24H, now: NOW })).toBe(false);
+  });
+
+  it("isVideoNarrativeRetentionWithinPolicy funciona com maxRetentionHours null", () => {
+    expect(
+      isVideoNarrativeRetentionWithinPolicy({
+        expiresAt: OVER_72H,
+        now: NOW,
+        maxRetentionHours: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("wantsProfileSignalsPersistence true gera issue porque persistência ainda não é permitida", () => {
+    expect(
+      issueCodes({
+        phase: "closed_beta",
+        hasExplicitConsent: true,
+        consentVersion: "v1",
+        expiresAt: WITHIN_24H,
+        now: NOW,
+        wantsProfileSignalsPersistence: true,
+      }),
+    ).toContain("profile_signals_persistence_not_allowed");
+  });
+
+  it.each<VideoNarrativeConsentRetentionPhase>([
+    "manual_real_test",
+    "internal_endpoint",
+    "closed_beta",
+    "production",
+  ])("canPersistProfileSignals false em %s", (phase) => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase,
+      hasExplicitConsent: true,
+      consentVersion: "v1",
+      isAdminOrDev: true,
+      expiresAt: phase === "manual_real_test" ? null : WITHIN_24H,
+      now: NOW,
+      wantsProfileSignalsPersistence: true,
+    });
+
+    expect(result.canPersistProfileSignals).toBe(false);
+  });
+
+  it("retorna ok true quando consent e retention passam", () => {
+    const result = validateVideoNarrativeConsentRetentionForPhase({
+      phase: "closed_beta",
+      hasExplicitConsent: true,
+      consentVersion: "v1",
+      expiresAt: WITHIN_24H,
+      now: NOW,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("retorna ok false quando consent falha", () => {
+    expect(
+      validateVideoNarrativeConsentRetentionForPhase({
+        phase: "closed_beta",
+        expiresAt: WITHIN_24H,
+        now: NOW,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("retorna ok false quando retention falha", () => {
+    expect(
+      validateVideoNarrativeConsentRetentionForPhase({
+        phase: "closed_beta",
+        hasExplicitConsent: true,
+        consentVersion: "v1",
+        expiresAt: PAST,
+        now: NOW,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("buildVideoNarrativeConsentGuardResult cria passed e blocked corretamente", () => {
+    const issue: VideoNarrativeConsentRetentionIssue = {
+      code: "consent_missing",
+      message: "Consentimento não informado.",
+    };
+
+    expect(buildVideoNarrativeConsentGuardResult({ ok: true }).status).toBe("passed");
+    expect(buildVideoNarrativeConsentGuardResult({ ok: false, issues: [issue] })).toMatchObject({
+      name: "consent",
+      status: "blocked",
+      code: "consent_missing",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("buildVideoNarrativeRetentionGuardResult cria passed e blocked corretamente", () => {
+    const issue: VideoNarrativeConsentRetentionIssue = {
+      code: "retention_expired",
+      message: "Arquivo temporário expirado.",
+    };
+
+    expect(buildVideoNarrativeRetentionGuardResult({ ok: true }).status).toBe("passed");
+    expect(buildVideoNarrativeRetentionGuardResult({ ok: false, issues: [issue] })).toMatchObject({
+      name: "retention",
+      status: "blocked",
+      code: "retention_expired",
+      shouldCallProvider: false,
+      shouldConsumeQuota: false,
+    });
+  });
+
+  it("redige AIza, GEMINI_API_KEY, GOOGLE_GENAI_API_KEY e base64 longo", () => {
+    expect(
+      sanitizeVideoNarrativeConsentRetentionMessage(
+        `AIza1234567890abcdefghi GEMINI_API_KEY=abc GOOGLE_GENAI_API_KEY=def ${"a".repeat(140)}`,
+      ),
+    ).toBe("[redigido] [redigido] [redigido] [redigido]");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const outputs = [
+      buildVideoNarrativeConsentGuardResult({ ok: true }).message,
+      buildVideoNarrativeRetentionGuardResult({ ok: true }).message,
+      validateVideoNarrativeConsentRetentionForPhase({
+        phase: "production",
+        hasExplicitConsent: false,
+        expiresAt: PAST,
+        now: NOW,
+        wantsProfileSignalsPersistence: true,
+      }).issues.map((issue) => issue.message),
+      sanitizeVideoNarrativeConsentRetentionMessage(
+        "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      ),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.ts
@@ -1,0 +1,358 @@
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  sanitizeVideoNarrativeGuardMessage,
+  type VideoNarrativeGuardResult,
+} from "./videoNarrativeGuardContracts";
+import type { VideoNarrativeInputSourcePhase } from "./videoNarrativeInputSourceGuards";
+
+export type VideoNarrativeConsentRetentionPhase = VideoNarrativeInputSourcePhase;
+
+export interface VideoNarrativeConsentPolicy {
+  phase: VideoNarrativeConsentRetentionPhase;
+  requiresExplicitConsent: boolean;
+  allowAdminBypass: boolean;
+  requiresConsentVersion: boolean;
+  allowProfileSignalsPersistence: boolean;
+}
+
+export interface VideoNarrativeRetentionPolicy {
+  phase: VideoNarrativeConsentRetentionPhase;
+  requiresExpiresAt: boolean;
+  maxRetentionHours: number | null;
+  allowPermanentVideoStorage: boolean;
+  allowRawTextStorage: boolean;
+  allowBase64Storage: boolean;
+  allowProfileSignalsPersistence: boolean;
+}
+
+export interface VideoNarrativeConsentRetentionInput {
+  phase: VideoNarrativeConsentRetentionPhase;
+  hasExplicitConsent?: boolean | null;
+  consentVersion?: string | null;
+  isAdminOrDev?: boolean | null;
+  expiresAt?: string | null;
+  now?: string | null;
+  wantsProfileSignalsPersistence?: boolean | null;
+}
+
+export interface VideoNarrativeConsentRetentionIssue {
+  code:
+    | "consent_missing"
+    | "consent_version_missing"
+    | "expires_at_missing"
+    | "retention_expired"
+    | "retention_exceeds_policy"
+    | "permanent_video_storage_not_allowed"
+    | "raw_text_storage_not_allowed"
+    | "base64_storage_not_allowed"
+    | "profile_signals_persistence_not_allowed"
+    | "invalid_date";
+  message: string;
+}
+
+export interface VideoNarrativeConsentRetentionGuardResult {
+  ok: boolean;
+  phase: VideoNarrativeConsentRetentionPhase;
+  consentGuardResult: VideoNarrativeGuardResult;
+  retentionGuardResult: VideoNarrativeGuardResult;
+  issues: VideoNarrativeConsentRetentionIssue[];
+  canPersistProfileSignals: boolean;
+}
+
+export const VIDEO_NARRATIVE_CONSENT_POLICIES: Record<
+  VideoNarrativeConsentRetentionPhase,
+  VideoNarrativeConsentPolicy
+> = {
+  manual_real_test: {
+    phase: "manual_real_test",
+    requiresExplicitConsent: false,
+    allowAdminBypass: true,
+    requiresConsentVersion: false,
+    allowProfileSignalsPersistence: false,
+  },
+  internal_endpoint: {
+    phase: "internal_endpoint",
+    requiresExplicitConsent: false,
+    allowAdminBypass: true,
+    requiresConsentVersion: false,
+    allowProfileSignalsPersistence: false,
+  },
+  closed_beta: {
+    phase: "closed_beta",
+    requiresExplicitConsent: true,
+    allowAdminBypass: false,
+    requiresConsentVersion: true,
+    allowProfileSignalsPersistence: false,
+  },
+  production: {
+    phase: "production",
+    requiresExplicitConsent: true,
+    allowAdminBypass: false,
+    requiresConsentVersion: true,
+    allowProfileSignalsPersistence: false,
+  },
+};
+
+export const VIDEO_NARRATIVE_RETENTION_POLICIES: Record<
+  VideoNarrativeConsentRetentionPhase,
+  VideoNarrativeRetentionPolicy
+> = {
+  manual_real_test: {
+    phase: "manual_real_test",
+    requiresExpiresAt: false,
+    maxRetentionHours: null,
+    allowPermanentVideoStorage: false,
+    allowRawTextStorage: false,
+    allowBase64Storage: false,
+    allowProfileSignalsPersistence: false,
+  },
+  internal_endpoint: {
+    phase: "internal_endpoint",
+    requiresExpiresAt: true,
+    maxRetentionHours: 72,
+    allowPermanentVideoStorage: false,
+    allowRawTextStorage: false,
+    allowBase64Storage: false,
+    allowProfileSignalsPersistence: false,
+  },
+  closed_beta: {
+    phase: "closed_beta",
+    requiresExpiresAt: true,
+    maxRetentionHours: 72,
+    allowPermanentVideoStorage: false,
+    allowRawTextStorage: false,
+    allowBase64Storage: false,
+    allowProfileSignalsPersistence: false,
+  },
+  production: {
+    phase: "production",
+    requiresExpiresAt: true,
+    maxRetentionHours: 72,
+    allowPermanentVideoStorage: false,
+    allowRawTextStorage: false,
+    allowBase64Storage: false,
+    allowProfileSignalsPersistence: false,
+  },
+};
+
+function createIssue(
+  code: VideoNarrativeConsentRetentionIssue["code"],
+  message: string,
+): VideoNarrativeConsentRetentionIssue {
+  return {
+    code,
+    message: sanitizeVideoNarrativeConsentRetentionMessage(message),
+  };
+}
+
+function parseDate(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function resolveNow(now?: string | null): number | null {
+  if (now) {
+    return parseDate(now);
+  }
+
+  return Date.now();
+}
+
+function hasConsentByPolicy(input: VideoNarrativeConsentRetentionInput): boolean {
+  const policy = getVideoNarrativeConsentPolicy(input.phase);
+  if (!policy.requiresExplicitConsent) {
+    return true;
+  }
+
+  if (policy.allowAdminBypass && input.isAdminOrDev === true) {
+    return true;
+  }
+
+  return input.hasExplicitConsent === true;
+}
+
+export function sanitizeVideoNarrativeConsentRetentionMessage(message: string): string {
+  return sanitizeVideoNarrativeGuardMessage(message);
+}
+
+export function getVideoNarrativeConsentPolicy(
+  phase: VideoNarrativeConsentRetentionPhase,
+): VideoNarrativeConsentPolicy {
+  return VIDEO_NARRATIVE_CONSENT_POLICIES[phase];
+}
+
+export function getVideoNarrativeRetentionPolicy(
+  phase: VideoNarrativeConsentRetentionPhase,
+): VideoNarrativeRetentionPolicy {
+  return VIDEO_NARRATIVE_RETENTION_POLICIES[phase];
+}
+
+export function requiresVideoNarrativeExplicitConsent(
+  phase: VideoNarrativeConsentRetentionPhase,
+): boolean {
+  return getVideoNarrativeConsentPolicy(phase).requiresExplicitConsent;
+}
+
+export function canVideoNarrativeAdminBypassConsent(
+  phase: VideoNarrativeConsentRetentionPhase,
+): boolean {
+  return getVideoNarrativeConsentPolicy(phase).allowAdminBypass;
+}
+
+export function requiresVideoNarrativeExpiresAt(
+  phase: VideoNarrativeConsentRetentionPhase,
+): boolean {
+  return getVideoNarrativeRetentionPolicy(phase).requiresExpiresAt;
+}
+
+export function isVideoNarrativeRetentionExpired(params: {
+  expiresAt: string | null | undefined;
+  now?: string | null;
+}): boolean {
+  const expiresAt = parseDate(params.expiresAt);
+  const now = resolveNow(params.now);
+
+  if (expiresAt === null || now === null) {
+    return false;
+  }
+
+  return expiresAt <= now;
+}
+
+export function isVideoNarrativeRetentionWithinPolicy(params: {
+  expiresAt: string | null | undefined;
+  now?: string | null;
+  maxRetentionHours: number | null;
+}): boolean {
+  if (params.maxRetentionHours === null) {
+    return true;
+  }
+
+  const expiresAt = parseDate(params.expiresAt);
+  const now = resolveNow(params.now);
+
+  if (expiresAt === null || now === null) {
+    return false;
+  }
+
+  const maxRetentionMs = params.maxRetentionHours * 60 * 60 * 1000;
+  return expiresAt - now <= maxRetentionMs;
+}
+
+export function buildVideoNarrativeConsentGuardResult(params: {
+  ok: boolean;
+  issues?: VideoNarrativeConsentRetentionIssue[];
+}): VideoNarrativeGuardResult {
+  return params.ok
+    ? createPassedVideoNarrativeGuardResult("consent")
+    : createBlockedVideoNarrativeGuardResult({
+        name: "consent",
+        code: "consent_missing",
+        message: params.issues?.[0]?.message ?? "Consentimento não validado.",
+      });
+}
+
+export function buildVideoNarrativeRetentionGuardResult(params: {
+  ok: boolean;
+  issues?: VideoNarrativeConsentRetentionIssue[];
+}): VideoNarrativeGuardResult {
+  return params.ok
+    ? createPassedVideoNarrativeGuardResult("retention")
+    : createBlockedVideoNarrativeGuardResult({
+        name: "retention",
+        code: "retention_expired",
+        message: params.issues?.[0]?.message ?? "Retenção não validada.",
+      });
+}
+
+export function validateVideoNarrativeConsentRetentionForPhase(
+  input: VideoNarrativeConsentRetentionInput,
+): VideoNarrativeConsentRetentionGuardResult {
+  const consentPolicy = getVideoNarrativeConsentPolicy(input.phase);
+  const retentionPolicy = getVideoNarrativeRetentionPolicy(input.phase);
+  const consentIssues: VideoNarrativeConsentRetentionIssue[] = [];
+  const retentionIssues: VideoNarrativeConsentRetentionIssue[] = [];
+  const profileIssues: VideoNarrativeConsentRetentionIssue[] = [];
+
+  if (!hasConsentByPolicy(input)) {
+    consentIssues.push(createIssue("consent_missing", "Consentimento não informado."));
+  }
+
+  if (
+    consentPolicy.requiresConsentVersion &&
+    (!input.consentVersion || input.consentVersion.trim().length === 0)
+  ) {
+    consentIssues.push(createIssue("consent_version_missing", "Versão do consentimento não informada."));
+  }
+
+  const hasExpiresAt = Boolean(input.expiresAt);
+  const parsedExpiresAt = parseDate(input.expiresAt);
+  const parsedNow = input.now ? parseDate(input.now) : resolveNow(input.now);
+
+  if (retentionPolicy.requiresExpiresAt && !hasExpiresAt) {
+    retentionIssues.push(createIssue("expires_at_missing", "Expiração não informada."));
+  }
+
+  if (hasExpiresAt && parsedExpiresAt === null) {
+    retentionIssues.push(createIssue("invalid_date", "Data de expiração não validada."));
+  }
+
+  if (input.now && parsedNow === null) {
+    retentionIssues.push(createIssue("invalid_date", "Data de referência não validada."));
+  }
+
+  if (parsedExpiresAt !== null && parsedNow !== null && parsedExpiresAt <= parsedNow) {
+    retentionIssues.push(createIssue("retention_expired", "Arquivo temporário expirado."));
+  }
+
+  if (
+    parsedExpiresAt !== null &&
+    parsedNow !== null &&
+    !isVideoNarrativeRetentionWithinPolicy({
+      expiresAt: input.expiresAt,
+      now: input.now,
+      maxRetentionHours: retentionPolicy.maxRetentionHours,
+    })
+  ) {
+    retentionIssues.push(createIssue("retention_exceeds_policy", "Retenção acima do limite da fase."));
+  }
+
+  if (input.wantsProfileSignalsPersistence === true && !consentPolicy.allowProfileSignalsPersistence) {
+    profileIssues.push(
+      createIssue(
+        "profile_signals_persistence_not_allowed",
+        "Persistência de sinais narrativos não habilitada.",
+      ),
+    );
+  }
+
+  const consentOk = consentIssues.length === 0;
+  const retentionOk = retentionIssues.length === 0;
+  const issues = [...consentIssues, ...retentionIssues, ...profileIssues];
+  const canPersistProfileSignals =
+    input.wantsProfileSignalsPersistence === true &&
+    consentPolicy.allowProfileSignalsPersistence &&
+    retentionPolicy.allowProfileSignalsPersistence &&
+    consentOk &&
+    retentionOk;
+
+  return {
+    ok: consentOk && retentionOk && profileIssues.length === 0,
+    phase: input.phase,
+    consentGuardResult: buildVideoNarrativeConsentGuardResult({
+      ok: consentOk,
+      issues: consentIssues,
+    }),
+    retentionGuardResult: buildVideoNarrativeRetentionGuardResult({
+      ok: retentionOk,
+      issues: retentionIssues,
+    }),
+    issues,
+    canPersistProfileSignals,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked sobre #818.

Este PR adiciona a fase MM22 com helpers puros para os futuros guards `consent` e `retention` da análise narrativa de vídeo.

Inclui:
- `VideoNarrativeConsentRetentionPhase`;
- `VideoNarrativeConsentPolicy`;
- `VideoNarrativeRetentionPolicy`;
- `VideoNarrativeConsentRetentionGuardResult`;
- políticas por fase para consentimento e retenção;
- helpers de consentimento explícito, bypass admin/dev, `expiresAt`, expiração e retenção máxima;
- `validateVideoNarrativeConsentRetentionForPhase`;
- integração com `VideoNarrativeGuardResult` para `consent` e `retention`.

## Policies

- `manual_real_test`: não exige consentimento explícito, permite bypass admin/dev, sem `expiresAt` obrigatório.
- `internal_endpoint`: permite admin/dev sem consentimento explícito nesta fase, exige `expiresAt` e retenção máxima de 72h.
- `closed_beta`: exige consentimento explícito, versão de consentimento, `expiresAt` e retenção máxima de 72h.
- `production`: exige consentimento explícito, versão de consentimento, `expiresAt` e retenção máxima de 72h.
- Persistência de `profileSignals`: bloqueada em todas as fases atuais.

## Non-goals

- Não cria endpoint real.
- Não cria `route.ts`.
- Não cria upload real.
- Não cria UI.
- Não cria banco/tabela.
- Não cria analytics real.
- Não cria storage real nem cleanup real.
- Não conecta no BoardShell.
- Não altera `PostCreationFunnelState` real.
- Não chama Gemini real.
- Não faz `fetch`.
- Não adiciona dependência nova.
- Não integra billing/Stripe/cobrança real.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeReadinessAudit.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeRealRunHarness.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProviderComposer.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeProvider.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload`
- `npm test -- --runInBand src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/narrative-source-preview/page.test.tsx src/app/dashboard/boards/adaptive-v2-preview/page.test.tsx src/app/dashboard/boards/components/narrativeSource/NarrativeSourcePreview.test.tsx src/app/dashboard/boards/components/adaptiveV2/AdaptiveV2Preview.test.tsx src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/postCreationAdaptiveFeatureFlag.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.test.tsx src/app/lib/brands/brandNarrativeReportBuilder.test.ts src/app/lib/brands/brandNarrativeMatcher.test.ts`
- `npm test -- --runInBand --runTestsByPath 'src/app/api/brand-narratives/reports/[slug]/route.test.ts'`
- `npm run typecheck`
- `git diff --check`
- `npm run build`