### PR TITLE
feat: add video narrative endpoint mock mode

### DIFF
--- a/src/app/api/internal/video-narrative/analyze/route.test.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.test.ts
@@ -47,6 +47,15 @@ function disableEndpointFlag(): void {
   delete process.env.VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED;
 }
 
+function setProviderMode(mode: "disabled" | "mock" | "real"): void {
+  if (mode === "disabled") {
+    delete process.env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE;
+    return;
+  }
+
+  process.env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE = mode;
+}
+
 function makeRequest(payload: unknown, headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/api/internal/video-narrative/analyze", {
     method: "POST",
@@ -90,6 +99,7 @@ describe("POST /api/internal/video-narrative/analyze skeleton", () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
     disableEndpointFlag();
+    setProviderMode("disabled");
   });
 
   it("GET returns 405 and a safe response", async () => {
@@ -217,7 +227,7 @@ describe("POST /api/internal/video-narrative/analyze skeleton", () => {
     });
   });
 
-  it("POST admin/dev with valid payload returns disabled because provider is not enabled in this phase", async () => {
+  it("POST admin/dev with valid payload and provider mode disabled returns disabled without analysis or seed", async () => {
     enableEndpointFlag();
     getServerSession.mockResolvedValue({ user: { role: "admin" } });
 
@@ -227,8 +237,137 @@ describe("POST /api/internal/video-narrative/analyze skeleton", () => {
     expect(response.status).toBe(200);
     expect(body.ok).toBe(false);
     expect(body.status).toBe("disabled");
-    expect(JSON.stringify(body)).toContain("Provider real desativado nesta fase.");
+    expect(body.analysis).toBeNull();
+    expect(body.seed).toBeNull();
+    expect(JSON.stringify(body)).toContain("Provider interno desativado.");
     expectSafeResponse(body);
+  });
+
+  it("POST admin/dev with provider mode real returns disabled and does not call real provider", async () => {
+    enableEndpointFlag();
+    setProviderMode("real");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.status).toBe("disabled");
+    expect(JSON.stringify(body)).toContain("real_provider_disabled_in_mock_phase");
+    expect(JSON.stringify(body)).toContain("Provider real continua desativado nesta fase.");
+    expectSafeResponse(body);
+  });
+
+  it("POST admin/dev with provider mode mock returns ready with analysis, seed, and primaryAction", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe("ready");
+    expect(body.analysis).toBeTruthy();
+    expect(body.seed).toBeTruthy();
+    expect(typeof body.primaryAction).toBe("string");
+    expectSafeResponse(body);
+  });
+
+  it("POST mock mode brand question returns coherent brand potential hints", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      creatorQuestion: "Como adaptar esse vídeo para marca ou publi?",
+      creatorContext: { knownNarratives: [] },
+    }));
+    const body = await readJson(response);
+    const analysis = body.analysis as { brandMatch?: { enabled?: boolean; territories?: string[] } };
+    const seed = body.seed as { brandMatchHints?: string[] };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(analysis.brandMatch?.enabled).toBe(true);
+    expect(seed.brandMatchHints?.length).toBeGreaterThan(0);
+    expect(JSON.stringify(body)).toContain("publi orgânica");
+  });
+
+  it("POST mock mode weak hook returns hook diagnosis and primaryAction", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      creatorQuestion: "Como melhorar o gancho?",
+      creatorContext: { knownNarratives: [] },
+    }));
+    const body = await readJson(response);
+    const analysis = body.analysis as { hook?: { strength?: string } };
+    const seed = body.seed as { strategicDiagnosis?: string | null };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(analysis.hook?.strength).toBe("weak");
+    expect(seed.strategicDiagnosis).toContain("gancho");
+    expect(body.primaryAction).toBe("Transformar a sugestão de blueprint em roteiro.");
+  });
+
+  it("POST mock mode unclear returns follow-up questions without breaking", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      creatorQuestion: "Não sei, está confuso",
+      creatorContext: { knownNarratives: [] },
+    }));
+    const body = await readJson(response);
+    const seed = body.seed as { followUpQuestions?: unknown[] };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(seed.followUpQuestions?.length).toBeGreaterThan(0);
+    expectSafeResponse(body);
+  });
+
+  it("response mock includes guard, usage, and observability summaries", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+
+    expect(body.guardSummary).toBeTruthy();
+    expect(body.usageSummary).toBeTruthy();
+    expect(body.observabilitySummary).toBeTruthy();
+  });
+
+  it("response mock includes local events without external analytics delivery", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+
+    const response = await POST(makeRequest(validPayload()));
+    const body = await readJson(response);
+    const observabilitySummary = body.observabilitySummary as { events: Array<{ eventName: string }> };
+    const eventNames = observabilitySummary.events.map((event) => event.eventName);
+
+    expect(eventNames).toEqual(expect.arrayContaining([
+      "video_narrative_analysis_requested",
+      "video_narrative_analysis_started",
+      "video_narrative_analysis_completed",
+      "video_narrative_seed_created",
+      "video_narrative_usage_not_consumed",
+    ]));
+    expect(JSON.stringify(body)).not.toContain("analytics.track");
   });
 
   it("rejects non JSON content-type", async () => {

--- a/src/app/api/internal/video-narrative/analyze/route.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.ts
@@ -10,9 +10,15 @@ import {
   type VideoNarrativeGuardPipelineSummary,
   type VideoNarrativeGuardResult,
 } from "@/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts";
+import {
+  getVideoNarrativeInternalProviderMode,
+  resolveVideoNarrativeMockScenarioFromPayload,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode";
 import { isVideoNarrativeInternalEndpointEnabled } from "@/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag";
 import { validateVideoNarrativeConsentRetentionForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards";
 import { validateVideoNarrativeInputSourceForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards";
+import { hasUsefulVideoNarrativeAnalysis } from "@/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes";
+import { runVideoNarrativeMockProvider } from "@/app/dashboard/boards/videoUpload/videoNarrativeMockProvider";
 import {
   buildVideoNarrativeObservabilityEvent,
   createVideoNarrativeRequestId,
@@ -21,7 +27,14 @@ import {
 } from "@/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents";
 import { validateVideoNarrativeAnalyzePayload } from "@/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation";
 import {
+  buildPostCreationVideoSeedFromAnalysis,
+  getPostCreationVideoSeedPrimaryAction,
+  hasUsefulPostCreationVideoSeed,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed";
+import {
   buildBlockedVideoNarrativeSafeResponse,
+  buildVideoNarrativeSafeResponse,
+  redactVideoNarrativeSafeResponse,
   validateVideoNarrativeSafeResponse,
   type VideoNarrativeSafeIssue,
   type VideoNarrativeSafeResponse,
@@ -58,6 +71,12 @@ function createEvent(params: {
   providerStatus?: string | null;
   guardBlockedBy?: string | null;
   issuesCount?: number | null;
+  inputSource?: string | null;
+  mimeType?: string | null;
+  quotaConsumed?: boolean | null;
+  usageReason?: string | null;
+  primaryAction?: string | null;
+  hasUsefulSeed?: boolean | null;
 }): VideoNarrativeObservabilityEventPayload | null {
   const result = buildVideoNarrativeObservabilityEvent({
     requestId: REQUEST_ID,
@@ -68,10 +87,15 @@ function createEvent(params: {
     providerStatus: params.providerStatus,
     guardBlockedBy: params.guardBlockedBy,
     issuesCount: params.issuesCount,
+    inputSource: params.inputSource,
+    mimeType: params.mimeType,
     hasRawText: false,
     fallbackUsed: false,
-    schemaParseOk: null,
-    quotaConsumed: false,
+    schemaParseOk: params.status === "completed" ? true : null,
+    quotaConsumed: params.quotaConsumed ?? false,
+    usageReason: params.usageReason,
+    primaryAction: params.primaryAction,
+    hasUsefulSeed: params.hasUsefulSeed,
   });
 
   return result.ok ? result.event : null;
@@ -415,12 +439,119 @@ export async function POST(request: Request): Promise<NextResponse<VideoNarrativ
     });
   }
 
+  const usageState = {
+    usedToday: 0,
+    usedThisMonth: 0,
+    repeatedFailureCount: 0,
+    isAdminOrDev: true,
+    now: CREATED_AT,
+  };
   const observabilityStartGuard = createPassedVideoNarrativeGuardResult("observability_start");
-  const providerGuard = createBlockedVideoNarrativeGuardResult({
-    name: "provider",
-    code: "disabled",
-    message: "Provider real desativado nesta fase.",
+  const providerMode = getVideoNarrativeInternalProviderMode();
+  const providerDisabledCode =
+    providerMode === "real" ? "real_provider_disabled_in_mock_phase" : "provider_disabled_in_skeleton";
+  const providerDisabledMessage =
+    providerMode === "real"
+      ? "Provider real continua desativado nesta fase."
+      : "Provider interno desativado.";
+
+  if (providerMode !== "mock") {
+    const providerGuard = createBlockedVideoNarrativeGuardResult({
+      name: "provider",
+      code: "disabled",
+      message: providerDisabledMessage,
+    });
+    const guardResults = [
+      methodGuard,
+      sessionGuard,
+      adminDevGuard,
+      featureFlagGuard,
+      contentTypeGuard,
+      payloadValidation.guardResult,
+      inputSourceGuard.guardResult,
+      consentRetentionGuard.consentGuardResult,
+      consentRetentionGuard.retentionGuardResult,
+      usageQuotaGuard.guardResult,
+      observabilityStartGuard,
+      providerGuard,
+    ];
+    const guardSummary = buildGuardSummary(guardResults);
+    const events = compactEvents([
+      createEvent({
+        eventName: "video_narrative_analysis_requested",
+        status: "requested",
+        providerStatus: providerMode,
+        inputSource: payloadValidation.normalized.source,
+        mimeType: payloadValidation.normalized.mimeType,
+        issuesCount: 0,
+      }),
+      createEvent({
+        eventName: "video_narrative_analysis_started",
+        status: "started",
+        providerStatus: providerMode,
+        inputSource: payloadValidation.normalized.source,
+        mimeType: payloadValidation.normalized.mimeType,
+        issuesCount: 0,
+      }),
+      createEvent({
+        eventName: "video_narrative_analysis_failed",
+        status: "blocked",
+        providerStatus: providerDisabledCode,
+        guardBlockedBy: guardSummary.blockedBy?.name ?? null,
+        inputSource: payloadValidation.normalized.source,
+        mimeType: payloadValidation.normalized.mimeType,
+        issuesCount: 1,
+      }),
+    ]);
+
+    return buildSafeJsonResponse(
+      buildBlockedVideoNarrativeSafeResponse({
+        status: "disabled",
+        issues: [
+          createSafeIssue({
+            code: providerDisabledCode,
+            message: providerDisabledMessage,
+          }),
+        ],
+        guardSummary,
+        observabilityEvents: events,
+      }),
+      200,
+    );
+  }
+
+  const scenario = resolveVideoNarrativeMockScenarioFromPayload(payloadValidation.normalized);
+  const analysis = runVideoNarrativeMockProvider({
+    input: {
+      id: payloadValidation.normalized.id,
+      creatorQuestion: payloadValidation.normalized.creatorQuestion,
+      createdAt: CREATED_AT,
+    },
+    options: {
+      scenario,
+    },
   });
+  const seed = buildPostCreationVideoSeedFromAnalysis({
+    id: `${payloadValidation.normalized.id}-seed`,
+    analysis,
+    creatorQuestion: payloadValidation.normalized.creatorQuestion,
+    createdAt: CREATED_AT,
+  });
+  const primaryAction = getPostCreationVideoSeedPrimaryAction(seed);
+  const analysisIsUseful = hasUsefulVideoNarrativeAnalysis(analysis);
+  const seedIsUseful = hasUsefulPostCreationVideoSeed(seed);
+  const usageDecision = usageQuotaGuards.decideVideoNarrativeUsageConsumption({
+    phase: PHASE,
+    usageState,
+    providerWasCalled: true,
+    providerReturnedUsefulAnalysis: analysisIsUseful && seedIsUseful,
+    providerReturnedUsefulPartialAnalysis: analysisIsUseful || seedIsUseful,
+  });
+  const providerGuard = createPassedVideoNarrativeGuardResult("provider");
+  const parseFallbackGuard = createPassedVideoNarrativeGuardResult("parse_fallback");
+  const seedGenerationGuard = createPassedVideoNarrativeGuardResult("seed_generation");
+  const observabilityCompletionGuard = createPassedVideoNarrativeGuardResult("observability_completion");
+  const safeResponseGuard = createPassedVideoNarrativeGuardResult("safe_response");
   const guardResults = [
     methodGuard,
     sessionGuard,
@@ -434,42 +565,79 @@ export async function POST(request: Request): Promise<NextResponse<VideoNarrativ
     usageQuotaGuard.guardResult,
     observabilityStartGuard,
     providerGuard,
+    parseFallbackGuard,
+    seedGenerationGuard,
+    usageDecision.guardResult,
+    observabilityCompletionGuard,
+    safeResponseGuard,
   ];
   const guardSummary = buildGuardSummary(guardResults);
   const events = compactEvents([
     createEvent({
       eventName: "video_narrative_analysis_requested",
       status: "requested",
-      providerStatus: "skeleton",
+      providerStatus: "mock",
+      inputSource: payloadValidation.normalized.source,
+      mimeType: payloadValidation.normalized.mimeType,
       issuesCount: 0,
     }),
     createEvent({
       eventName: "video_narrative_analysis_started",
       status: "started",
-      providerStatus: "skeleton",
+      providerStatus: "mock",
+      inputSource: payloadValidation.normalized.source,
+      mimeType: payloadValidation.normalized.mimeType,
       issuesCount: 0,
     }),
     createEvent({
-      eventName: "video_narrative_analysis_failed",
-      status: "blocked",
-      providerStatus: "provider_disabled_in_skeleton",
-      guardBlockedBy: guardSummary.blockedBy?.name ?? null,
-      issuesCount: 1,
+      eventName: "video_narrative_analysis_completed",
+      status: "completed",
+      providerStatus: "mock",
+      inputSource: payloadValidation.normalized.source,
+      mimeType: payloadValidation.normalized.mimeType,
+      issuesCount: analysis.diagnosis.recommendedAdjustments.length,
+      hasUsefulSeed: seedIsUseful,
+      primaryAction,
+    }),
+    createEvent({
+      eventName: "video_narrative_seed_created",
+      status: "completed",
+      providerStatus: "mock",
+      inputSource: payloadValidation.normalized.source,
+      mimeType: payloadValidation.normalized.mimeType,
+      issuesCount: 0,
+      hasUsefulSeed: seedIsUseful,
+      primaryAction,
+    }),
+    createEvent({
+      eventName: usageDecision.shouldConsumeQuota
+        ? "video_narrative_usage_consumed"
+        : "video_narrative_usage_not_consumed",
+      status: usageDecision.shouldConsumeQuota ? "consumed" : "not_consumed",
+      providerStatus: "mock",
+      inputSource: payloadValidation.normalized.source,
+      mimeType: payloadValidation.normalized.mimeType,
+      quotaConsumed: usageDecision.shouldConsumeQuota,
+      usageReason: usageDecision.reason,
+      issuesCount: usageDecision.issues.length,
     }),
   ]);
 
   return buildSafeJsonResponse(
-    buildBlockedVideoNarrativeSafeResponse({
-      status: "disabled",
-      issues: [
-        createSafeIssue({
-          code: "provider_disabled_in_skeleton",
-          message: "Provider real desativado nesta fase.",
-        }),
-      ],
-      guardSummary,
-      observabilityEvents: events,
-    }),
+    redactVideoNarrativeSafeResponse(
+      buildVideoNarrativeSafeResponse({
+        status: "ready",
+        analysis,
+        seed,
+        primaryAction,
+        issues: [],
+        hasRawText: false,
+        guardSummary,
+        usageDecision,
+        quotaGuard: usageQuotaGuard,
+        observabilityEvents: events,
+      }),
+    ),
     200,
   );
 }

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -79,6 +79,7 @@ Já existe:
 - safe response builder foi formalizado em MM25, mas ainda não foi conectado a endpoint real;
 - endpoint skeleton readiness foi formalizado em MM26;
 - endpoint skeleton admin/dev foi criado em MM27, mas bloqueia provider real e não chama Gemini;
+- endpoint mock mode foi criado em MM28 com `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`, mas ainda sem Gemini real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -133,6 +134,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - safe response builder puro;
 - endpoint skeleton readiness verde;
 - endpoint skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`, sem provider real;
+- endpoint mock mode interno com resposta simulada útil por `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -609,6 +609,31 @@ O que não faz:
 - não conecta BoardShell, navegação/menu ou `PostCreationFunnelState`;
 - não aceita multipart e não faz rede.
 
+### MM28 — Endpoint mock mode
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../../../../api/internal/video-narrative/analyze/route.ts`
+- `../../../../api/internal/video-narrative/analyze/route.test.ts`
+- `videoNarrativeEndpointMockMode.ts`
+- `videoNarrativeEndpointMockMode.test.ts`
+
+O que faz:
+
+- adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock` para o endpoint interno/admin-dev;
+- resolve cenário mock por `creatorQuestion` e `creatorContext.knownNarratives`;
+- executa o mock provider narrativo existente e retorna `VideoNarrativeAnalysis`, `PostCreationVideoSeed` e `primaryAction`;
+- mantém `usageSummary`, `guardSummary` e eventos locais resumidos para UX/UI futura.
+
+O que não faz:
+
+- não chama Gemini real nem provider real;
+- não importa SDK Gemini na rota;
+- não cria upload real, storage real, UI, banco/tabela ou analytics real;
+- não conecta BoardShell, navegação/menu, Stripe, billing ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -234,8 +234,9 @@ Exemplos:
 24. MM25 — Safe response builder. Define empacotamento seguro da resposta futura, sem endpoint.
 25. MM26 — Endpoint skeleton readiness. Define checklist final antes de endpoint skeleton admin/dev sem provider real.
 26. MM27 — Endpoint skeleton admin/dev sem provider real. Cria `route.ts` interno protegido por flag, com guards puros e resposta segura, sem provider real.
-27. Teste real manual quando houver quota/billing disponível.
-28. Integração experimental futura no Board de Criação.
+27. MM28 — Endpoint mock mode. Permite resposta narrativa simulada útil via mock provider, sem Gemini real.
+28. Teste real manual quando houver quota/billing disponível.
+29. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -282,6 +283,8 @@ MM25 adiciona `VideoNarrativeSafeResponse`, `buildVideoNarrativeSafeResponse` e 
 MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` para confirmar que a próxima fase pode criar endpoint skeleton admin/dev sem provider real, desde que nasça bloqueado, observável e sem vazamento de dados sensíveis.
 
 MM27 cria `POST /api/internal/video-narrative/analyze` como skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`. Ele valida payload, origem, consentimento/retenção e usage/quota, gera eventos locais em response e retorna safe response bloqueada/disabled sem chamar Gemini real, sem upload real, sem storage real, sem analytics real e sem UI.
+
+MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock` para que o skeleton retorne `VideoNarrativeAnalysis`, `PostCreationVideoSeed` e `primaryAction` a partir do mock provider narrativo existente. O modo `real` segue bloqueado nesta fase e a rota continua sem Gemini real, sem SDK Gemini, sem fetch, sem upload/storage real, sem UI e sem analytics real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md
@@ -91,6 +91,8 @@ Caminho futuro:
 
 MM27 cria esse caminho como skeleton interno/admin-dev. Ele continua sem provider real, sem upload real, sem persistência e sem analytics real.
 
+MM28 evolui o skeleton para `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`, permitindo retorno narrativo simulado útil para UX/UI futura. O provider real continua bloqueado e o modo `real` retorna safe response disabled.
+
 ## Comportamento Esperado Do Skeleton Futuro
 
 Quando for criado, o endpoint skeleton deve:
@@ -165,7 +167,7 @@ Provider real continua bloqueado por:
 
 MM27 implementa parcialmente a próxima fase: o endpoint skeleton admin/dev existe e nasce bloqueado por flag server-side e pela ausência intencional de provider real.
 
-A fase ainda não liga Gemini real.
+MM28 permite mock mode interno com análise simulada útil, mas ainda não liga Gemini real.
 
 ## Próximas Fases Possíveis
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -97,6 +97,8 @@ MM25 adiciona `VideoNarrativeSafeResponse` e helpers puros para montar essa resp
 
 MM27 cria o skeleton de `POST /api/internal/video-narrative/analyze` protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`. A flag é server-side, separada de `VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED`, e permite validar guards e safe response sem ligar provider real.
 
+MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE` com valores conceituais `disabled`, `mock` e `real`. Nesta fase a rota suporta `disabled` e `mock`; `real` retorna safe response disabled porque provider Gemini real continua fora de escopo.
+
 ## Status Futuros
 
 - `disabled`;
@@ -211,6 +213,7 @@ Só implementar depois que:
 - MM25: safe response builder;
 - MM26: endpoint skeleton readiness;
 - MM27: endpoint skeleton admin/dev sem provider real;
-- MM28: endpoint real somente depois de billing/teste real;
-- MM29: preview interno com chamada real;
-- MM30: integração experimental no board.
+- MM28: endpoint mock mode sem Gemini real;
+- MM29: endpoint real somente depois de billing/teste real;
+- MM30: preview interno com chamada real;
+- MM31: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_REAL_ENDPOINT_GUARDS_CONTRACT.md
@@ -305,6 +305,8 @@ MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` como checklist fi
 
 MM27 cria `src/app/api/internal/video-narrative/analyze/route.ts` como endpoint skeleton admin/dev. A rota usa guards puros, observabilidade local e safe response, mas bloqueia na etapa `provider` e não chama Gemini real.
 
+MM28 adiciona mock provider como etapa temporária controlada antes do provider real. Quando `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`, a rota chama apenas `runVideoNarrativeMockProvider`, gera seed e safe response; quando o modo é `real`, continua bloqueando sem chamar Gemini.
+
 ## Critérios Antes De Implementar Route.ts
 
 Só criar route.ts depois que:

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts
@@ -1,0 +1,90 @@
+import {
+  getVideoNarrativeInternalProviderMode,
+  resolveVideoNarrativeMockScenarioFromPayload,
+} from "./videoNarrativeEndpointMockMode";
+import type { VideoNarrativeNormalizedAnalyzePayload } from "./videoNarrativePayloadValidation";
+
+function makePayload(params: {
+  creatorQuestion?: string | null;
+  knownNarratives?: string[];
+}): VideoNarrativeNormalizedAnalyzePayload {
+  return {
+    id: "mock-mode-test",
+    creatorQuestion: params.creatorQuestion ?? null,
+    videoUri: "gemini://files/mock-video",
+    inlineVideoBase64: null,
+    mimeType: null,
+    source: "gemini_file_api",
+    creatorContext: params.knownNarratives
+      ? {
+          knownNarratives: params.knownNarratives,
+        }
+      : null,
+  };
+}
+
+describe("videoNarrativeEndpointMockMode", () => {
+  it("returns disabled by default", () => {
+    expect(getVideoNarrativeInternalProviderMode({})).toBe("disabled");
+  });
+
+  it("returns mock when VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE is mock", () => {
+    expect(
+      getVideoNarrativeInternalProviderMode({
+        VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE: "mock",
+      }),
+    ).toBe("mock");
+  });
+
+  it("returns real when VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE is real", () => {
+    expect(
+      getVideoNarrativeInternalProviderMode({
+        VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE: "real",
+      }),
+    ).toBe("real");
+  });
+
+  it("does not use NEXT_PUBLIC values", () => {
+    expect(
+      getVideoNarrativeInternalProviderMode({
+        NEXT_PUBLIC_VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE: "mock",
+        VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED: "true",
+      }),
+    ).toBe("disabled");
+  });
+
+  it("resolves brand_potential from marca/publi/brand", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Como adaptar para marca?" }))).toBe("brand_potential");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Funciona para publi?" }))).toBe("brand_potential");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Brand fit?" }))).toBe("brand_potential");
+  });
+
+  it("resolves weak_hook from gancho", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "O gancho está claro?" }))).toBe("weak_hook");
+  });
+
+  it("resolves collab_potential from collab or colaboração", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Dá para fazer collab?" }))).toBe("collab_potential");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Cabe colaboração?" }))).toBe("collab_potential");
+  });
+
+  it("resolves backstage_process from bastidor or processo", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Esse bastidor vira pauta?" }))).toBe("backstage_process");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Mostra processo?" }))).toBe("backstage_process");
+  });
+
+  it("resolves ad_adaptation from anúncio/adaptação/ad", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Viraria anúncio?" }))).toBe("ad_adaptation");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Precisa de adaptação?" }))).toBe("ad_adaptation");
+  });
+
+  it("resolves unclear_content from confuso/não sei", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Está confuso?" }))).toBe("unclear_content");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Não sei o caminho" }))).toBe("unclear_content");
+  });
+
+  it("uses skincare_routine by default and reads knownNarratives", () => {
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ creatorQuestion: "Qual caminho?" }))).toBe("skincare_routine");
+    expect(resolveVideoNarrativeMockScenarioFromPayload(makePayload({ knownNarratives: ["gancho"] }))).toBe("weak_hook");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.ts
@@ -1,0 +1,63 @@
+import { sanitizeVideoNarrativePayloadText, type VideoNarrativeNormalizedAnalyzePayload } from "./videoNarrativePayloadValidation";
+import type { VideoNarrativeMockProviderScenario } from "./videoNarrativeMockProvider";
+
+export type VideoNarrativeInternalProviderMode = "disabled" | "mock" | "real";
+
+export function getVideoNarrativeInternalProviderMode(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): VideoNarrativeInternalProviderMode {
+  if (env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE === "mock") {
+    return "mock";
+  }
+
+  if (env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE === "real") {
+    return "real";
+  }
+
+  return "disabled";
+}
+
+function normalizeSearchText(payload: VideoNarrativeNormalizedAnalyzePayload): string {
+  const knownNarratives = payload.creatorContext?.knownNarratives ?? [];
+  return sanitizeVideoNarrativePayloadText([
+    payload.creatorQuestion ?? "",
+    payload.creatorContext?.handle ?? "",
+    payload.creatorContext?.niche ?? "",
+    ...knownNarratives,
+  ].join(" "))
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+export function resolveVideoNarrativeMockScenarioFromPayload(
+  payload: VideoNarrativeNormalizedAnalyzePayload,
+): VideoNarrativeMockProviderScenario {
+  const text = normalizeSearchText(payload);
+
+  if (/\b(marca|publi|brand)\b/.test(text)) {
+    return "brand_potential";
+  }
+
+  if (/\bgancho\b/.test(text)) {
+    return "weak_hook";
+  }
+
+  if (/\b(collab|colaboracao)\b/.test(text)) {
+    return "collab_potential";
+  }
+
+  if (/\b(bastidor|processo)\b/.test(text)) {
+    return "backstage_process";
+  }
+
+  if (/\b(anuncio|adaptacao|ad)\b/.test(text)) {
+    return "ad_adaptation";
+  }
+
+  if (/(nao sei|confuso|duvida)/.test(text)) {
+    return "unclear_content";
+  }
+
+  return "skincare_routine";
+}


### PR DESCRIPTION
Stacked sobre #824.

## Resumo
- Evolui `POST /api/internal/video-narrative/analyze` para suportar modo mock interno.
- Adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE` com `disabled`, `mock` e `real`.
- Em `mock`, usa o mock provider narrativo existente para gerar `VideoNarrativeAnalysis`, `PostCreationVideoSeed` e `primaryAction`.
- Mantém `real` bloqueado com safe response disabled nesta fase.
- Mantém guardSummary, usageSummary e observabilitySummary seguros.

## Fora de escopo
- Não chama Gemini real.
- Não importa SDK Gemini nem provider real na rota.
- Não cria upload, storage, UI, banco/tabela, analytics real, billing, Stripe ou cobrança.
- Não conecta BoardShell, navegação/menu ou PostCreationFunnelState.

## Validação
- `npm test -- --runInBand src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts`
- bloco docs/Gemini/guards/payload/input/consent/usage/observability/safe-response/readiness
- regressões videoUpload/previews/guards/NSE/Adaptive V2
- `npm run typecheck`
- `git diff --check`
- `npm run build`