### PR TITLE
feat: add video narrative usage quota guards

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -74,6 +74,7 @@ Já existe:
 - payload validation contracts foram formalizados em MM20, mas ainda não foram conectados a endpoint real;
 - input/source guard helpers foram formalizados em MM21, mas ainda não foram conectados a endpoint real;
 - consent/retention guard helpers foram formalizados em MM22, mas ainda não foram conectados a endpoint real;
+- usage/quota guard helpers foram formalizados em MM23, mas ainda não foram conectados a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -123,6 +124,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contratos puros de payload validation;
 - helpers puros de input/source guard;
 - helpers puros de consent/retention guard;
+- helpers puros de usage/quota guard;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -496,6 +496,28 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM23 — Usage/quota guard helpers
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeUsageQuotaGuards.ts`
+- `videoNarrativeUsageQuotaGuards.test.ts`
+
+O que faz:
+
+- cria helpers puros para limite de uso, cooldown e decisão de consumo de quota;
+- define políticas para `manual_real_test`, `internal_endpoint`, `closed_beta` e `production`;
+- prepara o futuro `usage_quota` guard e a etapa `usage_consumption` sem billing real, Stripe ou cobrança.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria billing real, Stripe, cobrança, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -229,8 +229,9 @@ Exemplos:
 19. MM20 — Payload validation contracts. Define validação pura para o futuro payload_schema guard e parte do input_source guard.
 20. MM21 — Input/source guard helpers. Define políticas puras por fase para o futuro input_source guard.
 21. MM22 — Consent/retention guard helpers. Define políticas puras por fase para os futuros guards consent e retention.
-22. Teste real manual quando houver quota/billing disponível.
-23. Integração experimental futura no Board de Criação.
+22. MM23 — Usage/quota guard helpers. Define políticas puras para usage_quota e usage_consumption, sem billing real.
+23. Teste real manual quando houver quota/billing disponível.
+24. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -267,6 +268,8 @@ MM20 adiciona `VideoNarrativeAnalyzePayload`, `VideoNarrativeNormalizedAnalyzePa
 MM21 adiciona `VideoNarrativeInputSourceGuardPolicy` e `validateVideoNarrativeInputSourceForPhase` para aplicar políticas por fase sobre payload já normalizado, ainda sem endpoint, upload real ou storage real.
 
 MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` para preparar consentimento, retenção e expiração sem endpoint, upload real, storage real ou cleanup real.
+
+MM23 adiciona `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForPhase` e `decideVideoNarrativeUsageConsumption` para preparar limite, cooldown e consumo de quota sem endpoint, billing real, Stripe ou cobrança.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
@@ -218,6 +218,8 @@ O futuro endpoint deve seguir `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md`
 
 Os eventos e logs futuros podem usar `VideoNarrativeGuardResult` e `VideoNarrativeGuardPipelineSummary` para registrar qual guard bloqueou sem expor payload sensível.
 
+MM23 adiciona reasons puros de `decideVideoNarrativeUsageConsumption`, que podem alimentar futuramente `video_narrative_usage_consumed`, `video_narrative_usage_not_consumed`, `usage counted reason` e `usage not counted reason` sem criar analytics real nesta fase.
+
 ## Decisão Recomendada Agora
 
 Como ainda não há billing/quota:

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -106,6 +106,8 @@ MM22 adiciona helpers puros para validar `expiresAt`, expiração e limite máxi
 - `cooldown_active`;
 - falhas antes do provider não consomem quota.
 
+MM23 adiciona helpers puros para preparar este guard por fase, incluindo limite mensal, limite diário, cooldown e bypass interno quando permitido, sem billing real ou cobrança.
+
 ### 13. Observability Start Hook
 
 - criar requestId;
@@ -135,6 +137,8 @@ MM22 adiciona helpers puros para validar `expiresAt`, expiração e limite máxi
 - resposta parcial útil pode consumir;
 - payload inválido não consome;
 - falha antes do provider não consome.
+
+MM23 adiciona `decideVideoNarrativeUsageConsumption` para formalizar os motivos futuros de consumo ou não consumo de quota antes de qualquer endpoint real.
 
 ### 18. Observability Completion Hook
 
@@ -285,6 +289,8 @@ MM21 adiciona `VideoNarrativeInputSourceGuardPolicy`, `VideoNarrativeInputSource
 
 MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` como fundação pura para os guards consent e retention.
 
+MM23 adiciona `VideoNarrativeUsagePolicy`, `VideoNarrativeQuotaGuardResult` e `VideoNarrativeUsageConsumptionDecision` como fundação pura para usage_quota e usage_consumption.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -299,6 +305,7 @@ Só criar route.ts depois que:
 - payload validation contracts estiverem disponíveis para `payload_schema`;
 - input/source guard helpers estiverem disponíveis para `input_source`;
 - consent/retention guard helpers estiverem disponíveis para `consent` e `retention`;
+- usage/quota guard helpers estiverem disponíveis para `usage_quota` e `usage_consumption`;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -316,6 +323,7 @@ Como ainda não há billing/quota:
 - MM20: payload validation contracts;
 - MM21: input/source guard helpers;
 - MM22: consent/retention guard helpers;
-- MM23: storage cleanup contract;
-- MM24: endpoint real somente depois de billing/teste real;
-- MM25: preview interno com endpoint real.
+- MM23: usage/quota guard helpers;
+- MM24: storage cleanup contract;
+- MM25: endpoint real somente depois de billing/teste real;
+- MM26: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
@@ -33,6 +33,8 @@ Regra conceitual para consumo de quota:
 
 O usage guard do futuro endpoint deve seguir `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md`: falhas antes do provider não consomem quota, e consumo só acontece depois da regra de usage consumption.
 
+MM23 formaliza `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForPhase` e `decideVideoNarrativeUsageConsumption` como helpers puros para esse futuro guard. Isso ainda não cria billing real, Stripe, cobrança, endpoint ou persistência de quota.
+
 ## Limites Recomendados Por Fase
 
 ### Fase Admin/Manual
@@ -179,6 +181,7 @@ Só implementar limite real depois que houver:
 - logs seguros definidos;
 - observabilidade mínima definida;
 - usage guard definido;
+- usage/quota guard helpers puros definidos;
 - decisão sobre plano atual e pacotes extras.
 
 ## Decisão Recomendada Agora

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts
@@ -1,0 +1,405 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  buildVideoNarrativeUsageConsumptionGuardResult,
+  buildVideoNarrativeUsageQuotaGuardResult,
+  decideVideoNarrativeUsageConsumption,
+  getVideoNarrativeUsagePolicy,
+  isVideoNarrativeCooldownActive,
+  sanitizeVideoNarrativeUsageMessage,
+  validateVideoNarrativeUsageQuotaForPhase,
+  type VideoNarrativeUsageIssue,
+} from "./videoNarrativeUsageQuotaGuards";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeUsageQuotaGuards.ts");
+const NOW = "2026-05-17T12:00:00.000Z";
+const FUTURE = "2026-05-17T12:30:00.000Z";
+const PAST = "2026-05-17T11:59:00.000Z";
+
+function issueCodes(result: { issues: VideoNarrativeUsageIssue[] }): string[] {
+  return result.issues.map((issue) => issue.code);
+}
+
+describe("videoNarrativeUsageQuotaGuards", () => {
+  it("retorna manual_real_test sem limites", () => {
+    expect(getVideoNarrativeUsagePolicy("manual_real_test")).toMatchObject({
+      monthlyLimit: null,
+      dailyLimit: null,
+      allowAdminBypass: true,
+    });
+  });
+
+  it("retorna internal_endpoint com dailyLimit 20", () => {
+    expect(getVideoNarrativeUsagePolicy("internal_endpoint")).toMatchObject({
+      monthlyLimit: null,
+      dailyLimit: 20,
+      allowAdminBypass: true,
+    });
+  });
+
+  it("retorna closed_beta com monthlyLimit 5 e dailyLimit 3", () => {
+    expect(getVideoNarrativeUsagePolicy("closed_beta")).toMatchObject({
+      monthlyLimit: 5,
+      dailyLimit: 3,
+      allowAdminBypass: false,
+    });
+  });
+
+  it("retorna production com monthlyLimit 5 e dailyLimit 3", () => {
+    expect(getVideoNarrativeUsagePolicy("production")).toMatchObject({
+      monthlyLimit: 5,
+      dailyLimit: 3,
+      allowAdminBypass: false,
+    });
+  });
+
+  it("manual_real_test permite análise sem usageState", () => {
+    expect(validateVideoNarrativeUsageQuotaForPhase({ phase: "manual_real_test" })).toMatchObject({
+      ok: true,
+      canAttemptAnalysis: true,
+    });
+  });
+
+  it("internal_endpoint bloqueia quando usedToday >= 20 sem admin/dev", () => {
+    const result = validateVideoNarrativeUsageQuotaForPhase({
+      phase: "internal_endpoint",
+      usageState: { usedToday: 20 },
+    });
+
+    expect(result.canAttemptAnalysis).toBe(false);
+    expect(issueCodes(result)).toContain("daily_limit_exceeded");
+  });
+
+  it("internal_endpoint permite bypass admin/dev", () => {
+    const result = validateVideoNarrativeUsageQuotaForPhase({
+      phase: "internal_endpoint",
+      usageState: { usedToday: 20, isAdminOrDev: true },
+    });
+
+    expect(result.canAttemptAnalysis).toBe(true);
+  });
+
+  it("closed_beta bloqueia quando usedThisMonth >= 5", () => {
+    expect(
+      issueCodes(
+        validateVideoNarrativeUsageQuotaForPhase({
+          phase: "closed_beta",
+          usageState: { usedThisMonth: 5 },
+        }),
+      ),
+    ).toContain("quota_exceeded");
+  });
+
+  it("production bloqueia quando usedThisMonth >= 5", () => {
+    expect(
+      issueCodes(
+        validateVideoNarrativeUsageQuotaForPhase({
+          phase: "production",
+          usageState: { usedThisMonth: 5 },
+        }),
+      ),
+    ).toContain("quota_exceeded");
+  });
+
+  it("closed_beta bloqueia quando usedToday >= 3", () => {
+    expect(
+      issueCodes(
+        validateVideoNarrativeUsageQuotaForPhase({
+          phase: "closed_beta",
+          usageState: { usedToday: 3 },
+        }),
+      ),
+    ).toContain("daily_limit_exceeded");
+  });
+
+  it("cooldown ativo bloqueia usage guard", () => {
+    expect(
+      issueCodes(
+        validateVideoNarrativeUsageQuotaForPhase({
+          phase: "closed_beta",
+          usageState: { cooldownUntil: FUTURE, now: NOW },
+        }),
+      ),
+    ).toContain("cooldown_active");
+  });
+
+  it("cooldown expirado não bloqueia", () => {
+    expect(
+      validateVideoNarrativeUsageQuotaForPhase({
+        phase: "closed_beta",
+        usageState: { cooldownUntil: PAST, now: NOW },
+      }).canAttemptAnalysis,
+    ).toBe(true);
+  });
+
+  it("isVideoNarrativeCooldownActive funciona com now fixo", () => {
+    expect(isVideoNarrativeCooldownActive({ cooldownUntil: FUTURE, now: NOW })).toBe(true);
+    expect(isVideoNarrativeCooldownActive({ cooldownUntil: PAST, now: NOW })).toBe(false);
+  });
+
+  it("usageState com datas inválidas não quebra", () => {
+    const result = validateVideoNarrativeUsageQuotaForPhase({
+      phase: "closed_beta",
+      usageState: { cooldownUntil: "sem-data", now: "tambem-sem-data" },
+    });
+
+    expect(result.canAttemptAnalysis).toBe(true);
+    expect(issueCodes(result)).toContain("usage_state_invalid");
+  });
+
+  it("não consome se failedBeforeProvider", () => {
+    const decision = decideVideoNarrativeUsageConsumption({
+      phase: "closed_beta",
+      failedBeforeProvider: true,
+    });
+
+    expect(decision).toMatchObject({ shouldConsumeQuota: false, reason: "failed_before_provider" });
+  });
+
+  it("não consome se payloadWasInvalid", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        payloadWasInvalid: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "payload_invalid" });
+  });
+
+  it("não consome se consentWasMissing", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        consentWasMissing: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "consent_missing" });
+  });
+
+  it("não consome se retentionWasExpired", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        retentionWasExpired: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "retention_expired" });
+  });
+
+  it("não consome se providerWasCalled false", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: false,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "provider_not_called" });
+  });
+
+  it("não consome em provider failure", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "provider_failure" });
+  });
+
+  it("não consome em fallback only", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: true,
+        usedFallbackOnly: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "fallback_only" });
+  });
+
+  it("consome em useful_analysis", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: true,
+        providerReturnedUsefulAnalysis: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: true, reason: "useful_analysis" });
+  });
+
+  it("consome em useful_partial_analysis quando política permite", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: true,
+        providerReturnedUsefulPartialAnalysis: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: true, reason: "useful_partial_analysis" });
+  });
+
+  it("não consome manual retry em internal_endpoint com allowRetryWithoutConsumption", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "internal_endpoint",
+        providerWasCalled: true,
+        providerReturnedUsefulAnalysis: true,
+        userRequestedManualRetry: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "manual_retry" });
+  });
+
+  it("consome manual retry em closed_beta quando houve análise útil", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        providerWasCalled: true,
+        providerReturnedUsefulAnalysis: true,
+        userRequestedManualRetry: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: true, reason: "manual_retry" });
+  });
+
+  it("não consome para admin/dev bypass em internal_endpoint", () => {
+    expect(
+      decideVideoNarrativeUsageConsumption({
+        phase: "internal_endpoint",
+        usageState: { isAdminOrDev: true },
+        providerWasCalled: true,
+        providerReturnedUsefulAnalysis: true,
+      }),
+    ).toMatchObject({ shouldConsumeQuota: false, reason: "admin_bypass" });
+  });
+
+  it("buildVideoNarrativeUsageQuotaGuardResult cria passed guard quando ok", () => {
+    expect(buildVideoNarrativeUsageQuotaGuardResult({ ok: true, phase: "closed_beta" }).guardResult).toMatchObject({
+      name: "usage_quota",
+      status: "passed",
+      code: null,
+    });
+  });
+
+  it("buildVideoNarrativeUsageQuotaGuardResult cria blocked guard quando limite", () => {
+    const issue: VideoNarrativeUsageIssue = {
+      code: "quota_exceeded",
+      message: "Limite mensal atingido.",
+    };
+
+    expect(
+      buildVideoNarrativeUsageQuotaGuardResult({
+        ok: false,
+        phase: "closed_beta",
+        issues: [issue],
+      }).guardResult,
+    ).toMatchObject({
+      name: "usage_quota",
+      status: "blocked",
+      shouldCallProvider: false,
+    });
+  });
+
+  it("buildVideoNarrativeUsageConsumptionGuardResult cria passed guard para consumo calculado", () => {
+    expect(
+      buildVideoNarrativeUsageConsumptionGuardResult({
+        shouldConsumeQuota: false,
+        reason: "provider_not_called",
+      }),
+    ).toMatchObject({
+      name: "usage_consumption",
+      status: "passed",
+    });
+  });
+
+  it("buildVideoNarrativeUsageConsumptionGuardResult bloqueia quota_blocked/cooldown_active", () => {
+    expect(
+      buildVideoNarrativeUsageConsumptionGuardResult({
+        shouldConsumeQuota: false,
+        reason: "quota_blocked",
+      }).status,
+    ).toBe("blocked");
+    expect(
+      buildVideoNarrativeUsageConsumptionGuardResult({
+        shouldConsumeQuota: false,
+        reason: "cooldown_active",
+      }).code,
+    ).toBe("cooldown_active");
+  });
+
+  it("redige AIza, GEMINI_API_KEY, GOOGLE_GENAI_API_KEY e base64 longo", () => {
+    expect(
+      sanitizeVideoNarrativeUsageMessage(
+        `AIza1234567890abcdefghi GEMINI_API_KEY=abc GOOGLE_GENAI_API_KEY=def ${"a".repeat(140)}`,
+      ),
+    ).toBe("[redigido] [redigido] [redigido] [redigido]");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const outputs = [
+      validateVideoNarrativeUsageQuotaForPhase({
+        phase: "closed_beta",
+        usageState: { usedThisMonth: 5, cooldownUntil: FUTURE, now: NOW },
+      }).issues.map((issue) => issue.message),
+      decideVideoNarrativeUsageConsumption({
+        phase: "closed_beta",
+        payloadWasInvalid: true,
+      }).issues.map((issue) => issue.message),
+      sanitizeVideoNarrativeUsageMessage(
+        "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      ),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.ts
@@ -1,0 +1,390 @@
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  sanitizeVideoNarrativeGuardMessage,
+  type VideoNarrativeGuardResult,
+} from "./videoNarrativeGuardContracts";
+
+export type VideoNarrativeUsagePhase =
+  | "manual_real_test"
+  | "internal_endpoint"
+  | "closed_beta"
+  | "production";
+
+export interface VideoNarrativeUsagePolicy {
+  phase: VideoNarrativeUsagePhase;
+  monthlyLimit: number | null;
+  dailyLimit: number | null;
+  allowAdminBypass: boolean;
+  allowRetryWithoutConsumption: boolean;
+  consumeOnUsefulPartialAnalysis: boolean;
+  consumeOnProviderFailure: boolean;
+  consumeOnFallbackOnly: boolean;
+  cooldownMinutesAfterRepeatedFailures: number | null;
+}
+
+export interface VideoNarrativeUsageState {
+  usedThisMonth?: number | null;
+  usedToday?: number | null;
+  repeatedFailureCount?: number | null;
+  cooldownUntil?: string | null;
+  now?: string | null;
+  isAdminOrDev?: boolean | null;
+}
+
+export interface VideoNarrativeUsageDecisionInput {
+  phase: VideoNarrativeUsagePhase;
+  usageState?: VideoNarrativeUsageState | null;
+  providerWasCalled?: boolean | null;
+  providerReturnedUsefulAnalysis?: boolean | null;
+  providerReturnedUsefulPartialAnalysis?: boolean | null;
+  usedFallbackOnly?: boolean | null;
+  failedBeforeProvider?: boolean | null;
+  payloadWasInvalid?: boolean | null;
+  consentWasMissing?: boolean | null;
+  retentionWasExpired?: boolean | null;
+  userRequestedManualRetry?: boolean | null;
+}
+
+export interface VideoNarrativeUsageIssue {
+  code:
+    | "usage_limited"
+    | "quota_exceeded"
+    | "daily_limit_exceeded"
+    | "cooldown_active"
+    | "usage_state_invalid"
+    | "usage_not_consumed"
+    | "provider_not_called"
+    | "failed_before_provider"
+    | "payload_invalid"
+    | "consent_missing"
+    | "retention_expired";
+  message: string;
+}
+
+export interface VideoNarrativeQuotaGuardResult {
+  ok: boolean;
+  phase: VideoNarrativeUsagePhase;
+  issues: VideoNarrativeUsageIssue[];
+  guardResult: VideoNarrativeGuardResult;
+  canAttemptAnalysis: boolean;
+}
+
+export interface VideoNarrativeUsageConsumptionDecision {
+  shouldConsumeQuota: boolean;
+  reason:
+    | "useful_analysis"
+    | "useful_partial_analysis"
+    | "manual_retry"
+    | "admin_bypass"
+    | "provider_not_called"
+    | "failed_before_provider"
+    | "payload_invalid"
+    | "consent_missing"
+    | "retention_expired"
+    | "provider_failure"
+    | "fallback_only"
+    | "quota_blocked"
+    | "cooldown_active";
+  issues: VideoNarrativeUsageIssue[];
+  guardResult: VideoNarrativeGuardResult;
+}
+
+export const VIDEO_NARRATIVE_USAGE_POLICIES: Record<
+  VideoNarrativeUsagePhase,
+  VideoNarrativeUsagePolicy
+> = {
+  manual_real_test: {
+    phase: "manual_real_test",
+    monthlyLimit: null,
+    dailyLimit: null,
+    allowAdminBypass: true,
+    allowRetryWithoutConsumption: true,
+    consumeOnUsefulPartialAnalysis: false,
+    consumeOnProviderFailure: false,
+    consumeOnFallbackOnly: false,
+    cooldownMinutesAfterRepeatedFailures: null,
+  },
+  internal_endpoint: {
+    phase: "internal_endpoint",
+    monthlyLimit: null,
+    dailyLimit: 20,
+    allowAdminBypass: true,
+    allowRetryWithoutConsumption: true,
+    consumeOnUsefulPartialAnalysis: true,
+    consumeOnProviderFailure: false,
+    consumeOnFallbackOnly: false,
+    cooldownMinutesAfterRepeatedFailures: 15,
+  },
+  closed_beta: {
+    phase: "closed_beta",
+    monthlyLimit: 5,
+    dailyLimit: 3,
+    allowAdminBypass: false,
+    allowRetryWithoutConsumption: false,
+    consumeOnUsefulPartialAnalysis: true,
+    consumeOnProviderFailure: false,
+    consumeOnFallbackOnly: false,
+    cooldownMinutesAfterRepeatedFailures: 30,
+  },
+  production: {
+    phase: "production",
+    monthlyLimit: 5,
+    dailyLimit: 3,
+    allowAdminBypass: false,
+    allowRetryWithoutConsumption: false,
+    consumeOnUsefulPartialAnalysis: true,
+    consumeOnProviderFailure: false,
+    consumeOnFallbackOnly: false,
+    cooldownMinutesAfterRepeatedFailures: 30,
+  },
+};
+
+function createIssue(code: VideoNarrativeUsageIssue["code"], message: string): VideoNarrativeUsageIssue {
+  return {
+    code,
+    message: sanitizeVideoNarrativeUsageMessage(message),
+  };
+}
+
+function parseDate(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function resolveNow(now?: string | null): number | null {
+  if (now) {
+    return parseDate(now);
+  }
+
+  return Date.now();
+}
+
+function normalizeUsageCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function hasInvalidUsageCount(value: number | null | undefined): boolean {
+  return value !== undefined && value !== null && (!Number.isFinite(value) || value < 0);
+}
+
+function buildConsumptionIssueForReason(
+  reason: VideoNarrativeUsageConsumptionDecision["reason"],
+): VideoNarrativeUsageIssue | null {
+  switch (reason) {
+    case "provider_not_called":
+      return createIssue("provider_not_called", "Provider não chamado.");
+    case "failed_before_provider":
+      return createIssue("failed_before_provider", "Falha antes do provider.");
+    case "payload_invalid":
+      return createIssue("payload_invalid", "Payload não validado.");
+    case "consent_missing":
+      return createIssue("consent_missing", "Consentimento ausente.");
+    case "retention_expired":
+      return createIssue("retention_expired", "Retenção expirada.");
+    case "provider_failure":
+    case "fallback_only":
+    case "manual_retry":
+    case "admin_bypass":
+      return createIssue("usage_not_consumed", "Uso não consumido.");
+    case "quota_blocked":
+      return createIssue("quota_exceeded", "Quota indisponível.");
+    case "cooldown_active":
+      return createIssue("cooldown_active", "Cooldown ativo.");
+    case "useful_analysis":
+    case "useful_partial_analysis":
+      return null;
+  }
+}
+
+export function sanitizeVideoNarrativeUsageMessage(message: string): string {
+  return sanitizeVideoNarrativeGuardMessage(message);
+}
+
+export function getVideoNarrativeUsagePolicy(
+  phase: VideoNarrativeUsagePhase,
+): VideoNarrativeUsagePolicy {
+  return VIDEO_NARRATIVE_USAGE_POLICIES[phase];
+}
+
+export function isVideoNarrativeCooldownActive(params: {
+  cooldownUntil?: string | null;
+  now?: string | null;
+}): boolean {
+  const cooldownUntil = parseDate(params.cooldownUntil);
+  const now = resolveNow(params.now);
+
+  if (cooldownUntil === null || now === null) {
+    return false;
+  }
+
+  return cooldownUntil > now;
+}
+
+export function buildVideoNarrativeUsageQuotaGuardResult(params: {
+  ok: boolean;
+  phase: VideoNarrativeUsagePhase;
+  issues?: VideoNarrativeUsageIssue[];
+}): VideoNarrativeQuotaGuardResult {
+  const issues = params.issues ?? [];
+  const blockingIssue = issues.find((issue) =>
+    ["quota_exceeded", "daily_limit_exceeded", "cooldown_active", "usage_limited"].includes(issue.code),
+  );
+
+  return {
+    ok: params.ok,
+    phase: params.phase,
+    issues,
+    canAttemptAnalysis: params.ok,
+    guardResult: params.ok
+      ? createPassedVideoNarrativeGuardResult("usage_quota")
+      : createBlockedVideoNarrativeGuardResult({
+          name: "usage_quota",
+          code: blockingIssue?.code === "cooldown_active" ? "cooldown_active" : "usage_limited",
+          message: blockingIssue?.message ?? "Uso não disponível.",
+        }),
+  };
+}
+
+export function validateVideoNarrativeUsageQuotaForPhase(params: {
+  phase: VideoNarrativeUsagePhase;
+  usageState?: VideoNarrativeUsageState | null;
+}): VideoNarrativeQuotaGuardResult {
+  const policy = getVideoNarrativeUsagePolicy(params.phase);
+  const usageState = params.usageState ?? {};
+  const issues: VideoNarrativeUsageIssue[] = [];
+
+  if (
+    hasInvalidUsageCount(usageState.usedThisMonth) ||
+    hasInvalidUsageCount(usageState.usedToday) ||
+    hasInvalidUsageCount(usageState.repeatedFailureCount)
+  ) {
+    issues.push(createIssue("usage_state_invalid", "Estado de uso não validado."));
+  }
+
+  if (usageState.cooldownUntil && parseDate(usageState.cooldownUntil) === null) {
+    issues.push(createIssue("usage_state_invalid", "Cooldown não validado."));
+  }
+
+  if (usageState.now && parseDate(usageState.now) === null) {
+    issues.push(createIssue("usage_state_invalid", "Data de referência não validada."));
+  }
+
+  const canBypassLimits = policy.allowAdminBypass && usageState.isAdminOrDev === true;
+
+  if (!canBypassLimits && isVideoNarrativeCooldownActive({
+    cooldownUntil: usageState.cooldownUntil,
+    now: usageState.now,
+  })) {
+    issues.push(createIssue("cooldown_active", "Cooldown ativo."));
+  }
+
+  if (
+    !canBypassLimits &&
+    policy.monthlyLimit !== null &&
+    normalizeUsageCount(usageState.usedThisMonth) >= policy.monthlyLimit
+  ) {
+    issues.push(createIssue("quota_exceeded", "Limite mensal atingido."));
+  }
+
+  if (
+    !canBypassLimits &&
+    policy.dailyLimit !== null &&
+    normalizeUsageCount(usageState.usedToday) >= policy.dailyLimit
+  ) {
+    issues.push(createIssue("daily_limit_exceeded", "Limite diário atingido."));
+  }
+
+  const hasBlockingIssue = issues.some((issue) =>
+    ["quota_exceeded", "daily_limit_exceeded", "cooldown_active", "usage_limited"].includes(issue.code),
+  );
+
+  return buildVideoNarrativeUsageQuotaGuardResult({
+    ok: !hasBlockingIssue,
+    phase: params.phase,
+    issues,
+  });
+}
+
+export function buildVideoNarrativeUsageConsumptionGuardResult(params: {
+  shouldConsumeQuota: boolean;
+  reason: VideoNarrativeUsageConsumptionDecision["reason"];
+  issues?: VideoNarrativeUsageIssue[];
+}): VideoNarrativeGuardResult {
+  const shouldBlock = params.reason === "quota_blocked" || params.reason === "cooldown_active";
+
+  return shouldBlock
+    ? createBlockedVideoNarrativeGuardResult({
+        name: "usage_consumption",
+        code: params.reason === "cooldown_active" ? "cooldown_active" : "quota_exceeded",
+        message: params.issues?.[0]?.message ?? "Consumo de uso bloqueado.",
+      })
+    : createPassedVideoNarrativeGuardResult("usage_consumption");
+}
+
+export function decideVideoNarrativeUsageConsumption(
+  input: VideoNarrativeUsageDecisionInput,
+): VideoNarrativeUsageConsumptionDecision {
+  const policy = getVideoNarrativeUsagePolicy(input.phase);
+  const quotaGuard = validateVideoNarrativeUsageQuotaForPhase({
+    phase: input.phase,
+    usageState: input.usageState,
+  });
+  const usageState = input.usageState ?? {};
+
+  let reason: VideoNarrativeUsageConsumptionDecision["reason"];
+  let shouldConsumeQuota = false;
+
+  if (!quotaGuard.canAttemptAnalysis) {
+    reason = quotaGuard.issues.some((issue) => issue.code === "cooldown_active")
+      ? "cooldown_active"
+      : "quota_blocked";
+  } else if (input.failedBeforeProvider) {
+    reason = "failed_before_provider";
+  } else if (input.payloadWasInvalid) {
+    reason = "payload_invalid";
+  } else if (input.consentWasMissing) {
+    reason = "consent_missing";
+  } else if (input.retentionWasExpired) {
+    reason = "retention_expired";
+  } else if (input.providerWasCalled !== true) {
+    reason = "provider_not_called";
+  } else if (policy.allowAdminBypass && usageState.isAdminOrDev === true) {
+    reason = "admin_bypass";
+  } else if (input.userRequestedManualRetry && policy.allowRetryWithoutConsumption) {
+    reason = "manual_retry";
+  } else if (input.userRequestedManualRetry && input.providerReturnedUsefulAnalysis) {
+    reason = "manual_retry";
+    shouldConsumeQuota = true;
+  } else if (input.providerReturnedUsefulAnalysis) {
+    reason = "useful_analysis";
+    shouldConsumeQuota = true;
+  } else if (input.providerReturnedUsefulPartialAnalysis && policy.consumeOnUsefulPartialAnalysis) {
+    reason = "useful_partial_analysis";
+    shouldConsumeQuota = true;
+  } else if (input.usedFallbackOnly) {
+    reason = "fallback_only";
+    shouldConsumeQuota = policy.consumeOnFallbackOnly;
+  } else {
+    reason = "provider_failure";
+    shouldConsumeQuota = policy.consumeOnProviderFailure;
+  }
+
+  const reasonIssue = buildConsumptionIssueForReason(reason);
+  const issues = [...quotaGuard.issues, ...(reasonIssue ? [reasonIssue] : [])];
+
+  return {
+    shouldConsumeQuota,
+    reason,
+    issues,
+    guardResult: buildVideoNarrativeUsageConsumptionGuardResult({
+      shouldConsumeQuota,
+      reason,
+      issues,
+    }),
+  };
+}


### PR DESCRIPTION
Stacked sobre #819.

## Resumo
- Adiciona contratos puros para usage/quota da análise narrativa de vídeo.
- Define políticas por fase: `manual_real_test`, `internal_endpoint`, `closed_beta` e `production`.
- Implementa helpers determinísticos para cooldown, quota guard e decisão de consumo de quota.
- Integra os resultados com `VideoNarrativeGuardResult` para `usage_quota` e `usage_consumption`.

## Decisões documentadas
- Beta/produto começam como hipótese com 5 análises/mês e 3 análises/dia.
- `internal_endpoint` usa limite diário 20 com bypass admin/dev.
- Falha antes do provider, payload inválido, consentimento ausente, retenção expirada, provider não chamado, provider failure e fallback-only não consomem quota.
- Análise útil consome quota; análise parcial útil consome quando a política permite.
- Não há billing real, Stripe, cobrança, endpoint, route.ts, upload real, UI, banco/tabela ou analytics real nesta fase.

## Validação local
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts`
- Bloco docs/Gemini/guards/payload/input/consent
- Regressões narrativas/videoUpload principais, guard/previews, NSE e Adaptive V2
- Regressões de brand narrative relacionadas
- `npm run typecheck`
- `git diff --check`
- `npm run build`