### PR TITLE
feat: add video narrative observability events

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -75,6 +75,7 @@ Já existe:
 - input/source guard helpers foram formalizados em MM21, mas ainda não foram conectados a endpoint real;
 - consent/retention guard helpers foram formalizados em MM22, mas ainda não foram conectados a endpoint real;
 - usage/quota guard helpers foram formalizados em MM23, mas ainda não foram conectados a endpoint real;
+- observability event contracts foram formalizados em MM24, mas ainda não enviam eventos para analytics real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -125,6 +126,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - helpers puros de input/source guard;
 - helpers puros de consent/retention guard;
 - helpers puros de usage/quota guard;
+- contratos puros de eventos de observabilidade;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -518,6 +518,28 @@ O que não faz:
 - não cria billing real, Stripe, cobrança, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM24 — Observability event contracts
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeObservabilityEvents.ts`
+- `videoNarrativeObservabilityEvents.test.ts`
+
+O que faz:
+
+- cria tipos e helpers puros para eventos futuros de observabilidade;
+- define payloads seguros para requested, started, completed, failed, fallback, seed, usage consumed/not consumed e limit reached;
+- adiciona buckets de duração/tamanho, requestId determinístico, validação de payload e redação de API key, base64 e URL assinada.
+
+O que não faz:
+
+- não cria analytics real;
+- não cria banco/tabela;
+- não cria endpoint, `route.ts`, upload real ou UI;
+- não conecta provider externo nem envia eventos.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -230,8 +230,9 @@ Exemplos:
 20. MM21 — Input/source guard helpers. Define políticas puras por fase para o futuro input_source guard.
 21. MM22 — Consent/retention guard helpers. Define políticas puras por fase para os futuros guards consent e retention.
 22. MM23 — Usage/quota guard helpers. Define políticas puras para usage_quota e usage_consumption, sem billing real.
-23. Teste real manual quando houver quota/billing disponível.
-24. Integração experimental futura no Board de Criação.
+23. MM24 — Observability event contracts. Define eventos e payloads seguros, sem analytics real.
+24. Teste real manual quando houver quota/billing disponível.
+25. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -270,6 +271,8 @@ MM21 adiciona `VideoNarrativeInputSourceGuardPolicy` e `validateVideoNarrativeIn
 MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `validateVideoNarrativeConsentRetentionForPhase` para preparar consentimento, retenção e expiração sem endpoint, upload real, storage real ou cleanup real.
 
 MM23 adiciona `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForPhase` e `decideVideoNarrativeUsageConsumption` para preparar limite, cooldown e consumo de quota sem endpoint, billing real, Stripe ou cobrança.
+
+MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObservabilityEvent` e `validateVideoNarrativeObservabilityEvent` para preparar eventos seguros sem endpoint, analytics real, banco/tabela ou provider externo.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
@@ -220,6 +220,8 @@ Os eventos e logs futuros podem usar `VideoNarrativeGuardResult` e `VideoNarrati
 
 MM23 adiciona reasons puros de `decideVideoNarrativeUsageConsumption`, que podem alimentar futuramente `video_narrative_usage_consumed`, `video_narrative_usage_not_consumed`, `usage counted reason` e `usage not counted reason` sem criar analytics real nesta fase.
 
+MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObservabilityEvent`, `validateVideoNarrativeObservabilityEvent`, buckets de duração/tamanho e redação de campos sensíveis. Esses helpers apenas constroem e validam payloads locais; não enviam eventos para analytics real, não criam banco/tabela e não conectam provider externo.
+
 ## Decisão Recomendada Agora
 
 Como ainda não há billing/quota:

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -115,6 +115,8 @@ MM23 adiciona helpers puros para preparar este guard por fase, incluindo limite 
 - registrar evento conceitual video_narrative_analysis_started;
 - logs sem vídeo/base64/API key/rawText.
 
+MM24 adiciona `buildVideoNarrativeObservabilityEvent` para preparar esse hook futuro com payload seguro, requestId, buckets e redação de campos sensíveis, ainda sem analytics real.
+
 ### 14. Provider Call
 
 - chamar `runGeminiVideoNarrativeProviderFromEnv`;
@@ -147,6 +149,8 @@ MM23 adiciona `decideVideoNarrativeUsageConsumption` para formalizar os motivos 
 - registrar provider status;
 - registrar parse ok/fail;
 - registrar cost estimate no futuro.
+
+MM24 também prepara eventos de completion, failure, fallback, seed, usage consumed/not consumed e limit reached sem enviar nada para ferramenta externa.
 
 ### 19. Safe Response
 
@@ -291,6 +295,8 @@ MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `
 
 MM23 adiciona `VideoNarrativeUsagePolicy`, `VideoNarrativeQuotaGuardResult` e `VideoNarrativeUsageConsumptionDecision` como fundação pura para usage_quota e usage_consumption.
 
+MM24 adiciona `VideoNarrativeObservabilityEventPayload` e helpers de build/validate/redact como fundação pura para os hooks de observabilidade do endpoint futuro.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -306,6 +312,7 @@ Só criar route.ts depois que:
 - input/source guard helpers estiverem disponíveis para `input_source`;
 - consent/retention guard helpers estiverem disponíveis para `consent` e `retention`;
 - usage/quota guard helpers estiverem disponíveis para `usage_quota` e `usage_consumption`;
+- observability event contracts estiverem disponíveis para start/completion hooks;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -324,6 +331,7 @@ Como ainda não há billing/quota:
 - MM21: input/source guard helpers;
 - MM22: consent/retention guard helpers;
 - MM23: usage/quota guard helpers;
-- MM24: storage cleanup contract;
-- MM25: endpoint real somente depois de billing/teste real;
-- MM26: preview interno com endpoint real.
+- MM24: observability event contracts;
+- MM25: storage cleanup contract;
+- MM26: endpoint real somente depois de billing/teste real;
+- MM27: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md
@@ -35,6 +35,8 @@ O usage guard do futuro endpoint deve seguir `VIDEO_NARRATIVE_REAL_ENDPOINT_GUAR
 
 MM23 formaliza `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForPhase` e `decideVideoNarrativeUsageConsumption` como helpers puros para esse futuro guard. Isso ainda não cria billing real, Stripe, cobrança, endpoint ou persistência de quota.
 
+MM24 formaliza eventos puros para `video_narrative_usage_consumed`, `video_narrative_usage_not_consumed` e `video_narrative_limit_reached`, permitindo carregar `usageReason` e `quotaConsumed` futuramente sem analytics real, billing real, Stripe ou cobrança.
+
 ## Limites Recomendados Por Fase
 
 ### Fase Admin/Manual

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts
@@ -1,0 +1,371 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  VIDEO_NARRATIVE_OBSERVABILITY_EVENT_NAMES,
+  VIDEO_NARRATIVE_OBSERVABILITY_SOURCES,
+  VIDEO_NARRATIVE_OBSERVABILITY_STATUSES,
+  bucketVideoNarrativeDuration,
+  bucketVideoNarrativeSize,
+  buildVideoNarrativeObservabilityEvent,
+  createVideoNarrativeRequestId,
+  redactVideoNarrativeObservabilityPayload,
+  sanitizeVideoNarrativeObservabilityText,
+  validateVideoNarrativeObservabilityEvent,
+  type VideoNarrativeObservabilityEventPayload,
+} from "./videoNarrativeObservabilityEvents";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeObservabilityEvents.ts");
+const CREATED_AT = "2026-05-17T12:00:00.000Z";
+const MB = 1024 * 1024;
+
+const validEvent: VideoNarrativeObservabilityEventPayload = {
+  requestId: "req-1",
+  eventName: "video_narrative_analysis_requested",
+  status: "requested",
+  source: "internal_endpoint",
+  createdAt: CREATED_AT,
+};
+
+describe("videoNarrativeObservabilityEvents", () => {
+  it("event names contêm os 9 eventos esperados", () => {
+    expect(VIDEO_NARRATIVE_OBSERVABILITY_EVENT_NAMES).toEqual([
+      "video_narrative_analysis_requested",
+      "video_narrative_analysis_started",
+      "video_narrative_analysis_completed",
+      "video_narrative_analysis_failed",
+      "video_narrative_analysis_fallback_used",
+      "video_narrative_seed_created",
+      "video_narrative_usage_consumed",
+      "video_narrative_usage_not_consumed",
+      "video_narrative_limit_reached",
+    ]);
+  });
+
+  it("statuses contêm os statuses esperados", () => {
+    expect(VIDEO_NARRATIVE_OBSERVABILITY_STATUSES).toEqual([
+      "requested",
+      "started",
+      "completed",
+      "failed",
+      "blocked",
+      "fallback",
+      "consumed",
+      "not_consumed",
+    ]);
+  });
+
+  it("sources contêm as sources esperadas", () => {
+    expect(VIDEO_NARRATIVE_OBSERVABILITY_SOURCES).toEqual([
+      "manual_real_test",
+      "internal_endpoint",
+      "closed_beta",
+      "production",
+    ]);
+  });
+
+  it("createVideoNarrativeRequestId com prefix retorna id previsível", () => {
+    expect(createVideoNarrativeRequestId("mm24")).toBe("mm24-video-narrative-request");
+    expect(createVideoNarrativeRequestId()).toBe("video-narrative-request");
+  });
+
+  it("bucketVideoNarrativeDuration cobre null, negativo e faixas", () => {
+    expect(bucketVideoNarrativeDuration()).toBeNull();
+    expect(bucketVideoNarrativeDuration(-1)).toBeNull();
+    expect(bucketVideoNarrativeDuration(15)).toBe("0-15s");
+    expect(bucketVideoNarrativeDuration(30)).toBe("16-30s");
+    expect(bucketVideoNarrativeDuration(60)).toBe("31-60s");
+    expect(bucketVideoNarrativeDuration(120)).toBe("61-120s");
+    expect(bucketVideoNarrativeDuration(121)).toBe("over-120s");
+  });
+
+  it("bucketVideoNarrativeSize cobre null, negativo e faixas", () => {
+    expect(bucketVideoNarrativeSize()).toBeNull();
+    expect(bucketVideoNarrativeSize(-1)).toBeNull();
+    expect(bucketVideoNarrativeSize(10 * MB)).toBe("0-10mb");
+    expect(bucketVideoNarrativeSize(50 * MB)).toBe("10-50mb");
+    expect(bucketVideoNarrativeSize(100 * MB)).toBe("50-100mb");
+    expect(bucketVideoNarrativeSize(101 * MB)).toBe("over-100mb");
+  });
+
+  it("buildVideoNarrativeObservabilityEvent cria evento requested válido", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-1",
+      eventName: "video_narrative_analysis_requested",
+      status: "requested",
+      source: "internal_endpoint",
+      createdAt: CREATED_AT,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.event).toMatchObject(validEvent);
+  });
+
+  it("buildVideoNarrativeObservabilityEvent cria evento completed com latencyMs, schemaParseOk e hasUsefulSeed", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-2",
+      eventName: "video_narrative_analysis_completed",
+      status: "completed",
+      source: "closed_beta",
+      createdAt: CREATED_AT,
+      latencyMs: 1200,
+      schemaParseOk: true,
+      hasUsefulSeed: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.event).toMatchObject({
+      latencyMs: 1200,
+      schemaParseOk: true,
+      hasUsefulSeed: true,
+    });
+  });
+
+  it("buildVideoNarrativeObservabilityEvent cria evento failed com guardBlockedBy e providerStatus", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-3",
+      eventName: "video_narrative_analysis_failed",
+      status: "failed",
+      source: "internal_endpoint",
+      createdAt: CREATED_AT,
+      guardBlockedBy: "usage_quota",
+      providerStatus: "provider_unavailable",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.event).toMatchObject({
+      guardBlockedBy: "usage_quota",
+      providerStatus: "provider_unavailable",
+    });
+  });
+
+  it("buildVideoNarrativeObservabilityEvent transforma durationSeconds e sizeBytes em buckets", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-4",
+      eventName: "video_narrative_analysis_started",
+      status: "started",
+      source: "internal_endpoint",
+      createdAt: CREATED_AT,
+      durationSeconds: 42,
+      sizeBytes: 80 * MB,
+    });
+
+    expect(result.event).toMatchObject({
+      durationBucket: "31-60s",
+      sizeBucket: "50-100mb",
+    });
+  });
+
+  it("buildVideoNarrativeObservabilityEvent sanitiza model/inputSource/providerStatus com API key", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-5",
+      eventName: "video_narrative_analysis_started",
+      status: "started",
+      source: "internal_endpoint",
+      createdAt: CREATED_AT,
+      model: "gemini AIza1234567890abcdefghi",
+      inputSource: "GEMINI_API_KEY=abc",
+      providerStatus: "GOOGLE_GENAI_API_KEY=def",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.event?.model).toBe("gemini [redigido]");
+    expect(result.event?.inputSource).toBe("[redigido]");
+    expect(result.event?.providerStatus).toBe("[redigido]");
+  });
+
+  it("buildVideoNarrativeObservabilityEvent retorna issue para latencyMs negativo", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-6",
+      eventName: "video_narrative_analysis_completed",
+      status: "completed",
+      source: "internal_endpoint",
+      createdAt: CREATED_AT,
+      latencyMs: -1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toContain("invalid_latency");
+  });
+
+  it("buildVideoNarrativeObservabilityEvent retorna issue para estimatedCost negativo", () => {
+    const result = buildVideoNarrativeObservabilityEvent({
+      requestId: "req-7",
+      eventName: "video_narrative_usage_consumed",
+      status: "consumed",
+      source: "production",
+      createdAt: CREATED_AT,
+      estimatedCost: -0.01,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toContain("invalid_cost");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent aceita evento válido", () => {
+    expect(validateVideoNarrativeObservabilityEvent(validEvent).ok).toBe(true);
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita eventName inválido", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({ ...validEvent, eventName: "outro" }).issues.map(
+        (issue) => issue.code,
+      ),
+    ).toContain("invalid_event_name");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita status inválido", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({ ...validEvent, status: "outro" }).issues.map(
+        (issue) => issue.code,
+      ),
+    ).toContain("invalid_status");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita source inválida", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({ ...validEvent, source: "outro" }).issues.map(
+        (issue) => issue.code,
+      ),
+    ).toContain("invalid_source");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita createdAt inválido", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({ ...validEvent, createdAt: "sem-data" }).issues.map(
+        (issue) => issue.code,
+      ),
+    ).toContain("invalid_created_at");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita rawText extra", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({ ...validEvent, rawText: "texto completo" }).issues.map(
+        (issue) => issue.code,
+      ),
+    ).toContain("unsafe_payload");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita inlineVideoBase64 extra", () => {
+    expect(
+      validateVideoNarrativeObservabilityEvent({
+        ...validEvent,
+        inlineVideoBase64: "a".repeat(140),
+      }).issues.map((issue) => issue.code),
+    ).toContain("unsafe_payload");
+  });
+
+  it("validateVideoNarrativeObservabilityEvent rejeita signedUrl/videoUrl/apiKey extra", () => {
+    ["signedUrl", "videoUrl", "apiKey"].forEach((key) => {
+      expect(
+        validateVideoNarrativeObservabilityEvent({ ...validEvent, [key]: "valor" }).issues.map(
+          (issue) => issue.code,
+        ),
+      ).toContain("unsafe_payload");
+    });
+  });
+
+  it("redactVideoNarrativeObservabilityPayload redige AIza, GEMINI_API_KEY e GOOGLE_GENAI_API_KEY", () => {
+    const redacted = redactVideoNarrativeObservabilityPayload({
+      ...validEvent,
+      model: "AIza1234567890abcdefghi",
+      providerStatus: "GEMINI_API_KEY=abc",
+      inputSource: "GOOGLE_GENAI_API_KEY=def",
+    });
+
+    expect(redacted.model).toBe("[redigido]");
+    expect(redacted.providerStatus).toBe("[redigido]");
+    expect(redacted.inputSource).toBe("[redigido]");
+  });
+
+  it("redactVideoNarrativeObservabilityPayload redige base64 longo", () => {
+    const redacted = redactVideoNarrativeObservabilityPayload({
+      ...validEvent,
+      accountId: "a".repeat(140),
+    });
+
+    expect(redacted.accountId).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeObservabilityText redige URL assinada com token simples", () => {
+    expect(
+      sanitizeVideoNarrativeObservabilityText("https://cdn.example/video.mp4?token=abc123"),
+    ).toBe("[redigido]");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const outputs = [
+      buildVideoNarrativeObservabilityEvent({
+        requestId: "req-8",
+        eventName: "video_narrative_analysis_completed",
+        status: "completed",
+        source: "internal_endpoint",
+        createdAt: CREATED_AT,
+        latencyMs: -1,
+      }).issues.map((issue) => issue.message),
+      sanitizeVideoNarrativeObservabilityText(
+        "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      ),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.ts
@@ -1,0 +1,447 @@
+import { sanitizeVideoNarrativeGuardMessage } from "./videoNarrativeGuardContracts";
+import type { VideoNarrativeInputSource } from "./videoNarrativePayloadValidation";
+import type { VideoNarrativeInputSourcePhase } from "./videoNarrativeInputSourceGuards";
+import type { VideoNarrativeUsageConsumptionDecision } from "./videoNarrativeUsageQuotaGuards";
+
+export type VideoNarrativeObservabilityEventName =
+  | "video_narrative_analysis_requested"
+  | "video_narrative_analysis_started"
+  | "video_narrative_analysis_completed"
+  | "video_narrative_analysis_failed"
+  | "video_narrative_analysis_fallback_used"
+  | "video_narrative_seed_created"
+  | "video_narrative_usage_consumed"
+  | "video_narrative_usage_not_consumed"
+  | "video_narrative_limit_reached";
+
+export type VideoNarrativeObservabilityStatus =
+  | "requested"
+  | "started"
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "fallback"
+  | "consumed"
+  | "not_consumed";
+
+export type VideoNarrativeObservabilitySource = VideoNarrativeInputSourcePhase;
+
+export interface VideoNarrativeObservabilityEventPayload {
+  requestId: string;
+  eventName: VideoNarrativeObservabilityEventName;
+  status: VideoNarrativeObservabilityStatus;
+  source: VideoNarrativeObservabilitySource;
+  createdAt: string;
+  userId?: string | null;
+  accountId?: string | null;
+  model?: string | null;
+  providerStatus?: string | null;
+  inputSource?: VideoNarrativeInputSource | string | null;
+  mimeType?: string | null;
+  durationBucket?: string | null;
+  sizeBucket?: string | null;
+  latencyMs?: number | null;
+  hasRawText?: boolean | null;
+  fallbackUsed?: boolean | null;
+  schemaParseOk?: boolean | null;
+  quotaConsumed?: boolean | null;
+  usageReason?: VideoNarrativeUsageConsumptionDecision["reason"] | string | null;
+  guardBlockedBy?: string | null;
+  primaryAction?: string | null;
+  hasUsefulSeed?: boolean | null;
+  issuesCount?: number | null;
+  estimatedCost?: number | null;
+  costCurrency?: string | null;
+}
+
+export interface VideoNarrativeObservabilityEventBuildInput {
+  requestId?: string | null;
+  eventName: VideoNarrativeObservabilityEventName;
+  status: VideoNarrativeObservabilityStatus;
+  source: VideoNarrativeObservabilitySource;
+  createdAt?: string | null;
+  userId?: string | null;
+  accountId?: string | null;
+  model?: string | null;
+  providerStatus?: string | null;
+  inputSource?: VideoNarrativeInputSource | string | null;
+  mimeType?: string | null;
+  durationSeconds?: number | null;
+  sizeBytes?: number | null;
+  latencyMs?: number | null;
+  hasRawText?: boolean | null;
+  fallbackUsed?: boolean | null;
+  schemaParseOk?: boolean | null;
+  quotaConsumed?: boolean | null;
+  usageReason?: VideoNarrativeUsageConsumptionDecision["reason"] | string | null;
+  guardBlockedBy?: string | null;
+  primaryAction?: string | null;
+  hasUsefulSeed?: boolean | null;
+  issuesCount?: number | null;
+  estimatedCost?: number | null;
+  costCurrency?: string | null;
+}
+
+export interface VideoNarrativeObservabilityValidationIssue {
+  code:
+    | "missing_request_id"
+    | "invalid_event_name"
+    | "invalid_status"
+    | "invalid_source"
+    | "invalid_created_at"
+    | "unsafe_payload"
+    | "invalid_latency"
+    | "invalid_cost";
+  message: string;
+}
+
+export interface VideoNarrativeObservabilityValidationResult {
+  ok: boolean;
+  event: VideoNarrativeObservabilityEventPayload | null;
+  issues: VideoNarrativeObservabilityValidationIssue[];
+}
+
+export const VIDEO_NARRATIVE_OBSERVABILITY_EVENT_NAMES: VideoNarrativeObservabilityEventName[] = [
+  "video_narrative_analysis_requested",
+  "video_narrative_analysis_started",
+  "video_narrative_analysis_completed",
+  "video_narrative_analysis_failed",
+  "video_narrative_analysis_fallback_used",
+  "video_narrative_seed_created",
+  "video_narrative_usage_consumed",
+  "video_narrative_usage_not_consumed",
+  "video_narrative_limit_reached",
+];
+
+export const VIDEO_NARRATIVE_OBSERVABILITY_STATUSES: VideoNarrativeObservabilityStatus[] = [
+  "requested",
+  "started",
+  "completed",
+  "failed",
+  "blocked",
+  "fallback",
+  "consumed",
+  "not_consumed",
+];
+
+export const VIDEO_NARRATIVE_OBSERVABILITY_SOURCES: VideoNarrativeObservabilitySource[] = [
+  "manual_real_test",
+  "internal_endpoint",
+  "closed_beta",
+  "production",
+];
+
+const UNSAFE_PAYLOAD_KEYS = [
+  "rawText",
+  "inlineVideoBase64",
+  "base64",
+  "video",
+  "videoUrl",
+  "signedUrl",
+  "apiKey",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENAI_API_KEY",
+];
+
+const SIGNED_URL_PATTERN = /\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createIssue(
+  code: VideoNarrativeObservabilityValidationIssue["code"],
+  message: string,
+): VideoNarrativeObservabilityValidationIssue {
+  return {
+    code,
+    message: sanitizeVideoNarrativeObservabilityText(message),
+  };
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const sanitized = sanitizeVideoNarrativeObservabilityText(value).trim();
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+function isValidIsoDate(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
+function hasUnsafePayloadKey(value: Record<string, unknown>): boolean {
+  return UNSAFE_PAYLOAD_KEYS.some((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+export function createVideoNarrativeRequestId(prefix?: string): string {
+  const safePrefix = prefix ? sanitizeVideoNarrativeObservabilityText(prefix).trim() : "";
+  return safePrefix ? `${safePrefix}-video-narrative-request` : "video-narrative-request";
+}
+
+export function bucketVideoNarrativeDuration(durationSeconds?: number | null): string | null {
+  if (typeof durationSeconds !== "number" || !Number.isFinite(durationSeconds) || durationSeconds < 0) {
+    return null;
+  }
+
+  if (durationSeconds <= 15) {
+    return "0-15s";
+  }
+
+  if (durationSeconds <= 30) {
+    return "16-30s";
+  }
+
+  if (durationSeconds <= 60) {
+    return "31-60s";
+  }
+
+  if (durationSeconds <= 120) {
+    return "61-120s";
+  }
+
+  return "over-120s";
+}
+
+export function bucketVideoNarrativeSize(sizeBytes?: number | null): string | null {
+  if (typeof sizeBytes !== "number" || !Number.isFinite(sizeBytes) || sizeBytes < 0) {
+    return null;
+  }
+
+  const mb = 1024 * 1024;
+
+  if (sizeBytes <= 10 * mb) {
+    return "0-10mb";
+  }
+
+  if (sizeBytes <= 50 * mb) {
+    return "10-50mb";
+  }
+
+  if (sizeBytes <= 100 * mb) {
+    return "50-100mb";
+  }
+
+  return "over-100mb";
+}
+
+export function sanitizeVideoNarrativeObservabilityText(value: string): string {
+  const withoutSignedUrls = value.replace(SIGNED_URL_PATTERN, "[redigido]");
+  return sanitizeVideoNarrativeGuardMessage(withoutSignedUrls);
+}
+
+export function isVideoNarrativeObservabilityEventName(
+  value: unknown,
+): value is VideoNarrativeObservabilityEventName {
+  return (
+    typeof value === "string" &&
+    VIDEO_NARRATIVE_OBSERVABILITY_EVENT_NAMES.includes(value as VideoNarrativeObservabilityEventName)
+  );
+}
+
+export function isVideoNarrativeObservabilityStatus(
+  value: unknown,
+): value is VideoNarrativeObservabilityStatus {
+  return (
+    typeof value === "string" &&
+    VIDEO_NARRATIVE_OBSERVABILITY_STATUSES.includes(value as VideoNarrativeObservabilityStatus)
+  );
+}
+
+export function isVideoNarrativeObservabilitySource(
+  value: unknown,
+): value is VideoNarrativeObservabilitySource {
+  return (
+    typeof value === "string" &&
+    VIDEO_NARRATIVE_OBSERVABILITY_SOURCES.includes(value as VideoNarrativeObservabilitySource)
+  );
+}
+
+export function redactVideoNarrativeObservabilityPayload(
+  event: VideoNarrativeObservabilityEventPayload,
+): VideoNarrativeObservabilityEventPayload {
+  return {
+    ...event,
+    requestId: sanitizeVideoNarrativeObservabilityText(event.requestId),
+    createdAt: sanitizeVideoNarrativeObservabilityText(event.createdAt),
+    userId: normalizeOptionalText(event.userId),
+    accountId: normalizeOptionalText(event.accountId),
+    model: normalizeOptionalText(event.model),
+    providerStatus: normalizeOptionalText(event.providerStatus),
+    inputSource: normalizeOptionalText(event.inputSource),
+    mimeType: normalizeOptionalText(event.mimeType),
+    durationBucket: normalizeOptionalText(event.durationBucket),
+    sizeBucket: normalizeOptionalText(event.sizeBucket),
+    usageReason: normalizeOptionalText(event.usageReason),
+    guardBlockedBy: normalizeOptionalText(event.guardBlockedBy),
+    primaryAction: normalizeOptionalText(event.primaryAction),
+    costCurrency: normalizeOptionalText(event.costCurrency),
+  };
+}
+
+export function buildVideoNarrativeObservabilityEvent(
+  input: VideoNarrativeObservabilityEventBuildInput,
+): VideoNarrativeObservabilityValidationResult {
+  const requestId = normalizeOptionalText(input.requestId) ?? createVideoNarrativeRequestId();
+  const createdAt = normalizeOptionalText(input.createdAt) ?? new Date(0).toISOString();
+  const issues: VideoNarrativeObservabilityValidationIssue[] = [];
+
+  if (!requestId) {
+    issues.push(createIssue("missing_request_id", "RequestId não informado."));
+  }
+
+  if (!isVideoNarrativeObservabilityEventName(input.eventName)) {
+    issues.push(createIssue("invalid_event_name", "Evento não validado."));
+  }
+
+  if (!isVideoNarrativeObservabilityStatus(input.status)) {
+    issues.push(createIssue("invalid_status", "Status não validado."));
+  }
+
+  if (!isVideoNarrativeObservabilitySource(input.source)) {
+    issues.push(createIssue("invalid_source", "Origem não validada."));
+  }
+
+  if (!isValidIsoDate(createdAt)) {
+    issues.push(createIssue("invalid_created_at", "Data do evento não validada."));
+  }
+
+  if (typeof input.latencyMs === "number" && input.latencyMs < 0) {
+    issues.push(createIssue("invalid_latency", "Latência não validada."));
+  }
+
+  if (typeof input.estimatedCost === "number" && input.estimatedCost < 0) {
+    issues.push(createIssue("invalid_cost", "Custo não validado."));
+  }
+
+  if (typeof input.issuesCount === "number" && input.issuesCount < 0) {
+    issues.push(createIssue("unsafe_payload", "Quantidade de issues não validada."));
+  }
+
+  const event: VideoNarrativeObservabilityEventPayload = redactVideoNarrativeObservabilityPayload({
+    requestId,
+    eventName: input.eventName,
+    status: input.status,
+    source: input.source,
+    createdAt,
+    userId: input.userId,
+    accountId: input.accountId,
+    model: input.model,
+    providerStatus: input.providerStatus,
+    inputSource: input.inputSource,
+    mimeType: input.mimeType,
+    durationBucket: bucketVideoNarrativeDuration(input.durationSeconds),
+    sizeBucket: bucketVideoNarrativeSize(input.sizeBytes),
+    latencyMs: input.latencyMs ?? null,
+    hasRawText: input.hasRawText ?? null,
+    fallbackUsed: input.fallbackUsed ?? null,
+    schemaParseOk: input.schemaParseOk ?? null,
+    quotaConsumed: input.quotaConsumed ?? null,
+    usageReason: input.usageReason,
+    guardBlockedBy: input.guardBlockedBy,
+    primaryAction: input.primaryAction,
+    hasUsefulSeed: input.hasUsefulSeed ?? null,
+    issuesCount: typeof input.issuesCount === "number" && input.issuesCount >= 0 ? input.issuesCount : null,
+    estimatedCost: input.estimatedCost ?? null,
+    costCurrency: input.costCurrency,
+  });
+
+  const validation = validateVideoNarrativeObservabilityEvent(event);
+  const allIssues = [...issues, ...validation.issues];
+
+  return {
+    ok: allIssues.length === 0,
+    event: allIssues.length === 0 ? event : null,
+    issues: allIssues,
+  };
+}
+
+export function validateVideoNarrativeObservabilityEvent(
+  event: unknown,
+): VideoNarrativeObservabilityValidationResult {
+  if (!isRecord(event)) {
+    return {
+      ok: false,
+      event: null,
+      issues: [createIssue("unsafe_payload", "Evento não validado.")],
+    };
+  }
+
+  const issues: VideoNarrativeObservabilityValidationIssue[] = [];
+
+  if (hasUnsafePayloadKey(event)) {
+    issues.push(createIssue("unsafe_payload", "Payload contém campo sensível."));
+  }
+
+  if (typeof event.requestId !== "string" || event.requestId.trim().length === 0) {
+    issues.push(createIssue("missing_request_id", "RequestId não informado."));
+  }
+
+  if (!isVideoNarrativeObservabilityEventName(event.eventName)) {
+    issues.push(createIssue("invalid_event_name", "Evento não validado."));
+  }
+
+  if (!isVideoNarrativeObservabilityStatus(event.status)) {
+    issues.push(createIssue("invalid_status", "Status não validado."));
+  }
+
+  if (!isVideoNarrativeObservabilitySource(event.source)) {
+    issues.push(createIssue("invalid_source", "Origem não validada."));
+  }
+
+  if (typeof event.createdAt !== "string" || !isValidIsoDate(event.createdAt)) {
+    issues.push(createIssue("invalid_created_at", "Data do evento não validada."));
+  }
+
+  if (typeof event.latencyMs === "number" && event.latencyMs < 0) {
+    issues.push(createIssue("invalid_latency", "Latência não validada."));
+  }
+
+  if (typeof event.estimatedCost === "number" && event.estimatedCost < 0) {
+    issues.push(createIssue("invalid_cost", "Custo não validado."));
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      event: null,
+      issues,
+    };
+  }
+
+  const validEvent: VideoNarrativeObservabilityEventPayload = {
+    requestId: event.requestId as string,
+    eventName: event.eventName as VideoNarrativeObservabilityEventName,
+    status: event.status as VideoNarrativeObservabilityStatus,
+    source: event.source as VideoNarrativeObservabilitySource,
+    createdAt: event.createdAt as string,
+    userId: typeof event.userId === "string" ? event.userId : null,
+    accountId: typeof event.accountId === "string" ? event.accountId : null,
+    model: typeof event.model === "string" ? event.model : null,
+    providerStatus: typeof event.providerStatus === "string" ? event.providerStatus : null,
+    inputSource: typeof event.inputSource === "string" ? event.inputSource : null,
+    mimeType: typeof event.mimeType === "string" ? event.mimeType : null,
+    durationBucket: typeof event.durationBucket === "string" ? event.durationBucket : null,
+    sizeBucket: typeof event.sizeBucket === "string" ? event.sizeBucket : null,
+    latencyMs: typeof event.latencyMs === "number" ? event.latencyMs : null,
+    hasRawText: typeof event.hasRawText === "boolean" ? event.hasRawText : null,
+    fallbackUsed: typeof event.fallbackUsed === "boolean" ? event.fallbackUsed : null,
+    schemaParseOk: typeof event.schemaParseOk === "boolean" ? event.schemaParseOk : null,
+    quotaConsumed: typeof event.quotaConsumed === "boolean" ? event.quotaConsumed : null,
+    usageReason: typeof event.usageReason === "string" ? event.usageReason : null,
+    guardBlockedBy: typeof event.guardBlockedBy === "string" ? event.guardBlockedBy : null,
+    primaryAction: typeof event.primaryAction === "string" ? event.primaryAction : null,
+    hasUsefulSeed: typeof event.hasUsefulSeed === "boolean" ? event.hasUsefulSeed : null,
+    issuesCount: typeof event.issuesCount === "number" ? event.issuesCount : null,
+    estimatedCost: typeof event.estimatedCost === "number" ? event.estimatedCost : null,
+    costCurrency: typeof event.costCurrency === "string" ? event.costCurrency : null,
+  };
+
+  return {
+    ok: true,
+    event: redactVideoNarrativeObservabilityPayload(validEvent),
+    issues: [],
+  };
+}


### PR DESCRIPTION
Stacked sobre #820.

## Resumo
- Adiciona contratos puros para eventos futuros de observabilidade da análise narrativa de vídeo.
- Define payload seguro com requestId, status, source, buckets de duração/tamanho, latencyMs, hasRawText, fallback, schema parse, quota, usage reason, primaryAction e custo estimado.
- Implementa helpers determinísticos para requestId, buckets, build/validate/redact e sanitização de API key, base64 e URL assinada.
- Atualiza os contratos/documentos MM24 sem criar endpoint, route.ts, upload real, UI, banco/tabela ou analytics real.

## Eventos definidos
- `video_narrative_analysis_requested`
- `video_narrative_analysis_started`
- `video_narrative_analysis_completed`
- `video_narrative_analysis_failed`
- `video_narrative_analysis_fallback_used`
- `video_narrative_seed_created`
- `video_narrative_usage_consumed`
- `video_narrative_usage_not_consumed`
- `video_narrative_limit_reached`

## Não escopo
- Sem analytics real.
- Sem provider externo.
- Sem endpoint real ou `route.ts`.
- Sem upload/storage real.
- Sem UI, BoardShell ou navegação.
- Sem billing, Stripe ou cobrança.

## Validação local
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts`
- Bloco docs/Gemini/guards/payload/input/consent/usage
- Regressões `videoUpload`
- Regressões guard/previews, NSE e Adaptive V2
- Regressões narrativas de marca
- `npm run typecheck`
- `git diff --check`
- `npm run build`