### PR TITLE
feat: add video narrative endpoint skeleton

### DIFF
--- a/src/app/api/internal/video-narrative/analyze/route.test.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.test.ts
@@ -1,0 +1,314 @@
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("@/app/api/auth/[...nextauth]/route", () => ({
+  authOptions: {},
+}));
+
+const {
+  createBlockedVideoNarrativeGuardResult,
+} = require("@/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts");
+const { GET, POST } = require("./route");
+const getServerSession = require("next-auth/next").getServerSession as jest.Mock;
+
+const FORBIDDEN_RESPONSE_FIELDS = [
+  '"rawText"',
+  "inlineVideoBase64",
+  '"base64"',
+  "apiKey",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENAI_API_KEY",
+  "signedUrl",
+  "videoUrl",
+];
+
+const FORBIDDEN_LANGUAGE = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function enableEndpointFlag(): void {
+  process.env.VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED = "true";
+}
+
+function disableEndpointFlag(): void {
+  delete process.env.VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED;
+}
+
+function makeRequest(payload: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/internal/video-narrative/analyze", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+function validPayload(): Record<string, unknown> {
+  return {
+    id: "manual-video-narrative-run",
+    creatorQuestion: "Qual é a leitura narrativa deste vídeo?",
+    videoUri: "gemini://files/video-narrative-test",
+    source: "gemini_file_api",
+    expiresAt: "1970-01-01T01:00:00.000Z",
+    creatorContext: {
+      handle: "@d2c",
+      niche: "educação",
+      knownNarratives: ["bastidor", "prova social"],
+    },
+  };
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function expectSafeResponse(body: unknown): void {
+  const serialized = JSON.stringify(body);
+
+  FORBIDDEN_RESPONSE_FIELDS.forEach((term) => {
+    expect(serialized).not.toContain(term);
+  });
+}
+
+describe("POST /api/internal/video-narrative/analyze skeleton", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    disableEndpointFlag();
+  });
+
+  it("GET returns 405 and a safe response", async () => {
+    const response = await GET();
+    const body = await readJson(response);
+
+    expect(response.status).toBe(405);
+    expect(body.status).toBe("blocked");
+    expectSafeResponse(body);
+  });
+
+  it("POST with flag off returns disabled before provider validation", async () => {
+    getServerSession.mockResolvedValue(null);
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.status).toBe("disabled");
+    expect(JSON.stringify(body)).toContain("Endpoint interno de vídeo desativado.");
+    expectSafeResponse(body);
+  });
+
+  it("POST without session returns 401", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue(null);
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(401);
+    expect(body.status).toBe("blocked");
+    expect(JSON.stringify(body)).toContain("Sessão não informada.");
+  });
+
+  it("POST with non admin/dev session returns 403", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "member" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.status).toBe("blocked");
+    expect(JSON.stringify(body)).toContain("Acesso interno não permitido.");
+  });
+
+  it("POST admin/dev with invalid payload returns 400 and a safe issue", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(null));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(body.status).toBe("blocked");
+    expect(JSON.stringify(body)).toContain("Payload não validado.");
+    expectSafeResponse(body);
+  });
+
+  it("POST admin/dev with missing video returns 400", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "dev" } });
+
+    const response = await POST(makeRequest({ source: "gemini_file_api" }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(body)).toContain("Vídeo");
+  });
+
+  it("POST admin/dev with invalid source returns 400", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { isAdmin: true } });
+
+    const response = await POST(makeRequest({ ...validPayload(), source: "unknown_source" }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(body)).toContain("Origem do vídeo");
+  });
+
+  it("POST admin/dev with invalid retention returns 400", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { isDev: true } });
+
+    const response = await POST(makeRequest({ ...validPayload(), expiresAt: "invalid-date" }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(body)).toContain("Data de expiração");
+  });
+
+  it("POST admin/dev with mocked usage quota block returns 429", async () => {
+    enableEndpointFlag();
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock("next-auth/next", () => ({
+        getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
+      }));
+      jest.doMock("@/app/api/auth/resolveAuthOptions", () => ({
+        resolveAuthOptions: jest.fn().mockResolvedValue({}),
+      }));
+      jest.doMock("@/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards", () => ({
+        ...jest.requireActual("@/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards"),
+        validateVideoNarrativeUsageQuotaForPhase: jest.fn(() => ({
+          ok: false,
+          phase: "internal_endpoint",
+          issues: [{ code: "daily_limit_exceeded", message: "Limite diário atingido." }],
+          canAttemptAnalysis: false,
+          guardResult: createBlockedVideoNarrativeGuardResult({
+            name: "usage_quota",
+            code: "usage_limited",
+            message: "Limite diário atingido.",
+          }),
+        })),
+      }));
+
+      const { POST: isolatedPOST } = await import("./route");
+      const response = await isolatedPOST(makeRequest(validPayload()));
+      const body = await readJson(response);
+
+      expect(response.status).toBe(429);
+      expect(body.status).toBe("usage_limited");
+      expect(JSON.stringify(body)).toContain("Limite diário atingido.");
+    });
+  });
+
+  it("POST admin/dev with valid payload returns disabled because provider is not enabled in this phase", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.status).toBe("disabled");
+    expect(JSON.stringify(body)).toContain("Provider real desativado nesta fase.");
+    expectSafeResponse(body);
+  });
+
+  it("rejects non JSON content-type", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload(), { "content-type": "text/plain" }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(body)).toContain("Content-type não validado.");
+  });
+
+  it("creates local observability summary without external delivery", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+    const observabilitySummary = body.observabilitySummary as { events: unknown[] } | null;
+
+    expect(observabilitySummary?.events.length).toBeGreaterThanOrEqual(3);
+    expect(JSON.stringify(body)).toContain("video_narrative_analysis_requested");
+  });
+
+  it("reduces guard summary to safe fields", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+    const guardSummary = body.guardSummary as { blockedBy: string | null; results: unknown[] };
+
+    expect(guardSummary.blockedBy).toBe("provider");
+    expect(guardSummary.results.length).toBeGreaterThan(0);
+  });
+
+  it("validates safe response before returning", async () => {
+    const routeSource = require("fs").readFileSync(
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+      "utf8",
+    ) as string;
+
+    expect(routeSource).toContain("validateVideoNarrativeSafeResponse");
+  });
+
+  it("does not import or call provider, SDK, network, storage, billing, analytics, UI, or database code", () => {
+    const routeSource = require("fs").readFileSync(
+      "src/app/api/internal/video-narrative/analyze/route.ts",
+      "utf8",
+    ) as string;
+    const forbiddenFragments = [
+      "runGeminiVideoNarrativeProviderFromEnv",
+      "createGeminiVideoNarrativeClient",
+      "GoogleGenAI",
+      "fetch(",
+      "prisma",
+      "stripe",
+      "upload",
+      "storage",
+      "analytics.track",
+      "BoardShell",
+      "React",
+      "from \"@/components",
+    ];
+
+    forbiddenFragments.forEach((fragment) => {
+      expect(routeSource).not.toContain(fragment);
+    });
+  });
+
+  it("response strings do not use unsafe language", async () => {
+    enableEndpointFlag();
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const serialized = JSON.stringify(await readJson(response)).toLowerCase();
+
+    FORBIDDEN_LANGUAGE.forEach((term) => {
+      expect(serialized).not.toContain(term.toLowerCase());
+    });
+  });
+});

--- a/src/app/api/internal/video-narrative/analyze/route.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.ts
@@ -1,0 +1,475 @@
+import { resolveAuthOptions } from "@/app/api/auth/resolveAuthOptions";
+import {
+  canAccessInternalPreview,
+  type InternalPreviewUser,
+} from "@/app/dashboard/boards/internalPreviewAccess";
+import {
+  createBlockedVideoNarrativeGuardResult,
+  createPassedVideoNarrativeGuardResult,
+  summarizeVideoNarrativeGuardResults,
+  type VideoNarrativeGuardPipelineSummary,
+  type VideoNarrativeGuardResult,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts";
+import { isVideoNarrativeInternalEndpointEnabled } from "@/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag";
+import { validateVideoNarrativeConsentRetentionForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards";
+import { validateVideoNarrativeInputSourceForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards";
+import {
+  buildVideoNarrativeObservabilityEvent,
+  createVideoNarrativeRequestId,
+  type VideoNarrativeObservabilityEventPayload,
+  type VideoNarrativeObservabilityStatus,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents";
+import { validateVideoNarrativeAnalyzePayload } from "@/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation";
+import {
+  buildBlockedVideoNarrativeSafeResponse,
+  validateVideoNarrativeSafeResponse,
+  type VideoNarrativeSafeIssue,
+  type VideoNarrativeSafeResponse,
+  type VideoNarrativeSafeResponseStatus,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder";
+import * as usageQuotaGuards from "@/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards";
+import { getServerSession } from "next-auth/next";
+import { NextResponse } from "next/server";
+
+const PHASE = "internal_endpoint" as const;
+const REQUEST_ID = createVideoNarrativeRequestId("video-narrative-endpoint-skeleton");
+const CREATED_AT = new Date(0).toISOString();
+const DEFAULT_EXPIRES_AT = new Date(60 * 60 * 1000).toISOString();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createSafeIssue(params: {
+  code: string;
+  message: string;
+  severity?: VideoNarrativeSafeIssue["severity"];
+}): VideoNarrativeSafeIssue {
+  return {
+    code: params.code,
+    message: params.message,
+    severity: params.severity ?? "blocking",
+  };
+}
+
+function createEvent(params: {
+  eventName: VideoNarrativeObservabilityEventPayload["eventName"];
+  status: VideoNarrativeObservabilityStatus;
+  providerStatus?: string | null;
+  guardBlockedBy?: string | null;
+  issuesCount?: number | null;
+}): VideoNarrativeObservabilityEventPayload | null {
+  const result = buildVideoNarrativeObservabilityEvent({
+    requestId: REQUEST_ID,
+    eventName: params.eventName,
+    status: params.status,
+    source: PHASE,
+    createdAt: CREATED_AT,
+    providerStatus: params.providerStatus,
+    guardBlockedBy: params.guardBlockedBy,
+    issuesCount: params.issuesCount,
+    hasRawText: false,
+    fallbackUsed: false,
+    schemaParseOk: null,
+    quotaConsumed: false,
+  });
+
+  return result.ok ? result.event : null;
+}
+
+function compactEvents(
+  events: Array<VideoNarrativeObservabilityEventPayload | null>,
+): VideoNarrativeObservabilityEventPayload[] {
+  return events.filter((event): event is VideoNarrativeObservabilityEventPayload => Boolean(event));
+}
+
+function buildGuardSummary(results: VideoNarrativeGuardResult[]): VideoNarrativeGuardPipelineSummary {
+  return summarizeVideoNarrativeGuardResults(results);
+}
+
+function buildSafeJsonResponse(
+  response: VideoNarrativeSafeResponse,
+  status: number,
+): NextResponse<VideoNarrativeSafeResponse> {
+  const validation = validateVideoNarrativeSafeResponse(response);
+
+  if (validation.ok) {
+    return NextResponse.json(response, { status });
+  }
+
+  const fallback = buildBlockedVideoNarrativeSafeResponse({
+    status: "blocked",
+    issues: [
+      createSafeIssue({
+        code: "unsafe_response",
+        message: "Resposta segura não validada.",
+      }),
+    ],
+  });
+
+  return NextResponse.json(fallback, { status: 500 });
+}
+
+function buildBlockedResponse(params: {
+  httpStatus: number;
+  status?: VideoNarrativeSafeResponseStatus;
+  issue: VideoNarrativeSafeIssue;
+  guardResults: VideoNarrativeGuardResult[];
+  eventStatus?: VideoNarrativeObservabilityStatus;
+  providerStatus?: string | null;
+}): NextResponse<VideoNarrativeSafeResponse> {
+  const guardSummary = buildGuardSummary(params.guardResults);
+  const events = compactEvents([
+    createEvent({
+      eventName: "video_narrative_analysis_requested",
+      status: "requested",
+      providerStatus: params.providerStatus,
+      issuesCount: 0,
+    }),
+    createEvent({
+      eventName: "video_narrative_analysis_started",
+      status: "started",
+      providerStatus: params.providerStatus,
+      issuesCount: 0,
+    }),
+    createEvent({
+      eventName:
+        params.eventStatus === "blocked"
+          ? "video_narrative_limit_reached"
+          : "video_narrative_analysis_failed",
+      status: params.eventStatus ?? "failed",
+      providerStatus: params.providerStatus,
+      guardBlockedBy: guardSummary.blockedBy?.name ?? null,
+      issuesCount: 1,
+    }),
+  ]);
+
+  return buildSafeJsonResponse(
+    buildBlockedVideoNarrativeSafeResponse({
+      status: params.status ?? "blocked",
+      issues: [params.issue],
+      guardSummary,
+      observabilityEvents: events,
+    }),
+    params.httpStatus,
+  );
+}
+
+function getExpiresAtFromPayload(payload: unknown): string {
+  if (!isRecord(payload) || typeof payload.expiresAt !== "string") {
+    return DEFAULT_EXPIRES_AT;
+  }
+
+  return payload.expiresAt;
+}
+
+function methodNotAllowedResponse(): NextResponse<VideoNarrativeSafeResponse> {
+  return buildBlockedResponse({
+    httpStatus: 405,
+    issue: createSafeIssue({
+      code: "method_not_allowed",
+      message: "Método não permitido.",
+    }),
+    guardResults: [
+      createBlockedVideoNarrativeGuardResult({
+        name: "method",
+        code: "method_not_allowed",
+        message: "Método não permitido.",
+      }),
+    ],
+  });
+}
+
+export async function GET(): Promise<NextResponse<VideoNarrativeSafeResponse>> {
+  return methodNotAllowedResponse();
+}
+
+export async function PUT(): Promise<NextResponse<VideoNarrativeSafeResponse>> {
+  return methodNotAllowedResponse();
+}
+
+export async function PATCH(): Promise<NextResponse<VideoNarrativeSafeResponse>> {
+  return methodNotAllowedResponse();
+}
+
+export async function DELETE(): Promise<NextResponse<VideoNarrativeSafeResponse>> {
+  return methodNotAllowedResponse();
+}
+
+export async function POST(request: Request): Promise<NextResponse<VideoNarrativeSafeResponse>> {
+  const methodGuard = createPassedVideoNarrativeGuardResult("method");
+
+  if (!isVideoNarrativeInternalEndpointEnabled()) {
+    return buildBlockedResponse({
+      httpStatus: 403,
+      status: "disabled",
+      issue: createSafeIssue({
+        code: "disabled",
+        message: "Endpoint interno de vídeo desativado.",
+      }),
+      guardResults: [
+        methodGuard,
+        createBlockedVideoNarrativeGuardResult({
+          name: "feature_flag",
+          code: "disabled",
+          message: "Flag server-side desativada.",
+        }),
+      ],
+      providerStatus: "endpoint_disabled",
+    });
+  }
+
+  const session = (await getServerSession(await resolveAuthOptions())) as {
+    user?: InternalPreviewUser | null;
+  } | null;
+  const user = session?.user ?? null;
+  const sessionGuard = user
+    ? createPassedVideoNarrativeGuardResult("session")
+    : createBlockedVideoNarrativeGuardResult({
+        name: "session",
+        code: "unauthorized",
+        message: "Sessão não informada.",
+      });
+
+  if (!user) {
+    return buildBlockedResponse({
+      httpStatus: 401,
+      issue: createSafeIssue({
+        code: "unauthorized",
+        message: "Sessão não informada.",
+      }),
+      guardResults: [methodGuard, sessionGuard],
+    });
+  }
+
+  const adminDevGuard = canAccessInternalPreview(user)
+    ? createPassedVideoNarrativeGuardResult("admin_dev")
+    : createBlockedVideoNarrativeGuardResult({
+        name: "admin_dev",
+        code: "forbidden",
+        message: "Acesso interno não permitido.",
+      });
+
+  if (adminDevGuard.status === "blocked") {
+    return buildBlockedResponse({
+      httpStatus: 403,
+      issue: createSafeIssue({
+        code: "forbidden",
+        message: "Acesso interno não permitido.",
+      }),
+      guardResults: [methodGuard, sessionGuard, adminDevGuard],
+    });
+  }
+
+  const featureFlagGuard = createPassedVideoNarrativeGuardResult("feature_flag");
+  const contentType = request.headers.get("content-type") ?? "";
+  const contentTypeGuard = contentType.toLowerCase().includes("application/json")
+    ? createPassedVideoNarrativeGuardResult("content_type")
+    : createBlockedVideoNarrativeGuardResult({
+        name: "content_type",
+        code: "invalid_content_type",
+        message: "Content-type não validado.",
+      });
+
+  if (contentTypeGuard.status === "blocked") {
+    return buildBlockedResponse({
+      httpStatus: 400,
+      issue: createSafeIssue({
+        code: "invalid_content_type",
+        message: "Content-type não validado.",
+      }),
+      guardResults: [methodGuard, sessionGuard, adminDevGuard, featureFlagGuard, contentTypeGuard],
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    const payloadGuard = createBlockedVideoNarrativeGuardResult({
+      name: "payload_schema",
+      code: "invalid_payload",
+      message: "Payload não validado.",
+    });
+
+    return buildBlockedResponse({
+      httpStatus: 400,
+      issue: createSafeIssue({
+        code: "invalid_payload",
+        message: "Payload não validado.",
+      }),
+      guardResults: [
+        methodGuard,
+        sessionGuard,
+        adminDevGuard,
+        featureFlagGuard,
+        contentTypeGuard,
+        payloadGuard,
+      ],
+    });
+  }
+
+  const payloadValidation = validateVideoNarrativeAnalyzePayload(payload);
+  if (!payloadValidation.ok || !payloadValidation.normalized) {
+    return buildBlockedResponse({
+      httpStatus: 400,
+      issue: createSafeIssue({
+        code: payloadValidation.issues[0]?.code ?? "invalid_payload",
+        message: payloadValidation.issues[0]?.message ?? "Payload não validado.",
+      }),
+      guardResults: [
+        methodGuard,
+        sessionGuard,
+        adminDevGuard,
+        featureFlagGuard,
+        contentTypeGuard,
+        payloadValidation.guardResult,
+      ],
+    });
+  }
+
+  const inputSourceGuard = validateVideoNarrativeInputSourceForPhase({
+    payload: payloadValidation.normalized,
+    phase: PHASE,
+  });
+
+  if (!inputSourceGuard.ok) {
+    return buildBlockedResponse({
+      httpStatus: 400,
+      issue: createSafeIssue({
+        code: inputSourceGuard.issues[0]?.code ?? "invalid_source",
+        message: inputSourceGuard.issues[0]?.message ?? "Origem do vídeo não validada.",
+      }),
+      guardResults: [
+        methodGuard,
+        sessionGuard,
+        adminDevGuard,
+        featureFlagGuard,
+        contentTypeGuard,
+        payloadValidation.guardResult,
+        inputSourceGuard.guardResult,
+      ],
+    });
+  }
+
+  const consentRetentionGuard = validateVideoNarrativeConsentRetentionForPhase({
+    phase: PHASE,
+    isAdminOrDev: true,
+    expiresAt: getExpiresAtFromPayload(payload),
+    now: CREATED_AT,
+  });
+
+  if (!consentRetentionGuard.ok) {
+    return buildBlockedResponse({
+      httpStatus: 400,
+      issue: createSafeIssue({
+        code: consentRetentionGuard.issues[0]?.code ?? "retention_expired",
+        message: consentRetentionGuard.issues[0]?.message ?? "Retenção não validada.",
+      }),
+      guardResults: [
+        methodGuard,
+        sessionGuard,
+        adminDevGuard,
+        featureFlagGuard,
+        contentTypeGuard,
+        payloadValidation.guardResult,
+        inputSourceGuard.guardResult,
+        consentRetentionGuard.consentGuardResult,
+        consentRetentionGuard.retentionGuardResult,
+      ],
+    });
+  }
+
+  const usageQuotaGuard = usageQuotaGuards.validateVideoNarrativeUsageQuotaForPhase({
+    phase: PHASE,
+    usageState: {
+      usedToday: 0,
+      usedThisMonth: 0,
+      repeatedFailureCount: 0,
+      isAdminOrDev: true,
+      now: CREATED_AT,
+    },
+  });
+
+  if (!usageQuotaGuard.ok) {
+    return buildBlockedResponse({
+      httpStatus: 429,
+      status: "usage_limited",
+      issue: createSafeIssue({
+        code: usageQuotaGuard.issues[0]?.code ?? "usage_limited",
+        message: usageQuotaGuard.issues[0]?.message ?? "Uso não disponível.",
+      }),
+      guardResults: [
+        methodGuard,
+        sessionGuard,
+        adminDevGuard,
+        featureFlagGuard,
+        contentTypeGuard,
+        payloadValidation.guardResult,
+        inputSourceGuard.guardResult,
+        consentRetentionGuard.consentGuardResult,
+        consentRetentionGuard.retentionGuardResult,
+        usageQuotaGuard.guardResult,
+      ],
+      eventStatus: "blocked",
+    });
+  }
+
+  const observabilityStartGuard = createPassedVideoNarrativeGuardResult("observability_start");
+  const providerGuard = createBlockedVideoNarrativeGuardResult({
+    name: "provider",
+    code: "disabled",
+    message: "Provider real desativado nesta fase.",
+  });
+  const guardResults = [
+    methodGuard,
+    sessionGuard,
+    adminDevGuard,
+    featureFlagGuard,
+    contentTypeGuard,
+    payloadValidation.guardResult,
+    inputSourceGuard.guardResult,
+    consentRetentionGuard.consentGuardResult,
+    consentRetentionGuard.retentionGuardResult,
+    usageQuotaGuard.guardResult,
+    observabilityStartGuard,
+    providerGuard,
+  ];
+  const guardSummary = buildGuardSummary(guardResults);
+  const events = compactEvents([
+    createEvent({
+      eventName: "video_narrative_analysis_requested",
+      status: "requested",
+      providerStatus: "skeleton",
+      issuesCount: 0,
+    }),
+    createEvent({
+      eventName: "video_narrative_analysis_started",
+      status: "started",
+      providerStatus: "skeleton",
+      issuesCount: 0,
+    }),
+    createEvent({
+      eventName: "video_narrative_analysis_failed",
+      status: "blocked",
+      providerStatus: "provider_disabled_in_skeleton",
+      guardBlockedBy: guardSummary.blockedBy?.name ?? null,
+      issuesCount: 1,
+    }),
+  ]);
+
+  return buildSafeJsonResponse(
+    buildBlockedVideoNarrativeSafeResponse({
+      status: "disabled",
+      issues: [
+        createSafeIssue({
+          code: "provider_disabled_in_skeleton",
+          message: "Provider real desativado nesta fase.",
+        }),
+      ],
+      guardSummary,
+      observabilityEvents: events,
+    }),
+    200,
+  );
+}

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -77,7 +77,8 @@ Já existe:
 - usage/quota guard helpers foram formalizados em MM23, mas ainda não foram conectados a endpoint real;
 - observability event contracts foram formalizados em MM24, mas ainda não enviam eventos para analytics real;
 - safe response builder foi formalizado em MM25, mas ainda não foi conectado a endpoint real;
-- endpoint skeleton readiness foi formalizado em MM26, mas ainda não criou route.ts;
+- endpoint skeleton readiness foi formalizado em MM26;
+- endpoint skeleton admin/dev foi criado em MM27, mas bloqueia provider real e não chama Gemini;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -131,6 +132,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - contratos puros de eventos de observabilidade;
 - safe response builder puro;
 - endpoint skeleton readiness verde;
+- endpoint skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`, sem provider real;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -584,6 +584,31 @@ O que não faz:
 - não cria upload real, UI, banco/tabela ou analytics real;
 - não liga Gemini real.
 
+### MM27 — Endpoint skeleton admin/dev sem provider real
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../../../../api/internal/video-narrative/analyze/route.ts`
+- `../../../../api/internal/video-narrative/analyze/route.test.ts`
+- `videoNarrativeInternalEndpointFeatureFlag.ts`
+- `videoNarrativeInternalEndpointFeatureFlag.test.ts`
+
+O que faz:
+
+- cria `POST /api/internal/video-narrative/analyze` como skeleton interno/admin-dev;
+- protege a rota com `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`;
+- executa guards de sessão, admin/dev, content-type, payload, input source, consent/retention e usage/quota;
+- retorna `VideoNarrativeSafeResponse` bloqueada/disabled com observabilidade local resumida.
+
+O que não faz:
+
+- não chama Gemini real nem provider real;
+- não cria upload real, storage real, UI, banco/tabela, analytics real, billing, Stripe ou cobrança;
+- não conecta BoardShell, navegação/menu ou `PostCreationFunnelState`;
+- não aceita multipart e não faz rede.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -233,8 +233,9 @@ Exemplos:
 23. MM24 — Observability event contracts. Define eventos e payloads seguros, sem analytics real.
 24. MM25 — Safe response builder. Define empacotamento seguro da resposta futura, sem endpoint.
 25. MM26 — Endpoint skeleton readiness. Define checklist final antes de endpoint skeleton admin/dev sem provider real.
-26. Teste real manual quando houver quota/billing disponível.
-27. Integração experimental futura no Board de Criação.
+26. MM27 — Endpoint skeleton admin/dev sem provider real. Cria `route.ts` interno protegido por flag, com guards puros e resposta segura, sem provider real.
+27. Teste real manual quando houver quota/billing disponível.
+28. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -279,6 +280,8 @@ MM24 adiciona `VideoNarrativeObservabilityEventPayload`, `buildVideoNarrativeObs
 MM25 adiciona `VideoNarrativeSafeResponse`, `buildVideoNarrativeSafeResponse` e `validateVideoNarrativeSafeResponse` para preparar a resposta segura futura sem endpoint, route.ts, upload real ou UI.
 
 MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` para confirmar que a próxima fase pode criar endpoint skeleton admin/dev sem provider real, desde que nasça bloqueado, observável e sem vazamento de dados sensíveis.
+
+MM27 cria `POST /api/internal/video-narrative/analyze` como skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`. Ele valida payload, origem, consentimento/retenção e usage/quota, gera eventos locais em response e retorna safe response bloqueada/disabled sem chamar Gemini real, sem upload real, sem storage real, sem analytics real e sem UI.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
@@ -9,8 +9,10 @@ Ele mapeia o que já existe, o que o endpoint skeleton poderá usar, o que deve 
 ## Escopo
 
 - é checklist, não implementação;
-- não existe endpoint real nesta fase;
-- não existe route.ts nesta fase;
+- MM26 era checklist, não implementação;
+- em MM27 existe endpoint skeleton interno/admin-dev;
+- em MM27 existe `route.ts` skeleton;
+- não existe provider real nesta fase;
 - não existe chamada Gemini real;
 - sem chamada Gemini real;
 - não existe upload real;
@@ -87,7 +89,7 @@ Caminho futuro:
 
 `POST /api/internal/video-narrative/analyze`
 
-Esse caminho ainda não será criado neste PR. Esta fase não cria endpoint, rota, `route.ts` ou diretório `app/api/internal/video-narrative/analyze`.
+MM27 cria esse caminho como skeleton interno/admin-dev. Ele continua sem provider real, sem upload real, sem persistência e sem analytics real.
 
 ## Comportamento Esperado Do Skeleton Futuro
 
@@ -161,13 +163,12 @@ Provider real continua bloqueado por:
 
 ## Decisão Recomendada
 
-A próxima fase pode criar endpoint skeleton admin/dev sem provider real.
+MM27 implementa parcialmente a próxima fase: o endpoint skeleton admin/dev existe e nasce bloqueado por flag server-side e pela ausência intencional de provider real.
 
-A fase ainda não deve ligar Gemini real.
+A fase ainda não liga Gemini real.
 
 ## Próximas Fases Possíveis
 
-- MM27: endpoint skeleton admin/dev sem provider real;
-- MM28: endpoint skeleton com integração dos guards puros;
-- MM29: endpoint com safe blocked response e observability local;
+- MM28: reforço dos guards puros do skeleton, se necessário;
+- MM29: storage cleanup contract;
 - MM30: provider real somente depois de billing/teste manual.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -95,6 +95,8 @@ Regras:
 
 MM25 adiciona `VideoNarrativeSafeResponse` e helpers puros para montar essa resposta futura sem retornar `rawText` completo, base64, API key, vídeo bruto ou URL assinada com token.
 
+MM27 cria o skeleton de `POST /api/internal/video-narrative/analyze` protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`. A flag é server-side, separada de `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED`, e permite validar guards e safe response sem ligar provider real.
+
 ## Status Futuros
 
 - `disabled`;
@@ -202,6 +204,13 @@ Só implementar depois que:
 - MM18: contrato dos guards do endpoint real;
 - MM19: contratos puros de guard result/status;
 - MM20: payload validation contracts;
-- MM21: endpoint interno real, se billing existir;
-- MM22: preview interno com chamada real;
-- MM23: integração experimental no board.
+- MM21: input/source guard helpers;
+- MM22: consent/retention guard helpers;
+- MM23: usage/quota guard helpers;
+- MM24: observability event contracts;
+- MM25: safe response builder;
+- MM26: endpoint skeleton readiness;
+- MM27: endpoint skeleton admin/dev sem provider real;
+- MM28: endpoint real somente depois de billing/teste real;
+- MM29: preview interno com chamada real;
+- MM30: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -303,6 +303,8 @@ MM25 adiciona `VideoNarrativeSafeResponse` como fundação pura para o safe_resp
 
 MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` como checklist final antes de qualquer `route.ts`, separando endpoint skeleton admin/dev sem provider real de provider real com Gemini.
 
+MM27 cria `src/app/api/internal/video-narrative/analyze/route.ts` como endpoint skeleton admin/dev. A rota usa guards puros, observabilidade local e safe response, mas bloqueia na etapa `provider` e não chama Gemini real.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionContract.test.ts
@@ -75,13 +75,13 @@ describe("videoNarrativeConsentRetentionContract", () => {
     expect(readContract()).toContain("O rawText completo não deve ser retornado/salvo por padrão.");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém linguagem consultiva no documento", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts
@@ -391,12 +391,12 @@ describe("videoNarrativeConsentRetentionGuards", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointSkeletonReadiness.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointSkeletonReadiness.test.ts
@@ -75,12 +75,12 @@ describe("videoNarrativeEndpointSkeletonReadiness", () => {
     expect(readReadiness()).toContain("provider real continua dependente da flag Gemini");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
-    expect(fs.existsSync(FUTURE_ROUTE_PATH)).toBe(false);
+  it("confirma que a rota skeleton MM27 existe", () => {
+    expect(fs.existsSync(FUTURE_ROUTE_PATH)).toBe(true);
   });
 
-  it("confirma que o diretório futuro do endpoint ainda não foi criado", () => {
-    expect(fs.existsSync(FUTURE_ENDPOINT_DIR)).toBe(false);
+  it("confirma que o diretório skeleton MM27 foi criado", () => {
+    expect(fs.existsSync(FUTURE_ENDPOINT_DIR)).toBe(true);
   });
 
   it("mantém linguagem segura no documento", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts
@@ -324,12 +324,12 @@ describe("videoNarrativeGuardContracts", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceContract.test.ts
@@ -59,13 +59,13 @@ describe("videoNarrativeInputSourceContract", () => {
     expect(readContract()).not.toContain("route.ts");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém linguagem consultiva no documento", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts
@@ -419,12 +419,12 @@ describe("videoNarrativeInputSourceGuards", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointContract.test.ts
@@ -41,6 +41,7 @@ describe("videoNarrativeInternalEndpointContract", () => {
       "sem upload real",
       "sem UI",
       "sem endpoint real nesta fase",
+      "VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED",
     ];
 
     expectedTerms.forEach((term) => {
@@ -50,20 +51,19 @@ describe("videoNarrativeInternalEndpointContract", () => {
 
   it("não inclui implementação real, credencial ou payload bruto extenso", () => {
     const contract = readContract();
-    expect(contract).not.toContain("route.ts");
     expect(contract).not.toMatch(/AIza[0-9A-Za-z_-]{20,}/);
     expect(contract).not.toMatch(/[A-Za-z0-9+/]{120,}={0,2}/);
     expect(contract).not.toContain("usuário comum pode");
     expect(contract.toLowerCase()).not.toContain("promessa de performance");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém linguagem consultiva no documento", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts
@@ -1,0 +1,34 @@
+import { isVideoNarrativeInternalEndpointEnabled } from "./videoNarrativeInternalEndpointFeatureFlag";
+
+describe("videoNarrativeInternalEndpointFeatureFlag", () => {
+  it("returns false by default", () => {
+    expect(isVideoNarrativeInternalEndpointEnabled({})).toBe(false);
+  });
+
+  it("returns true only when VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED is true", () => {
+    expect(
+      isVideoNarrativeInternalEndpointEnabled({
+        VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED: "true",
+      }),
+    ).toBe(true);
+    expect(
+      isVideoNarrativeInternalEndpointEnabled({
+        VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED: "1",
+      }),
+    ).toBe(false);
+    expect(
+      isVideoNarrativeInternalEndpointEnabled({
+        VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED: "TRUE",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not use NEXT_PUBLIC or the Gemini provider flag", () => {
+    expect(
+      isVideoNarrativeInternalEndpointEnabled({
+        NEXT_PUBLIC_VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED: "true",
+        VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED: "true",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.ts
@@ -1,0 +1,5 @@
+export function isVideoNarrativeInternalEndpointEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  return env.VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED === "true";
+}

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityContract.test.ts
@@ -80,13 +80,13 @@ describe("videoNarrativeObservabilityContract", () => {
     expect(readContract()).toContain("O rawText completo não deve ser logado.");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém os novos arquivos sem imports proibidos", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts
@@ -360,12 +360,12 @@ describe("videoNarrativeObservabilityEvents", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts
@@ -358,12 +358,12 @@ describe("videoNarrativePayloadValidation", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealEndpointGuardsContract.test.ts
@@ -66,9 +66,10 @@ describe("videoNarrativeRealEndpointGuardsContract", () => {
     );
   });
 
-  it("bloqueia criação de route.ts nesta fase", () => {
+  it("documenta a transição de contrato MM18 para skeleton MM27", () => {
     expect(readContract()).toContain("não existe route.ts nesta fase");
-    expect(readContract()).toContain("não criar route.ts");
+    expect(readContract()).toContain("MM27 cria");
+    expect(readContract()).toContain("endpoint skeleton admin/dev");
   });
 
   it("documenta que falha antes do provider não consome quota", () => {
@@ -76,13 +77,13 @@ describe("videoNarrativeRealEndpointGuardsContract", () => {
     expect(readContract()).toContain("falha antes de chamar provider");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém os novos arquivos sem imports proibidos", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
@@ -438,12 +438,12 @@ describe("videoNarrativeSafeResponseBuilder", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeUsageLimitsCostContract.test.ts
@@ -81,13 +81,13 @@ describe("videoNarrativeUsageLimitsCostContract", () => {
     expect(contract).toContain("Tente novamente mais tarde ou use um vídeo menor.");
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 
   it("mantém os novos arquivos sem imports proibidos", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts
@@ -394,12 +394,12 @@ describe("videoNarrativeUsageQuotaGuards", () => {
     });
   });
 
-  it("confirma que a rota futura ainda não existe", () => {
+  it("confirma que a rota skeleton MM27 existe", () => {
     const routePath = path.join(
       process.cwd(),
       "src/app/api/internal/video-narrative/analyze/route.ts",
     );
 
-    expect(fs.existsSync(routePath)).toBe(false);
+    expect(fs.existsSync(routePath)).toBe(true);
   });
 });


### PR DESCRIPTION
Stacked sobre #823.

## Resumo
- Cria o endpoint skeleton interno/admin-dev em `POST /api/internal/video-narrative/analyze`.
- Adiciona a flag server-side `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`.
- Usa guards puros de payload, input source, consent/retention e usage/quota.
- Gera eventos locais em response e retorna `VideoNarrativeSafeResponse` validada.

## Fora de escopo
- Não chama Gemini real.
- Não importa SDK Gemini nem provider real na rota.
- Não cria upload, storage, UI, banco/tabela, analytics real, billing, Stripe ou cobrança.
- Não conecta BoardShell, navegação/menu ou PostCreationFunnelState.

## Validação
- `npm test -- --runInBand src/app/api/internal/video-narrative/analyze/route.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts`
- bloco docs/Gemini/guards/payload/input/consent/usage/observability/safe-response/readiness
- regressões videoUpload/previews/guards/NSE/Adaptive V2
- `npm run typecheck`
- `git diff --check`
- `npm run build`