### PR TITLE
docs: add video narrative endpoint skeleton readiness

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -77,6 +77,7 @@ Já existe:
 - usage/quota guard helpers foram formalizados em MM23, mas ainda não foram conectados a endpoint real;
 - observability event contracts foram formalizados em MM24, mas ainda não enviam eventos para analytics real;
 - safe response builder foi formalizado em MM25, mas ainda não foi conectado a endpoint real;
+- endpoint skeleton readiness foi formalizado em MM26, mas ainda não criou route.ts;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -129,6 +130,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - helpers puros de usage/quota guard;
 - contratos puros de eventos de observabilidade;
 - safe response builder puro;
+- endpoint skeleton readiness verde;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -562,6 +562,28 @@ O que não faz:
 - não cria upload real, UI, banco/tabela ou analytics real;
 - não conecta nada ao fluxo real do produto.
 
+### MM26 — Endpoint skeleton readiness
+
+Status: concluído.
+
+Arquivos principais:
+
+- `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md`
+- `videoNarrativeEndpointSkeletonReadiness.test.ts`
+
+O que faz:
+
+- cria checklist documental e testável para o futuro endpoint skeleton admin/dev sem provider real;
+- mapeia fundação disponível, helpers que o skeleton pode usar e itens que continuam desligados;
+- prepara MM27 sem criar `route.ts`.
+
+O que não faz:
+
+- não cria endpoint;
+- não cria `route.ts`;
+- não cria upload real, UI, banco/tabela ou analytics real;
+- não liga Gemini real.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -232,8 +232,9 @@ Exemplos:
 22. MM23 — Usage/quota guard helpers. Define políticas puras para usage_quota e usage_consumption, sem billing real.
 23. MM24 — Observability event contracts. Define eventos e payloads seguros, sem analytics real.
 24. MM25 — Safe response builder. Define empacotamento seguro da resposta futura, sem endpoint.
-25. Teste real manual quando houver quota/billing disponível.
-26. Integração experimental futura no Board de Criação.
+25. MM26 — Endpoint skeleton readiness. Define checklist final antes de endpoint skeleton admin/dev sem provider real.
+26. Teste real manual quando houver quota/billing disponível.
+27. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -276,6 +277,8 @@ MM23 adiciona `VideoNarrativeUsagePolicy`, `validateVideoNarrativeUsageQuotaForP
 MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObservabilityEvent` e `validateVideoNarrativeObservabilityEvent` para preparar eventos seguros sem endpoint, analytics real, banco/tabela ou provider externo.
 
 MM25 adiciona `VideoNarrativeSafeResponse`, `buildVideoNarrativeSafeResponse` e `validateVideoNarrativeSafeResponse` para preparar a resposta segura futura sem endpoint, route.ts, upload real ou UI.
+
+MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` para confirmar que a próxima fase pode criar endpoint skeleton admin/dev sem provider real, desde que nasça bloqueado, observável e sem vazamento de dados sensíveis.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
@@ -1,0 +1,173 @@
+# Video Narrative Endpoint Skeleton Readiness
+
+## Objetivo
+
+Este documento confirma se a fundação atual está pronta para criar um futuro endpoint skeleton admin/dev sem provider real para análise narrativa de vídeo.
+
+Ele mapeia o que já existe, o que o endpoint skeleton poderá usar, o que deve continuar desligado, quais riscos bloqueiam provider real e quais critérios precisam estar verdes antes de criar `route.ts`.
+
+## Escopo
+
+- é checklist, não implementação;
+- não existe endpoint real nesta fase;
+- não existe route.ts nesta fase;
+- não existe chamada Gemini real;
+- sem chamada Gemini real;
+- não existe upload real;
+- sem upload real;
+- não existe UI;
+- sem UI;
+- não existe banco/tabela;
+- sem banco/tabela;
+- não existe analytics real.
+- sem analytics real.
+
+## Princípio Central
+
+Só criar o endpoint skeleton se ele puder nascer bloqueado, observável e incapaz de vazar dados sensíveis.
+
+## Fundação Disponível
+
+A fundação já disponível para uma próxima fase de skeleton inclui:
+
+- `VideoNarrativeAnalysis`;
+- `PostCreationVideoSeed`;
+- Gemini prompt/schema;
+- Gemini provider/factory/composer;
+- real run harness;
+- readiness audit;
+- endpoint contract;
+- input source contract;
+- consent/retention contract;
+- usage/cost contract;
+- observability contract;
+- real endpoint guards contract;
+- guard contracts;
+- payload validation;
+- input source guards;
+- consent/retention guards;
+- usage/quota guards;
+- observability events;
+- safe response builder.
+
+## O Que O Endpoint Skeleton Pode Usar
+
+O futuro endpoint skeleton pode usar:
+
+- `validateVideoNarrativeAnalyzePayload`;
+- `validateVideoNarrativeInputSourceForPhase`;
+- `validateVideoNarrativeConsentRetentionForPhase`;
+- `validateVideoNarrativeUsageQuotaForPhase`;
+- `summarizeVideoNarrativeGuardResults`;
+- `buildVideoNarrativeObservabilityEvent`;
+- `buildBlockedVideoNarrativeSafeResponse`;
+- `buildVideoNarrativeSafeResponse`;
+- `validateVideoNarrativeSafeResponse`.
+
+## O Que O Endpoint Skeleton Não Deve Fazer Ainda
+
+O endpoint skeleton não deve:
+
+- chamar `runGeminiVideoNarrativeProviderFromEnv`;
+- chamar Gemini real;
+- aceitar usuário comum;
+- aceitar upload real;
+- aceitar multipart;
+- persistir dados;
+- consumir quota real;
+- enviar analytics real;
+- conectar BoardShell;
+- alterar PostCreationFunnelState;
+- criar billing/Stripe;
+- usar storage real.
+
+## Endpoint Skeleton Futuro
+
+Caminho futuro:
+
+`POST /api/internal/video-narrative/analyze`
+
+Esse caminho ainda não será criado neste PR. Esta fase não cria endpoint, rota, `route.ts` ou diretório `app/api/internal/video-narrative/analyze`.
+
+## Comportamento Esperado Do Skeleton Futuro
+
+Quando for criado, o endpoint skeleton deve:
+
+- aceitar apenas POST;
+- exigir sessão;
+- exigir admin/dev;
+- exigir flag server-side específica do endpoint skeleton;
+- validar payload;
+- validar input source para `internal_endpoint`;
+- validar consent/retention para `internal_endpoint`;
+- validar usage/quota para `internal_endpoint`;
+- criar eventos locais em memória/response apenas;
+- nunca chamar provider real nesta primeira versão;
+- retornar safe response bloqueado ou fallback controlado;
+- nunca retornar rawText/base64/API key/vídeo/URL assinada.
+
+## Nova Flag Futura Sugerida
+
+Flag sugerida:
+
+`VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`
+
+Regras:
+
+- server-side;
+- não `NEXT_PUBLIC`;
+- separada de `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED`;
+- endpoint skeleton pode estar ligado sem ligar provider real;
+- provider real continua dependente da flag Gemini.
+
+## Status Esperados Do Skeleton
+
+- `disabled`;
+- `unauthorized`;
+- `forbidden`;
+- `invalid_payload`;
+- `invalid_source`;
+- `consent_missing`;
+- `retention_expired`;
+- `usage_limited`;
+- `ready_without_provider`;
+- `blocked`.
+
+## Critérios Para Criar Route.ts Na Próxima Fase
+
+Só criar route.ts se:
+
+- este checklist estiver verde;
+- #822 estiver verde;
+- endpoint skeleton flag estiver definida;
+- rota nascer admin/dev only;
+- provider real permanecer desligado;
+- response builder for usado;
+- não houver `app/api/internal/video-narrative/analyze/route.ts` ainda;
+- testes cobrirem bloqueios principais;
+- build passar.
+
+## Critérios Que Continuam Bloqueando Provider Real
+
+Provider real continua bloqueado por:
+
+- billing/quota ausente;
+- teste real com 3 vídeos curtos ainda não realizado;
+- custo/latência real desconhecidos;
+- origem real do vídeo ainda não finalizada para produto;
+- storage/cleanup real ausentes;
+- analytics real ausente;
+- limite por usuário ainda sem persistência.
+
+## Decisão Recomendada
+
+A próxima fase pode criar endpoint skeleton admin/dev sem provider real.
+
+A fase ainda não deve ligar Gemini real.
+
+## Próximas Fases Possíveis
+
+- MM27: endpoint skeleton admin/dev sem provider real;
+- MM28: endpoint skeleton com integração dos guards puros;
+- MM29: endpoint com safe blocked response e observability local;
+- MM30: provider real somente depois de billing/teste manual.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -62,9 +62,12 @@ Regras:
 - limites, quota e cooldown ficam no contrato `VIDEO_NARRATIVE_USAGE_LIMITS_COST_CONTRACT.md`;
 - métricas, eventos e logs seguros ficam no contrato `VIDEO_NARRATIVE_OBSERVABILITY_CONTRACT.md`;
 - a ordem de guards fica no contrato `VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md`;
+- readiness do endpoint skeleton fica em `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md`;
 - não aceitar arquivo multipart neste contrato inicial;
 - não aceitar input livre sem limites;
 - não aceitar usuário comum.
+
+Flag futura sugerida para o skeleton: `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`. Ela deve ser server-side, não `NEXT_PUBLIC`, e separada de `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED`.
 
 ## Resposta Futura
 
@@ -165,6 +168,7 @@ MM25 adiciona `VideoNarrativeSafeResponse` e helpers puros para montar essa resp
 - `VideoNarrativeAnalyzePayload`;
 - `VideoNarrativeNormalizedAnalyzePayload`;
 - `VideoNarrativeSafeResponse`;
+- `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
 - `getPostCreationVideoSeedPrimaryAction`;

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -301,6 +301,8 @@ MM24 adiciona `VideoNarrativeObservabilityEventPayload` e helpers de build/valid
 
 MM25 adiciona `VideoNarrativeSafeResponse` como fundação pura para o safe_response guard e para o empacotamento final do endpoint futuro.
 
+MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` como checklist final antes de qualquer `route.ts`, separando endpoint skeleton admin/dev sem provider real de provider real com Gemini.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:
@@ -318,6 +320,7 @@ Só criar route.ts depois que:
 - usage/quota guard helpers estiverem disponíveis para `usage_quota` e `usage_consumption`;
 - observability event contracts estiverem disponíveis para start/completion hooks;
 - safe response builder estiver disponível para `safe_response`;
+- endpoint skeleton readiness estiver verde;
 - admin/dev guard server-side estiver confirmado.
 
 ## Decisão Recomendada Agora
@@ -338,6 +341,8 @@ Como ainda não há billing/quota:
 - MM23: usage/quota guard helpers;
 - MM24: observability event contracts;
 - MM25: safe response builder;
-- MM26: storage cleanup contract;
-- MM27: endpoint real somente depois de billing/teste real;
-- MM28: preview interno com endpoint real.
+- MM26: endpoint skeleton readiness;
+- MM27: endpoint skeleton admin/dev sem provider real;
+- MM28: storage cleanup contract;
+- MM29: endpoint real somente depois de billing/teste real;
+- MM30: preview interno com endpoint real.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointSkeletonReadiness.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointSkeletonReadiness.test.ts
@@ -1,0 +1,136 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const READINESS_PATH = path.join(VIDEO_UPLOAD_DIR, "VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md");
+const TEST_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "videoNarrativeEndpointSkeletonReadiness.test.ts");
+const FUTURE_ROUTE_PATH = path.join(
+  process.cwd(),
+  "src/app/api/internal/video-narrative/analyze/route.ts",
+);
+const FUTURE_ENDPOINT_DIR = path.join(
+  process.cwd(),
+  "src/app/api/internal/video-narrative/analyze",
+);
+
+function readReadiness(): string {
+  return fs.readFileSync(READINESS_PATH, "utf8");
+}
+
+describe("videoNarrativeEndpointSkeletonReadiness", () => {
+  it("cria o documento de readiness do endpoint skeleton", () => {
+    expect(fs.existsSync(READINESS_PATH)).toBe(true);
+  });
+
+  it("menciona a fundação e helpers necessários para o skeleton futuro", () => {
+    const content = readReadiness();
+
+    [
+      "VideoNarrativeAnalysis",
+      "PostCreationVideoSeed",
+      "validateVideoNarrativeAnalyzePayload",
+      "validateVideoNarrativeInputSourceForPhase",
+      "validateVideoNarrativeConsentRetentionForPhase",
+      "validateVideoNarrativeUsageQuotaForPhase",
+      "summarizeVideoNarrativeGuardResults",
+      "buildVideoNarrativeObservabilityEvent",
+      "buildBlockedVideoNarrativeSafeResponse",
+      "buildVideoNarrativeSafeResponse",
+      "validateVideoNarrativeSafeResponse",
+      "POST /api/internal/video-narrative/analyze",
+      "VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED",
+      "VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED",
+      "NEXT_PUBLIC",
+      "admin/dev",
+      "sessão",
+      "sem provider real",
+      "sem chamada Gemini real",
+      "sem upload real",
+      "sem UI",
+      "sem banco/tabela",
+      "sem analytics real",
+      "rawText",
+      "base64",
+      "API key",
+      "URL assinada",
+      "billing/quota",
+      "3 vídeos curtos",
+      "ready_without_provider",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contém o princípio central", () => {
+    expect(readReadiness()).toContain(
+      "Só criar o endpoint skeleton se ele puder nascer bloqueado, observável e incapaz de vazar dados sensíveis.",
+    );
+  });
+
+  it("declara que o skeleton pode estar ligado sem ligar provider real", () => {
+    expect(readReadiness()).toContain("endpoint skeleton pode estar ligado sem ligar provider real");
+  });
+
+  it("declara que provider real continua dependente da flag Gemini", () => {
+    expect(readReadiness()).toContain("provider real continua dependente da flag Gemini");
+  });
+
+  it("confirma que a rota futura ainda não existe", () => {
+    expect(fs.existsSync(FUTURE_ROUTE_PATH)).toBe(false);
+  });
+
+  it("confirma que o diretório futuro do endpoint ainda não foi criado", () => {
+    expect(fs.existsSync(FUTURE_ENDPOINT_DIR)).toBe(false);
+  });
+
+  it("mantém linguagem segura no documento", () => {
+    const content = readReadiness().toLowerCase();
+
+    [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ].forEach((term) => {
+      expect(content).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("mantém arquivos novos sem imports proibidos", () => {
+    const combinedSource = [readReadiness(), fs.readFileSync(TEST_SOURCE_PATH, "utf8")].join("\n");
+    const forbiddenImports = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbiddenImports.forEach((term) => {
+      expect(combinedSource).not.toContain(`from "${term}`);
+      expect(combinedSource).not.toContain(`from '${term}`);
+    });
+  });
+});


### PR DESCRIPTION
Stacked sobre #822.

## Resumo
- Adiciona checklist documental e testável para readiness do futuro endpoint skeleton admin/dev.
- Mapeia a fundação já disponível para um skeleton sem provider real.
- Define helpers que o skeleton pode usar, itens que devem continuar desligados e critérios antes de criar `route.ts`.
- Documenta a flag futura `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`, separada de `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED`.

## Decisão documentada
A próxima fase pode criar um endpoint skeleton admin/dev sem provider real, desde que nasça bloqueado, observável e incapaz de vazar dados sensíveis. Provider real continua bloqueado por billing/quota, teste real com 3 vídeos curtos e métricas reais de custo/latência.

## Não escopo
- Sem endpoint real ou `route.ts`.
- Sem upload/storage real.
- Sem UI, BoardShell ou navegação.
- Sem banco/tabela ou analytics real.
- Sem chamada Gemini real, fetch, billing, Stripe ou cobrança.

## Validação local
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEndpointSkeletonReadiness.test.ts`
- Bloco docs/Gemini/guards/payload/input/consent/usage/observability/safe-response
- Regressões `videoUpload`
- Regressões guard/previews, NSE e Adaptive V2
- Regressões narrativas de marca
- `npm run typecheck`
- `git diff --check`
- `npm run build`