### PR TITLE
feat: add video narrative safe response builder

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -76,6 +76,7 @@ Já existe:
 - consent/retention guard helpers foram formalizados em MM22, mas ainda não foram conectados a endpoint real;
 - usage/quota guard helpers foram formalizados em MM23, mas ainda não foram conectados a endpoint real;
 - observability event contracts foram formalizados em MM24, mas ainda não enviam eventos para analytics real;
+- safe response builder foi formalizado em MM25, mas ainda não foi conectado a endpoint real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -127,6 +128,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - helpers puros de consent/retention guard;
 - helpers puros de usage/quota guard;
 - contratos puros de eventos de observabilidade;
+- safe response builder puro;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -540,6 +540,28 @@ O que não faz:
 - não cria endpoint, `route.ts`, upload real ou UI;
 - não conecta provider externo nem envia eventos.
 
+### MM25 — Safe response builder
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeSafeResponseBuilder.ts`
+- `videoNarrativeSafeResponseBuilder.test.ts`
+
+O que faz:
+
+- cria helpers puros para montar a resposta segura do futuro endpoint interno/admin;
+- reduz guard, usage e observability para summaries seguros;
+- garante resposta sem `rawText` completo, base64, API key, vídeo bruto ou URL assinada com token.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, UI, banco/tabela ou analytics real;
+- não conecta nada ao fluxo real do produto.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -231,8 +231,9 @@ Exemplos:
 21. MM22 — Consent/retention guard helpers. Define políticas puras por fase para os futuros guards consent e retention.
 22. MM23 — Usage/quota guard helpers. Define políticas puras para usage_quota e usage_consumption, sem billing real.
 23. MM24 — Observability event contracts. Define eventos e payloads seguros, sem analytics real.
-24. Teste real manual quando houver quota/billing disponível.
-25. Integração experimental futura no Board de Criação.
+24. MM25 — Safe response builder. Define empacotamento seguro da resposta futura, sem endpoint.
+25. Teste real manual quando houver quota/billing disponível.
+26. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -273,6 +274,8 @@ MM22 adiciona `VideoNarrativeConsentPolicy`, `VideoNarrativeRetentionPolicy` e `
 MM23 adiciona `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForPhase` e `decideVideoNarrativeUsageConsumption` para preparar limite, cooldown e consumo de quota sem endpoint, billing real, Stripe ou cobrança.
 
 MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObservabilityEvent` e `validateVideoNarrativeObservabilityEvent` para preparar eventos seguros sem endpoint, analytics real, banco/tabela ou provider externo.
+
+MM25 adiciona `VideoNarrativeSafeResponse`, `buildVideoNarrativeSafeResponse` e `validateVideoNarrativeSafeResponse` para preparar a resposta segura futura sem endpoint, route.ts, upload real ou UI.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -90,6 +90,8 @@ Regras:
 - `issues` devem ser sanitizadas;
 - fallback deve retornar `ok false` com analysis segura.
 
+MM25 adiciona `VideoNarrativeSafeResponse` e helpers puros para montar essa resposta futura sem retornar `rawText` completo, base64, API key, vídeo bruto ou URL assinada com token.
+
 ## Status Futuros
 
 - `disabled`;
@@ -162,6 +164,7 @@ Regras:
 - `VideoNarrativeGuardPipelineSummary`;
 - `VideoNarrativeAnalyzePayload`;
 - `VideoNarrativeNormalizedAnalyzePayload`;
+- `VideoNarrativeSafeResponse`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
 - `getPostCreationVideoSeedPrimaryAction`;

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md
@@ -222,6 +222,8 @@ MM23 adiciona reasons puros de `decideVideoNarrativeUsageConsumption`, que podem
 
 MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObservabilityEvent`, `validateVideoNarrativeObservabilityEvent`, buckets de duração/tamanho e redação de campos sensíveis. Esses helpers apenas constroem e validam payloads locais; não enviam eventos para analytics real, não criam banco/tabela e não conectam provider externo.
 
+MM25 adiciona `observabilitySummary` reduzido dentro de `VideoNarrativeSafeResponse`: apenas `requestId` e eventos mínimos com `eventName`, `status`, `source` e `createdAt`. O response não retorna payload completo de observabilidade.
+
 ## Decisão Recomendada Agora
 
 Como ainda não há billing/quota:

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -159,6 +159,8 @@ MM24 também prepara eventos de completion, failure, fallback, seed, usage consu
 - nunca retornar API key;
 - nunca retornar base64.
 
+MM25 adiciona `buildVideoNarrativeSafeResponse`, `buildBlockedVideoNarrativeSafeResponse` e `validateVideoNarrativeSafeResponse` como fundação pura para esta etapa, garantindo que `rawText`, base64, API key, vídeo bruto e URL assinada não saiam no response.
+
 ## Payload Futuro
 
 Exemplo conceitual:
@@ -297,6 +299,8 @@ MM23 adiciona `VideoNarrativeUsagePolicy`, `VideoNarrativeQuotaGuardResult` e `V
 
 MM24 adiciona `VideoNarrativeObservabilityEventPayload` e helpers de build/validate/redact como fundação pura para os hooks de observabilidade do endpoint futuro.
 
+MM25 adiciona `VideoNarrativeSafeResponse` como fundação pura para o safe_response guard e para o empacotamento final do endpoint futuro.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -313,6 +317,7 @@ Só criar route.ts depois que:
 - consent/retention guard helpers estiverem disponíveis para `consent` e `retention`;
 - usage/quota guard helpers estiverem disponíveis para `usage_quota` e `usage_consumption`;
 - observability event contracts estiverem disponíveis para start/completion hooks;
+- safe response builder estiver disponível para `safe_response`;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -332,6 +337,7 @@ Como ainda não há billing/quota:
 - MM22: consent/retention guard helpers;
 - MM23: usage/quota guard helpers;
 - MM24: observability event contracts;
-- MM25: storage cleanup contract;
-- MM26: endpoint real somente depois de billing/teste real;
-- MM27: preview interno com endpoint real.
+- MM25: safe response builder;
+- MM26: storage cleanup contract;
+- MM27: endpoint real somente depois de billing/teste real;
+- MM28: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
@@ -1,0 +1,449 @@
+import fs from "fs";
+import path from "path";
+
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  summarizeVideoNarrativeGuardResults,
+} from "./videoNarrativeGuardContracts";
+import {
+  buildBlockedVideoNarrativeSafeResponse,
+  buildVideoNarrativeSafeResponse,
+  redactVideoNarrativeSafeResponse,
+  sanitizeVideoNarrativeSafeResponseText,
+  validateVideoNarrativeSafeResponse,
+  type VideoNarrativeSafeIssue,
+  type VideoNarrativeSafeResponse,
+} from "./videoNarrativeSafeResponseBuilder";
+import { createEmptyVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import { createEmptyPostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+import type {
+  VideoNarrativeQuotaGuardResult,
+  VideoNarrativeUsageConsumptionDecision,
+} from "./videoNarrativeUsageQuotaGuards";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CONTRACT_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeSafeResponseBuilder.ts");
+const CREATED_AT = "2026-05-17T12:00:00.000Z";
+
+function createAnalysis() {
+  return {
+    ...createEmptyVideoNarrativeAnalysis({ id: "analysis-1", createdAt: CREATED_AT }),
+    summary: "Vídeo com narrativa clara.",
+    blueprintSuggestion: {
+      whatToPost: "Transformar em pauta.",
+      whyThisPath: "Há um caminho narrativo.",
+      howItShouldWork: "Abrir com contexto.",
+      scenes: ["Cena inicial."],
+    },
+  };
+}
+
+function createSeed() {
+  return {
+    ...createEmptyPostCreationVideoSeed({
+      id: "seed-1",
+      analysisId: "analysis-1",
+      createdAt: CREATED_AT,
+    }),
+    initialIdea: "Criar uma pauta a partir do vídeo.",
+  };
+}
+
+function createBlockedSummary() {
+  return summarizeVideoNarrativeGuardResults([
+    createPassedVideoNarrativeGuardResult("method"),
+    createBlockedVideoNarrativeGuardResult({
+      name: "usage_quota",
+      code: "quota_exceeded",
+      message: "Limite mensal atingido.",
+    }),
+  ]);
+}
+
+function createUsageDecision(): VideoNarrativeUsageConsumptionDecision {
+  return {
+    shouldConsumeQuota: true,
+    reason: "useful_analysis",
+    issues: [],
+    guardResult: createPassedVideoNarrativeGuardResult("usage_consumption"),
+  };
+}
+
+function createQuotaGuard(): VideoNarrativeQuotaGuardResult {
+  return {
+    ok: true,
+    phase: "closed_beta",
+    issues: [],
+    guardResult: createPassedVideoNarrativeGuardResult("usage_quota"),
+    canAttemptAnalysis: true,
+  };
+}
+
+describe("videoNarrativeSafeResponseBuilder", () => {
+  it("retorna ready quando analysis e seed existem", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      seed: createSeed(),
+      primaryAction: "Transformar em roteiro.",
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      status: "ready",
+      hasRawText: false,
+      primaryAction: "Transformar em roteiro.",
+    });
+    expect(response.analysis?.id).toBe("analysis-1");
+    expect(response.seed?.id).toBe("seed-1");
+  });
+
+  it("retorna blocked quando guardSummary tem blockedBy", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      guardSummary: createBlockedSummary(),
+    });
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe("blocked");
+    expect(response.guardSummary?.blockedBy).toBe("usage_quota");
+  });
+
+  it("retorna failed quando há issue blocking sem analysis/seed", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      issues: [{ code: "provider_unavailable", message: "Provider não disponível.", severity: "blocking" }],
+    });
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe("failed");
+  });
+
+  it("buildBlockedVideoNarrativeSafeResponse cria response blocked seguro", () => {
+    const response = buildBlockedVideoNarrativeSafeResponse({
+      issues: [{ code: "usage_limited", message: "Uso não disponível.", severity: "blocking" }],
+      guardSummary: createBlockedSummary(),
+    });
+
+    expect(response).toMatchObject({
+      ok: false,
+      status: "blocked",
+      analysis: null,
+      seed: null,
+    });
+  });
+
+  it("response nunca inclui rawText, apenas hasRawText", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      seed: createSeed(),
+      hasRawText: true,
+    });
+
+    expect(JSON.stringify(response)).not.toContain("rawText");
+    expect(response.hasRawText).toBe(true);
+  });
+
+  it("guardSummary é reduzido para shape seguro", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      guardSummary: createBlockedSummary(),
+    });
+
+    expect(response.guardSummary).toMatchObject({
+      canCallProvider: false,
+      canConsumeQuota: false,
+      blockedBy: "usage_quota",
+    });
+    expect(response.guardSummary?.results[0]).toEqual({
+      name: "method",
+      status: "passed",
+      code: null,
+      severity: "info",
+      message: "Método validado.",
+    });
+  });
+
+  it("usageSummary inclui shouldConsumeQuota/reason/quotaGuardOk", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      usageDecision: createUsageDecision(),
+      quotaGuard: createQuotaGuard(),
+    });
+
+    expect(response.usageSummary).toEqual({
+      shouldConsumeQuota: true,
+      reason: "useful_analysis",
+      quotaGuardOk: true,
+    });
+  });
+
+  it("observabilitySummary inclui apenas requestId e eventos mínimos", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      observabilityEvents: [
+        {
+          requestId: "req-1",
+          eventName: "video_narrative_analysis_started",
+          status: "started",
+          source: "internal_endpoint",
+          createdAt: CREATED_AT,
+          providerStatus: "provider_unavailable",
+        },
+      ],
+    });
+
+    expect(response.observabilitySummary).toEqual({
+      requestId: "req-1",
+      events: [
+        {
+          eventName: "video_narrative_analysis_started",
+          status: "started",
+          source: "internal_endpoint",
+          createdAt: CREATED_AT,
+        },
+      ],
+    });
+    expect(JSON.stringify(response.observabilitySummary)).not.toContain("providerStatus");
+  });
+
+  it("observabilitySummary redige payload antes de resumir", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      observabilityEvents: [
+        {
+          requestId: "AIza1234567890abcdefghi",
+          eventName: "video_narrative_analysis_started",
+          status: "started",
+          source: "internal_endpoint",
+          createdAt: CREATED_AT,
+        },
+      ],
+    });
+
+    expect(response.observabilitySummary?.requestId).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeSafeResponseText redige AIza, GEMINI_API_KEY e GOOGLE_GENAI_API_KEY", () => {
+    expect(
+      sanitizeVideoNarrativeSafeResponseText(
+        "AIza1234567890abcdefghi GEMINI_API_KEY=abc GOOGLE_GENAI_API_KEY=def",
+      ),
+    ).toBe("[redigido] [redigido] [redigido]");
+  });
+
+  it("sanitizeVideoNarrativeSafeResponseText redige base64 longo", () => {
+    expect(sanitizeVideoNarrativeSafeResponseText("a".repeat(140))).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeSafeResponseText redige URL assinada com token", () => {
+    expect(
+      sanitizeVideoNarrativeSafeResponseText("https://cdn.example/video.mp4?token=abc123"),
+    ).toBe("[redigido]");
+  });
+
+  it("redactVideoNarrativeSafeResponse redige strings perigosas dentro de analysis", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: {
+        ...createAnalysis(),
+        summary: "GEMINI_API_KEY=abc",
+      },
+    });
+
+    expect(response.analysis?.summary).toBe("[redigido]");
+  });
+
+  it("redactVideoNarrativeSafeResponse redige strings perigosas dentro de seed", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      seed: {
+        ...createSeed(),
+        initialIdea: "https://cdn.example/video.mp4?token=abc123",
+      },
+    });
+
+    expect(response.seed?.initialIdea).toBe("[redigido]");
+  });
+
+  it("validateVideoNarrativeSafeResponse aceita response seguro", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      seed: createSeed(),
+    });
+
+    expect(validateVideoNarrativeSafeResponse(response).ok).toBe(true);
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita rawText em qualquer nível", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      analysis: { ...createAnalysis(), rawText: "texto completo" },
+    };
+
+    expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+      "unsafe_response",
+    );
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita inlineVideoBase64/base64 em qualquer nível", () => {
+    ["inlineVideoBase64", "base64"].forEach((key) => {
+      const response = {
+        ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+        analysis: { ...createAnalysis(), [key]: "a".repeat(140) },
+      };
+
+      expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+        "unsafe_response",
+      );
+    });
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita apiKey/GEMINI_API_KEY/GOOGLE_GENAI_API_KEY em qualquer nível", () => {
+    ["apiKey", "GEMINI_API_KEY", "GOOGLE_GENAI_API_KEY"].forEach((key) => {
+      const response = {
+        ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+        analysis: { ...createAnalysis(), [key]: "valor" },
+      };
+
+      expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+        "unsafe_response",
+      );
+    });
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita signedUrl/videoUrl em qualquer nível", () => {
+    ["signedUrl", "videoUrl"].forEach((key) => {
+      const response = {
+        ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+        analysis: { ...createAnalysis(), [key]: "https://cdn.example/video.mp4?token=abc123" },
+      };
+
+      expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+        "unsafe_response",
+      );
+    });
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita status desconhecido", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      status: "outro",
+    };
+
+    expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+      "invalid_status",
+    );
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita issue sem code/message", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      issues: [{ code: "x" }],
+    };
+
+    expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+      "invalid_issue",
+    );
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita string com API key", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      primaryAction: "AIza1234567890abcdefghi",
+    };
+
+    expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+      "unsafe_response",
+    );
+  });
+
+  it("validateVideoNarrativeSafeResponse rejeita base64 longo", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      primaryAction: "a".repeat(140),
+    };
+
+    expect(validateVideoNarrativeSafeResponse(response).issues.map((issue) => issue.code)).toContain(
+      "unsafe_response",
+    );
+  });
+
+  it("redactVideoNarrativeSafeResponse substitui chave perigosa sem quebrar shape", () => {
+    const response = {
+      ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
+      analysis: { ...createAnalysis(), apiKey: "secret" },
+    } as unknown as VideoNarrativeSafeResponse;
+
+    expect(
+      JSON.stringify(redactVideoNarrativeSafeResponse(response)),
+    ).toContain("[redigido]");
+  });
+
+  it("mantém linguagem segura em mensagens e defaults", () => {
+    const unsafeIssue: VideoNarrativeSafeIssue = {
+      code: "unsafe",
+      message:
+        "garantido certeza comprovado viralizar garantido score nota pontuação acerto gabarito resposta correta venceu perdeu treinado permanentemente",
+      severity: "blocking",
+    };
+    const outputs = [
+      buildBlockedVideoNarrativeSafeResponse({ issues: [unsafeIssue] }).issues.map((issue) => issue.message),
+      sanitizeVideoNarrativeSafeResponseText(unsafeIssue.message),
+    ]
+      .flat()
+      .join(" ")
+      .toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(outputs).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém o contrato puro sem imports proibidos", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    const routePath = path.join(
+      process.cwd(),
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+    );
+
+    expect(fs.existsSync(routePath)).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
@@ -1,0 +1,397 @@
+import {
+  sanitizeVideoNarrativeGuardMessage,
+  type VideoNarrativeGuardPipelineSummary,
+} from "./videoNarrativeGuardContracts";
+import {
+  redactVideoNarrativeObservabilityPayload,
+  type VideoNarrativeObservabilityEventPayload,
+} from "./videoNarrativeObservabilityEvents";
+import type {
+  VideoNarrativeQuotaGuardResult,
+  VideoNarrativeUsageConsumptionDecision,
+} from "./videoNarrativeUsageQuotaGuards";
+import type { VideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+export type VideoNarrativeSafeResponseStatus =
+  | "ready"
+  | "blocked"
+  | "failed"
+  | "fallback"
+  | "insufficient_context"
+  | "usage_limited"
+  | "disabled";
+
+export interface VideoNarrativeSafeIssue {
+  code: string;
+  message: string;
+  severity: "info" | "warning" | "blocking";
+}
+
+export interface VideoNarrativeSafeGuardSummary {
+  canCallProvider: boolean;
+  canConsumeQuota: boolean;
+  blockedBy: string | null;
+  results: Array<{
+    name: string;
+    status: string;
+    code: string | null;
+    severity: string;
+    message: string;
+  }>;
+}
+
+export interface VideoNarrativeSafeUsageSummary {
+  shouldConsumeQuota: boolean;
+  reason: string | null;
+  quotaGuardOk: boolean | null;
+}
+
+export interface VideoNarrativeSafeObservabilitySummary {
+  requestId: string | null;
+  events: Array<{
+    eventName: string;
+    status: string;
+    source: string;
+    createdAt: string;
+  }>;
+}
+
+export interface VideoNarrativeSafeResponse {
+  ok: boolean;
+  status: VideoNarrativeSafeResponseStatus;
+  analysis: VideoNarrativeAnalysis | null;
+  seed: PostCreationVideoSeed | null;
+  primaryAction: string | null;
+  issues: VideoNarrativeSafeIssue[];
+  hasRawText: boolean;
+  guardSummary: VideoNarrativeSafeGuardSummary | null;
+  usageSummary: VideoNarrativeSafeUsageSummary | null;
+  observabilitySummary: VideoNarrativeSafeObservabilitySummary | null;
+}
+
+export interface VideoNarrativeSafeResponseInput {
+  status?: VideoNarrativeSafeResponseStatus;
+  analysis?: VideoNarrativeAnalysis | null;
+  seed?: PostCreationVideoSeed | null;
+  primaryAction?: string | null;
+  issues?: Array<{
+    code?: string | null;
+    message?: string | null;
+    severity?: "info" | "warning" | "blocking" | null;
+  }> | null;
+  hasRawText?: boolean | null;
+  guardSummary?: VideoNarrativeGuardPipelineSummary | null;
+  usageDecision?: VideoNarrativeUsageConsumptionDecision | null;
+  quotaGuard?: VideoNarrativeQuotaGuardResult | null;
+  observabilityEvents?: VideoNarrativeObservabilityEventPayload[] | null;
+}
+
+const SAFE_RESPONSE_STATUSES: VideoNarrativeSafeResponseStatus[] = [
+  "ready",
+  "blocked",
+  "failed",
+  "fallback",
+  "insufficient_context",
+  "usage_limited",
+  "disabled",
+];
+
+const DANGEROUS_KEYS = [
+  "rawText",
+  "inlineVideoBase64",
+  "base64",
+  "video",
+  "videoUrl",
+  "signedUrl",
+  "apiKey",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENAI_API_KEY",
+];
+
+const SIGNED_URL_PATTERN = /\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi;
+const API_KEY_PATTERN = /(?:AIza[0-9A-Za-z_-]{8,}|\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+)/;
+const BASE64_PATTERN = /\b[A-Za-z0-9+/]{120,}={0,2}\b/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createIssue(params: {
+  code: string;
+  message: string;
+  severity?: "info" | "warning" | "blocking";
+}): VideoNarrativeSafeIssue {
+  return {
+    code: sanitizeVideoNarrativeSafeResponseText(params.code),
+    message: sanitizeVideoNarrativeSafeResponseText(params.message),
+    severity: params.severity ?? "warning",
+  };
+}
+
+function normalizeIssue(issue: {
+  code?: string | null;
+  message?: string | null;
+  severity?: "info" | "warning" | "blocking" | null;
+}): VideoNarrativeSafeIssue {
+  return createIssue({
+    code: issue.code?.trim() || "safe_response_issue",
+    message: issue.message?.trim() || "Resposta avaliada.",
+    severity: issue.severity ?? "warning",
+  });
+}
+
+function hasBlockingIssue(issues: VideoNarrativeSafeIssue[]): boolean {
+  return issues.some((issue) => issue.severity === "blocking");
+}
+
+function inferStatus(input: VideoNarrativeSafeResponseInput, issues: VideoNarrativeSafeIssue[]): VideoNarrativeSafeResponseStatus {
+  if (input.status) {
+    return input.status;
+  }
+
+  if (input.guardSummary?.blockedBy) {
+    return "blocked";
+  }
+
+  if (input.analysis || input.seed) {
+    return "ready";
+  }
+
+  if (hasBlockingIssue(issues)) {
+    return "failed";
+  }
+
+  return "failed";
+}
+
+function sanitizeDeep<T>(value: T): T {
+  if (typeof value === "string") {
+    return sanitizeVideoNarrativeSafeResponseText(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeDeep(item)) as T;
+  }
+
+  if (isRecord(value)) {
+    const sanitized: Record<string, unknown> = {};
+
+    Object.entries(value).forEach(([key, nestedValue]) => {
+      sanitized[key] = DANGEROUS_KEYS.includes(key) ? "[redigido]" : sanitizeDeep(nestedValue);
+    });
+
+    return sanitized as T;
+  }
+
+  return value;
+}
+
+function buildGuardSummary(
+  guardSummary: VideoNarrativeGuardPipelineSummary | null | undefined,
+): VideoNarrativeSafeGuardSummary | null {
+  if (!guardSummary) {
+    return null;
+  }
+
+  return {
+    canCallProvider: guardSummary.canCallProvider,
+    canConsumeQuota: guardSummary.canConsumeQuota,
+    blockedBy: guardSummary.blockedBy?.name ?? null,
+    results: guardSummary.results.map((result) => ({
+      name: result.name,
+      status: result.status,
+      code: result.code,
+      severity: result.severity,
+      message: sanitizeVideoNarrativeSafeResponseText(result.message),
+    })),
+  };
+}
+
+function buildUsageSummary(params: {
+  usageDecision?: VideoNarrativeUsageConsumptionDecision | null;
+  quotaGuard?: VideoNarrativeQuotaGuardResult | null;
+}): VideoNarrativeSafeUsageSummary | null {
+  if (!params.usageDecision && !params.quotaGuard) {
+    return null;
+  }
+
+  return {
+    shouldConsumeQuota: params.usageDecision?.shouldConsumeQuota ?? false,
+    reason: params.usageDecision?.reason ?? null,
+    quotaGuardOk: params.quotaGuard?.ok ?? null,
+  };
+}
+
+function buildObservabilitySummary(
+  events: VideoNarrativeObservabilityEventPayload[] | null | undefined,
+): VideoNarrativeSafeObservabilitySummary | null {
+  if (!events || events.length === 0) {
+    return null;
+  }
+
+  const redactedEvents = events.map(redactVideoNarrativeObservabilityPayload);
+
+  return {
+    requestId: redactedEvents[0]?.requestId ?? null,
+    events: redactedEvents.map((event) => ({
+      eventName: sanitizeVideoNarrativeSafeResponseText(event.eventName),
+      status: sanitizeVideoNarrativeSafeResponseText(event.status),
+      source: sanitizeVideoNarrativeSafeResponseText(event.source),
+      createdAt: sanitizeVideoNarrativeSafeResponseText(event.createdAt),
+    })),
+  };
+}
+
+function findUnsafePayload(value: unknown, issues: VideoNarrativeSafeIssue[]): void {
+  if (typeof value === "string") {
+    if (API_KEY_PATTERN.test(value)) {
+      issues.push(createIssue({
+        code: "unsafe_response",
+        message: "Resposta contém credencial.",
+        severity: "blocking",
+      }));
+    }
+
+    if (BASE64_PATTERN.test(value)) {
+      issues.push(createIssue({
+        code: "unsafe_response",
+        message: "Resposta contém base64.",
+        severity: "blocking",
+      }));
+    }
+
+    if (SIGNED_URL_PATTERN.test(value)) {
+      issues.push(createIssue({
+        code: "unsafe_response",
+        message: "Resposta contém URL assinada.",
+        severity: "blocking",
+      }));
+    }
+
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => findUnsafePayload(item, issues));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  Object.entries(value).forEach(([key, nestedValue]) => {
+    if (DANGEROUS_KEYS.includes(key)) {
+      issues.push(createIssue({
+        code: "unsafe_response",
+        message: `Campo sensível não permitido: ${key}.`,
+        severity: "blocking",
+      }));
+    }
+
+    findUnsafePayload(nestedValue, issues);
+  });
+}
+
+export function sanitizeVideoNarrativeSafeResponseText(value: string): string {
+  const withoutSignedUrls = value.replace(SIGNED_URL_PATTERN, "[redigido]");
+  return sanitizeVideoNarrativeGuardMessage(withoutSignedUrls);
+}
+
+export function redactVideoNarrativeSafeResponse(
+  response: VideoNarrativeSafeResponse,
+): VideoNarrativeSafeResponse {
+  return sanitizeDeep(response);
+}
+
+export function buildVideoNarrativeSafeResponse(
+  input: VideoNarrativeSafeResponseInput,
+): VideoNarrativeSafeResponse {
+  const issues = (input.issues ?? []).map(normalizeIssue);
+  const status = inferStatus(input, issues);
+  const response: VideoNarrativeSafeResponse = {
+    ok: (status === "ready" || status === "fallback") && !hasBlockingIssue(issues),
+    status,
+    analysis: input.analysis ? sanitizeDeep(input.analysis) : null,
+    seed: input.seed ? sanitizeDeep(input.seed) : null,
+    primaryAction: input.primaryAction ? sanitizeVideoNarrativeSafeResponseText(input.primaryAction) : null,
+    issues,
+    hasRawText: input.hasRawText === true,
+    guardSummary: buildGuardSummary(input.guardSummary),
+    usageSummary: buildUsageSummary({
+      usageDecision: input.usageDecision,
+      quotaGuard: input.quotaGuard,
+    }),
+    observabilitySummary: buildObservabilitySummary(input.observabilityEvents),
+  };
+
+  return redactVideoNarrativeSafeResponse(response);
+}
+
+export function buildBlockedVideoNarrativeSafeResponse(params: {
+  status?: VideoNarrativeSafeResponseStatus;
+  issues: VideoNarrativeSafeIssue[];
+  guardSummary?: VideoNarrativeGuardPipelineSummary | null;
+  observabilityEvents?: VideoNarrativeObservabilityEventPayload[] | null;
+}): VideoNarrativeSafeResponse {
+  return buildVideoNarrativeSafeResponse({
+    status: params.status ?? "blocked",
+    issues: params.issues,
+    guardSummary: params.guardSummary,
+    observabilityEvents: params.observabilityEvents,
+  });
+}
+
+export function validateVideoNarrativeSafeResponse(response: unknown): {
+  ok: boolean;
+  issues: VideoNarrativeSafeIssue[];
+} {
+  const issues: VideoNarrativeSafeIssue[] = [];
+
+  if (!isRecord(response)) {
+    return {
+      ok: false,
+      issues: [
+        createIssue({
+          code: "invalid_response",
+          message: "Resposta não validada.",
+          severity: "blocking",
+        }),
+      ],
+    };
+  }
+
+  if (!SAFE_RESPONSE_STATUSES.includes(response.status as VideoNarrativeSafeResponseStatus)) {
+    issues.push(createIssue({
+      code: "invalid_status",
+      message: "Status não validado.",
+      severity: "blocking",
+    }));
+  }
+
+  if (Array.isArray(response.issues)) {
+    response.issues.forEach((issue) => {
+      if (!isRecord(issue) || typeof issue.code !== "string" || typeof issue.message !== "string") {
+        issues.push(createIssue({
+          code: "invalid_issue",
+          message: "Issue não validada.",
+          severity: "blocking",
+        }));
+      }
+    });
+  } else {
+    issues.push(createIssue({
+      code: "invalid_issue",
+      message: "Issues não validadas.",
+      severity: "blocking",
+    }));
+  }
+
+  findUnsafePayload(response, issues);
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}


### PR DESCRIPTION
Stacked sobre #821.

## Resumo
- Adiciona o safe response builder puro para o futuro endpoint interno/admin de análise narrativa de vídeo.
- Define `VideoNarrativeSafeResponse`, status seguros, issues sanitizadas, guard summary, usage summary e observability summary reduzido.
- Garante que o response carregue apenas `hasRawText`, nunca `rawText` completo.
- Redige API key, base64 longo, vídeo bruto e URL assinada com token em strings e objetos aninhados.
- Valida recursivamente o response para bloquear chaves perigosas antes de qualquer endpoint real.

## Regras de segurança
- Nunca retornar `rawText` completo.
- Nunca retornar base64.
- Nunca retornar API key.
- Nunca retornar vídeo bruto.
- Nunca retornar URL assinada com token.
- Observability summary expõe apenas `requestId`, `eventName`, `status`, `source` e `createdAt`.

## Não escopo
- Sem endpoint real ou `route.ts`.
- Sem upload/storage real.
- Sem UI, BoardShell ou navegação.
- Sem banco/tabela ou analytics real.
- Sem Gemini real, fetch, billing, Stripe ou cobrança.

## Validação local
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts`
- Bloco docs/Gemini/guards/payload/input/consent/usage/observability
- Regressões `videoUpload`
- Regressões guard/previews, NSE e Adaptive V2
- Regressões narrativas de marca
- `npm run typecheck`
- `git diff --check`
- `npm run build`