### PR TITLE
feat: add video narrative app first preview

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from "@testing-library/react";
+import { VideoNarrativeAppPreview } from "./VideoNarrativeAppPreview";
+import { buildVideoNarrativeAppPreviewScenario } from "./buildVideoNarrativeAppPreviewScenario";
+
+describe("VideoNarrativeAppPreview", () => {
+  it("renders internal header", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario()} />);
+
+    expect(screen.getByText("Preview interno — Análise Guiada de Vídeo")).toBeInTheDocument();
+  });
+
+  it("renders mock and safety notice", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario()} />);
+
+    expect(screen.getByText(/Cenários mockados/)).toBeInTheDocument();
+    expect(screen.getByText(/Sem upload real, Gemini, storage, banco ou fluxo real/)).toBeInTheDocument();
+  });
+
+  it("renders scenario, stage, access and instagram controls", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario()} />);
+
+    expect(screen.getByText("Cenário")).toBeInTheDocument();
+    expect(screen.getByText("Etapa")).toBeInTheDocument();
+    expect(screen.getByText("Acesso")).toBeInTheDocument();
+    expect(screen.getByText("Instagram")).toBeInTheDocument();
+    expect(screen.getByText("Skincare")).toBeInTheDocument();
+    expect(screen.getByText("welcome")).toBeInTheDocument();
+    expect(screen.getByText("free")).toBeInTheDocument();
+    expect(screen.getByText("disconnected")).toBeInTheDocument();
+  });
+
+  it("renders progress", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" })} />);
+
+    expect(screen.getByText(/Passo 4 de 6/)).toBeInTheDocument();
+  });
+
+  it("renders stage card title", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "upload_video" })} />);
+
+    expect(screen.getByText("Suba seu vídeo")).toBeInTheDocument();
+  });
+
+  it("renders loading messages in analyzing_video", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "analyzing_video" })} />);
+
+    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+  });
+
+  it("renders central question in asking_creator_goal", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "asking_creator_goal" })} />);
+
+    expect(screen.getByText("O que você quer entender sobre esse vídeo?")).toBeInTheDocument();
+  });
+
+  it("renders quiz in adaptive_quiz", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" })} />);
+
+    expect(screen.getByText("Algumas perguntas rápidas")).toBeInTheDocument();
+    expect(screen.getAllByText(/Qual era sua intenção principal|Como você quer que a abertura|Qual contexto falta/).length).toBeGreaterThan(0);
+  });
+
+  it("renders diagnosis blocks in diagnosis_ready", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />);
+
+    expect(screen.getByText("Diagnóstico")).toBeInTheDocument();
+    expect(screen.getByText("Potencial de marcas")).toBeInTheDocument();
+    expect(screen.getByText("Blueprint")).toBeInTheDocument();
+    expect(screen.getByText("Próximas ações")).toBeInTheDocument();
+  });
+
+  it("renders locked sections for free access", () => {
+    render(
+      <VideoNarrativeAppPreview
+        preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", access: "free" })}
+      />,
+    );
+
+    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
+    expect(screen.getAllByText(/premium|Instagram/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders creator profile summary", () => {
+    render(
+      <VideoNarrativeAppPreview
+        preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", scenario: "brand" })}
+      />,
+    );
+
+    expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Territórios")).toBeInTheDocument();
+  });
+
+  it("renders upgrade prompt", () => {
+    render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "upgrade_prompt" })} />);
+
+    expect(screen.getByText("Quer liberar diagnósticos completos?")).toBeInTheDocument();
+    expect(screen.getByText("Ver planos")).toBeInTheDocument();
+  });
+
+  it("renders Instagram prompt", () => {
+    render(
+      <VideoNarrativeAppPreview
+        preview={buildVideoNarrativeAppPreviewScenario({ stage: "instagram_optimization_prompt" })}
+      />,
+    );
+
+    expect(screen.getByText("Quer deixar o diagnóstico mais preciso?")).toBeInTheDocument();
+    expect(screen.getAllByText("Conectar Instagram").length).toBeGreaterThan(0);
+  });
+
+  it("does not render raw payload, API key or signed URL fields", () => {
+    const { container } = render(
+      <VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />,
+    );
+    const text = container.textContent || "";
+
+    for (const forbidden of ["rawText", "inlineVideoBase64", "base64", "apiKey", "signedUrl", "videoUrl", "AIza"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps rendered language safe", () => {
+    const { container } = render(
+      <VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />,
+    );
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
@@ -1,0 +1,360 @@
+import {
+  VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS,
+  VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS,
+  VIDEO_NARRATIVE_APP_PREVIEW_STAGES,
+  type buildVideoNarrativeAppPreviewScenario,
+} from "./buildVideoNarrativeAppPreviewScenario";
+import type { ReactNode } from "react";
+
+type VideoNarrativeAppPreviewData = ReturnType<typeof buildVideoNarrativeAppPreviewScenario>;
+
+type VideoNarrativeAppPreviewProps = {
+  preview: VideoNarrativeAppPreviewData;
+};
+
+function chipHref(params: {
+  scenario: string;
+  stage: string;
+  access: string;
+  instagramConnected: boolean;
+  patch: Partial<{
+    scenario: string;
+    stage: string;
+    access: string;
+    instagramConnected: boolean;
+  }>;
+}) {
+  const search = new URLSearchParams({
+    scenario: params.patch.scenario ?? params.scenario,
+    stage: params.patch.stage ?? params.stage,
+    access: params.patch.access ?? params.access,
+    instagram: (params.patch.instagramConnected ?? params.instagramConnected) ? "connected" : "disconnected",
+  });
+
+  return `/dashboard/boards/video-narrative-app-preview?${search.toString()}`;
+}
+
+function Chip({
+  label,
+  href,
+  active,
+}: {
+  label: string;
+  href: string;
+  active: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      className={
+        active
+          ? "rounded-full bg-zinc-950 px-3 py-1.5 text-sm font-semibold text-white"
+          : "rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700"
+      }
+    >
+      {label}
+    </a>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+      <h2 className="text-base font-semibold text-zinc-950">{title}</h2>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function TextList({ items, empty = "Sem sinais neste cenário." }: { items: string[]; empty?: string }) {
+  if (items.length === 0) return <p className="text-sm leading-6 text-zinc-600">{empty}</p>;
+
+  return (
+    <ul className="space-y-2 text-sm leading-6 text-zinc-700">
+      {items.map((item, index) => (
+        <li key={`${item}-${index}`} className="rounded-md bg-zinc-50 px-3 py-2">
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string | null | undefined }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-md bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
+    </div>
+  );
+}
+
+function StageCard({ preview }: VideoNarrativeAppPreviewProps) {
+  const { flowState, quiz, diagnosis } = preview;
+
+  return (
+    <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase text-zinc-500">
+            Passo {flowState.progress.currentStep} de {flowState.progress.totalSteps} · {flowState.progress.label}
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-zinc-950">{flowState.copy.title}</h2>
+        </div>
+        <div className="h-2 w-full rounded-full bg-zinc-100 md:w-56">
+          <div
+            className="h-2 rounded-full bg-zinc-950"
+            style={{ width: `${Math.round((flowState.progress.currentStep / flowState.progress.totalSteps) * 100)}%` }}
+          />
+        </div>
+      </div>
+
+      {flowState.copy.subtitle ? <p className="mt-3 text-sm leading-6 text-zinc-700">{flowState.copy.subtitle}</p> : null}
+      {flowState.copy.helper ? <p className="mt-2 text-sm leading-6 text-zinc-500">{flowState.copy.helper}</p> : null}
+
+      {flowState.copy.loadingMessages.length > 0 ? (
+        <ul className="mt-5 grid gap-2 md:grid-cols-2">
+          {flowState.copy.loadingMessages.map((message) => (
+            <li key={message} className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700">
+              {message}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {flowState.stage === "adaptive_quiz" ? (
+        <div className="mt-5 grid gap-3">
+          {quiz.questions.map((question) => (
+            <article key={question.id} className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <h3 className="text-sm font-semibold text-zinc-950">{question.title}</h3>
+              <p className="mt-1 text-sm leading-6 text-zinc-600">{question.reason}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {question.options.map((option) => (
+                  <span key={option.id} className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700">
+                    {option.label}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      {flowState.stage === "upgrade_prompt" ? (
+        <div className="mt-5 rounded-lg bg-zinc-50 p-4">
+          <h3 className="text-sm font-semibold text-zinc-950">Seções liberadas em planos superiores</h3>
+          <TextList items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
+        </div>
+      ) : null}
+
+      {flowState.stage === "instagram_optimization_prompt" ? (
+        <div className="mt-5 rounded-lg bg-zinc-50 p-4 text-sm leading-6 text-zinc-700">
+          Conectar Instagram permitirá comparar narrativas, formatos e territórios com o histórico do perfil quando essa
+          integração existir no produto.
+        </div>
+      ) : null}
+
+      {flowState.copy.ctas.length > 0 ? (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {flowState.copy.ctas.map((cta) => (
+            <span
+              key={cta.id}
+              className={
+                cta.primary
+                  ? "rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
+                  : "rounded-md border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-700"
+              }
+            >
+              {cta.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function DiagnosisPreview({ preview }: VideoNarrativeAppPreviewProps) {
+  const { diagnosis, creatorProfile } = preview;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Section title="Diagnóstico">
+        <dl className="grid gap-3">
+          <Field label="Narrativa principal" value={diagnosis.mainNarrative} />
+          <Field label="O que o vídeo comunica" value={diagnosis.whatVideoCommunicates} />
+          <Field label="Intenção do criador" value={diagnosis.creatorIntent} />
+          <Field label="Leitura estratégica" value={diagnosis.strategicReading} />
+          <Field label="Ponto forte" value={diagnosis.strength} />
+          <Field label="Ponto de atenção" value={diagnosis.weakness} />
+          <Field label="Ajuste recomendado" value={diagnosis.recommendedAdjustment} />
+          <Field label="Gancho sugerido" value={diagnosis.suggestedHook} />
+        </dl>
+      </Section>
+
+      <Section title="Potencial de marcas">
+        <TextList items={diagnosis.brandPotential.territories} />
+        {diagnosis.brandPotential.whyItFits ? (
+          <p className="mt-3 text-sm leading-6 text-zinc-700">{diagnosis.brandPotential.whyItFits}</p>
+        ) : null}
+      </Section>
+
+      <Section title="Blueprint">
+        <dl className="grid gap-3">
+          <Field label="O que postar" value={diagnosis.blueprint.whatToPost} />
+          <Field label="Por que seguir" value={diagnosis.blueprint.whyThisPath} />
+          <Field label="Como funcionar" value={diagnosis.blueprint.howItShouldWork} />
+        </dl>
+        <div className="mt-3">
+          <TextList items={diagnosis.blueprint.scenes} />
+        </div>
+      </Section>
+
+      <Section title="Direção de roteiro">
+        {diagnosis.scriptDirection.locked ? (
+          <p className="text-sm leading-6 text-zinc-600">Direção completa bloqueada neste nível de acesso.</p>
+        ) : (
+          <dl className="grid gap-3">
+            <Field label="Abertura" value={diagnosis.scriptDirection.opening} />
+            <Field label="Fechamento" value={diagnosis.scriptDirection.closing} />
+            <Field label="Tom" value={diagnosis.scriptDirection.tone} />
+            <div>
+              <dt className="mb-2 text-xs font-semibold uppercase text-zinc-500">Desenvolvimento</dt>
+              <TextList items={diagnosis.scriptDirection.development} />
+            </div>
+          </dl>
+        )}
+      </Section>
+
+      <Section title="Seções bloqueadas">
+        <TextList items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
+      </Section>
+
+      <Section title="Próximas ações">
+        <TextList items={diagnosis.nextActions.map((action) => `${action.label}: ${action.description ?? "Ação disponível."}`)} />
+      </Section>
+
+      <Section title="Sinais do criador">
+        <TextList items={diagnosis.creatorSignals.map((signal) => `${signal.type}: ${signal.value}`)} />
+      </Section>
+
+      <Section title="Resumo do perfil narrativo">
+        <dl className="grid gap-3">
+          <Field label="Objetivos" value={creatorProfile.summary.strongestContentGoals.join(", ") || null} />
+          <Field label="Formatos" value={creatorProfile.summary.preferredFormats.join(", ") || null} />
+          <Field label="Ganchos" value={creatorProfile.summary.preferredHookDirections.join(", ") || null} />
+          <Field label="Territórios" value={creatorProfile.summary.preferredBrandTerritories.join(", ") || null} />
+          <Field label="Comercial" value={creatorProfile.summary.commercialPreferences.join(", ") || null} />
+          <Field label="Posicionamento" value={creatorProfile.summary.positioningSignals.join(", ") || null} />
+        </dl>
+      </Section>
+
+      <Section title="Comparação com Instagram">
+        <dl className="grid gap-3">
+          <Field label="Resumo" value={diagnosis.instagramComparison.summary} />
+          <Field label="Narrativas próximas" value={diagnosis.instagramComparison.matchingNarratives.join(", ") || null} />
+          <Field label="Formatos próximos" value={diagnosis.instagramComparison.matchingFormats.join(", ") || null} />
+        </dl>
+        {diagnosis.instagramComparison.locked ? (
+          <p className="mt-3 text-sm leading-6 text-zinc-600">Comparação depende de conexão Instagram futura.</p>
+        ) : null}
+      </Section>
+    </div>
+  );
+}
+
+export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewProps) {
+  const active = {
+    scenario: preview.scenario.id,
+    stage: preview.flowState.stage,
+    access: preview.accessLevel,
+    instagramConnected: preview.instagramConnected,
+  };
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950 sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-6xl gap-5">
+        <header className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Análise Guiada de Vídeo</p>
+          <h1 className="mt-2 text-2xl font-semibold">Experiência app-first com mock narrativo</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Cenários mockados. Sem upload real, Gemini, storage, banco ou fluxo real.
+          </p>
+        </header>
+
+        <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+          <div className="grid gap-4">
+            <div>
+              <h2 className="mb-2 text-sm font-semibold text-zinc-950">Cenário</h2>
+              <div className="flex flex-wrap gap-2">
+                {VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS.map((scenario) => (
+                  <Chip
+                    key={scenario.id}
+                    label={scenario.label}
+                    active={scenario.id === active.scenario}
+                    href={chipHref({ ...active, patch: { scenario: scenario.id } })}
+                  />
+                ))}
+              </div>
+            </div>
+            <div>
+              <h2 className="mb-2 text-sm font-semibold text-zinc-950">Etapa</h2>
+              <div className="flex flex-wrap gap-2">
+                {VIDEO_NARRATIVE_APP_PREVIEW_STAGES.map((stage) => (
+                  <Chip
+                    key={stage}
+                    label={stage}
+                    active={stage === active.stage}
+                    href={chipHref({ ...active, patch: { stage } })}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <h2 className="mb-2 text-sm font-semibold text-zinc-950">Acesso</h2>
+                <div className="flex flex-wrap gap-2">
+                  {VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS.map((access) => (
+                    <Chip
+                      key={access}
+                      label={access}
+                      active={access === active.access}
+                      href={chipHref({ ...active, patch: { access } })}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h2 className="mb-2 text-sm font-semibold text-zinc-950">Instagram</h2>
+                <div className="flex flex-wrap gap-2">
+                  <Chip
+                    label="connected"
+                    active={active.instagramConnected}
+                    href={chipHref({ ...active, patch: { instagramConnected: true } })}
+                  />
+                  <Chip
+                    label="disconnected"
+                    active={!active.instagramConnected}
+                    href={chipHref({ ...active, patch: { instagramConnected: false } })}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <StageCard preview={preview} />
+
+        {preview.flowState.stage === "diagnosis_ready" ? <DiagnosisPreview preview={preview} /> : null}
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
@@ -1,0 +1,157 @@
+import fs from "fs";
+import path from "path";
+import { buildVideoNarrativeAppPreviewScenario } from "./buildVideoNarrativeAppPreviewScenario";
+
+describe("buildVideoNarrativeAppPreviewScenario", () => {
+  it("builds the default skincare scenario", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario();
+
+    expect(preview.scenario.id).toBe("skincare");
+    expect(preview.scenario.creatorQuestion).toBe("Quero saber se vale postar");
+    expect(preview.analysis.id).toContain("skincare");
+    expect(preview.seed.analysisId).toBe(preview.analysis.id);
+  });
+
+  it("builds the brand scenario with brand question", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ scenario: "brand" });
+
+    expect(preview.scenario.id).toBe("brand");
+    expect(preview.scenario.creatorQuestion).toContain("marcas");
+    expect(preview.diagnosis.brandPotential.enabled).toBe(true);
+  });
+
+  it("builds the weak hook scenario with hook question", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ scenario: "weak-hook" });
+
+    expect(preview.scenario.creatorQuestion).toContain("gancho");
+    expect(preview.analysis.hook.strength).toBe("weak");
+  });
+
+  it("uses free access by default", () => {
+    expect(buildVideoNarrativeAppPreviewScenario().accessLevel).toBe("free");
+  });
+
+  it("uses disconnected Instagram by default", () => {
+    expect(buildVideoNarrativeAppPreviewScenario().instagramConnected).toBe(false);
+  });
+
+  it("respects premium access", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "premium" });
+
+    expect(preview.accessLevel).toBe("premium");
+    expect(preview.flowState.context.accessLevel).toBe("premium");
+  });
+
+  it("respects instagram_optimized access", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "instagram_optimized" });
+
+    expect(preview.accessLevel).toBe("instagram_optimized");
+    expect(preview.flowState.context.accessLevel).toBe("instagram_optimized");
+  });
+
+  it("respects connected Instagram", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ instagram: "connected" });
+
+    expect(preview.instagramConnected).toBe(true);
+    expect(preview.flowState.context.instagramConnected).toBe(true);
+  });
+
+  it("welcome stage has no video or diagnosis context", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "welcome" });
+
+    expect(preview.flowState.context.hasVideo).toBe(false);
+    expect(preview.flowState.context.hasDiagnosis).toBe(false);
+  });
+
+  it("upload_video stage shows upload CTA", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "upload_video" });
+
+    expect(preview.flowState.copy.ctas.some((cta) => cta.label === "Subir vídeo")).toBe(true);
+  });
+
+  it("analyzing_video stage has loading messages", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "analyzing_video" });
+
+    expect(preview.flowState.copy.loadingMessages).toContain("Identificando gancho");
+  });
+
+  it("asking_creator_goal stage has central question", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "asking_creator_goal" });
+
+    expect(preview.flowState.copy.title).toBe("O que você quer entender sobre esse vídeo?");
+  });
+
+  it("adaptive_quiz stage includes 3 to 5 questions", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" });
+
+    expect(preview.quiz.questions.length).toBeGreaterThanOrEqual(3);
+    expect(preview.quiz.questions.length).toBeLessThanOrEqual(5);
+  });
+
+  it("diagnosis_ready stage includes useful diagnosis", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" });
+
+    expect(preview.flowState.context.hasDiagnosis).toBe(true);
+    expect(preview.flowState.context.hasUsefulDiagnosis).toBe(true);
+    expect(preview.diagnosis.mainNarrative || preview.diagnosis.strategicReading).toBeTruthy();
+  });
+
+  it("diagnosis_ready free has locked sections", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", access: "free" });
+
+    expect(preview.diagnosis.lockedSections.length).toBeGreaterThan(0);
+    expect(preview.flowState.context.lockedSectionsCount).toBe(preview.diagnosis.lockedSections.length);
+  });
+
+  it("instagram_optimized connected unlocks Instagram comparison when possible", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      access: "instagram_optimized",
+      instagram: "connected",
+      scenario: "brand",
+    });
+
+    expect(preview.diagnosis.instagramComparison.connected).toBe(true);
+    expect(preview.diagnosis.instagramComparison.locked).toBe(false);
+  });
+
+  it("creates creator profile from diagnosis creatorSignals", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", scenario: "brand" });
+
+    expect(preview.diagnosis.creatorSignals.length).toBeGreaterThan(0);
+    expect(preview.creatorProfile.signals.length).toBeGreaterThan(0);
+  });
+
+  it("unclear scenario generates missing context quiz or context question", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ scenario: "unclear", stage: "adaptive_quiz" });
+    const keys = preview.quiz.questions.map((question) => question.key);
+
+    expect(keys.some((key) => key === "missing_context" || key === "narrative_preference")).toBe(true);
+  });
+
+  it("does not import forbidden integrations", () => {
+    const source = fs.readFileSync(path.join(__dirname, "buildVideoNarrativeAppPreviewScenario.ts"), "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "endpoint",
+      "storage",
+      "analytics",
+      "ffmpeg",
+      "Stripe",
+      "billing",
+      "GoogleGenAI",
+      "BoardShell",
+      "PostCreationFunnelState",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
@@ -1,0 +1,261 @@
+import {
+  buildPostCreationVideoSeedFromAnalysis,
+  getPostCreationVideoSeedPrimaryAction,
+} from "../../videoUpload/videoNarrativePostCreationSeed";
+import {
+  buildVideoNarrativeStrategicDiagnosis,
+  hasUsefulVideoNarrativeStrategicDiagnosis,
+  type VideoNarrativeDiagnosisAccessLevel,
+  type VideoNarrativeInstagramContext,
+} from "../../videoUpload/videoNarrativeDiagnosisLearningModel";
+import { buildVideoNarrativeDiagnosisQuiz } from "../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
+import { buildVideoNarrativeCreatorProfile } from "../../videoUpload/videoNarrativeCreatorProfileContract";
+import {
+  buildVideoNarrativeAppFlowState,
+  type VideoNarrativeAppFlowAccessLevel,
+  type VideoNarrativeAppFlowContext,
+  type VideoNarrativeAppFlowStage,
+} from "../../videoUpload/videoNarrativeAppFlowState";
+import {
+  runVideoNarrativeMockProvider,
+  type VideoNarrativeMockProviderScenario,
+} from "../../videoUpload/videoNarrativeMockProvider";
+
+export type VideoNarrativeAppPreviewScenarioId =
+  | "skincare"
+  | "backstage"
+  | "brand"
+  | "weak-hook"
+  | "collab"
+  | "ad-adaptation"
+  | "unclear";
+
+export type VideoNarrativeAppPreviewAccess = "free" | "premium" | "instagram_optimized";
+export type VideoNarrativeAppPreviewInstagramState = "connected" | "disconnected";
+
+export type VideoNarrativeAppPreviewScenarioDefinition = {
+  id: VideoNarrativeAppPreviewScenarioId;
+  label: string;
+  creatorQuestion: string;
+  mockScenario: VideoNarrativeMockProviderScenario;
+};
+
+export type VideoNarrativeAppPreviewScenarioParams = {
+  scenario?: string | string[] | null;
+  stage?: string | string[] | null;
+  access?: string | string[] | null;
+  instagram?: string | string[] | null;
+};
+
+export const VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS: VideoNarrativeAppPreviewScenarioDefinition[] = [
+  {
+    id: "skincare",
+    label: "Skincare",
+    creatorQuestion: "Quero saber se vale postar",
+    mockScenario: "skincare_routine",
+  },
+  {
+    id: "backstage",
+    label: "Bastidor",
+    creatorQuestion: "Não sei qual narrativa esse vídeo comunica",
+    mockScenario: "backstage_process",
+  },
+  {
+    id: "brand",
+    label: "Marca",
+    creatorQuestion: "Quero saber se esse vídeo pode atrair marcas",
+    mockScenario: "brand_potential",
+  },
+  {
+    id: "weak-hook",
+    label: "Gancho",
+    creatorQuestion: "Acho que o começo está fraco e queria melhorar o gancho",
+    mockScenario: "weak_hook",
+  },
+  {
+    id: "collab",
+    label: "Collab",
+    creatorQuestion: "Esse vídeo poderia virar uma collab com outro creator?",
+    mockScenario: "collab_potential",
+  },
+  {
+    id: "ad-adaptation",
+    label: "Publi",
+    creatorQuestion: "Quero transformar esse vídeo em uma publi sem parecer forçado",
+    mockScenario: "ad_adaptation",
+  },
+  {
+    id: "unclear",
+    label: "Contexto",
+    creatorQuestion: "Me ajuda a entender o que falta nesse vídeo",
+    mockScenario: "unclear_content",
+  },
+];
+
+export const VIDEO_NARRATIVE_APP_PREVIEW_STAGES: VideoNarrativeAppFlowStage[] = [
+  "welcome",
+  "upload_video",
+  "analyzing_video",
+  "asking_creator_goal",
+  "understanding_goal",
+  "adaptive_quiz",
+  "building_diagnosis",
+  "diagnosis_ready",
+  "upgrade_prompt",
+  "instagram_optimization_prompt",
+];
+
+export const VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS: VideoNarrativeAppPreviewAccess[] = [
+  "free",
+  "premium",
+  "instagram_optimized",
+];
+
+function first(value?: string | string[] | null): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function resolveScenario(value?: string | string[] | null): VideoNarrativeAppPreviewScenarioDefinition {
+  const id = first(value) ?? "skincare";
+  return VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS.find((scenario) => scenario.id === id) ?? VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS[0]!;
+}
+
+function resolveStage(value?: string | string[] | null): VideoNarrativeAppFlowStage {
+  const stage = first(value);
+  return VIDEO_NARRATIVE_APP_PREVIEW_STAGES.find((candidate) => candidate === stage) ?? "welcome";
+}
+
+function resolveAccess(value?: string | string[] | null): VideoNarrativeAppPreviewAccess {
+  const access = first(value);
+  return VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS.find((candidate) => candidate === access) ?? "free";
+}
+
+function resolveInstagram(value?: string | string[] | null): boolean {
+  return first(value) === "connected";
+}
+
+function toFlowAccessLevel(access: VideoNarrativeAppPreviewAccess): VideoNarrativeAppFlowAccessLevel {
+  return access;
+}
+
+function toDiagnosisAccessLevel(access: VideoNarrativeAppPreviewAccess): VideoNarrativeDiagnosisAccessLevel {
+  return access;
+}
+
+function stageContext(params: {
+  stage: VideoNarrativeAppFlowStage;
+  accessLevel: VideoNarrativeAppFlowAccessLevel;
+  instagramConnected: boolean;
+  lockedSectionsCount: number;
+  hasUsefulDiagnosis: boolean;
+  hasCreatorProfile: boolean;
+}): VideoNarrativeAppFlowContext {
+  const stageIndex = VIDEO_NARRATIVE_APP_PREVIEW_STAGES.indexOf(params.stage);
+  const atOrAfter = (stage: VideoNarrativeAppFlowStage) =>
+    stageIndex >= VIDEO_NARRATIVE_APP_PREVIEW_STAGES.indexOf(stage);
+
+  return {
+    accessLevel: params.accessLevel,
+    hasVideo: atOrAfter("analyzing_video"),
+    hasVideoAnalysis: atOrAfter("asking_creator_goal"),
+    hasCreatorGoal: atOrAfter("understanding_goal"),
+    hasQuiz: atOrAfter("adaptive_quiz"),
+    quizCompleted: atOrAfter("building_diagnosis"),
+    hasDiagnosis:
+      atOrAfter("diagnosis_ready") ||
+      params.stage === "upgrade_prompt" ||
+      params.stage === "instagram_optimization_prompt",
+    hasUsefulDiagnosis:
+      (atOrAfter("diagnosis_ready") ||
+        params.stage === "upgrade_prompt" ||
+        params.stage === "instagram_optimization_prompt") &&
+      params.hasUsefulDiagnosis,
+    hasCreatorProfile: params.hasCreatorProfile,
+    instagramConnected: params.instagramConnected,
+    hasRemainingFreeCredit: true,
+    isSubscriber: params.accessLevel === "premium" || params.accessLevel === "instagram_optimized",
+    lockedSectionsCount: params.lockedSectionsCount,
+    errorCode: null,
+  };
+}
+
+function buildInstagramContext(connected: boolean): VideoNarrativeInstagramContext {
+  return {
+    connected,
+    topNarratives: connected ? ["rotina orgânica -> produto -> continuidade", "bastidor -> processo -> pauta"] : [],
+    topFormats: connected ? ["reel", "stories"] : [],
+    topContexts: connected ? ["autocuidado", "processo"] : [],
+    strongestMetricsSummary: connected ? "Histórico simulado com formatos e narrativas recorrentes." : null,
+    brandTerritories: connected ? ["beleza", "autocuidado", "creator economy"] : [],
+  };
+}
+
+export function buildVideoNarrativeAppPreviewScenario(params: VideoNarrativeAppPreviewScenarioParams = {}) {
+  const scenario = resolveScenario(params.scenario);
+  const stage = resolveStage(params.stage);
+  const accessLevel = resolveAccess(params.access);
+  const instagramConnected = resolveInstagram(params.instagram);
+  const analysis = runVideoNarrativeMockProvider({
+    input: {
+      id: `video-narrative-app-preview-${scenario.id}`,
+      creatorQuestion: scenario.creatorQuestion,
+      createdAt: "2026-05-15T10:00:00.000Z",
+    },
+    options: { scenario: scenario.mockScenario },
+  });
+  const seed = buildPostCreationVideoSeedFromAnalysis({
+    id: `video-narrative-app-preview-${scenario.id}-seed`,
+    analysis,
+    creatorQuestion: scenario.creatorQuestion,
+    createdAt: analysis.createdAt,
+  });
+  const instagramContext = buildInstagramContext(instagramConnected);
+  const diagnosis = buildVideoNarrativeStrategicDiagnosis({
+    accessLevel: toDiagnosisAccessLevel(accessLevel),
+    analysis,
+    seed,
+    creatorQuestion: scenario.creatorQuestion,
+    instagramContext,
+  });
+  const quiz = buildVideoNarrativeDiagnosisQuiz({
+    analysis,
+    seed,
+    diagnosis,
+    creatorQuestion: scenario.creatorQuestion,
+    accessLevel: toDiagnosisAccessLevel(accessLevel),
+    existingSignals: diagnosis.creatorSignals,
+  });
+  const creatorProfile = buildVideoNarrativeCreatorProfile({
+    creatorId: "video-narrative-app-preview-creator",
+    newSignals: diagnosis.creatorSignals,
+    diagnosisId: diagnosis.id,
+    createdAt: analysis.createdAt,
+  });
+  const hasUsefulDiagnosis = hasUsefulVideoNarrativeStrategicDiagnosis(diagnosis);
+  const flowState = buildVideoNarrativeAppFlowState({
+    stage,
+    context: stageContext({
+      stage,
+      accessLevel: toFlowAccessLevel(accessLevel),
+      instagramConnected,
+      lockedSectionsCount: diagnosis.lockedSections.length,
+      hasUsefulDiagnosis,
+      hasCreatorProfile: creatorProfile.signals.length > 0,
+    }),
+    updatedAt: analysis.createdAt,
+  });
+
+  return {
+    scenario,
+    flowState,
+    analysis,
+    seed,
+    diagnosis,
+    quiz,
+    creatorProfile,
+    primaryAction: getPostCreationVideoSeedPrimaryAction(seed),
+    accessLevel,
+    instagramConnected,
+  };
+}

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
@@ -1,0 +1,110 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import VideoNarrativeAppPreviewPage from "./page";
+
+const originalFlag = process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED;
+const adminViewer = { role: "admin" };
+const commonViewer = { role: "user" };
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (originalFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED;
+    return;
+  }
+  process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = originalFlag;
+});
+
+describe("VideoNarrativeAppPreviewPage", () => {
+  it("renders blocked by flag when flag is off", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "0";
+
+    render(await VideoNarrativeAppPreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Preview interno bloqueado")).toBeInTheDocument();
+    expect(screen.getByText(/Preview bloqueado por flag/)).toBeInTheDocument();
+    expect(screen.queryByText("Experiência app-first com mock narrativo")).not.toBeInTheDocument();
+  });
+
+  it("renders blocked by permission without admin/dev", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativeAppPreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Experiência app-first com mock narrativo")).not.toBeInTheDocument();
+  });
+
+  it("renders preview with flag on and admin/dev", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(await VideoNarrativeAppPreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Preview interno — Análise Guiada de Vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Experiência app-first com mock narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+  });
+
+  it("query params alter scenario, stage, access and Instagram state", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(
+      await VideoNarrativeAppPreviewPage({
+        viewer: adminViewer,
+        searchParams: {
+          scenario: "brand",
+          stage: "diagnosis_ready",
+          access: "instagram_optimized",
+          instagram: "connected",
+        },
+      }),
+    );
+
+    expect(screen.getAllByText("Marca").length).toBeGreaterThan(0);
+    expect(screen.getByText("Seu diagnóstico está pronto")).toBeInTheDocument();
+    expect(screen.getAllByText("instagram_optimized").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("connected").length).toBeGreaterThan(0);
+    expect(screen.getByText("Comparação com Instagram")).toBeInTheDocument();
+  });
+
+  it("does not call endpoint or fetch", () => {
+    const pageSource = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+    const importLines = pageSource
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(pageSource).not.toContain("fetch(");
+    expect(importLines).not.toContain("app/api");
+    expect(importLines).not.toContain("route");
+  });
+
+  it("does not import Gemini SDK or provider real", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).not.toContain("GoogleGenAI");
+    expect(source).not.toContain("runGeminiVideoNarrativeProviderFromEnv");
+    expect(source).not.toContain("createGeminiVideoNarrativeClient");
+  });
+
+  it("does not import upload or storage real", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).not.toMatch(/upload service|storage provider|file picker/i);
+  });
+
+  it("does not connect BoardShell or PostCreationFunnelState", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).not.toContain("BoardShell");
+    expect(source).not.toContain("PostCreationFunnelBoardShell");
+    expect(source).not.toContain("PostCreationFunnelState");
+  });
+
+  it("does not add a navigation or menu link", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).not.toMatch(/menu|navigation|nav/i);
+  });
+});

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.tsx
@@ -1,0 +1,51 @@
+import { VideoNarrativeAppPreview } from "../components/videoUpload/VideoNarrativeAppPreview";
+import { buildVideoNarrativeAppPreviewScenario } from "../components/videoUpload/buildVideoNarrativeAppPreviewScenario";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
+import { isVideoNarrativeAppPreviewEnabled } from "../videoUpload/videoNarrativeAppPreviewFeatureFlag";
+
+type VideoNarrativeAppPreviewPageProps = {
+  searchParams?: {
+    scenario?: string | string[];
+    stage?: string | string[];
+    access?: string | string[];
+    instagram?: string | string[];
+  };
+  viewer?: InternalPreviewUser | null;
+};
+
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno bloqueado</p>
+        <h1 className="mt-2 text-2xl font-semibold">Análise Guiada de Vídeo</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview bloqueado por flag. Ative NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED=1 para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function VideoNarrativeAppPreviewPage({
+  searchParams,
+  viewer,
+}: VideoNarrativeAppPreviewPageProps = {}) {
+  if (!isVideoNarrativeAppPreviewEnabled()) {
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
+  }
+
+  const preview = buildVideoNarrativeAppPreviewScenario(searchParams);
+  return <VideoNarrativeAppPreview preview={preview} />;
+}

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -88,6 +88,8 @@ Já existe:
 - `shouldPersistLater` segue apenas metadado e persistência continua bloqueada;
 - app-first flow state model foi criado em MM32 para modelar jornada, copy e prompts antes da UI;
 - prompts de upgrade e Instagram foram definidos em MM32 sem conectar billing ou Instagram real;
+- internal app-first preview foi criado em MM33 para visualizar a jornada com cenários mockados;
+- a preview MM33 continua sem upload real, persistência, BoardShell, endpoint real ou Instagram real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -726,6 +726,35 @@ O que não faz:
 - não conecta Instagram real nem usa dados reais de Instagram;
 - não altera navegação/menu ou `PostCreationFunnelState`.
 
+### MM33 — Internal app-first preview with mock
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../video-narrative-app-preview/page.tsx`
+- `../video-narrative-app-preview/page.test.tsx`
+- `../components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts`
+- `../components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts`
+- `../components/videoUpload/VideoNarrativeAppPreview.tsx`
+- `../components/videoUpload/VideoNarrativeAppPreview.test.tsx`
+- `videoNarrativeAppPreviewFeatureFlag.ts`
+- `videoNarrativeAppPreviewFeatureFlag.test.ts`
+
+O que faz:
+
+- cria a rota interna `/dashboard/boards/video-narrative-app-preview`;
+- protege a preview com `NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED=1` e sessão admin/dev;
+- monta cenários mockados com análise, seed, diagnóstico, quiz, perfil narrativo e estado app-first;
+- permite alternar scenario, stage, access e Instagram por query params para sentir a jornada.
+
+O que não faz:
+
+- não cria upload real, storage real, banco/tabela, analytics real ou persistência;
+- não chama Gemini, OpenAI, endpoint real ou rede;
+- não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta Instagram real, billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -239,8 +239,9 @@ Exemplos:
 29. MM30 — Diagnosis-driven quiz builder. Gera perguntas por lacunas do diagnóstico e opções com sinais de aprendizado futuro.
 30. MM31 — Creator Narrative Profile contract. Organiza sinais acumulados do criador sem persistência, banco ou Instagram real.
 31. MM32 — App-first flow state model. Define estados, transições, copy e prompts antes de qualquer UI real.
-32. Teste real manual quando houver quota/billing disponível.
-33. Integração experimental futura no Board de Criação.
+32. MM33 — Internal app-first preview with mock. Permite sentir a experiência app-first em preview interna/admin-dev com cenários mockados, sem produto real.
+33. Teste real manual quando houver quota/billing disponível.
+34. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -297,6 +298,8 @@ MM30 adiciona `buildVideoNarrativeDiagnosisQuiz` para gerar perguntas adaptativa
 MM31 adiciona `VideoNarrativeCreatorProfile` como contrato puro para agregar sinais narrativos ao longo do tempo. O perfil futuro pode melhorar diagnósticos recorrentes, mas nesta fase não há banco, persistência, Instagram real ou sinal transformado em verdade permanente automaticamente.
 
 MM32 adiciona `VideoNarrativeAppFlowState` para modelar a experiência app-first antes da UI. A jornada cobre upload, análise, pergunta central, quiz, diagnóstico, CTAs e prompts de upgrade/Instagram sem alterar endpoint, criar upload real ou persistir respostas/sinais.
+
+MM33 adiciona `/dashboard/boards/video-narrative-app-preview` como preview interna protegida por flag e admin/dev. A experiência já pode ser sentida com cenários mockados, controles por query param, diagnóstico, quiz, perfil narrativo e prompts, mas continua fora do produto real, sem upload real, storage, banco, BoardShell, endpoint real ou persistência.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_INTERNAL_ENDPOINT_CONTRACT.md
@@ -107,6 +107,8 @@ MM31 adiciona `VideoNarrativeCreatorProfile` como contrato futuro para agregar s
 
 MM32 adiciona `VideoNarrativeAppFlowState` como modelo futuro de jornada app-first. O endpoint/mock pode alimentar essa jornada com análise, safe response, diagnóstico, quiz e perfil, mas a rota não foi alterada nesta fase.
 
+MM33 adiciona `/dashboard/boards/video-narrative-app-preview` como preview interna da jornada app-first. Ela usa helpers locais e mock provider para montar análise, seed, diagnóstico, quiz, perfil narrativo e flow state por query params. A preview não chama o endpoint real, não altera a rota interna e não cria upload, storage, persistência, BoardShell ou fluxo real.
+
 ## Status Futuros
 
 - `disabled`;
@@ -234,6 +236,7 @@ Só implementar depois que:
 - MM30: diagnosis-driven quiz builder;
 - MM31: creator narrative profile contract;
 - MM32: app-first flow state model;
-- MM33: endpoint real somente depois de billing/teste real;
-- MM34: preview interno com chamada real;
-- MM35: integração experimental no board.
+- MM33: internal app-first preview with mock;
+- MM34: endpoint real somente depois de billing/teste real;
+- MM35: preview interno com chamada real;
+- MM36: integração experimental no board.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.test.ts
@@ -1,0 +1,20 @@
+import { isVideoNarrativeAppPreviewEnabled } from "./videoNarrativeAppPreviewFeatureFlag";
+
+describe("videoNarrativeAppPreviewFeatureFlag", () => {
+  it("returns false by default", () => {
+    expect(isVideoNarrativeAppPreviewEnabled({})).toBe(false);
+  });
+
+  it("returns true only when NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED is 1", () => {
+    expect(isVideoNarrativeAppPreviewEnabled({ NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED: "1" })).toBe(true);
+    expect(isVideoNarrativeAppPreviewEnabled({ NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED: "true" })).toBe(false);
+  });
+
+  it("does not depend on VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED", () => {
+    expect(isVideoNarrativeAppPreviewEnabled({ VIDEO_NARRATIVE_INTERNAL_ENDPOINT_ENABLED: "true" })).toBe(false);
+  });
+
+  it("does not depend on VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE", () => {
+    expect(isVideoNarrativeAppPreviewEnabled({ VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE: "mock" })).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.ts
@@ -1,0 +1,5 @@
+export function isVideoNarrativeAppPreviewEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  return env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED === "1";
+}


### PR DESCRIPTION
## Summary

Stacked over #829.

Adds the MM33 internal app-first preview with mock data:
- creates `/dashboard/boards/video-narrative-app-preview` protected by `NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED=1` and admin/dev access;
- adds a scenario builder that uses mock narrative analysis, `PostCreationVideoSeed`, strategic diagnosis, adaptive quiz, creator profile, and app flow state;
- adds a preview component with scenario/stage/access/Instagram query controls, progress, stage copy, loading messages, quiz, diagnosis blocks, locked sections, next actions, creator signals, creator profile summary, and Instagram prompt content;
- documents MM33 in the video upload README, multimodal architecture, internal endpoint contract, and readiness audit.

## Scope constraints

This remains an internal preview only. It does not alter the endpoint route, create real upload/storage, connect BoardShell, change PostCreationFunnelState, persist responses/signals, add navigation/menu links, call Gemini/OpenAI, call fetch, connect Instagram real, or integrate billing/Stripe.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.test.ts src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisQuizBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoUploadTypes.test.ts src/app/dashboard/boards/videoUpload/videoUploadPipeline.test.ts src/app/dashboard/boards/videoUpload/videoUploadNarrativeSourceBridge.test.ts src/app/dashboard/boards/videoUpload/videoUploadProcessedNarrativeSource.test.ts src/app/dashboard/boards/videoUpload/videoUploadProcessedPipeline.test.ts src/app/dashboard/boards/videoUpload/videoProcessingArtifacts.test.ts src/app/dashboard/boards/videoUpload/videoTemporaryStorageTypes.test.ts src/app/dashboard/boards/videoUpload/videoUploadSessionContracts.test.ts src/app/dashboard/boards/videoUpload/videoStorageRetentionContracts.test.ts src/app/dashboard/boards/videoUpload/videoProcessingProviderContracts.test.ts src/app/dashboard/boards/videoUpload/videoProcessingProviderPipeline.test.ts src/app/dashboard/boards/videoUpload/videoProcessingMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoProcessingMockProviderPipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePreviewFeatureFlag.test.ts src/app/dashboard/boards/internalPreviewAccess.test.ts src/app/dashboard/boards/video-narrative-preview/page.test.tsx src/app/dashboard/boards/video-upload-preview/page.test.tsx src/app/dashboard/boards/videoUpload/videoUploadPreviewFeatureFlag.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/narrativeSource/narrativeSourceTypes.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceIntentRouter.test.ts src/app/dashboard/boards/narrativeSource/narrativeAssetExtractor.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourcePipeline.test.ts src/app/dashboard/boards/narrativeSource/narrativeSourceAdaptiveAdapter.test.ts src/app/dashboard/boards/postCreationAdaptiveAnswerKey.test.ts src/app/dashboard/boards/postCreationAdaptiveRouter.test.ts src/app/dashboard/boards/postCreationAdaptiveQuizBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePlanBuilder.test.ts src/app/dashboard/boards/postCreationAdaptivePipeline.test.ts src/app/dashboard/boards/postCreationBlueprintBuilder.test.ts src/app/dashboard/boards/postCreationBlueprintAdjuster.test.ts src/app/dashboard/boards/postCreationDecisionEngine.test.ts src/app/dashboard/boards/postCreationFunnel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `git diff --cached --check`
- `npm run build`