### PR TITLE
feat: add video narrative creator profile contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -84,6 +84,8 @@ Já existe:
 - sinais do criador são extraídos em MM29, mas não são persistidos;
 - diagnosis-driven quiz builder foi criado em MM30 para gerar perguntas a partir do diagnóstico;
 - perguntas de MM30 têm `learningSignalType` e respostas ainda não persistem;
+- creator narrative profile contract foi criado em MM31 para agregar sinais sem banco ou persistência;
+- `shouldPersistLater` segue apenas metadado e persistência continua bloqueada;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -142,6 +144,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - diagnóstico estratégico puro para níveis `free`, `premium` e `instagram_optimized`;
 - creatorSignals derivados de quiz/pergunta/análise/seed/Instagram futuro, sempre sem persistência automática;
 - quiz builder puro orientado por lacunas do diagnóstico, sem UI e sem persistir respostas;
+- contrato de perfil narrativo do criador com merge/summary em memória, sem banco;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -680,6 +680,29 @@ O que não faz:
 - não conecta Instagram real nem usa dados reais de Instagram;
 - não altera endpoint real, BoardShell, navegação/menu ou `PostCreationFunnelState`.
 
+### MM31 — Creator Narrative Profile contract
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeCreatorProfileContract.ts`
+- `videoNarrativeCreatorProfileContract.test.ts`
+
+O que faz:
+
+- cria um contrato puro para organizar sinais narrativos acumulados do criador;
+- mapeia `creatorSignals` para categorias como objetivos, preferências criativas, dores recorrentes, formatos e territórios de marca;
+- mescla sinais repetidos por categoria/tipo/valor e recalcula recorrência, força, status e evidências;
+- gera summary limitado para contexto futuro de diagnóstico.
+
+O que não faz:
+
+- não cria banco, tabela, Prisma ou persistência;
+- não conecta Instagram real nem usa dados reais de Instagram;
+- não cria UI, endpoint, upload real, storage real ou analytics real;
+- não transforma sinais em verdade permanente automaticamente.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -237,8 +237,9 @@ Exemplos:
 27. MM28 — Endpoint mock mode. Permite resposta narrativa simulada útil via mock provider, sem Gemini real.
 28. MM29 — Diagnosis and Creator Learning Model. Define diagnóstico estratégico e sinais de aprendizado do criador, sem UI, persistência ou Instagram real.
 29. MM30 — Diagnosis-driven quiz builder. Gera perguntas por lacunas do diagnóstico e opções com sinais de aprendizado futuro.
-30. Teste real manual quando houver quota/billing disponível.
-31. Integração experimental futura no Board de Criação.
+30. MM31 — Creator Narrative Profile contract. Organiza sinais acumulados do criador sem persistência, banco ou Instagram real.
+31. Teste real manual quando houver quota/billing disponível.
+32. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -291,6 +292,8 @@ MM28 adiciona `VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE=mock` para que o skeleton 
 MM29 adiciona `VideoNarrativeStrategicDiagnosis` e `VideoNarrativeDiagnosisCreatorSignal` como camada pura posterior à análise/seed. O diagnóstico passa a orientar quiz, UX futura e extração narrativa por níveis `free`, `premium` e `instagram_optimized`, enquanto as respostas do quiz geram sinais internos com `shouldPersistLater: false`.
 
 MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` para gerar perguntas adaptativas a partir das lacunas do diagnóstico. O quiz existe para completar o diagnóstico daquele vídeo e capturar respostas com `learningSignalType`/`learningSignalValue`, ainda sem UI, persistência, endpoint real ou integração com Instagram real.
+
+MM31 adiciona `VideoNarrativeCreatorProfile` como contrato puro para agregar sinais narrativos ao longo do tempo. O perfil futuro pode melhorar diagnósticos recorrentes, mas nesta fase não há banco, persistência, Instagram real ou sinal transformado em verdade permanente automaticamente.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -103,6 +103,8 @@ MM29 adiciona `VideoNarrativeStrategicDiagnosis` como camada futura depois do mo
 
 MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` como camada futura depois do diagnosis builder. O endpoint/mock pode alimentar diagnóstico e quiz builder no futuro, mas a rota não foi alterada nesta fase.
 
+MM31 adiciona `VideoNarrativeCreatorProfile` como contrato futuro para agregar sinais vindos de diagnóstico e quiz. O endpoint não persiste nada nesta fase, e `shouldPersistLater` continua apenas metadado para decisão posterior.
+
 ## Status Futuros
 
 - `disabled`;
@@ -180,6 +182,8 @@ MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` como camada futura depois do di
 - `VideoNarrativeDiagnosisCreatorSignal`;
 - `VideoNarrativeDiagnosisQuizQuestion`;
 - `buildVideoNarrativeDiagnosisQuiz`;
+- `VideoNarrativeCreatorProfile`;
+- `buildVideoNarrativeCreatorProfile`;
 - `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
@@ -224,6 +228,7 @@ Só implementar depois que:
 - MM28: endpoint mock mode sem Gemini real;
 - MM29: diagnosis and creator learning model;
 - MM30: diagnosis-driven quiz builder;
-- MM31: endpoint real somente depois de billing/teste real;
-- MM32: preview interno com chamada real;
-- MM33: integração experimental no board.
+- MM31: creator narrative profile contract;
+- MM32: endpoint real somente depois de billing/teste real;
+- MM33: preview interno com chamada real;
+- MM34: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts
@@ -1,0 +1,336 @@
+import {
+  buildVideoNarrativeCreatorProfile,
+  createEmptyVideoNarrativeCreatorProfile,
+  hasUsefulVideoNarrativeCreatorProfile,
+  mapDiagnosisSignalToCreatorProfileSignal,
+  mergeVideoNarrativeCreatorProfileSignals,
+  sanitizeVideoNarrativeCreatorProfileText,
+  summarizeVideoNarrativeCreatorProfile,
+  type VideoNarrativeCreatorProfileSignal,
+} from "./videoNarrativeCreatorProfileContract";
+import type { VideoNarrativeDiagnosisCreatorSignal } from "./videoNarrativeDiagnosisLearningModel";
+
+const FORBIDDEN_TERMS = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function diagnosisSignal(
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+  value = type,
+  overrides: Partial<VideoNarrativeDiagnosisCreatorSignal> = {},
+): VideoNarrativeDiagnosisCreatorSignal {
+  return {
+    id: `${type}-${value}`,
+    type,
+    value,
+    source: "quiz_answer",
+    confidence: "medium",
+    evidence: "Resposta do quiz",
+    shouldPersistLater: false,
+    ...overrides,
+  };
+}
+
+function profileSignal(
+  signal: VideoNarrativeDiagnosisCreatorSignal,
+  createdAt = "2026-05-17T00:00:00.000Z",
+): VideoNarrativeCreatorProfileSignal {
+  return mapDiagnosisSignalToCreatorProfileSignal({
+    signal,
+    diagnosisId: "diagnosis-1",
+    createdAt,
+  });
+}
+
+describe("videoNarrativeCreatorProfileContract", () => {
+  it("createEmptyVideoNarrativeCreatorProfile creates an empty profile", () => {
+    const profile = createEmptyVideoNarrativeCreatorProfile();
+
+    expect(profile.creatorId).toBeNull();
+    expect(profile.signals).toHaveLength(0);
+    expect(profile.summary.strongestContentGoals).toHaveLength(0);
+  });
+
+  it("maps content_goal to content_goals", () => {
+    expect(profileSignal(diagnosisSignal("content_goal")).category).toBe("content_goals");
+  });
+
+  it("maps hook_preference to hook_preferences", () => {
+    expect(profileSignal(diagnosisSignal("hook_preference")).category).toBe("hook_preferences");
+  });
+
+  it("maps format_preference to format_preferences", () => {
+    expect(profileSignal(diagnosisSignal("format_preference")).category).toBe("format_preferences");
+  });
+
+  it("maps commercial_preference to commercial_preferences", () => {
+    expect(profileSignal(diagnosisSignal("commercial_preference")).category).toBe("commercial_preferences");
+  });
+
+  it("maps brand_territory to brand_territories", () => {
+    expect(profileSignal(diagnosisSignal("brand_territory")).category).toBe("brand_territories");
+  });
+
+  it("maps recurring_pain to recurring_pains", () => {
+    expect(profileSignal(diagnosisSignal("recurring_pain")).category).toBe("recurring_pains");
+  });
+
+  it("keeps shouldPersistLater false when source signal is false", () => {
+    expect(profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+      shouldPersistLater: false,
+    })).shouldPersistLater).toBe(false);
+  });
+
+  it("creates high strength for high confidence", () => {
+    expect(profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+      confidence: "high",
+    })).strength).toBe("high");
+  });
+
+  it("creates weak status for low confidence", () => {
+    expect(profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+      confidence: "low",
+    })).status).toBe("weak");
+  });
+
+  it("starts new medium/high signal as emerging", () => {
+    expect(profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+      confidence: "medium",
+    })).status).toBe("emerging");
+    expect(profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+      confidence: "high",
+    })).status).toBe("emerging");
+  });
+
+  it("merges equal signals by category/type/value", () => {
+    const merged = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"))],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"))],
+    });
+
+    expect(merged).toHaveLength(1);
+  });
+
+  it("merge sums recurrenceCount", () => {
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"))],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"))],
+    });
+
+    expect(merged.recurrenceCount).toBe(2);
+  });
+
+  it("merge concatenates evidence without duplicating identical entries", () => {
+    const signal = profileSignal(diagnosisSignal("content_goal", "validar pauta"));
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [signal],
+      newSignals: [signal],
+    });
+
+    expect(merged.evidence).toHaveLength(1);
+  });
+
+  it("merge keeps highest confidence", () => {
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+        confidence: "low",
+      }))],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+        confidence: "high",
+      }))],
+    });
+
+    expect(merged.confidence).toBe("high");
+  });
+
+  it("merge recalculates active when recurrenceCount is at least 2", () => {
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+        confidence: "medium",
+      }))],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta", {
+        confidence: "medium",
+      }))],
+    });
+
+    expect(merged.status).toBe("active");
+  });
+
+  it("merge keeps oldest firstSeenAt", () => {
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"), "2026-05-17T00:00:00.000Z")],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"), "2026-05-18T00:00:00.000Z")],
+    });
+
+    expect(merged.firstSeenAt).toBe("2026-05-17T00:00:00.000Z");
+  });
+
+  it("merge uses newest lastSeenAt", () => {
+    const [merged] = mergeVideoNarrativeCreatorProfileSignals({
+      existingSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"), "2026-05-17T00:00:00.000Z")],
+      newSignals: [profileSignal(diagnosisSignal("content_goal", "validar pauta"), "2026-05-18T00:00:00.000Z")],
+    });
+
+    expect(merged.lastSeenAt).toBe("2026-05-18T00:00:00.000Z");
+  });
+
+  it("buildVideoNarrativeCreatorProfile creates profile from newSignals", () => {
+    const profile = buildVideoNarrativeCreatorProfile({
+      creatorId: "creator-1",
+      newSignals: [diagnosisSignal("content_goal", "validar pauta")],
+      createdAt: "2026-05-17T00:00:00.000Z",
+    });
+
+    expect(profile.creatorId).toBe("creator-1");
+    expect(profile.signals).toHaveLength(1);
+  });
+
+  it("buildVideoNarrativeCreatorProfile merges with existingProfile", () => {
+    const existingProfile = buildVideoNarrativeCreatorProfile({
+      creatorId: "creator-1",
+      newSignals: [diagnosisSignal("content_goal", "validar pauta")],
+      createdAt: "2026-05-17T00:00:00.000Z",
+    });
+    const profile = buildVideoNarrativeCreatorProfile({
+      existingProfile,
+      newSignals: [diagnosisSignal("content_goal", "validar pauta")],
+      createdAt: "2026-05-18T00:00:00.000Z",
+    });
+
+    expect(profile.signals).toHaveLength(1);
+    expect(profile.signals[0].recurrenceCount).toBe(2);
+  });
+
+  it("summary fills strongestContentGoals", () => {
+    const summary = summarizeVideoNarrativeCreatorProfile([
+      profileSignal(diagnosisSignal("content_goal", "validar pauta")),
+    ]);
+
+    expect(summary.strongestContentGoals).toContain("validar pauta");
+  });
+
+  it("summary fills recurringPainPoints", () => {
+    const summary = summarizeVideoNarrativeCreatorProfile([
+      profileSignal(diagnosisSignal("recurring_pain", "melhorar gancho")),
+    ]);
+
+    expect(summary.recurringPainPoints).toContain("melhorar gancho");
+  });
+
+  it("summary fills preferredFormats", () => {
+    const summary = summarizeVideoNarrativeCreatorProfile([
+      profileSignal(diagnosisSignal("format_preference", "reels direto")),
+    ]);
+
+    expect(summary.preferredFormats).toContain("reels direto");
+  });
+
+  it("summary fills preferredHookDirections", () => {
+    const summary = summarizeVideoNarrativeCreatorProfile([
+      profileSignal(diagnosisSignal("hook_preference", "mais direta")),
+    ]);
+
+    expect(summary.preferredHookDirections).toContain("mais direta");
+  });
+
+  it("summary fills preferredBrandTerritories", () => {
+    const summary = summarizeVideoNarrativeCreatorProfile([
+      profileSignal(diagnosisSignal("brand_territory", "beleza")),
+    ]);
+
+    expect(summary.preferredBrandTerritories).toContain("beleza");
+  });
+
+  it("summary limits arrays to 5 items", () => {
+    const signals = Array.from({ length: 7 }, (_, index) =>
+      profileSignal(diagnosisSignal("content_goal", `objetivo ${index}`)),
+    );
+
+    expect(summarizeVideoNarrativeCreatorProfile(signals).strongestContentGoals).toHaveLength(5);
+  });
+
+  it("hasUsefulVideoNarrativeCreatorProfile returns false for empty profile", () => {
+    expect(hasUsefulVideoNarrativeCreatorProfile(createEmptyVideoNarrativeCreatorProfile())).toBe(false);
+  });
+
+  it("hasUsefulVideoNarrativeCreatorProfile returns true with useful signals", () => {
+    const profile = buildVideoNarrativeCreatorProfile({
+      newSignals: [diagnosisSignal("content_goal", "validar pauta")],
+    });
+
+    expect(hasUsefulVideoNarrativeCreatorProfile(profile)).toBe(true);
+  });
+
+  it("sanitizeVideoNarrativeCreatorProfileText redacts AIza and env API keys", () => {
+    expect(sanitizeVideoNarrativeCreatorProfileText("AIza1234567890abcdef")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeCreatorProfileText("GEMINI_API_KEY=abc")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeCreatorProfileText("GOOGLE_GENAI_API_KEY=abc")).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeCreatorProfileText redacts long base64", () => {
+    expect(sanitizeVideoNarrativeCreatorProfileText("A".repeat(140))).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeCreatorProfileText redacts signed URL token", () => {
+    expect(sanitizeVideoNarrativeCreatorProfileText("https://example.com/video.mp4?token=abc")).toBe("[redigido]");
+  });
+
+  it("keeps safe language across profile, signals, evidence and summary", () => {
+    const profile = buildVideoNarrativeCreatorProfile({
+      newSignals: [
+        diagnosisSignal("content_goal", "viralizar garantido", {
+          evidence: "resposta correta",
+        }),
+      ],
+    });
+    const content = JSON.stringify(profile).toLowerCase();
+
+    FORBIDDEN_TERMS.forEach((term) => {
+      expect(content).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("does not import forbidden runtime integrations", () => {
+    const source = require("fs").readFileSync(
+      "src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.ts",
+      "utf8",
+    ) as string;
+    const forbidden = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "route",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbidden.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.ts
@@ -1,0 +1,432 @@
+import {
+  sanitizeVideoNarrativeDiagnosisText,
+  type VideoNarrativeDiagnosisCreatorSignal,
+  type VideoNarrativeDiagnosisCreatorSignalType,
+} from "./videoNarrativeDiagnosisLearningModel";
+
+export type VideoNarrativeCreatorProfileSignalStatus =
+  | "active"
+  | "emerging"
+  | "weak"
+  | "archived";
+
+export type VideoNarrativeCreatorProfileSignalStrength = "low" | "medium" | "high";
+
+export type VideoNarrativeCreatorProfileSignalCategory =
+  | "content_goals"
+  | "creative_preferences"
+  | "commercial_preferences"
+  | "recurring_pains"
+  | "hook_preferences"
+  | "format_preferences"
+  | "brand_territories"
+  | "collab_preferences"
+  | "production_constraints"
+  | "audience_relationship"
+  | "positioning_signals"
+  | "instagram_patterns"
+  | "unknown";
+
+export type VideoNarrativeCreatorProfileSignalSource =
+  | "creator_question"
+  | "quiz_answer"
+  | "video_analysis"
+  | "diagnosis"
+  | "instagram_context"
+  | "manual_review"
+  | "historical_diagnosis";
+
+export interface VideoNarrativeCreatorProfileSignalEvidence {
+  source: VideoNarrativeCreatorProfileSignalSource;
+  value: string;
+  diagnosisId?: string | null;
+  questionId?: string | null;
+  createdAt?: string | null;
+}
+
+export interface VideoNarrativeCreatorProfileSignal {
+  id: string;
+  category: VideoNarrativeCreatorProfileSignalCategory;
+  type: string;
+  value: string;
+  strength: VideoNarrativeCreatorProfileSignalStrength;
+  status: VideoNarrativeCreatorProfileSignalStatus;
+  confidence: "low" | "medium" | "high";
+  recurrenceCount: number;
+  evidence: VideoNarrativeCreatorProfileSignalEvidence[];
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+  shouldPersistLater: boolean;
+}
+
+export interface VideoNarrativeCreatorProfileSummary {
+  strongestContentGoals: string[];
+  recurringPainPoints: string[];
+  preferredFormats: string[];
+  preferredHookDirections: string[];
+  preferredBrandTerritories: string[];
+  commercialPreferences: string[];
+  productionConstraints: string[];
+  audienceRelationshipSignals: string[];
+  positioningSignals: string[];
+}
+
+export interface VideoNarrativeCreatorProfile {
+  creatorId: string | null;
+  signals: VideoNarrativeCreatorProfileSignal[];
+  summary: VideoNarrativeCreatorProfileSummary;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface VideoNarrativeCreatorProfileBuildInput {
+  creatorId?: string | null;
+  existingProfile?: VideoNarrativeCreatorProfile | null;
+  newSignals: VideoNarrativeDiagnosisCreatorSignal[];
+  diagnosisId?: string | null;
+  createdAt?: string | null;
+}
+
+const CATEGORY_BY_DIAGNOSIS_SIGNAL_TYPE: Record<
+  VideoNarrativeDiagnosisCreatorSignalType,
+  VideoNarrativeCreatorProfileSignalCategory
+> = {
+  content_goal: "content_goals",
+  creative_preference: "creative_preferences",
+  commercial_preference: "commercial_preferences",
+  recurring_pain: "recurring_pains",
+  hook_preference: "hook_preferences",
+  format_preference: "format_preferences",
+  brand_territory: "brand_territories",
+  collab_preference: "collab_preferences",
+  production_constraint: "production_constraints",
+  audience_relationship: "audience_relationship",
+  positioning_signal: "positioning_signals",
+  unknown: "unknown",
+};
+
+const PROFILE_SOURCE_BY_DIAGNOSIS_SOURCE: Record<
+  VideoNarrativeDiagnosisCreatorSignal["source"],
+  VideoNarrativeCreatorProfileSignalSource
+> = {
+  creator_question: "creator_question",
+  quiz_answer: "quiz_answer",
+  video_analysis: "video_analysis",
+  seed: "diagnosis",
+  instagram_context: "instagram_context",
+  diagnosis_inference: "diagnosis",
+};
+
+const CONFIDENCE_RANK: Record<"low" | "medium" | "high", number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+const STRENGTH_RANK: Record<VideoNarrativeCreatorProfileSignalStrength, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+const BLOCKED_TERMS = [
+  "viralizar garantido",
+  "treinado permanentemente",
+  "resposta correta",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "venceu",
+  "perdeu",
+];
+
+function emptySummary(): VideoNarrativeCreatorProfileSummary {
+  return {
+    strongestContentGoals: [],
+    recurringPainPoints: [],
+    preferredFormats: [],
+    preferredHookDirections: [],
+    preferredBrandTerritories: [],
+    commercialPreferences: [],
+    productionConstraints: [],
+    audienceRelationshipSignals: [],
+    positioningSignals: [],
+  };
+}
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function normalize(value: string): string {
+  return sanitizeVideoNarrativeCreatorProfileText(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function pickHigherConfidence(
+  left: "low" | "medium" | "high",
+  right: "low" | "medium" | "high",
+): "low" | "medium" | "high" {
+  return CONFIDENCE_RANK[right] > CONFIDENCE_RANK[left] ? right : left;
+}
+
+function strengthFromConfidence(confidence: "low" | "medium" | "high"): VideoNarrativeCreatorProfileSignalStrength {
+  if (confidence === "high") return "high";
+  if (confidence === "medium") return "medium";
+  return "low";
+}
+
+function statusFromSignal(params: {
+  confidence: "low" | "medium" | "high";
+  recurrenceCount: number;
+}): VideoNarrativeCreatorProfileSignalStatus {
+  if (params.confidence === "low") return "weak";
+  if (params.recurrenceCount >= 2) return "active";
+  return "emerging";
+}
+
+function mergeDates(
+  left: string | null,
+  right: string | null,
+  direction: "oldest" | "newest",
+): string | null {
+  if (!left) return right;
+  if (!right) return left;
+  return direction === "oldest"
+    ? (left <= right ? left : right)
+    : (left >= right ? left : right);
+}
+
+function evidenceKey(evidence: VideoNarrativeCreatorProfileSignalEvidence): string {
+  return [
+    evidence.source,
+    evidence.value,
+    evidence.diagnosisId ?? "",
+    evidence.questionId ?? "",
+    evidence.createdAt ?? "",
+  ].join("|");
+}
+
+function dedupeEvidence(
+  evidence: VideoNarrativeCreatorProfileSignalEvidence[],
+): VideoNarrativeCreatorProfileSignalEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = evidenceKey(item);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function mergeKey(signal: VideoNarrativeCreatorProfileSignal): string {
+  return [
+    signal.category,
+    normalize(signal.type),
+    normalize(signal.value),
+  ].join("|");
+}
+
+function sortSignalsForSummary(
+  signals: VideoNarrativeCreatorProfileSignal[],
+): VideoNarrativeCreatorProfileSignal[] {
+  return [...signals].sort((left, right) => {
+    const strengthDelta = STRENGTH_RANK[right.strength] - STRENGTH_RANK[left.strength];
+    if (strengthDelta !== 0) return strengthDelta;
+    return right.recurrenceCount - left.recurrenceCount;
+  });
+}
+
+function valuesForCategory(
+  signals: VideoNarrativeCreatorProfileSignal[],
+  category: VideoNarrativeCreatorProfileSignalCategory,
+): string[] {
+  return sortSignalsForSummary(signals)
+    .filter((signal) =>
+      signal.category === category &&
+      (signal.status === "active" || signal.status === "emerging") &&
+      hasText(signal.value),
+    )
+    .map((signal) => signal.value)
+    .slice(0, 5);
+}
+
+export function createEmptyVideoNarrativeCreatorProfile(params?: {
+  creatorId?: string | null;
+  createdAt?: string | null;
+}): VideoNarrativeCreatorProfile {
+  return {
+    creatorId: params?.creatorId ?? null,
+    signals: [],
+    summary: emptySummary(),
+    createdAt: params?.createdAt ?? null,
+    updatedAt: params?.createdAt ?? null,
+  };
+}
+
+export function sanitizeVideoNarrativeCreatorProfileText(value: string): string {
+  let sanitized = sanitizeVideoNarrativeDiagnosisText(value);
+  sanitized = sanitized.replace(/\bAIza[0-9A-Za-z_-]{8,}/g, "[redigido]");
+  sanitized = sanitized.replace(/\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+/g, "[redigido]");
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/]{120,}={0,2}\b/g, "[redigido]");
+  sanitized = sanitized.replace(/\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi, "[redigido]");
+
+  BLOCKED_TERMS.forEach((term) => {
+    sanitized = sanitized.replace(new RegExp(term.replace(/\s+/g, "\\s+"), "gi"), "[redigido]");
+  });
+
+  return sanitized.trim();
+}
+
+export function mapDiagnosisSignalToCreatorProfileSignal(params: {
+  signal: VideoNarrativeDiagnosisCreatorSignal;
+  diagnosisId?: string | null;
+  createdAt?: string | null;
+}): VideoNarrativeCreatorProfileSignal {
+  const category = CATEGORY_BY_DIAGNOSIS_SIGNAL_TYPE[params.signal.type] ?? "unknown";
+  const value = sanitizeVideoNarrativeCreatorProfileText(params.signal.value);
+  const type = sanitizeVideoNarrativeCreatorProfileText(params.signal.type);
+  const confidence = params.signal.confidence;
+  const recurrenceCount = 1;
+  const createdAt = params.createdAt ?? null;
+  const source = PROFILE_SOURCE_BY_DIAGNOSIS_SOURCE[params.signal.source] ?? "diagnosis";
+  const evidenceValue = sanitizeVideoNarrativeCreatorProfileText(params.signal.evidence ?? params.signal.value);
+
+  return {
+    id: `creator-profile-${category}-${normalize(type)}-${normalize(value) || "signal"}`,
+    category,
+    type,
+    value,
+    strength: strengthFromConfidence(confidence),
+    status: statusFromSignal({ confidence, recurrenceCount }),
+    confidence,
+    recurrenceCount,
+    evidence: evidenceValue
+      ? [{
+          source,
+          value: evidenceValue,
+          diagnosisId: params.diagnosisId ?? null,
+          createdAt,
+        }]
+      : [],
+    firstSeenAt: createdAt,
+    lastSeenAt: createdAt,
+    shouldPersistLater: params.signal.shouldPersistLater,
+  };
+}
+
+export function mergeVideoNarrativeCreatorProfileSignals(params: {
+  existingSignals: VideoNarrativeCreatorProfileSignal[];
+  newSignals: VideoNarrativeCreatorProfileSignal[];
+}): VideoNarrativeCreatorProfileSignal[] {
+  const merged = new Map<string, VideoNarrativeCreatorProfileSignal>();
+
+  [...params.existingSignals, ...params.newSignals].forEach((signal) => {
+    const sanitizedSignal: VideoNarrativeCreatorProfileSignal = {
+      ...signal,
+      type: sanitizeVideoNarrativeCreatorProfileText(signal.type),
+      value: sanitizeVideoNarrativeCreatorProfileText(signal.value),
+      evidence: signal.evidence.map((item) => ({
+        ...item,
+        value: sanitizeVideoNarrativeCreatorProfileText(item.value),
+      })),
+    };
+    const key = mergeKey(sanitizedSignal);
+    const existing = merged.get(key);
+
+    if (!existing) {
+      const confidence = sanitizedSignal.confidence;
+      const recurrenceCount = Math.max(1, sanitizedSignal.recurrenceCount);
+      merged.set(key, {
+        ...sanitizedSignal,
+        confidence,
+        recurrenceCount,
+        strength: strengthFromConfidence(confidence),
+        status: statusFromSignal({ confidence, recurrenceCount }),
+        evidence: dedupeEvidence(sanitizedSignal.evidence),
+      });
+      return;
+    }
+
+    const confidence = pickHigherConfidence(existing.confidence, sanitizedSignal.confidence);
+    const recurrenceCount = existing.recurrenceCount + Math.max(1, sanitizedSignal.recurrenceCount);
+    merged.set(key, {
+      ...existing,
+      confidence,
+      recurrenceCount,
+      strength: strengthFromConfidence(confidence),
+      status: statusFromSignal({ confidence, recurrenceCount }),
+      evidence: dedupeEvidence([...existing.evidence, ...sanitizedSignal.evidence]),
+      firstSeenAt: mergeDates(existing.firstSeenAt, sanitizedSignal.firstSeenAt, "oldest"),
+      lastSeenAt: mergeDates(existing.lastSeenAt, sanitizedSignal.lastSeenAt, "newest"),
+      shouldPersistLater: existing.shouldPersistLater || sanitizedSignal.shouldPersistLater,
+    });
+  });
+
+  return Array.from(merged.values());
+}
+
+export function summarizeVideoNarrativeCreatorProfile(
+  signals: VideoNarrativeCreatorProfileSignal[],
+): VideoNarrativeCreatorProfileSummary {
+  return {
+    strongestContentGoals: valuesForCategory(signals, "content_goals"),
+    recurringPainPoints: valuesForCategory(signals, "recurring_pains"),
+    preferredFormats: valuesForCategory(signals, "format_preferences"),
+    preferredHookDirections: valuesForCategory(signals, "hook_preferences"),
+    preferredBrandTerritories: valuesForCategory(signals, "brand_territories"),
+    commercialPreferences: valuesForCategory(signals, "commercial_preferences"),
+    productionConstraints: valuesForCategory(signals, "production_constraints"),
+    audienceRelationshipSignals: valuesForCategory(signals, "audience_relationship"),
+    positioningSignals: valuesForCategory(signals, "positioning_signals"),
+  };
+}
+
+export function buildVideoNarrativeCreatorProfile(
+  input: VideoNarrativeCreatorProfileBuildInput,
+): VideoNarrativeCreatorProfile {
+  const existingProfile =
+    input.existingProfile ??
+    createEmptyVideoNarrativeCreatorProfile({
+      creatorId: input.creatorId ?? null,
+      createdAt: input.createdAt ?? null,
+    });
+  const mappedSignals = input.newSignals.map((signal) =>
+    mapDiagnosisSignalToCreatorProfileSignal({
+      signal,
+      diagnosisId: input.diagnosisId ?? null,
+      createdAt: input.createdAt ?? null,
+    }),
+  );
+  const signals = mergeVideoNarrativeCreatorProfileSignals({
+    existingSignals: existingProfile.signals,
+    newSignals: mappedSignals,
+  });
+
+  return {
+    creatorId: input.creatorId ?? existingProfile.creatorId ?? null,
+    signals,
+    summary: summarizeVideoNarrativeCreatorProfile(signals),
+    createdAt: existingProfile.createdAt ?? input.createdAt ?? null,
+    updatedAt: input.createdAt ?? existingProfile.updatedAt ?? null,
+  };
+}
+
+export function hasUsefulVideoNarrativeCreatorProfile(
+  profile: VideoNarrativeCreatorProfile,
+): boolean {
+  return profile.signals.some((signal) =>
+    hasText(signal.value) &&
+    signal.status !== "archived" &&
+    signal.status !== "weak",
+  );
+}


### PR DESCRIPTION
Stacked sobre #827.

## Summary
- Adds pure Creator Narrative Profile contract for accumulated video narrative signals.
- Maps diagnosis creatorSignals into profile categories, strength, status, recurrence, and evidence.
- Merges repeated signals by category/type/value and builds a limited profile summary.
- Updates MM31 docs/readiness notes.

## Scope
- No UI.
- No endpoint route changes.
- No upload/storage real.
- No database/table, Prisma, or persistence.
- No persisted answers/signals.
- No Gemini/OpenAI/fetch/network calls.
- No real Instagram integration.
- No Stripe/billing/cobranca.
- No BoardShell/PostCreationFunnelState changes.

## Validation
- npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts
- npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisQuizBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts
- videoUpload/preview/guards regression block
- NSE/Adaptive V2 regression block
- npm run typecheck
- git diff --check
- npm run build