### PR TITLE
feat: add video narrative diagnosis learning model

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -80,6 +80,8 @@ Já existe:
 - endpoint skeleton readiness foi formalizado em MM26;
 - endpoint skeleton admin/dev foi criado em MM27, mas bloqueia provider real e não chama Gemini;
 - endpoint mock mode foi criado em MM28 com `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`, mas ainda sem Gemini real;
+- diagnosis and creator learning model foi criado em MM29 para orientar extração, quiz e UX futura;
+- sinais do criador são extraídos em MM29, mas não são persistidos;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -135,6 +137,8 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - endpoint skeleton readiness verde;
 - endpoint skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`, sem provider real;
 - endpoint mock mode interno com resposta simulada útil por `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock`;
+- diagnóstico estratégico puro para níveis `free`, `premium` e `instagram_optimized`;
+- creatorSignals derivados de quiz/pergunta/análise/seed/Instagram futuro, sempre sem persistência automática;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -634,6 +634,29 @@ O que não faz:
 - não cria upload real, storage real, UI, banco/tabela ou analytics real;
 - não conecta BoardShell, navegação/menu, Stripe, billing ou cobrança.
 
+### MM29 — Diagnosis and Creator Learning Model
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeDiagnosisLearningModel.ts`
+- `videoNarrativeDiagnosisLearningModel.test.ts`
+
+O que faz:
+
+- cria um modelo puro de diagnóstico estratégico para `free`, `premium` e `instagram_optimized`;
+- cruza `VideoNarrativeAnalysis`, `PostCreationVideoSeed`, pergunta do criador, respostas futuras de quiz, perfil narrativo futuro e contexto futuro de Instagram;
+- transforma respostas do quiz em `creatorSignals` para aprendizado progressivo futuro do criador;
+- mantém `shouldPersistLater: false` em todos os sinais nesta fase.
+
+O que não faz:
+
+- não cria UI, upload real, storage real, banco/tabela, analytics real ou persistência;
+- não conecta Instagram real nem usa dados reais de Instagram;
+- não chama Gemini real, OpenAI, fetch, Stripe, billing ou cobrança;
+- não conecta BoardShell, navegação/menu ou `PostCreationFunnelState`.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -235,8 +235,9 @@ Exemplos:
 25. MM26 — Endpoint skeleton readiness. Define checklist final antes de endpoint skeleton admin/dev sem provider real.
 26. MM27 — Endpoint skeleton admin/dev sem provider real. Cria `route.ts` interno protegido por flag, com guards puros e resposta segura, sem provider real.
 27. MM28 — Endpoint mock mode. Permite resposta narrativa simulada útil via mock provider, sem Gemini real.
-28. Teste real manual quando houver quota/billing disponível.
-29. Integração experimental futura no Board de Criação.
+28. MM29 — Diagnosis and Creator Learning Model. Define diagnóstico estratégico e sinais de aprendizado do criador, sem UI, persistência ou Instagram real.
+29. Teste real manual quando houver quota/billing disponível.
+30. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -285,6 +286,8 @@ MM26 adiciona `VIDEO_NARRATIVE_ENDPOINT_SKELETON_READINESS.md` para confirmar qu
 MM27 cria `POST /api/internal/video-narrative/analyze` como skeleton admin/dev protegido por `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED=true`. Ele valida payload, origem, consentimento/retenção e usage/quota, gera eventos locais em response e retorna safe response bloqueada/disabled sem chamar Gemini real, sem upload real, sem storage real, sem analytics real e sem UI.
 
 MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock` para que o skeleton retorne `VideoNarrativeAnalysis`, `PostCreationVideoSeed` e `primaryAction` a partir do mock provider narrativo existente. O modo `real` segue bloqueado nesta fase e a rota continua sem Gemini real, sem SDK Gemini, sem fetch, sem upload/storage real, sem UI e sem analytics real.
+
+MM29 adiciona `VideoNarrativeStrategicDiagnosis` e `VideoNarrativeDiagnosisCreatorSignal` como camada pura posterior à análise/seed. O diagnóstico passa a orientar quiz, UX futura e extração narrativa por níveis `free`, `premium` e `instagram_optimized`, enquanto as respostas do quiz geram sinais internos com `shouldPersistLater: false`.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -99,6 +99,8 @@ MM27 cria o skeleton de `POST /api/internal/video-narrative/analyze` protegido p
 
 MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE` com valores conceituais `disabled`, `mock` e `real`. Nesta fase a rota suporta `disabled` e `mock`; `real` retorna safe response disabled porque provider Gemini real continua fora de escopo.
 
+MM29 adiciona `VideoNarrativeStrategicDiagnosis` como camada futura depois do mock endpoint e da safe response. Essa camada cruza `VideoNarrativeAnalysis`, `PostCreationVideoSeed`, pergunta do criador, quiz futuro, perfil narrativo futuro e contexto futuro de Instagram sem alterar a rota nesta fase.
+
 ## Status Futuros
 
 - `disabled`;
@@ -172,6 +174,8 @@ MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE` com valores conceituais `
 - `VideoNarrativeAnalyzePayload`;
 - `VideoNarrativeNormalizedAnalyzePayload`;
 - `VideoNarrativeSafeResponse`;
+- `VideoNarrativeStrategicDiagnosis`;
+- `VideoNarrativeDiagnosisCreatorSignal`;
 - `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
@@ -214,6 +218,7 @@ Só implementar depois que:
 - MM26: endpoint skeleton readiness;
 - MM27: endpoint skeleton admin/dev sem provider real;
 - MM28: endpoint mock mode sem Gemini real;
-- MM29: endpoint real somente depois de billing/teste real;
-- MM30: preview interno com chamada real;
-- MM31: integração experimental no board.
+- MM29: diagnosis and creator learning model;
+- MM30: endpoint real somente depois de billing/teste real;
+- MM31: preview interno com chamada real;
+- MM32: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts
@@ -1,0 +1,396 @@
+import {
+  buildVideoNarrativeStrategicDiagnosis,
+  extractVideoNarrativeCreatorSignals,
+  getVideoNarrativeDiagnosisLockedSections,
+  hasUsefulVideoNarrativeStrategicDiagnosis,
+  sanitizeVideoNarrativeDiagnosisText,
+  type VideoNarrativeDiagnosisInput,
+  type VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+import { createEmptyVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  createEmptyPostCreationVideoSeed,
+} from "./videoNarrativePostCreationSeed";
+import { runVideoNarrativeMockProvider } from "./videoNarrativeMockProvider";
+
+const FORBIDDEN_TERMS = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function makeInput(overrides: Partial<VideoNarrativeDiagnosisInput> = {}): VideoNarrativeDiagnosisInput {
+  const analysis =
+    overrides.analysis ??
+    runVideoNarrativeMockProvider({
+      input: {
+        id: "diagnosis-test",
+        creatorQuestion: "Quero saber se vale postar para uma marca",
+        createdAt: "2026-05-17T00:00:00.000Z",
+      },
+      options: { scenario: "brand_potential" },
+    });
+  const seed =
+    overrides.seed ??
+    buildPostCreationVideoSeedFromAnalysis({
+      id: "diagnosis-test-seed",
+      analysis,
+      creatorQuestion: "Quero saber se vale postar para uma marca",
+      createdAt: "2026-05-17T00:00:00.000Z",
+    });
+
+  return {
+    accessLevel: "free",
+    analysis,
+    seed,
+    creatorQuestion: "Quero saber se vale postar para uma marca",
+    quizAnswers: [],
+    creatorProfile: null,
+    instagramContext: null,
+    ...overrides,
+  };
+}
+
+function stringifyDiagnosis(diagnosis: VideoNarrativeStrategicDiagnosis): string {
+  return JSON.stringify(diagnosis).toLowerCase();
+}
+
+describe("videoNarrativeDiagnosisLearningModel", () => {
+  it("builds a free diagnosis with mainNarrative, whatVideoCommunicates and creatorIntent", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput());
+
+    expect(diagnosis.mainNarrative).toBeTruthy();
+    expect(diagnosis.whatVideoCommunicates).toContain("Esse vídeo comunica");
+    expect(diagnosis.creatorIntent).toContain("marca");
+  });
+
+  it("limits free brandPotential to at most 2 territories", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput());
+
+    expect(diagnosis.brandPotential.territories.length).toBeLessThanOrEqual(2);
+  });
+
+  it("limits free blueprint scenes to at most 2", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput());
+
+    expect(diagnosis.blueprint.scenes.length).toBeLessThanOrEqual(2);
+  });
+
+  it("locks scriptDirection for free", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "free" }));
+
+    expect(diagnosis.scriptDirection.locked).toBe(true);
+    expect(diagnosis.scriptDirection.opening).toBeNull();
+  });
+
+  it("unlocks scriptDirection for premium", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "premium" }));
+
+    expect(diagnosis.scriptDirection.locked).toBe(false);
+    expect(diagnosis.scriptDirection.opening).toBeTruthy();
+  });
+
+  it("locks instagramComparison for premium without Instagram", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "premium" }));
+
+    expect(diagnosis.instagramComparison.locked).toBe(true);
+  });
+
+  it("unlocks instagramComparison for instagram_optimized when connected", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({
+        accessLevel: "instagram_optimized",
+        instagramContext: {
+          connected: true,
+          topNarratives: ["rotina orgânica -> produto -> continuidade"],
+          topFormats: ["reel"],
+        },
+      }),
+    );
+
+    expect(diagnosis.instagramComparison.locked).toBe(false);
+  });
+
+  it("finds matchingNarratives with simple overlap", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({
+        accessLevel: "instagram_optimized",
+        creatorProfile: {
+          knownSignals: [],
+          recurringNarratives: ["rotina orgânica -> produto -> continuidade"],
+        },
+        instagramContext: {
+          connected: true,
+          topNarratives: ["rotina orgânica -> produto -> continuidade"],
+        },
+      }),
+    );
+
+    expect(diagnosis.instagramComparison.matchingNarratives).toContain("rotina orgânica -> produto -> continuidade");
+  });
+
+  it("finds matchingFormats with simple overlap", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({
+        accessLevel: "instagram_optimized",
+        creatorProfile: { knownSignals: [], preferredFormats: ["reel"] },
+        instagramContext: { connected: true, topFormats: ["reel"] },
+      }),
+    );
+
+    expect(diagnosis.instagramComparison.matchingFormats).toContain("reel");
+  });
+
+  it("prioritizes quiz objective/intent/goal for creatorIntent", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({
+        quizAnswers: [{ questionId: "q1", key: "objective", value: "Validar pauta antes de postar" }],
+      }),
+    );
+
+    expect(diagnosis.creatorIntent).toBe("Validar pauta antes de postar");
+  });
+
+  it("uses creatorQuestion as creatorIntent fallback", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({ quizAnswers: [], creatorQuestion: "Quero melhorar o gancho" }),
+    );
+
+    expect(diagnosis.creatorIntent).toContain("gancho");
+  });
+
+  it("strategicReading crosses video, stated objective and recommended adjustment", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(
+      makeInput({
+        quizAnswers: [{ questionId: "q1", key: "goal", value: "Criar versão para publi" }],
+      }),
+    );
+
+    expect(diagnosis.strategicReading).toContain("Pelo vídeo");
+    expect(diagnosis.strategicReading).toContain("Pelo objetivo declarado");
+    expect(diagnosis.strategicReading).toContain("O melhor caminho");
+  });
+
+  it("suggestedHook uses seed scriptDirection opening", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput());
+
+    expect(diagnosis.suggestedHook).toBeTruthy();
+  });
+
+  it("suggestedHook uses recommendedAdjustment when hook is weak", () => {
+    const analysis = runVideoNarrativeMockProvider({
+      input: { id: "weak-hook", creatorQuestion: "Gancho?", createdAt: null },
+      options: { scenario: "weak_hook" },
+    });
+    const seed = buildPostCreationVideoSeedFromAnalysis({ id: "weak-hook-seed", analysis });
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ analysis, seed }));
+
+    expect(diagnosis.suggestedHook).toContain("Abrir");
+  });
+
+  it("brandPotential uses analysis brandMatch and seed hints", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "premium" }));
+
+    expect(diagnosis.brandPotential.enabled).toBe(true);
+    expect(diagnosis.brandPotential.territories.length).toBeGreaterThan(0);
+  });
+
+  it("premium shows more brand territories than free", () => {
+    const free = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "free" }));
+    const premium = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "premium" }));
+
+    expect(premium.brandPotential.territories.length).toBeGreaterThanOrEqual(free.brandPotential.territories.length);
+  });
+
+  it("limits free nextActions", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "free" }));
+
+    expect(diagnosis.nextActions.length).toBeLessThanOrEqual(2);
+  });
+
+  it("premium includes complete nextActions", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({ accessLevel: "premium" }));
+
+    expect(diagnosis.nextActions.length).toBeGreaterThan(2);
+  });
+
+  it("lockedSections free contains premium and Instagram reasons", () => {
+    const locked = getVideoNarrativeDiagnosisLockedSections({ accessLevel: "free" });
+
+    expect(locked.some((section) => section.reason === "requires_premium")).toBe(true);
+    expect(locked.some((section) => section.reason === "requires_instagram_connection")).toBe(true);
+  });
+
+  it("lockedSections premium without Instagram contains Instagram reason", () => {
+    const locked = getVideoNarrativeDiagnosisLockedSections({ accessLevel: "premium", instagramConnected: false });
+
+    expect(locked.some((section) => section.reason === "requires_instagram_connection")).toBe(true);
+  });
+
+  it("lockedSections instagram_optimized connected reduces Instagram blocks", () => {
+    const locked = getVideoNarrativeDiagnosisLockedSections({ accessLevel: "instagram_optimized", instagramConnected: true });
+
+    expect(locked.some((section) => section.reason === "requires_instagram_connection")).toBe(false);
+  });
+
+  it("extracts content_goal from quiz objective", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({
+      quizAnswers: [{ questionId: "q1", key: "objective", value: "Validar pauta" }],
+    }));
+
+    expect(signals.some((signal) => signal.type === "content_goal")).toBe(true);
+  });
+
+  it("extracts hook_preference from quiz hook", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({
+      quizAnswers: [{ questionId: "q1", key: "hook", value: "Direto ao ponto" }],
+    }));
+
+    expect(signals.some((signal) => signal.type === "hook_preference")).toBe(true);
+  });
+
+  it("extracts format_preference from quiz format", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({
+      quizAnswers: [{ questionId: "q1", key: "format", value: "reel" }],
+    }));
+
+    expect(signals.some((signal) => signal.type === "format_preference")).toBe(true);
+  });
+
+  it("extracts commercial_preference from creatorQuestion with publi/marca", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({ creatorQuestion: "Serve para publi de marca?" }));
+
+    expect(signals.some((signal) => signal.type === "commercial_preference")).toBe(true);
+  });
+
+  it("extracts recurring_pain from creatorQuestion with gancho", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({ creatorQuestion: "Como melhorar o gancho?" }));
+
+    expect(signals.some((signal) => signal.type === "recurring_pain")).toBe(true);
+  });
+
+  it("extracts collab_preference from creatorQuestion with collab", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({ creatorQuestion: "Dá para fazer collab?" }));
+
+    expect(signals.some((signal) => signal.type === "collab_preference")).toBe(true);
+  });
+
+  it("extracts brand_territory from analysis and seed", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput());
+
+    expect(signals.some((signal) => signal.type === "brand_territory")).toBe(true);
+  });
+
+  it("extracts instagram_context signals when connected", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({
+      instagramContext: {
+        connected: true,
+        topNarratives: ["rotina"],
+        brandTerritories: ["beleza"],
+        strongestMetricsSummary: "Histórico conectado futuro.",
+      },
+    }));
+
+    expect(signals.some((signal) => signal.source === "instagram_context")).toBe(true);
+  });
+
+  it("keeps shouldPersistLater false for all creator signals", () => {
+    const signals = extractVideoNarrativeCreatorSignals(makeInput({
+      quizAnswers: [{ questionId: "q1", key: "objective", value: "Validar pauta" }],
+      instagramContext: { connected: true, topNarratives: ["rotina"] },
+    }));
+
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals.every((signal) => signal.shouldPersistLater === false)).toBe(true);
+  });
+
+  it("hasUsefulVideoNarrativeStrategicDiagnosis returns true for useful diagnosis", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput());
+
+    expect(hasUsefulVideoNarrativeStrategicDiagnosis(diagnosis)).toBe(true);
+  });
+
+  it("hasUsefulVideoNarrativeStrategicDiagnosis returns false for empty diagnosis", () => {
+    const analysis = createEmptyVideoNarrativeAnalysis({ id: "empty" });
+    const seed = createEmptyPostCreationVideoSeed({ id: "empty-seed", analysisId: "empty" });
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({
+      analysis,
+      seed,
+      creatorQuestion: null,
+      quizAnswers: [],
+    }));
+
+    expect(hasUsefulVideoNarrativeStrategicDiagnosis(diagnosis)).toBe(false);
+  });
+
+  it("sanitizeVideoNarrativeDiagnosisText redacts AIza and env API keys", () => {
+    expect(sanitizeVideoNarrativeDiagnosisText("AIza1234567890abcdef")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeDiagnosisText("GEMINI_API_KEY=abc")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeDiagnosisText("GOOGLE_GENAI_API_KEY=abc")).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeDiagnosisText redacts long base64", () => {
+    const base64 = "A".repeat(140);
+
+    expect(sanitizeVideoNarrativeDiagnosisText(base64)).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeDiagnosisText redacts signed URLs", () => {
+    expect(sanitizeVideoNarrativeDiagnosisText("https://example.com/video.mp4?token=abc")).toBe("[redigido]");
+  });
+
+  it("keeps safe language across diagnosis, locked sections, next actions and signals", () => {
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis(makeInput({
+      quizAnswers: [{ questionId: "q1", key: "objective", value: "viralizar garantido" }],
+    }));
+    const content = stringifyDiagnosis(diagnosis);
+
+    FORBIDDEN_TERMS.forEach((term) => {
+      expect(content).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("does not import forbidden runtime integrations", () => {
+    const source = require("fs").readFileSync(
+      "src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.ts",
+      "utf8",
+    ) as string;
+    const forbidden = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "route",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+      "Instagram",
+    ];
+
+    forbidden.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.ts
@@ -1,0 +1,611 @@
+import {
+  sanitizeVideoNarrativeAnalysisText,
+  type VideoNarrativeAnalysis,
+} from "./videoNarrativeAnalysisTypes";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+export type VideoNarrativeDiagnosisAccessLevel = "free" | "premium" | "instagram_optimized";
+
+export type VideoNarrativeDiagnosisSectionKey =
+  | "main_narrative"
+  | "what_video_communicates"
+  | "creator_intent"
+  | "strategic_reading"
+  | "strength"
+  | "weakness"
+  | "recommended_adjustment"
+  | "suggested_hook"
+  | "brand_potential"
+  | "blueprint"
+  | "script_direction"
+  | "next_actions"
+  | "instagram_comparison"
+  | "performance_context"
+  | "creator_profile_learning";
+
+export type VideoNarrativeDiagnosisLockedReason =
+  | "requires_premium"
+  | "requires_instagram_connection"
+  | "requires_more_context";
+
+export interface VideoNarrativeDiagnosisLockedSection {
+  key: VideoNarrativeDiagnosisSectionKey;
+  title: string;
+  reason: VideoNarrativeDiagnosisLockedReason;
+  message: string;
+}
+
+export type VideoNarrativeDiagnosisCreatorSignalType =
+  | "content_goal"
+  | "creative_preference"
+  | "commercial_preference"
+  | "recurring_pain"
+  | "hook_preference"
+  | "format_preference"
+  | "brand_territory"
+  | "collab_preference"
+  | "production_constraint"
+  | "audience_relationship"
+  | "positioning_signal"
+  | "unknown";
+
+export type VideoNarrativeDiagnosisCreatorSignalSource =
+  | "creator_question"
+  | "quiz_answer"
+  | "video_analysis"
+  | "seed"
+  | "instagram_context"
+  | "diagnosis_inference";
+
+export interface VideoNarrativeDiagnosisCreatorSignal {
+  id: string;
+  type: VideoNarrativeDiagnosisCreatorSignalType;
+  value: string;
+  source: VideoNarrativeDiagnosisCreatorSignalSource;
+  confidence: "low" | "medium" | "high";
+  evidence: string | null;
+  shouldPersistLater: boolean;
+}
+
+export interface VideoNarrativeDiagnosisQuizAnswer {
+  questionId: string;
+  key: string;
+  value: string | string[] | boolean | null;
+  label?: string | null;
+}
+
+export interface VideoNarrativeCreatorProfileContext {
+  knownSignals: VideoNarrativeDiagnosisCreatorSignal[];
+  recurringNarratives?: string[];
+  recurringPainPoints?: string[];
+  preferredFormats?: string[];
+  preferredBrandTerritories?: string[];
+}
+
+export interface VideoNarrativeInstagramContext {
+  connected: boolean;
+  topNarratives?: string[];
+  topFormats?: string[];
+  topContexts?: string[];
+  strongestMetricsSummary?: string | null;
+  brandTerritories?: string[];
+}
+
+export interface VideoNarrativeDiagnosisInput {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  analysis: VideoNarrativeAnalysis;
+  seed: PostCreationVideoSeed;
+  creatorQuestion?: string | null;
+  quizAnswers?: VideoNarrativeDiagnosisQuizAnswer[];
+  creatorProfile?: VideoNarrativeCreatorProfileContext | null;
+  instagramContext?: VideoNarrativeInstagramContext | null;
+}
+
+export interface VideoNarrativeDiagnosisBrandPotential {
+  enabled: boolean;
+  territories: string[];
+  whyItFits: string | null;
+  locked: boolean;
+}
+
+export interface VideoNarrativeDiagnosisBlueprint {
+  whatToPost: string | null;
+  whyThisPath: string | null;
+  howItShouldWork: string | null;
+  scenes: string[];
+  locked: boolean;
+}
+
+export interface VideoNarrativeDiagnosisNextAction {
+  id: string;
+  label: string;
+  description: string | null;
+  locked: boolean;
+}
+
+export interface VideoNarrativeStrategicDiagnosis {
+  id: string;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  mainNarrative: string | null;
+  whatVideoCommunicates: string | null;
+  creatorIntent: string | null;
+  strategicReading: string | null;
+  strength: string | null;
+  weakness: string | null;
+  recommendedAdjustment: string | null;
+  suggestedHook: string | null;
+  brandPotential: VideoNarrativeDiagnosisBrandPotential;
+  blueprint: VideoNarrativeDiagnosisBlueprint;
+  scriptDirection: {
+    opening: string | null;
+    development: string[];
+    closing: string | null;
+    tone: string | null;
+    locked: boolean;
+  };
+  nextActions: VideoNarrativeDiagnosisNextAction[];
+  lockedSections: VideoNarrativeDiagnosisLockedSection[];
+  creatorSignals: VideoNarrativeDiagnosisCreatorSignal[];
+  instagramComparison: {
+    connected: boolean;
+    summary: string | null;
+    matchingNarratives: string[];
+    matchingFormats: string[];
+    locked: boolean;
+  };
+  createdAt: string | null;
+}
+
+export const VIDEO_NARRATIVE_DIAGNOSIS_FREE_UNLOCKED_SECTIONS: VideoNarrativeDiagnosisSectionKey[] = [
+  "main_narrative",
+  "what_video_communicates",
+  "creator_intent",
+  "strategic_reading",
+  "strength",
+  "weakness",
+  "recommended_adjustment",
+  "suggested_hook",
+  "brand_potential",
+  "blueprint",
+  "next_actions",
+];
+
+export const VIDEO_NARRATIVE_DIAGNOSIS_PREMIUM_UNLOCKED_SECTIONS: VideoNarrativeDiagnosisSectionKey[] = [
+  ...VIDEO_NARRATIVE_DIAGNOSIS_FREE_UNLOCKED_SECTIONS,
+  "script_direction",
+  "creator_profile_learning",
+];
+
+export const VIDEO_NARRATIVE_DIAGNOSIS_INSTAGRAM_UNLOCKED_SECTIONS: VideoNarrativeDiagnosisSectionKey[] = [
+  ...VIDEO_NARRATIVE_DIAGNOSIS_PREMIUM_UNLOCKED_SECTIONS,
+  "instagram_comparison",
+  "performance_context",
+];
+
+const BLOCKED_TERMS = [
+  "viralizar garantido",
+  "treinado permanentemente",
+  "resposta correta",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "venceu",
+  "perdeu",
+];
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function cleanText(value: string | null | undefined): string | null {
+  if (!value?.trim()) return null;
+  return sanitizeVideoNarrativeDiagnosisText(value);
+}
+
+function cleanTexts(values: Array<string | null | undefined>): string[] {
+  return values.map(cleanText).filter((value): value is string => Boolean(value));
+}
+
+function normalize(value: string): string {
+  return sanitizeVideoNarrativeDiagnosisText(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function answerValueToText(value: VideoNarrativeDiagnosisQuizAnswer["value"]): string | null {
+  if (Array.isArray(value)) return cleanTexts(value).join(", ") || null;
+  if (typeof value === "boolean") return value ? "sim" : "não";
+  return cleanText(value ?? null);
+}
+
+function makeSignal(params: {
+  type: VideoNarrativeDiagnosisCreatorSignalType;
+  value: string | null | undefined;
+  source: VideoNarrativeDiagnosisCreatorSignalSource;
+  confidence?: "low" | "medium" | "high";
+  evidence?: string | null;
+}): VideoNarrativeDiagnosisCreatorSignal | null {
+  const value = cleanText(params.value);
+  if (!value) return null;
+
+  return {
+    id: `${params.source}-${params.type}-${normalize(value).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "signal"}`,
+    type: params.type,
+    value,
+    source: params.source,
+    confidence: params.confidence ?? "medium",
+    evidence: cleanText(params.evidence ?? null),
+    shouldPersistLater: false,
+  };
+}
+
+function firstUseful(values: Array<string | null | undefined>): string | null {
+  return cleanTexts(values)[0] ?? null;
+}
+
+function getCreatorIntent(input: VideoNarrativeDiagnosisInput): string | null {
+  const answer = (input.quizAnswers ?? []).find((item) =>
+    ["objective", "intent", "goal"].includes(normalize(item.key)),
+  );
+
+  return firstUseful([
+    answerValueToText(answer?.value ?? null),
+    input.creatorQuestion,
+    input.seed.creatorQuestion,
+    input.analysis.d2cClassification.intent,
+  ]);
+}
+
+function getMainNarrative(input: VideoNarrativeDiagnosisInput): string | null {
+  return firstUseful([
+    input.seed.detectedNarrative,
+    input.analysis.d2cClassification.narrative,
+    input.analysis.summary,
+  ]);
+}
+
+function getWhatVideoCommunicates(mainNarrative: string | null, input: VideoNarrativeDiagnosisInput): string | null {
+  const context = firstUseful([input.analysis.d2cClassification.context, input.analysis.summary, input.creatorQuestion]);
+  if (!mainNarrative && !context) return null;
+
+  const basis = mainNarrative ?? context;
+  return sanitizeVideoNarrativeDiagnosisText(
+    `Esse vídeo comunica uma direção de conteúdo ligada a ${basis}.`,
+  );
+}
+
+function getStrategicReading(params: {
+  mainNarrative: string | null;
+  creatorIntent: string | null;
+  input: VideoNarrativeDiagnosisInput;
+  recommendedAdjustment: string | null;
+}): string | null {
+  const videoPart = params.mainNarrative ?? params.input.analysis.summary;
+  const objectivePart = params.creatorIntent;
+  const pathPart =
+    params.recommendedAdjustment ??
+    params.input.seed.strategicDiagnosis ??
+    params.input.seed.initialIdea ??
+    params.input.analysis.blueprintSuggestion.whatToPost;
+
+  if (!videoPart && !objectivePart && !pathPart) return null;
+
+  return cleanText([
+    videoPart ? `Pelo vídeo, a leitura principal aponta para ${videoPart}.` : null,
+    objectivePart ? `Pelo objetivo declarado, a análise deve priorizar ${objectivePart}.` : null,
+    pathPart ? `O melhor caminho é ${pathPart}.` : null,
+  ].filter(Boolean).join(" "));
+}
+
+function buildBrandPotential(input: VideoNarrativeDiagnosisInput): VideoNarrativeDiagnosisBrandPotential {
+  const isFree = input.accessLevel === "free";
+  const instagramTerritories =
+    input.accessLevel === "instagram_optimized" && input.instagramContext?.connected
+      ? input.instagramContext.brandTerritories ?? []
+      : [];
+  const territories = Array.from(new Set(cleanTexts([
+    ...input.analysis.brandMatch.territories,
+    ...input.seed.brandMatchHints,
+    ...instagramTerritories,
+  ])));
+
+  return {
+    enabled: input.analysis.brandMatch.enabled || territories.length > 0,
+    territories: isFree ? territories.slice(0, 2) : territories,
+    whyItFits: cleanText(input.analysis.brandMatch.whyBrandsWouldFit ?? input.seed.brandMatchHints[0] ?? null),
+    locked: false,
+  };
+}
+
+function buildBlueprint(input: VideoNarrativeDiagnosisInput): VideoNarrativeDiagnosisBlueprint {
+  const isFree = input.accessLevel === "free";
+  const whatToPost = firstUseful([input.seed.blueprintDraft.whatToPost, input.analysis.blueprintSuggestion.whatToPost]);
+  const whyThisPath = firstUseful([input.seed.blueprintDraft.whyThisPath, input.analysis.blueprintSuggestion.whyThisPath]);
+  const howItShouldWork = isFree
+    ? null
+    : firstUseful([input.seed.blueprintDraft.howItShouldWork, input.analysis.blueprintSuggestion.howItShouldWork]);
+  const scenes = cleanTexts(input.seed.blueprintDraft.scenes.length ? input.seed.blueprintDraft.scenes : input.analysis.blueprintSuggestion.scenes);
+
+  return {
+    whatToPost,
+    whyThisPath,
+    howItShouldWork,
+    scenes: isFree ? scenes.slice(0, 2) : scenes,
+    locked: !whatToPost && !whyThisPath && scenes.length === 0,
+  };
+}
+
+function buildNextActions(input: VideoNarrativeDiagnosisInput): VideoNarrativeDiagnosisNextAction[] {
+  const actions: VideoNarrativeDiagnosisNextAction[] = [
+    {
+      id: "improve_hook",
+      label: "Melhorar gancho",
+      description: "Refinar a abertura antes de transformar o vídeo em roteiro.",
+      locked: false,
+    },
+    {
+      id: "turn_into_blueprint",
+      label: "Transformar em blueprint",
+      description: "Usar a leitura narrativa para estruturar uma pauta.",
+      locked: false,
+    },
+    {
+      id: "generate_script",
+      label: "Gerar roteiro",
+      description: "Converter o blueprint em direção de roteiro.",
+      locked: input.accessLevel === "free",
+    },
+    {
+      id: "ad_version",
+      label: "Criar versão para publi",
+      description: "Adaptar a narrativa para um encaixe comercial cuidadoso.",
+      locked: input.accessLevel === "free",
+    },
+    {
+      id: "explore_brands",
+      label: "Explorar marcas potenciais",
+      description: "Cruzar territórios de marca com a narrativa detectada.",
+      locked: input.accessLevel === "free",
+    },
+  ];
+
+  if (!input.instagramContext?.connected) {
+    actions.push({
+      id: "connect_instagram",
+      label: "Conectar Instagram para otimizar diagnóstico",
+      description: "Usar histórico futuro para comparar narrativas e formatos.",
+      locked: input.accessLevel !== "instagram_optimized",
+    });
+  }
+
+  return input.accessLevel === "free" ? actions.slice(0, 2) : actions;
+}
+
+function buildInstagramComparison(
+  input: VideoNarrativeDiagnosisInput,
+  mainNarrative: string | null,
+): VideoNarrativeStrategicDiagnosis["instagramComparison"] {
+  const connected = input.instagramContext?.connected === true;
+  const unlocked = input.accessLevel === "instagram_optimized" && connected;
+  if (!unlocked) {
+    return { connected, summary: null, matchingNarratives: [], matchingFormats: [], locked: true };
+  }
+
+  const narrativeCandidates = cleanTexts([
+    mainNarrative,
+    ...(input.creatorProfile?.recurringNarratives ?? []),
+  ]);
+  const formatCandidates = cleanTexts([
+    input.seed.suggestedFormat,
+    input.analysis.d2cClassification.format === "unknown" ? null : input.analysis.d2cClassification.format,
+    ...(input.creatorProfile?.preferredFormats ?? []),
+  ]);
+  const topNarratives = cleanTexts(input.instagramContext?.topNarratives ?? []);
+  const topFormats = cleanTexts(input.instagramContext?.topFormats ?? []);
+
+  const matchingNarratives = intersectByNormalized(narrativeCandidates, topNarratives);
+  const matchingFormats = intersectByNormalized(formatCandidates, topFormats);
+  const summary =
+    matchingNarratives.length > 0 || matchingFormats.length > 0
+      ? cleanText(`O vídeo conversa com padrões já vistos no histórico conectado: ${[...matchingNarratives, ...matchingFormats].join(", ")}.`)
+      : "Ainda falta histórico suficiente para comparar esta narrativa com segurança.";
+
+  return {
+    connected,
+    summary,
+    matchingNarratives,
+    matchingFormats,
+    locked: false,
+  };
+}
+
+function intersectByNormalized(left: string[], right: string[]): string[] {
+  const rightNormalized = new Set(right.map(normalize));
+  return left.filter((item) => rightNormalized.has(normalize(item)));
+}
+
+export function sanitizeVideoNarrativeDiagnosisText(value: string): string {
+  let sanitized = sanitizeVideoNarrativeAnalysisText(value);
+  sanitized = sanitized.replace(/\bAIza[0-9A-Za-z_-]{8,}/g, "[redigido]");
+  sanitized = sanitized.replace(/\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+/g, "[redigido]");
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/]{120,}={0,2}\b/g, "[redigido]");
+  sanitized = sanitized.replace(/\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi, "[redigido]");
+
+  BLOCKED_TERMS.forEach((term) => {
+    sanitized = sanitized.replace(new RegExp(term.replace(/\s+/g, "\\s+"), "gi"), "[redigido]");
+  });
+
+  return sanitized.trim();
+}
+
+export function getVideoNarrativeDiagnosisLockedSections(input: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+}): VideoNarrativeDiagnosisLockedSection[] {
+  const locked: VideoNarrativeDiagnosisLockedSection[] = [];
+
+  if (input.accessLevel === "free") {
+    locked.push(
+      {
+        key: "script_direction",
+        title: "Direção de roteiro completa",
+        reason: "requires_premium",
+        message: "Disponível em planos com diagnóstico narrativo ampliado.",
+      },
+      {
+        key: "creator_profile_learning",
+        title: "Aprendizado progressivo do criador",
+        reason: "requires_premium",
+        message: "Os sinais podem ser usados como contexto interno futuro, sem persistência automática nesta fase.",
+      },
+    );
+  }
+
+  if (input.accessLevel !== "instagram_optimized" || input.instagramConnected !== true) {
+    locked.push(
+      {
+        key: "instagram_comparison",
+        title: "Comparação com Instagram",
+        reason: "requires_instagram_connection",
+        message: "Conectar Instagram no futuro permitirá comparar narrativa e formato com histórico do perfil.",
+      },
+      {
+        key: "performance_context",
+        title: "Contexto de performance",
+        reason: "requires_instagram_connection",
+        message: "O contexto de performance depende de Instagram conectado e não usa dados reais nesta fase.",
+      },
+    );
+  }
+
+  return locked.map((section) => ({
+    ...section,
+    title: sanitizeVideoNarrativeDiagnosisText(section.title),
+    message: sanitizeVideoNarrativeDiagnosisText(section.message),
+  }));
+}
+
+export function extractVideoNarrativeCreatorSignals(
+  input: VideoNarrativeDiagnosisInput,
+): VideoNarrativeDiagnosisCreatorSignal[] {
+  const signals: Array<VideoNarrativeDiagnosisCreatorSignal | null> = [];
+  const question = cleanText(input.creatorQuestion ?? input.seed.creatorQuestion);
+  const normalizedQuestion = question ? normalize(question) : "";
+
+  (input.quizAnswers ?? []).forEach((answer) => {
+    const key = normalize(answer.key);
+    const value = answerValueToText(answer.value);
+    if (!value) return;
+
+    if (["objective", "intent", "goal"].includes(key)) signals.push(makeSignal({ type: "content_goal", value, source: "quiz_answer", confidence: "high", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("hook")) signals.push(makeSignal({ type: "hook_preference", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("format")) signals.push(makeSignal({ type: "format_preference", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("brand")) signals.push(makeSignal({ type: "brand_territory", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("collab")) signals.push(makeSignal({ type: "collab_preference", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("effort")) signals.push(makeSignal({ type: "production_constraint", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+    else if (key.includes("narrative")) signals.push(makeSignal({ type: "creative_preference", value, source: "quiz_answer", evidence: answer.label ?? answer.questionId }));
+  });
+
+  if (question) {
+    if (normalizedQuestion.includes("gancho")) signals.push(makeSignal({ type: "recurring_pain", value: "hook_improvement", source: "creator_question", evidence: question }));
+    if (/(marca|publi|brand)/.test(normalizedQuestion)) signals.push(makeSignal({ type: "commercial_preference", value: "brand_or_adaptation_interest", source: "creator_question", evidence: question }));
+    if (/(collab|colaboracao)/.test(normalizedQuestion)) signals.push(makeSignal({ type: "collab_preference", value: "collaboration_interest", source: "creator_question", evidence: question }));
+    if (normalizedQuestion.includes("vale postar")) signals.push(makeSignal({ type: "content_goal", value: "validate_before_posting", source: "creator_question", evidence: question }));
+  }
+
+  input.analysis.profileSignals.forEach((signal) => {
+    signals.push(makeSignal({
+      type: signal.type === "brand_territory" ? "brand_territory" : "positioning_signal",
+      value: signal.value,
+      source: "video_analysis",
+      confidence: signal.confidence === "unknown" ? "low" : signal.confidence,
+      evidence: input.analysis.summary,
+    }));
+  });
+
+  cleanTexts(input.seed.brandMatchHints).forEach((hint) => {
+    signals.push(makeSignal({ type: "brand_territory", value: hint, source: "seed", evidence: input.seed.initialIdea }));
+  });
+
+  if (input.instagramContext?.connected) {
+    cleanTexts(input.instagramContext.topNarratives ?? []).forEach((item) => {
+      signals.push(makeSignal({ type: "positioning_signal", value: item, source: "instagram_context", confidence: "low", evidence: input.instagramContext?.strongestMetricsSummary ?? null }));
+    });
+    cleanTexts(input.instagramContext.brandTerritories ?? []).forEach((item) => {
+      signals.push(makeSignal({ type: "brand_territory", value: item, source: "instagram_context", confidence: "low", evidence: input.instagramContext?.strongestMetricsSummary ?? null }));
+    });
+  }
+
+  return signals.filter((signal): signal is VideoNarrativeDiagnosisCreatorSignal => Boolean(signal));
+}
+
+export function buildVideoNarrativeStrategicDiagnosis(
+  input: VideoNarrativeDiagnosisInput,
+): VideoNarrativeStrategicDiagnosis {
+  const mainNarrative = getMainNarrative(input);
+  const creatorIntent = getCreatorIntent(input);
+  const strength = firstUseful(input.analysis.diagnosis.strengths);
+  const weakness = firstUseful(input.analysis.diagnosis.weaknesses);
+  const recommendedAdjustment = firstUseful([input.analysis.diagnosis.recommendedAdjustments[0], input.seed.strategicDiagnosis]);
+  const suggestedHook =
+    input.analysis.hook.strength === "weak" && recommendedAdjustment
+      ? recommendedAdjustment
+      : firstUseful([input.seed.scriptDirection.opening, input.analysis.hook.detected]);
+  const brandPotential = buildBrandPotential(input);
+  const blueprint = buildBlueprint(input);
+  const instagramComparison = buildInstagramComparison(input, mainNarrative);
+  const scriptUnlocked = input.accessLevel !== "free";
+
+  return {
+    id: `video-narrative-diagnosis-${input.analysis.id}`,
+    accessLevel: input.accessLevel,
+    mainNarrative,
+    whatVideoCommunicates: getWhatVideoCommunicates(mainNarrative, input),
+    creatorIntent,
+    strategicReading: getStrategicReading({
+      mainNarrative,
+      creatorIntent,
+      input,
+      recommendedAdjustment,
+    }),
+    strength,
+    weakness,
+    recommendedAdjustment,
+    suggestedHook,
+    brandPotential,
+    blueprint,
+    scriptDirection: {
+      opening: scriptUnlocked ? cleanText(input.seed.scriptDirection.opening) : null,
+      development: scriptUnlocked ? cleanTexts(input.seed.scriptDirection.development) : [],
+      closing: scriptUnlocked ? cleanText(input.seed.scriptDirection.closing) : null,
+      tone: scriptUnlocked ? cleanText(input.seed.scriptDirection.tone) : null,
+      locked: !scriptUnlocked,
+    },
+    nextActions: buildNextActions(input),
+    lockedSections: getVideoNarrativeDiagnosisLockedSections({
+      accessLevel: input.accessLevel,
+      instagramConnected: input.instagramContext?.connected,
+    }),
+    creatorSignals: extractVideoNarrativeCreatorSignals(input),
+    instagramComparison,
+    createdAt: input.analysis.createdAt ?? input.seed.createdAt ?? null,
+  };
+}
+
+export function hasUsefulVideoNarrativeStrategicDiagnosis(
+  diagnosis: VideoNarrativeStrategicDiagnosis,
+): boolean {
+  return Boolean(
+    hasText(diagnosis.mainNarrative) ||
+      hasText(diagnosis.strategicReading) ||
+      hasText(diagnosis.recommendedAdjustment) ||
+      hasText(diagnosis.blueprint.whatToPost) ||
+      hasText(diagnosis.suggestedHook),
+  );
+}


### PR DESCRIPTION
Stacked sobre #825.

## Summary
- Adds pure diagnosis and creator learning model for video narrative analysis.
- Defines free, premium, and instagram_optimized access behavior.
- Extracts creatorSignals from quiz answers, creator question, analysis, seed, and future Instagram context with shouldPersistLater=false.
- Updates video narrative docs/readiness notes for MM29.

## Scope
- No UI.
- No upload/storage real.
- No database/table or persistence.
- No Gemini/OpenAI/fetch/network calls.
- No real Instagram integration.
- No Stripe/billing/cobranca.
- No BoardShell/PostCreationFunnelState changes.

## Validation
- npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts
- npm test -- --runInBand src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts
- videoUpload/preview/guards regression block
- NSE/Adaptive V2 regression block
- npm run typecheck
- git diff --check
- npm run build