### PR TITLE
feat: add video narrative app first flow state

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -86,6 +86,8 @@ Já existe:
 - perguntas de MM30 têm `learningSignalType` e respostas ainda não persistem;
 - creator narrative profile contract foi criado em MM31 para agregar sinais sem banco ou persistência;
 - `shouldPersistLater` segue apenas metadado e persistência continua bloqueada;
+- app-first flow state model foi criado em MM32 para modelar jornada, copy e prompts antes da UI;
+- prompts de upgrade e Instagram foram definidos em MM32 sem conectar billing ou Instagram real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 
@@ -145,6 +147,7 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - creatorSignals derivados de quiz/pergunta/análise/seed/Instagram futuro, sempre sem persistência automática;
 - quiz builder puro orientado por lacunas do diagnóstico, sem UI e sem persistir respostas;
 - contrato de perfil narrativo do criador com merge/summary em memória, sem banco;
+- modelo puro de fluxo app-first com estados, CTAs e prompts, sem UI;
 - sem expor para usuário.
 
 ## Frase Norte

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -703,6 +703,29 @@ O que não faz:
 - não cria UI, endpoint, upload real, storage real ou analytics real;
 - não transforma sinais em verdade permanente automaticamente.
 
+### MM32 — App-first flow state model
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeAppFlowState.ts`
+- `videoNarrativeAppFlowState.test.ts`
+
+O que faz:
+
+- define estados puros da jornada app-first de análise narrativa de vídeo;
+- modela transições, progresso, copies, loading messages e CTAs;
+- define prompts de upgrade e otimização com Instagram a partir do contexto;
+- permite carregar diagnóstico, quiz e perfil como contexto futuro sem persistir nada.
+
+O que não faz:
+
+- não cria UI, upload real, storage real, banco/tabela, analytics real ou persistência;
+- não altera endpoint real nem conecta BoardShell;
+- não conecta Instagram real nem usa dados reais de Instagram;
+- não altera navegação/menu ou `PostCreationFunnelState`.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -238,8 +238,9 @@ Exemplos:
 28. MM29 — Diagnosis and Creator Learning Model. Define diagnóstico estratégico e sinais de aprendizado do criador, sem UI, persistência ou Instagram real.
 29. MM30 — Diagnosis-driven quiz builder. Gera perguntas por lacunas do diagnóstico e opções com sinais de aprendizado futuro.
 30. MM31 — Creator Narrative Profile contract. Organiza sinais acumulados do criador sem persistência, banco ou Instagram real.
-31. Teste real manual quando houver quota/billing disponível.
-32. Integração experimental futura no Board de Criação.
+31. MM32 — App-first flow state model. Define estados, transições, copy e prompts antes de qualquer UI real.
+32. Teste real manual quando houver quota/billing disponível.
+33. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -294,6 +295,8 @@ MM29 adiciona `VideoNarrativeStrategicDiagnosis` e `VideoNarrativeDiagnosisCreat
 MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` para gerar perguntas adaptativas a partir das lacunas do diagnóstico. O quiz existe para completar o diagnóstico daquele vídeo e capturar respostas com `learningSignalType`/`learningSignalValue`, ainda sem UI, persistência, endpoint real ou integração com Instagram real.
 
 MM31 adiciona `VideoNarrativeCreatorProfile` como contrato puro para agregar sinais narrativos ao longo do tempo. O perfil futuro pode melhorar diagnósticos recorrentes, mas nesta fase não há banco, persistência, Instagram real ou sinal transformado em verdade permanente automaticamente.
+
+MM32 adiciona `VideoNarrativeAppFlowState` para modelar a experiência app-first antes da UI. A jornada cobre upload, análise, pergunta central, quiz, diagnóstico, CTAs e prompts de upgrade/Instagram sem alterar endpoint, criar upload real ou persistir respostas/sinais.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -105,6 +105,8 @@ MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` como camada futura depois do di
 
 MM31 adiciona `VideoNarrativeCreatorProfile` como contrato futuro para agregar sinais vindos de diagnóstico e quiz. O endpoint não persiste nada nesta fase, e `shouldPersistLater` continua apenas metadado para decisão posterior.
 
+MM32 adiciona `VideoNarrativeAppFlowState` como modelo futuro de jornada app-first. O endpoint/mock pode alimentar essa jornada com análise, safe response, diagnóstico, quiz e perfil, mas a rota não foi alterada nesta fase.
+
 ## Status Futuros
 
 - `disabled`;
@@ -184,6 +186,8 @@ MM31 adiciona `VideoNarrativeCreatorProfile` como contrato futuro para agregar s
 - `buildVideoNarrativeDiagnosisQuiz`;
 - `VideoNarrativeCreatorProfile`;
 - `buildVideoNarrativeCreatorProfile`;
+- `VideoNarrativeAppFlowState`;
+- `transitionVideoNarrativeAppFlowState`;
 - `VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED`;
 - `VideoNarrativeAnalysis`;
 - `buildPostCreationVideoSeedFromAnalysis`;
@@ -229,6 +233,7 @@ Só implementar depois que:
 - MM29: diagnosis and creator learning model;
 - MM30: diagnosis-driven quiz builder;
 - MM31: creator narrative profile contract;
-- MM32: endpoint real somente depois de billing/teste real;
-- MM33: preview interno com chamada real;
-- MM34: integração experimental no board.
+- MM32: app-first flow state model;
+- MM33: endpoint real somente depois de billing/teste real;
+- MM34: preview interno com chamada real;
+- MM35: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts
@@ -1,0 +1,372 @@
+import {
+  buildVideoNarrativeAppFlowState,
+  createInitialVideoNarrativeAppFlowState,
+  getVideoNarrativeAppFlowNextEvents,
+  getVideoNarrativeAppFlowProgress,
+  sanitizeVideoNarrativeAppFlowText,
+  shouldShowVideoNarrativeInstagramPrompt,
+  shouldShowVideoNarrativeUpgradePrompt,
+  transitionVideoNarrativeAppFlowState,
+  type VideoNarrativeAppFlowContext,
+  type VideoNarrativeAppFlowStage,
+} from "./videoNarrativeAppFlowState";
+
+const FORBIDDEN_TERMS = [
+  "garantido",
+  "certeza",
+  "comprovado",
+  "viralizar garantido",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "resposta correta",
+  "venceu",
+  "perdeu",
+  "treinado permanentemente",
+];
+
+function context(overrides: Partial<VideoNarrativeAppFlowContext> = {}): VideoNarrativeAppFlowContext {
+  return {
+    accessLevel: "free",
+    hasVideo: false,
+    hasVideoAnalysis: false,
+    hasCreatorGoal: false,
+    hasQuiz: false,
+    quizCompleted: false,
+    hasDiagnosis: false,
+    hasUsefulDiagnosis: false,
+    hasCreatorProfile: false,
+    instagramConnected: false,
+    hasRemainingFreeCredit: true,
+    isSubscriber: false,
+    lockedSectionsCount: 0,
+    errorCode: null,
+    ...overrides,
+  };
+}
+
+function flowTo(stage: VideoNarrativeAppFlowStage, ctx = context()) {
+  return buildVideoNarrativeAppFlowState({ stage, context: ctx, updatedAt: "2026-05-18T00:00:00.000Z" });
+}
+
+describe("videoNarrativeAppFlowState", () => {
+  it("starts initial state at welcome", () => {
+    expect(createInitialVideoNarrativeAppFlowState().stage).toBe("welcome");
+  });
+
+  it("initial state has start CTA", () => {
+    const state = createInitialVideoNarrativeAppFlowState();
+
+    expect(state.copy.ctas.some((cta) => cta.label === "Começar")).toBe(true);
+  });
+
+  it("transitions start to upload_video", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: createInitialVideoNarrativeAppFlowState({ accessLevel: "free", hasRemainingFreeCredit: true }),
+      event: "start",
+    });
+
+    expect(state.stage).toBe("upload_video");
+  });
+
+  it("upload_video has upload CTA", () => {
+    expect(flowTo("upload_video").copy.ctas.some((cta) => cta.label === "Subir vídeo")).toBe(true);
+  });
+
+  it("video_selected with credit/free/subscriber goes to analyzing_video", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("upload_video", context({ accessLevel: "free", hasRemainingFreeCredit: true })),
+      event: "video_selected",
+    });
+
+    expect(state.stage).toBe("analyzing_video");
+    expect(state.context.hasVideo).toBe(true);
+  });
+
+  it("video_selected without credit and subscriber goes to upgrade_prompt", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("upload_video", context({
+        accessLevel: "guest",
+        hasRemainingFreeCredit: false,
+        isSubscriber: false,
+      })),
+      event: "video_selected",
+    });
+
+    expect(state.stage).toBe("upgrade_prompt");
+  });
+
+  it("analyzing_video includes analysis loading messages", () => {
+    const messages = flowTo("analyzing_video").copy.loadingMessages;
+
+    expect(messages).toContain("Identificando gancho");
+    expect(messages).toContain("Mapeando narrativa");
+  });
+
+  it("video_analysis_ready goes to asking_creator_goal", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("analyzing_video"),
+      event: "video_analysis_ready",
+    });
+
+    expect(state.stage).toBe("asking_creator_goal");
+    expect(state.context.hasVideoAnalysis).toBe(true);
+  });
+
+  it("asking_creator_goal has central question copy", () => {
+    expect(flowTo("asking_creator_goal").copy.title).toBe("O que você quer entender sobre esse vídeo?");
+  });
+
+  it("creator_goal_submitted goes to understanding_goal and marks creator goal", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("asking_creator_goal"),
+      event: "creator_goal_submitted",
+    });
+
+    expect(state.stage).toBe("understanding_goal");
+    expect(state.context.hasCreatorGoal).toBe(true);
+  });
+
+  it("understanding_goal includes goal loading messages", () => {
+    const messages = flowTo("understanding_goal").copy.loadingMessages;
+
+    expect(messages).toContain("Cruzando seu objetivo com a narrativa do vídeo");
+    expect(messages).toContain("Preparando perguntas estratégicas");
+  });
+
+  it("creator_goal_understood goes to adaptive_quiz", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("understanding_goal"),
+      event: "creator_goal_understood",
+    });
+
+    expect(state.stage).toBe("adaptive_quiz");
+  });
+
+  it("adaptive_quiz copy explains answers improve diagnosis", () => {
+    expect(flowTo("adaptive_quiz").copy.subtitle).toContain("diagnóstico mais preciso");
+  });
+
+  it("quiz_completed goes to building_diagnosis and marks quizCompleted", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("adaptive_quiz"),
+      event: "quiz_completed",
+    });
+
+    expect(state.stage).toBe("building_diagnosis");
+    expect(state.context.quizCompleted).toBe(true);
+  });
+
+  it("building_diagnosis includes diagnosis loading messages", () => {
+    const messages = flowTo("building_diagnosis").copy.loadingMessages;
+
+    expect(messages).toContain("Organizando narrativa, intenção e oportunidade");
+    expect(messages).toContain("Preparando próximos passos");
+  });
+
+  it("diagnosis_ready event goes to diagnosis_ready and marks diagnosis", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("building_diagnosis"),
+      event: "diagnosis_ready",
+    });
+
+    expect(state.stage).toBe("diagnosis_ready");
+    expect(state.context.hasDiagnosis).toBe(true);
+  });
+
+  it("diagnosis_ready free with locked sections includes upgrade_requested", () => {
+    const state = flowTo("diagnosis_ready", context({
+      accessLevel: "free",
+      hasDiagnosis: true,
+      hasUsefulDiagnosis: true,
+      lockedSectionsCount: 2,
+    }));
+
+    expect(state.nextEvents).toContain("upgrade_requested");
+  });
+
+  it("diagnosis_ready without Instagram includes instagram_connect_requested", () => {
+    const state = flowTo("diagnosis_ready", context({
+      hasDiagnosis: true,
+      hasUsefulDiagnosis: true,
+      instagramConnected: false,
+    }));
+
+    expect(state.nextEvents).toContain("instagram_connect_requested");
+  });
+
+  it("completed event goes to completed", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("diagnosis_ready"),
+      event: "completed",
+    });
+
+    expect(state.stage).toBe("completed");
+  });
+
+  it("reset returns to welcome preserving basic access context", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("diagnosis_ready", context({
+        accessLevel: "premium",
+        isSubscriber: true,
+        instagramConnected: true,
+      })),
+      event: "reset",
+    });
+
+    expect(state.stage).toBe("welcome");
+    expect(state.context.accessLevel).toBe("premium");
+    expect(state.context.isSubscriber).toBe(true);
+    expect(state.context.instagramConnected).toBe(true);
+  });
+
+  it("error event goes to error with errorCode", () => {
+    const state = transitionVideoNarrativeAppFlowState({
+      state: flowTo("upload_video"),
+      event: "error",
+      patch: { errorCode: "AIza1234567890abcdef" },
+    });
+
+    expect(state.stage).toBe("error");
+    expect(state.context.errorCode).toBe("[redigido]");
+  });
+
+  it("blocked event goes to blocked", () => {
+    expect(transitionVideoNarrativeAppFlowState({
+      state: flowTo("upload_video"),
+      event: "blocked",
+    }).stage).toBe("blocked");
+  });
+
+  it("shouldShowVideoNarrativeUpgradePrompt returns true for free with locked sections", () => {
+    expect(shouldShowVideoNarrativeUpgradePrompt(context({
+      accessLevel: "free",
+      lockedSectionsCount: 1,
+    }))).toBe(true);
+  });
+
+  it("shouldShowVideoNarrativeUpgradePrompt returns false for premium subscriber without locked sections", () => {
+    expect(shouldShowVideoNarrativeUpgradePrompt(context({
+      accessLevel: "premium",
+      isSubscriber: true,
+      lockedSectionsCount: 0,
+    }))).toBe(false);
+  });
+
+  it("shouldShowVideoNarrativeInstagramPrompt returns true with useful diagnosis and disconnected Instagram", () => {
+    expect(shouldShowVideoNarrativeInstagramPrompt(context({
+      accessLevel: "premium",
+      hasDiagnosis: true,
+      hasUsefulDiagnosis: true,
+      instagramConnected: false,
+    }))).toBe(true);
+  });
+
+  it("shouldShowVideoNarrativeInstagramPrompt returns false when Instagram connected", () => {
+    expect(shouldShowVideoNarrativeInstagramPrompt(context({
+      accessLevel: "premium",
+      hasDiagnosis: true,
+      hasUsefulDiagnosis: true,
+      instagramConnected: true,
+    }))).toBe(false);
+  });
+
+  it("progress maps upload, analysis, goal, quiz, diagnosis and actions", () => {
+    expect(getVideoNarrativeAppFlowProgress("upload_video").currentStep).toBe(1);
+    expect(getVideoNarrativeAppFlowProgress("analyzing_video").currentStep).toBe(2);
+    expect(getVideoNarrativeAppFlowProgress("asking_creator_goal").currentStep).toBe(3);
+    expect(getVideoNarrativeAppFlowProgress("adaptive_quiz").currentStep).toBe(4);
+    expect(getVideoNarrativeAppFlowProgress("diagnosis_ready").currentStep).toBe(5);
+    expect(getVideoNarrativeAppFlowProgress("completed").currentStep).toBe(6);
+  });
+
+  it("getVideoNarrativeAppFlowNextEvents returns valid events by stage", () => {
+    expect(getVideoNarrativeAppFlowNextEvents("welcome", context())).toContain("start");
+    expect(getVideoNarrativeAppFlowNextEvents("upload_video", context())).toContain("video_selected");
+    expect(getVideoNarrativeAppFlowNextEvents("adaptive_quiz", context())).toContain("quiz_completed");
+  });
+
+  it("buildVideoNarrativeAppFlowState sanitizes copy", () => {
+    const state = buildVideoNarrativeAppFlowState({
+      stage: "error",
+      context: context({ errorCode: "GEMINI_API_KEY=abc" }),
+    });
+
+    expect(JSON.stringify(state)).not.toContain("GEMINI_API_KEY");
+  });
+
+  it("sanitizeVideoNarrativeAppFlowText redacts AIza and env API keys", () => {
+    expect(sanitizeVideoNarrativeAppFlowText("AIza1234567890abcdef")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeAppFlowText("GEMINI_API_KEY=abc")).toBe("[redigido]");
+    expect(sanitizeVideoNarrativeAppFlowText("GOOGLE_GENAI_API_KEY=abc")).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeAppFlowText redacts long base64", () => {
+    expect(sanitizeVideoNarrativeAppFlowText("A".repeat(140))).toBe("[redigido]");
+  });
+
+  it("sanitizeVideoNarrativeAppFlowText redacts signed URL token", () => {
+    expect(sanitizeVideoNarrativeAppFlowText("https://example.com/video.mp4?token=abc")).toBe("[redigido]");
+  });
+
+  it("keeps safe language across copy, helpers, CTAs and loading messages", () => {
+    const stages: VideoNarrativeAppFlowStage[] = [
+      "welcome",
+      "upload_video",
+      "analyzing_video",
+      "asking_creator_goal",
+      "understanding_goal",
+      "adaptive_quiz",
+      "building_diagnosis",
+      "diagnosis_ready",
+      "upgrade_prompt",
+      "instagram_optimization_prompt",
+      "completed",
+      "blocked",
+      "error",
+    ];
+    const content = JSON.stringify(stages.map((stage) => flowTo(stage, context({
+      hasDiagnosis: true,
+      hasUsefulDiagnosis: true,
+      lockedSectionsCount: 2,
+    })).copy)).toLowerCase();
+
+    FORBIDDEN_TERMS.forEach((term) => {
+      expect(content).not.toMatch(new RegExp(`(^|\\W)${term.replace(/\s+/g, "\\s+")}(\\W|$)`, "i"));
+    });
+  });
+
+  it("does not import forbidden runtime integrations", () => {
+    const source = require("fs").readFileSync(
+      "src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.ts",
+      "utf8",
+    ) as string;
+    const forbidden = [
+      "React",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "componentes",
+      "hooks",
+      "route",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "UI",
+      "Stripe",
+      "billing",
+      "@google/genai",
+    ];
+
+    forbidden.forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.ts
@@ -1,0 +1,532 @@
+import type { VideoNarrativeStrategicDiagnosis } from "./videoNarrativeDiagnosisLearningModel";
+import type { VideoNarrativeDiagnosisQuizResult } from "./videoNarrativeDiagnosisQuizBuilder";
+import type { VideoNarrativeCreatorProfile } from "./videoNarrativeCreatorProfileContract";
+import type { VideoNarrativeSafeResponse } from "./videoNarrativeSafeResponseBuilder";
+
+export type VideoNarrativeAppFlowStage =
+  | "welcome"
+  | "upload_video"
+  | "analyzing_video"
+  | "asking_creator_goal"
+  | "understanding_goal"
+  | "adaptive_quiz"
+  | "building_diagnosis"
+  | "diagnosis_ready"
+  | "upgrade_prompt"
+  | "instagram_optimization_prompt"
+  | "completed"
+  | "blocked"
+  | "error";
+
+export type VideoNarrativeAppFlowAccessLevel =
+  | "guest"
+  | "free"
+  | "premium"
+  | "instagram_optimized";
+
+export type VideoNarrativeAppFlowEvent =
+  | "start"
+  | "video_selected"
+  | "video_analysis_started"
+  | "video_analysis_ready"
+  | "creator_goal_submitted"
+  | "creator_goal_understood"
+  | "quiz_started"
+  | "quiz_answered"
+  | "quiz_completed"
+  | "diagnosis_started"
+  | "diagnosis_ready"
+  | "upgrade_requested"
+  | "instagram_connect_requested"
+  | "completed"
+  | "blocked"
+  | "error"
+  | "reset";
+
+export interface VideoNarrativeAppFlowCta {
+  id: string;
+  label: string;
+  action:
+    | "select_video"
+    | "continue"
+    | "submit_goal"
+    | "answer_quiz"
+    | "build_diagnosis"
+    | "upgrade"
+    | "connect_instagram"
+    | "generate_script"
+    | "create_blueprint"
+    | "restart"
+    | "close";
+  primary: boolean;
+  locked?: boolean;
+  helper?: string | null;
+}
+
+export interface VideoNarrativeAppFlowCopy {
+  title: string;
+  subtitle: string | null;
+  helper: string | null;
+  loadingMessages: string[];
+  ctas: VideoNarrativeAppFlowCta[];
+}
+
+export interface VideoNarrativeAppFlowContext {
+  accessLevel: VideoNarrativeAppFlowAccessLevel;
+  hasVideo: boolean;
+  hasVideoAnalysis: boolean;
+  hasCreatorGoal: boolean;
+  hasQuiz: boolean;
+  quizCompleted: boolean;
+  hasDiagnosis: boolean;
+  hasUsefulDiagnosis: boolean;
+  hasCreatorProfile: boolean;
+  instagramConnected: boolean;
+  hasRemainingFreeCredit: boolean;
+  isSubscriber: boolean;
+  lockedSectionsCount: number;
+  errorCode?: string | null;
+}
+
+export interface VideoNarrativeAppFlowState {
+  stage: VideoNarrativeAppFlowStage;
+  context: VideoNarrativeAppFlowContext;
+  copy: VideoNarrativeAppFlowCopy;
+  progress: {
+    currentStep: number;
+    totalSteps: number;
+    label: string;
+  };
+  nextEvents: VideoNarrativeAppFlowEvent[];
+  updatedAt: string | null;
+}
+
+export interface VideoNarrativeAppFlowRuntimeContext {
+  diagnosis?: VideoNarrativeStrategicDiagnosis | null;
+  quiz?: VideoNarrativeDiagnosisQuizResult | null;
+  creatorProfile?: VideoNarrativeCreatorProfile | null;
+  safeResponse?: VideoNarrativeSafeResponse | null;
+}
+
+const TOTAL_STEPS = 6;
+
+const BLOCKED_TERMS = [
+  "viralizar garantido",
+  "treinado permanentemente",
+  "resposta correta",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "score",
+  "nota",
+  "pontuação",
+  "acerto",
+  "gabarito",
+  "venceu",
+  "perdeu",
+];
+
+function cta(params: VideoNarrativeAppFlowCta): VideoNarrativeAppFlowCta {
+  return {
+    ...params,
+    label: sanitizeVideoNarrativeAppFlowText(params.label),
+    helper: params.helper ? sanitizeVideoNarrativeAppFlowText(params.helper) : params.helper ?? null,
+  };
+}
+
+function copy(params: VideoNarrativeAppFlowCopy): VideoNarrativeAppFlowCopy {
+  return {
+    title: sanitizeVideoNarrativeAppFlowText(params.title),
+    subtitle: params.subtitle ? sanitizeVideoNarrativeAppFlowText(params.subtitle) : null,
+    helper: params.helper ? sanitizeVideoNarrativeAppFlowText(params.helper) : null,
+    loadingMessages: params.loadingMessages.map(sanitizeVideoNarrativeAppFlowText),
+    ctas: params.ctas.map(cta),
+  };
+}
+
+function baseContext(params?: {
+  accessLevel?: VideoNarrativeAppFlowAccessLevel;
+  hasRemainingFreeCredit?: boolean;
+  isSubscriber?: boolean;
+  instagramConnected?: boolean;
+}): VideoNarrativeAppFlowContext {
+  return {
+    accessLevel: params?.accessLevel ?? "guest",
+    hasVideo: false,
+    hasVideoAnalysis: false,
+    hasCreatorGoal: false,
+    hasQuiz: false,
+    quizCompleted: false,
+    hasDiagnosis: false,
+    hasUsefulDiagnosis: false,
+    hasCreatorProfile: false,
+    instagramConnected: params?.instagramConnected ?? false,
+    hasRemainingFreeCredit: params?.hasRemainingFreeCredit ?? false,
+    isSubscriber: params?.isSubscriber ?? false,
+    lockedSectionsCount: 0,
+    errorCode: null,
+  };
+}
+
+function canAnalyzeVideo(context: VideoNarrativeAppFlowContext): boolean {
+  return context.hasRemainingFreeCredit || context.isSubscriber || context.accessLevel !== "guest";
+}
+
+export function sanitizeVideoNarrativeAppFlowText(value: string): string {
+  let sanitized = value;
+  sanitized = sanitized.replace(/\bAIza[0-9A-Za-z_-]{8,}/g, "[redigido]");
+  sanitized = sanitized.replace(/\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+/g, "[redigido]");
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/]{120,}={0,2}\b/g, "[redigido]");
+  sanitized = sanitized.replace(/\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi, "[redigido]");
+
+  BLOCKED_TERMS.forEach((term) => {
+    sanitized = sanitized.replace(new RegExp(term.replace(/\s+/g, "\\s+"), "gi"), "[redigido]");
+  });
+
+  return sanitized.trim();
+}
+
+export function shouldShowVideoNarrativeUpgradePrompt(context: VideoNarrativeAppFlowContext): boolean {
+  return (
+    (context.accessLevel === "free" || context.accessLevel === "guest") &&
+    (context.lockedSectionsCount > 0 || !context.isSubscriber)
+  );
+}
+
+export function shouldShowVideoNarrativeInstagramPrompt(context: VideoNarrativeAppFlowContext): boolean {
+  return (
+    context.hasDiagnosis &&
+    context.hasUsefulDiagnosis &&
+    !context.instagramConnected &&
+    (context.accessLevel === "free" || context.accessLevel === "premium")
+  );
+}
+
+export function getVideoNarrativeAppFlowProgress(
+  stage: VideoNarrativeAppFlowStage,
+): VideoNarrativeAppFlowState["progress"] {
+  if (stage === "analyzing_video") return { currentStep: 2, totalSteps: TOTAL_STEPS, label: "Análise" };
+  if (stage === "asking_creator_goal" || stage === "understanding_goal") {
+    return { currentStep: 3, totalSteps: TOTAL_STEPS, label: "Objetivo" };
+  }
+  if (stage === "adaptive_quiz") return { currentStep: 4, totalSteps: TOTAL_STEPS, label: "Quiz" };
+  if (stage === "building_diagnosis" || stage === "diagnosis_ready") {
+    return { currentStep: 5, totalSteps: TOTAL_STEPS, label: "Diagnóstico" };
+  }
+  if (
+    stage === "upgrade_prompt" ||
+    stage === "instagram_optimization_prompt" ||
+    stage === "completed"
+  ) {
+    return { currentStep: 6, totalSteps: TOTAL_STEPS, label: "Ações" };
+  }
+  return { currentStep: 1, totalSteps: TOTAL_STEPS, label: "Upload" };
+}
+
+export function getVideoNarrativeAppFlowCopy(
+  stage: VideoNarrativeAppFlowStage,
+  context: VideoNarrativeAppFlowContext,
+): VideoNarrativeAppFlowCopy {
+  if (stage === "welcome") {
+    return copy({
+      title: "Entenda a narrativa do seu vídeo",
+      subtitle: "Envie um vídeo e receba um diagnóstico com narrativa, gancho, marcas potenciais e próximos passos.",
+      helper: null,
+      loadingMessages: [],
+      ctas: [cta({ id: "start", label: "Começar", action: "continue", primary: true })],
+    });
+  }
+
+  if (stage === "upload_video") {
+    return copy({
+      title: "Suba seu vídeo",
+      subtitle: "Escolha um vídeo para a D2C analisar a narrativa.",
+      helper: "Você poderá explicar sua dúvida depois do envio.",
+      loadingMessages: [],
+      ctas: [cta({ id: "select-video", label: "Subir vídeo", action: "select_video", primary: true })],
+    });
+  }
+
+  if (stage === "analyzing_video") {
+    return copy({
+      title: "Analisando seu vídeo",
+      subtitle: null,
+      helper: null,
+      loadingMessages: [
+        "Identificando gancho",
+        "Lendo cenas e contexto",
+        "Mapeando narrativa",
+        "Buscando sinais de marca",
+      ],
+      ctas: [],
+    });
+  }
+
+  if (stage === "asking_creator_goal") {
+    return copy({
+      title: "O que você quer entender sobre esse vídeo?",
+      subtitle: "Escreva sua dúvida, objetivo ou incômodo.",
+      helper: "Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi.",
+      loadingMessages: [],
+      ctas: [cta({ id: "submit-goal", label: "Continuar", action: "submit_goal", primary: true })],
+    });
+  }
+
+  if (stage === "understanding_goal") {
+    return copy({
+      title: "Entendendo sua dúvida",
+      subtitle: null,
+      helper: null,
+      loadingMessages: [
+        "Cruzando seu objetivo com a narrativa do vídeo",
+        "Preparando perguntas estratégicas",
+        "Organizando o caminho do diagnóstico",
+      ],
+      ctas: [],
+    });
+  }
+
+  if (stage === "adaptive_quiz") {
+    return copy({
+      title: "Algumas perguntas rápidas",
+      subtitle: "Suas respostas ajudam a deixar o diagnóstico mais preciso.",
+      helper: "O quiz também ajuda a D2C a entender melhor seu estilo ao longo do tempo.",
+      loadingMessages: [],
+      ctas: [cta({ id: "answer-quiz", label: "Responder", action: "answer_quiz", primary: true })],
+    });
+  }
+
+  if (stage === "building_diagnosis") {
+    return copy({
+      title: "Montando seu diagnóstico",
+      subtitle: null,
+      helper: null,
+      loadingMessages: [
+        "Organizando narrativa, intenção e oportunidade",
+        "Transformando suas respostas em direção de conteúdo",
+        "Preparando próximos passos",
+      ],
+      ctas: [],
+    });
+  }
+
+  if (stage === "diagnosis_ready") {
+    const ctas = [
+      cta({ id: "generate-script", label: "Transformar em roteiro", action: "generate_script", primary: true }),
+      cta({ id: "create-blueprint", label: "Criar blueprint", action: "create_blueprint", primary: false }),
+    ];
+
+    if (shouldShowVideoNarrativeInstagramPrompt(context)) {
+      ctas.push(cta({ id: "connect-instagram", label: "Conectar Instagram", action: "connect_instagram", primary: false }));
+    }
+    if (shouldShowVideoNarrativeUpgradePrompt(context)) {
+      ctas.push(cta({ id: "upgrade", label: "Assinar para liberar mais análises", action: "upgrade", primary: false }));
+    }
+
+    return copy({
+      title: "Seu diagnóstico está pronto",
+      subtitle: "Veja a narrativa, os ajustes recomendados e os próximos caminhos para esse vídeo.",
+      helper: null,
+      loadingMessages: [],
+      ctas,
+    });
+  }
+
+  if (stage === "upgrade_prompt") {
+    return copy({
+      title: "Quer liberar diagnósticos completos?",
+      subtitle: "Assinantes podem fazer novas análises e acessar ações mais profundas.",
+      helper: null,
+      loadingMessages: [],
+      ctas: [cta({ id: "upgrade", label: "Ver planos", action: "upgrade", primary: true })],
+    });
+  }
+
+  if (stage === "instagram_optimization_prompt") {
+    return copy({
+      title: "Quer deixar o diagnóstico mais preciso?",
+      subtitle: "Conecte seu Instagram para comparar esse vídeo com o que já funciona no seu perfil.",
+      helper: null,
+      loadingMessages: [],
+      ctas: [cta({ id: "connect-instagram", label: "Conectar Instagram", action: "connect_instagram", primary: true })],
+    });
+  }
+
+  if (stage === "completed") {
+    return copy({
+      title: "Análise concluída",
+      subtitle: "Você pode transformar o diagnóstico em roteiro ou começar uma nova análise.",
+      helper: null,
+      loadingMessages: [],
+      ctas: [
+        cta({ id: "generate-script", label: "Transformar em roteiro", action: "generate_script", primary: true }),
+        cta({ id: "restart", label: "Analisar outro vídeo", action: "restart", primary: false }),
+      ],
+    });
+  }
+
+  if (stage === "blocked") {
+    return copy({
+      title: "Análise não disponível agora",
+      subtitle: "Revise seu acesso ou tente novamente quando houver crédito disponível.",
+      helper: context.errorCode ?? null,
+      loadingMessages: [],
+      ctas: [
+        cta({ id: "upgrade", label: "Ver planos", action: "upgrade", primary: true }),
+        cta({ id: "close", label: "Fechar", action: "close", primary: false }),
+      ],
+    });
+  }
+
+  return copy({
+    title: "Não foi possível continuar",
+    subtitle: "Tente novamente ou reinicie a análise.",
+    helper: context.errorCode ?? null,
+    loadingMessages: [],
+    ctas: [
+      cta({ id: "restart", label: "Recomeçar", action: "restart", primary: true }),
+      cta({ id: "close", label: "Fechar", action: "close", primary: false }),
+    ],
+  });
+}
+
+export function getVideoNarrativeAppFlowNextEvents(
+  stage: VideoNarrativeAppFlowStage,
+  context: VideoNarrativeAppFlowContext,
+): VideoNarrativeAppFlowEvent[] {
+  if (stage === "welcome") return ["start", "reset"];
+  if (stage === "upload_video") return ["video_selected", "blocked", "error", "reset"];
+  if (stage === "analyzing_video") return ["video_analysis_ready", "error", "reset"];
+  if (stage === "asking_creator_goal") return ["creator_goal_submitted", "error", "reset"];
+  if (stage === "understanding_goal") return ["creator_goal_understood", "error", "reset"];
+  if (stage === "adaptive_quiz") return ["quiz_answered", "quiz_completed", "error", "reset"];
+  if (stage === "building_diagnosis") return ["diagnosis_ready", "error", "reset"];
+  if (stage === "upgrade_prompt") return ["upgrade_requested", "reset", "completed"];
+  if (stage === "instagram_optimization_prompt") return ["instagram_connect_requested", "reset", "completed"];
+  if (stage === "completed") return ["reset"];
+  if (stage === "blocked" || stage === "error") return ["reset"];
+
+  const events: VideoNarrativeAppFlowEvent[] = ["completed", "reset"];
+  if (shouldShowVideoNarrativeUpgradePrompt(context)) events.push("upgrade_requested");
+  if (shouldShowVideoNarrativeInstagramPrompt(context)) events.push("instagram_connect_requested");
+  return events;
+}
+
+export function buildVideoNarrativeAppFlowState(params: {
+  stage: VideoNarrativeAppFlowStage;
+  context: VideoNarrativeAppFlowContext;
+  updatedAt?: string | null;
+}): VideoNarrativeAppFlowState {
+  const context = {
+    ...params.context,
+    errorCode: params.context.errorCode ? sanitizeVideoNarrativeAppFlowText(params.context.errorCode) : null,
+  };
+
+  return {
+    stage: params.stage,
+    context,
+    copy: getVideoNarrativeAppFlowCopy(params.stage, context),
+    progress: getVideoNarrativeAppFlowProgress(params.stage),
+    nextEvents: getVideoNarrativeAppFlowNextEvents(params.stage, context),
+    updatedAt: params.updatedAt ?? null,
+  };
+}
+
+export function createInitialVideoNarrativeAppFlowState(params?: {
+  accessLevel?: VideoNarrativeAppFlowAccessLevel;
+  hasRemainingFreeCredit?: boolean;
+  isSubscriber?: boolean;
+  instagramConnected?: boolean;
+  updatedAt?: string | null;
+}): VideoNarrativeAppFlowState {
+  return buildVideoNarrativeAppFlowState({
+    stage: "welcome",
+    context: baseContext(params),
+    updatedAt: params?.updatedAt ?? null,
+  });
+}
+
+export function transitionVideoNarrativeAppFlowState(params: {
+  state: VideoNarrativeAppFlowState;
+  event: VideoNarrativeAppFlowEvent;
+  patch?: Partial<VideoNarrativeAppFlowContext>;
+  updatedAt?: string | null;
+}): VideoNarrativeAppFlowState {
+  const patchedContext = {
+    ...params.state.context,
+    ...params.patch,
+  };
+
+  if (params.event === "reset") {
+    return createInitialVideoNarrativeAppFlowState({
+      accessLevel: patchedContext.accessLevel,
+      hasRemainingFreeCredit: patchedContext.hasRemainingFreeCredit,
+      isSubscriber: patchedContext.isSubscriber,
+      instagramConnected: patchedContext.instagramConnected,
+      updatedAt: params.updatedAt ?? null,
+    });
+  }
+
+  if (params.event === "error") {
+    return buildVideoNarrativeAppFlowState({
+      stage: "error",
+      context: {
+        ...patchedContext,
+        errorCode: params.patch?.errorCode ?? patchedContext.errorCode ?? "flow_error",
+      },
+      updatedAt: params.updatedAt ?? null,
+    });
+  }
+
+  if (params.event === "blocked") {
+    return buildVideoNarrativeAppFlowState({
+      stage: "blocked",
+      context: patchedContext,
+      updatedAt: params.updatedAt ?? null,
+    });
+  }
+
+  let stage = params.state.stage;
+  let context = patchedContext;
+
+  if (params.state.stage === "welcome" && params.event === "start") {
+    stage = "upload_video";
+  } else if (params.state.stage === "upload_video" && params.event === "video_selected") {
+    context = { ...context, hasVideo: true };
+    stage = canAnalyzeVideo(context) ? "analyzing_video" : "upgrade_prompt";
+  } else if (params.state.stage === "upload_video" && params.event === "video_analysis_started") {
+    stage = "analyzing_video";
+  } else if (params.state.stage === "analyzing_video" && params.event === "video_analysis_ready") {
+    context = { ...context, hasVideoAnalysis: true };
+    stage = "asking_creator_goal";
+  } else if (params.state.stage === "asking_creator_goal" && params.event === "creator_goal_submitted") {
+    context = { ...context, hasCreatorGoal: true };
+    stage = "understanding_goal";
+  } else if (params.state.stage === "understanding_goal" && params.event === "creator_goal_understood") {
+    stage = "adaptive_quiz";
+  } else if (params.state.stage === "adaptive_quiz" && params.event === "quiz_started") {
+    context = { ...context, hasQuiz: true };
+  } else if (params.state.stage === "adaptive_quiz" && params.event === "quiz_answered") {
+    context = { ...context, hasQuiz: true };
+  } else if (params.state.stage === "adaptive_quiz" && params.event === "quiz_completed") {
+    context = { ...context, hasQuiz: true, quizCompleted: true };
+    stage = "building_diagnosis";
+  } else if (params.state.stage === "building_diagnosis" && params.event === "diagnosis_started") {
+    stage = "building_diagnosis";
+  } else if (params.state.stage === "building_diagnosis" && params.event === "diagnosis_ready") {
+    context = { ...context, hasDiagnosis: true, hasUsefulDiagnosis: params.patch?.hasUsefulDiagnosis ?? true };
+    stage = "diagnosis_ready";
+  } else if (params.state.stage === "diagnosis_ready" && params.event === "upgrade_requested") {
+    stage = "upgrade_prompt";
+  } else if (params.state.stage === "diagnosis_ready" && params.event === "instagram_connect_requested") {
+    stage = "instagram_optimization_prompt";
+  } else if (params.event === "completed") {
+    stage = "completed";
+  }
+
+  return buildVideoNarrativeAppFlowState({
+    stage,
+    context,
+    updatedAt: params.updatedAt ?? null,
+  });
+}


### PR DESCRIPTION
## Summary

Stacked over #828.

Adds the MM32 pure app-first flow state model for the future video narrative analysis experience:
- models the app-first journey stages, events, context, progress, copy, loading messages, and CTAs;
- defines valid transitions for upload, analysis, creator goal, adaptive quiz, diagnosis, upgrade prompt, Instagram prompt, completion, blocked, error, and reset states;
- adds prompt rules for upgrade and Instagram optimization without UI, persistence, billing, or real Instagram integration;
- documents MM32 in the video narrative roadmap, internal endpoint contract, README, and readiness audit.

## Scope constraints

This PR does not alter the real endpoint route, create UI, upload/storage, database tables, persistence, analytics, BoardShell integration, PostCreationFunnelState changes, Gemini/OpenAI calls, fetch calls, Instagram integration, or billing/Stripe integration.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisQuizBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts src/app/dashboard/boards/videoUpload/videoProcessingProviderPipeline.test.ts src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoProcessingMockProviderPipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.test.ts src/app/dashboard/boards/internalPreviewAccess.test.ts src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts src/app/dashboard/boards/postCreationBlueprintBuilder.test.ts src/app/dashboard/boards/postCreationBlueprintAdjuster.test.ts src/app/dashboard/boards/postCreationDecisionEngine.test.ts src/app/dashboard/boards/postCreationFunnel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `git diff --cached --check`
- `npm run build`