### PR TITLE
feat: add video narrative UI primitives

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
@@ -24,15 +24,15 @@ describe("VideoNarrativeAppPreview", () => {
     expect(screen.getByText("Acesso")).toBeInTheDocument();
     expect(screen.getByText("Instagram")).toBeInTheDocument();
     expect(screen.getByText("Skincare")).toBeInTheDocument();
-    expect(screen.getByText("welcome")).toBeInTheDocument();
-    expect(screen.getByText("free")).toBeInTheDocument();
-    expect(screen.getByText("disconnected")).toBeInTheDocument();
+    expect(screen.getAllByText("Boas-vindas").length).toBeGreaterThan(0);
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByText("Desconectado")).toBeInTheDocument();
   });
 
   it("renders progress", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" })} />);
 
-    expect(screen.getByText(/Passo 4 de 6/)).toBeInTheDocument();
+    expect(screen.getByText("Etapa 4 de 6")).toBeInTheDocument();
   });
 
   it("renders stage card title", () => {
@@ -64,7 +64,7 @@ describe("VideoNarrativeAppPreview", () => {
   it("renders diagnosis blocks in diagnosis_ready", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />);
 
-    expect(screen.getByText("Diagnóstico")).toBeInTheDocument();
+    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
     expect(screen.getByText("Potencial de marcas")).toBeInTheDocument();
     expect(screen.getByText("Blueprint")).toBeInTheDocument();
     expect(screen.getByText("Próximas ações")).toBeInTheDocument();
@@ -95,8 +95,8 @@ describe("VideoNarrativeAppPreview", () => {
   it("renders upgrade prompt", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "upgrade_prompt" })} />);
 
-    expect(screen.getByText("Quer liberar diagnósticos completos?")).toBeInTheDocument();
-    expect(screen.getByText("Ver planos")).toBeInTheDocument();
+    expect(screen.getAllByText("Quer liberar diagnósticos completos?").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Ver planos").length).toBeGreaterThan(0);
   });
 
   it("renders Instagram prompt", () => {
@@ -106,7 +106,7 @@ describe("VideoNarrativeAppPreview", () => {
       />,
     );
 
-    expect(screen.getByText("Quer deixar o diagnóstico mais preciso?")).toBeInTheDocument();
+    expect(screen.getAllByText("Quer deixar o diagnóstico mais preciso?").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Conectar Instagram").length).toBeGreaterThan(0);
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
@@ -1,10 +1,19 @@
+import { VideoNarrativeDiagnosisBlocks } from "./appPreview/VideoNarrativeDiagnosisBlocks";
+import { VideoNarrativeLoadingBlock } from "./appPreview/VideoNarrativeLoadingBlock";
+import { VideoNarrativeProgress } from "./appPreview/VideoNarrativeProgress";
+import { VideoNarrativePromptCards } from "./appPreview/VideoNarrativePromptCards";
+import { VideoNarrativeQuizCard } from "./appPreview/VideoNarrativeQuizCard";
+import { VideoNarrativeStageShell } from "./appPreview/VideoNarrativeStageShell";
+import {
+  formatAccessLabel,
+  formatStageLabel,
+} from "./appPreview/VideoNarrativeAppPreviewPrimitives";
 import {
   VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS,
   VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS,
   VIDEO_NARRATIVE_APP_PREVIEW_STAGES,
   type buildVideoNarrativeAppPreviewScenario,
 } from "./buildVideoNarrativeAppPreviewScenario";
-import type { ReactNode } from "react";
 
 type VideoNarrativeAppPreviewData = ReturnType<typeof buildVideoNarrativeAppPreviewScenario>;
 
@@ -34,15 +43,7 @@ function chipHref(params: {
   return `/dashboard/boards/video-narrative-app-preview?${search.toString()}`;
 }
 
-function Chip({
-  label,
-  href,
-  active,
-}: {
-  label: string;
-  href: string;
-  active: boolean;
-}) {
+function Chip({ label, href, active }: { label: string; href: string; active: boolean }) {
   return (
     <a
       href={href}
@@ -57,221 +58,7 @@ function Chip({
   );
 }
 
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
-      <h2 className="text-base font-semibold text-zinc-950">{title}</h2>
-      <div className="mt-3">{children}</div>
-    </section>
-  );
-}
-
-function TextList({ items, empty = "Sem sinais neste cenário." }: { items: string[]; empty?: string }) {
-  if (items.length === 0) return <p className="text-sm leading-6 text-zinc-600">{empty}</p>;
-
-  return (
-    <ul className="space-y-2 text-sm leading-6 text-zinc-700">
-      {items.map((item, index) => (
-        <li key={`${item}-${index}`} className="rounded-md bg-zinc-50 px-3 py-2">
-          {item}
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-function Field({ label, value }: { label: string; value: string | null | undefined }) {
-  if (!value) return null;
-
-  return (
-    <div className="rounded-md bg-zinc-50 p-3">
-      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
-      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
-    </div>
-  );
-}
-
-function StageCard({ preview }: VideoNarrativeAppPreviewProps) {
-  const { flowState, quiz, diagnosis } = preview;
-
-  return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <p className="text-xs font-semibold uppercase text-zinc-500">
-            Passo {flowState.progress.currentStep} de {flowState.progress.totalSteps} · {flowState.progress.label}
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold text-zinc-950">{flowState.copy.title}</h2>
-        </div>
-        <div className="h-2 w-full rounded-full bg-zinc-100 md:w-56">
-          <div
-            className="h-2 rounded-full bg-zinc-950"
-            style={{ width: `${Math.round((flowState.progress.currentStep / flowState.progress.totalSteps) * 100)}%` }}
-          />
-        </div>
-      </div>
-
-      {flowState.copy.subtitle ? <p className="mt-3 text-sm leading-6 text-zinc-700">{flowState.copy.subtitle}</p> : null}
-      {flowState.copy.helper ? <p className="mt-2 text-sm leading-6 text-zinc-500">{flowState.copy.helper}</p> : null}
-
-      {flowState.copy.loadingMessages.length > 0 ? (
-        <ul className="mt-5 grid gap-2 md:grid-cols-2">
-          {flowState.copy.loadingMessages.map((message) => (
-            <li key={message} className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700">
-              {message}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-
-      {flowState.stage === "adaptive_quiz" ? (
-        <div className="mt-5 grid gap-3">
-          {quiz.questions.map((question) => (
-            <article key={question.id} className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-              <h3 className="text-sm font-semibold text-zinc-950">{question.title}</h3>
-              <p className="mt-1 text-sm leading-6 text-zinc-600">{question.reason}</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {question.options.map((option) => (
-                  <span key={option.id} className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700">
-                    {option.label}
-                  </span>
-                ))}
-              </div>
-            </article>
-          ))}
-        </div>
-      ) : null}
-
-      {flowState.stage === "upgrade_prompt" ? (
-        <div className="mt-5 rounded-lg bg-zinc-50 p-4">
-          <h3 className="text-sm font-semibold text-zinc-950">Seções liberadas em planos superiores</h3>
-          <TextList items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
-        </div>
-      ) : null}
-
-      {flowState.stage === "instagram_optimization_prompt" ? (
-        <div className="mt-5 rounded-lg bg-zinc-50 p-4 text-sm leading-6 text-zinc-700">
-          Conectar Instagram permitirá comparar narrativas, formatos e territórios com o histórico do perfil quando essa
-          integração existir no produto.
-        </div>
-      ) : null}
-
-      {flowState.copy.ctas.length > 0 ? (
-        <div className="mt-5 flex flex-wrap gap-2">
-          {flowState.copy.ctas.map((cta) => (
-            <span
-              key={cta.id}
-              className={
-                cta.primary
-                  ? "rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
-                  : "rounded-md border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-700"
-              }
-            >
-              {cta.label}
-            </span>
-          ))}
-        </div>
-      ) : null}
-    </section>
-  );
-}
-
-function DiagnosisPreview({ preview }: VideoNarrativeAppPreviewProps) {
-  const { diagnosis, creatorProfile } = preview;
-
-  return (
-    <div className="grid gap-4 lg:grid-cols-2">
-      <Section title="Diagnóstico">
-        <dl className="grid gap-3">
-          <Field label="Narrativa principal" value={diagnosis.mainNarrative} />
-          <Field label="O que o vídeo comunica" value={diagnosis.whatVideoCommunicates} />
-          <Field label="Intenção do criador" value={diagnosis.creatorIntent} />
-          <Field label="Leitura estratégica" value={diagnosis.strategicReading} />
-          <Field label="Ponto forte" value={diagnosis.strength} />
-          <Field label="Ponto de atenção" value={diagnosis.weakness} />
-          <Field label="Ajuste recomendado" value={diagnosis.recommendedAdjustment} />
-          <Field label="Gancho sugerido" value={diagnosis.suggestedHook} />
-        </dl>
-      </Section>
-
-      <Section title="Potencial de marcas">
-        <TextList items={diagnosis.brandPotential.territories} />
-        {diagnosis.brandPotential.whyItFits ? (
-          <p className="mt-3 text-sm leading-6 text-zinc-700">{diagnosis.brandPotential.whyItFits}</p>
-        ) : null}
-      </Section>
-
-      <Section title="Blueprint">
-        <dl className="grid gap-3">
-          <Field label="O que postar" value={diagnosis.blueprint.whatToPost} />
-          <Field label="Por que seguir" value={diagnosis.blueprint.whyThisPath} />
-          <Field label="Como funcionar" value={diagnosis.blueprint.howItShouldWork} />
-        </dl>
-        <div className="mt-3">
-          <TextList items={diagnosis.blueprint.scenes} />
-        </div>
-      </Section>
-
-      <Section title="Direção de roteiro">
-        {diagnosis.scriptDirection.locked ? (
-          <p className="text-sm leading-6 text-zinc-600">Direção completa bloqueada neste nível de acesso.</p>
-        ) : (
-          <dl className="grid gap-3">
-            <Field label="Abertura" value={diagnosis.scriptDirection.opening} />
-            <Field label="Fechamento" value={diagnosis.scriptDirection.closing} />
-            <Field label="Tom" value={diagnosis.scriptDirection.tone} />
-            <div>
-              <dt className="mb-2 text-xs font-semibold uppercase text-zinc-500">Desenvolvimento</dt>
-              <TextList items={diagnosis.scriptDirection.development} />
-            </div>
-          </dl>
-        )}
-      </Section>
-
-      <Section title="Seções bloqueadas">
-        <TextList items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
-      </Section>
-
-      <Section title="Próximas ações">
-        <TextList items={diagnosis.nextActions.map((action) => `${action.label}: ${action.description ?? "Ação disponível."}`)} />
-      </Section>
-
-      <Section title="Sinais do criador">
-        <TextList items={diagnosis.creatorSignals.map((signal) => `${signal.type}: ${signal.value}`)} />
-      </Section>
-
-      <Section title="Resumo do perfil narrativo">
-        <dl className="grid gap-3">
-          <Field label="Objetivos" value={creatorProfile.summary.strongestContentGoals.join(", ") || null} />
-          <Field label="Formatos" value={creatorProfile.summary.preferredFormats.join(", ") || null} />
-          <Field label="Ganchos" value={creatorProfile.summary.preferredHookDirections.join(", ") || null} />
-          <Field label="Territórios" value={creatorProfile.summary.preferredBrandTerritories.join(", ") || null} />
-          <Field label="Comercial" value={creatorProfile.summary.commercialPreferences.join(", ") || null} />
-          <Field label="Posicionamento" value={creatorProfile.summary.positioningSignals.join(", ") || null} />
-        </dl>
-      </Section>
-
-      <Section title="Comparação com Instagram">
-        <dl className="grid gap-3">
-          <Field label="Resumo" value={diagnosis.instagramComparison.summary} />
-          <Field label="Narrativas próximas" value={diagnosis.instagramComparison.matchingNarratives.join(", ") || null} />
-          <Field label="Formatos próximos" value={diagnosis.instagramComparison.matchingFormats.join(", ") || null} />
-        </dl>
-        {diagnosis.instagramComparison.locked ? (
-          <p className="mt-3 text-sm leading-6 text-zinc-600">Comparação depende de conexão Instagram futura.</p>
-        ) : null}
-      </Section>
-    </div>
-  );
-}
-
-export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewProps) {
+function PreviewControls({ preview }: VideoNarrativeAppPreviewProps) {
   const active = {
     scenario: preview.scenario.id,
     stage: preview.flowState.stage,
@@ -280,9 +67,120 @@ export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewPr
   };
 
   return (
+    <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="grid gap-4">
+        <div>
+          <h2 className="mb-2 text-sm font-semibold text-zinc-950">Cenário</h2>
+          <div className="flex flex-wrap gap-2">
+            {VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS.map((scenario) => (
+              <Chip
+                key={scenario.id}
+                label={scenario.label}
+                active={scenario.id === active.scenario}
+                href={chipHref({ ...active, patch: { scenario: scenario.id } })}
+              />
+            ))}
+          </div>
+        </div>
+        <div>
+          <h2 className="mb-2 text-sm font-semibold text-zinc-950">Etapa</h2>
+          <div className="flex flex-wrap gap-2">
+            {VIDEO_NARRATIVE_APP_PREVIEW_STAGES.map((stage) => (
+              <Chip
+                key={stage}
+                label={formatStageLabel(stage)}
+                active={stage === active.stage}
+                href={chipHref({ ...active, patch: { stage } })}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-zinc-950">Acesso</h2>
+            <div className="flex flex-wrap gap-2">
+              {VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS.map((access) => (
+                <Chip
+                  key={access}
+                  label={formatAccessLabel(access)}
+                  active={access === active.access}
+                  href={chipHref({ ...active, patch: { access } })}
+                />
+              ))}
+            </div>
+          </div>
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-zinc-950">Instagram</h2>
+            <div className="flex flex-wrap gap-2">
+              <Chip
+                label="Conectado"
+                active={active.instagramConnected}
+                href={chipHref({ ...active, patch: { instagramConnected: true } })}
+              />
+              <Chip
+                label="Desconectado"
+                active={!active.instagramConnected}
+                href={chipHref({ ...active, patch: { instagramConnected: false } })}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StageBody({ preview }: VideoNarrativeAppPreviewProps) {
+  const { flowState, quiz, diagnosis } = preview;
+
+  if (flowState.copy.loadingMessages.length > 0) {
+    return <VideoNarrativeLoadingBlock title="Processando etapa" messages={flowState.copy.loadingMessages} />;
+  }
+
+  if (flowState.stage === "adaptive_quiz") {
+    return <VideoNarrativeQuizCard questions={quiz.questions} />;
+  }
+
+  if (flowState.stage === "upgrade_prompt") {
+    return <VideoNarrativePromptCards lockedSections={diagnosis.lockedSections} showUpgrade />;
+  }
+
+  if (flowState.stage === "instagram_optimization_prompt") {
+    return <VideoNarrativePromptCards showInstagram />;
+  }
+
+  return null;
+}
+
+function StageFooter({ preview }: VideoNarrativeAppPreviewProps) {
+  const ctas = preview.flowState.copy.ctas;
+  if (ctas.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ctas.map((cta) => (
+        <span
+          key={cta.id}
+          className={
+            cta.primary
+              ? "rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
+              : "rounded-md border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-700"
+          }
+        >
+          {cta.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewProps) {
+  const { flowState } = preview;
+
+  return (
     <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950 sm:px-6 lg:px-8">
       <div className="mx-auto grid max-w-6xl gap-5">
-        <header className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
           <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Análise Guiada de Vídeo</p>
           <h1 className="mt-2 text-2xl font-semibold">Experiência app-first com mock narrativo</h1>
           <p className="mt-3 text-sm leading-6 text-zinc-700">
@@ -290,70 +188,28 @@ export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewPr
           </p>
         </header>
 
-        <section className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
-          <div className="grid gap-4">
-            <div>
-              <h2 className="mb-2 text-sm font-semibold text-zinc-950">Cenário</h2>
-              <div className="flex flex-wrap gap-2">
-                {VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS.map((scenario) => (
-                  <Chip
-                    key={scenario.id}
-                    label={scenario.label}
-                    active={scenario.id === active.scenario}
-                    href={chipHref({ ...active, patch: { scenario: scenario.id } })}
-                  />
-                ))}
-              </div>
-            </div>
-            <div>
-              <h2 className="mb-2 text-sm font-semibold text-zinc-950">Etapa</h2>
-              <div className="flex flex-wrap gap-2">
-                {VIDEO_NARRATIVE_APP_PREVIEW_STAGES.map((stage) => (
-                  <Chip
-                    key={stage}
-                    label={stage}
-                    active={stage === active.stage}
-                    href={chipHref({ ...active, patch: { stage } })}
-                  />
-                ))}
-              </div>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div>
-                <h2 className="mb-2 text-sm font-semibold text-zinc-950">Acesso</h2>
-                <div className="flex flex-wrap gap-2">
-                  {VIDEO_NARRATIVE_APP_PREVIEW_ACCESS_LEVELS.map((access) => (
-                    <Chip
-                      key={access}
-                      label={access}
-                      active={access === active.access}
-                      href={chipHref({ ...active, patch: { access } })}
-                    />
-                  ))}
-                </div>
-              </div>
-              <div>
-                <h2 className="mb-2 text-sm font-semibold text-zinc-950">Instagram</h2>
-                <div className="flex flex-wrap gap-2">
-                  <Chip
-                    label="connected"
-                    active={active.instagramConnected}
-                    href={chipHref({ ...active, patch: { instagramConnected: true } })}
-                  />
-                  <Chip
-                    label="disconnected"
-                    active={!active.instagramConnected}
-                    href={chipHref({ ...active, patch: { instagramConnected: false } })}
-                  />
-                </div>
-              </div>
-            </div>
+        <PreviewControls preview={preview} />
+
+        <VideoNarrativeStageShell
+          eyebrow={formatStageLabel(flowState.stage)}
+          title={flowState.copy.title}
+          subtitle={flowState.copy.subtitle}
+          helper={flowState.copy.helper}
+          footer={<StageFooter preview={preview} />}
+        >
+          <VideoNarrativeProgress
+            currentStep={flowState.progress.currentStep}
+            totalSteps={flowState.progress.totalSteps}
+            label={flowState.progress.label}
+          />
+          <div className="mt-6">
+            <StageBody preview={preview} />
           </div>
-        </section>
+        </VideoNarrativeStageShell>
 
-        <StageCard preview={preview} />
-
-        {preview.flowState.stage === "diagnosis_ready" ? <DiagnosisPreview preview={preview} /> : null}
+        {flowState.stage === "diagnosis_ready" ? (
+          <VideoNarrativeDiagnosisBlocks diagnosis={preview.diagnosis} creatorProfile={preview.creatorProfile} />
+        ) : null}
       </div>
     </main>
   );

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.test.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.test.ts
@@ -1,0 +1,82 @@
+import {
+  clampStep,
+  formatAccessLabel,
+  formatSignalLabel,
+  formatStageLabel,
+  isSafeVideoNarrativePreviewText,
+} from "./VideoNarrativeAppPreviewPrimitives";
+import fs from "fs";
+import path from "path";
+
+describe("VideoNarrativeAppPreviewPrimitives", () => {
+  it("clampStep limits currentStep below 1", () => {
+    expect(clampStep(0, 6)).toBe(1);
+  });
+
+  it("clampStep limits currentStep above total", () => {
+    expect(clampStep(9, 6)).toBe(6);
+  });
+
+  it("formatAccessLabel maps free, premium and instagram_optimized", () => {
+    expect(formatAccessLabel("free")).toBe("Free");
+    expect(formatAccessLabel("premium")).toBe("Premium");
+    expect(formatAccessLabel("instagram_optimized")).toBe("Instagram otimizado");
+  });
+
+  it("formatStageLabel maps known stages", () => {
+    expect(formatStageLabel("upload_video")).toBe("Upload simulado");
+    expect(formatStageLabel("analyzing_video")).toBe("Análise do vídeo");
+    expect(formatStageLabel("diagnosis_ready")).toBe("Diagnóstico pronto");
+  });
+
+  it("formatSignalLabel turns snake case into readable label", () => {
+    expect(formatSignalLabel("hook_preference")).toBe("Hook preference");
+  });
+
+  it("isSafeVideoNarrativePreviewText returns false for API key, base64 and signed URL", () => {
+    expect(isSafeVideoNarrativePreviewText("AIza1234567890abcdef")).toBe(false);
+    expect(isSafeVideoNarrativePreviewText("a".repeat(140))).toBe(false);
+    expect(isSafeVideoNarrativePreviewText("https://cdn.test/video.mp4?token=abc")).toBe(false);
+  });
+
+  it("does not import forbidden integrations in preview runtime files", () => {
+    const root = path.join(__dirname, "..");
+    const files = [
+      path.join(root, "VideoNarrativeAppPreview.tsx"),
+      path.join(__dirname, "VideoNarrativeStageShell.tsx"),
+      path.join(__dirname, "VideoNarrativeProgress.tsx"),
+      path.join(__dirname, "VideoNarrativeLoadingBlock.tsx"),
+      path.join(__dirname, "VideoNarrativeQuizCard.tsx"),
+      path.join(__dirname, "VideoNarrativeDiagnosisBlocks.tsx"),
+      path.join(__dirname, "VideoNarrativePromptCards.tsx"),
+      path.join(__dirname, "VideoNarrativeAppPreviewPrimitives.ts"),
+    ];
+    const importLines = files
+      .map((file) => fs.readFileSync(file, "utf8"))
+      .join("\n")
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "endpoint",
+      "upload service",
+      "storage provider",
+      "analytics",
+      "ffmpeg",
+      "Stripe",
+      "billing",
+      "GoogleGenAI",
+      "Instagram client",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "PostCreationFunnelState",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.ts
@@ -1,0 +1,54 @@
+const SENSITIVE_PATTERNS = [
+  /\bAIza[0-9A-Za-z_-]{8,}/,
+  /\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY)=\S+/,
+  /\b[A-Za-z0-9+/]{120,}={0,2}\b/,
+  /\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/i,
+];
+
+const ACCESS_LABELS: Record<string, string> = {
+  free: "Free",
+  premium: "Premium",
+  instagram_optimized: "Instagram otimizado",
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  welcome: "Boas-vindas",
+  upload_video: "Upload simulado",
+  analyzing_video: "Análise do vídeo",
+  asking_creator_goal: "Pergunta central",
+  understanding_goal: "Entendimento da dúvida",
+  adaptive_quiz: "Quiz adaptativo",
+  building_diagnosis: "Montagem do diagnóstico",
+  diagnosis_ready: "Diagnóstico pronto",
+  upgrade_prompt: "Prompt de upgrade",
+  instagram_optimization_prompt: "Prompt de Instagram",
+  completed: "Concluído",
+  blocked: "Bloqueado",
+  error: "Erro",
+};
+
+export function clampStep(currentStep: number, totalSteps: number): number {
+  const safeTotal = Number.isFinite(totalSteps) && totalSteps > 0 ? Math.floor(totalSteps) : 1;
+  if (!Number.isFinite(currentStep)) return 1;
+  return Math.min(Math.max(Math.floor(currentStep), 1), safeTotal);
+}
+
+export function formatAccessLabel(access: string): string {
+  return ACCESS_LABELS[access] ?? formatSignalLabel(access);
+}
+
+export function formatStageLabel(stage: string): string {
+  return STAGE_LABELS[stage] ?? formatSignalLabel(stage);
+}
+
+export function formatSignalLabel(signalType: string): string {
+  return signalType
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+export function isSafeVideoNarrativePreviewText(value: string): boolean {
+  return !SENSITIVE_PATTERNS.some((pattern) => pattern.test(value));
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+import { VideoNarrativeDiagnosisBlocks } from "./VideoNarrativeDiagnosisBlocks";
+
+describe("VideoNarrativeDiagnosisBlocks", () => {
+  const preview = buildVideoNarrativeAppPreviewScenario({
+    stage: "diagnosis_ready",
+    scenario: "brand",
+    access: "instagram_optimized",
+    instagram: "connected",
+  });
+
+  function renderBlocks() {
+    return render(
+      <VideoNarrativeDiagnosisBlocks diagnosis={preview.diagnosis} creatorProfile={preview.creatorProfile} />,
+    );
+  }
+
+  it("renders main narrative", () => {
+    renderBlocks();
+    expect(screen.getByText("Narrativa principal")).toBeInTheDocument();
+  });
+
+  it("renders what video communicates", () => {
+    renderBlocks();
+    expect(screen.getByText("O que o vídeo comunica")).toBeInTheDocument();
+  });
+
+  it("renders creator intent", () => {
+    renderBlocks();
+    expect(screen.getByText("Intenção do criador")).toBeInTheDocument();
+  });
+
+  it("renders strength, weakness and adjustment", () => {
+    const weakHookPreview = buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      scenario: "weak-hook",
+      access: "premium",
+    });
+    render(<VideoNarrativeDiagnosisBlocks diagnosis={weakHookPreview.diagnosis} />);
+
+    expect(screen.getByText("Ponto forte")).toBeInTheDocument();
+    expect(screen.getByText("Ponto de atenção")).toBeInTheDocument();
+    expect(screen.getByText("Ajuste recomendado")).toBeInTheDocument();
+  });
+
+  it("renders suggested hook", () => {
+    renderBlocks();
+    expect(screen.getByText("Gancho sugerido")).toBeInTheDocument();
+  });
+
+  it("renders brand potential", () => {
+    renderBlocks();
+    expect(screen.getByText("Potencial de marcas")).toBeInTheDocument();
+  });
+
+  it("renders blueprint", () => {
+    renderBlocks();
+    expect(screen.getByText("Blueprint")).toBeInTheDocument();
+  });
+
+  it("renders scriptDirection when unlocked", () => {
+    renderBlocks();
+    expect(screen.getByText("Direção de roteiro")).toBeInTheDocument();
+    expect(screen.getByText("Abertura")).toBeInTheDocument();
+  });
+
+  it("renders lockedSections", () => {
+    render(
+      <VideoNarrativeDiagnosisBlocks
+        diagnosis={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", access: "free" }).diagnosis}
+      />,
+    );
+
+    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
+    expect(screen.getAllByText(/premium|Instagram/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders nextActions", () => {
+    renderBlocks();
+    expect(screen.getByText("Próximas ações")).toBeInTheDocument();
+  });
+
+  it("renders creatorSignals", () => {
+    renderBlocks();
+    expect(screen.getByText("Sinais do criador")).toBeInTheDocument();
+  });
+
+  it("renders creatorProfile summary", () => {
+    renderBlocks();
+    expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Territórios")).toBeInTheDocument();
+  });
+
+  it("renders instagramComparison", () => {
+    renderBlocks();
+    expect(screen.getByText("Comparação com Instagram")).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
@@ -1,0 +1,134 @@
+import type { VideoNarrativeCreatorProfile } from "../../../videoUpload/videoNarrativeCreatorProfileContract";
+import type { VideoNarrativeStrategicDiagnosis } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
+import { formatSignalLabel } from "./VideoNarrativeAppPreviewPrimitives";
+import type { ReactNode } from "react";
+
+type VideoNarrativeDiagnosisBlocksProps = {
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+  creatorProfile?: VideoNarrativeCreatorProfile | null;
+};
+
+function Block({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <h3 className="text-base font-semibold text-zinc-950">{title}</h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+
+  return (
+    <div className="rounded-lg bg-zinc-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
+    </div>
+  );
+}
+
+function List({ items, empty = "Sem dados para este bloco." }: { items: string[]; empty?: string }) {
+  if (items.length === 0) return <p className="text-sm leading-6 text-zinc-600">{empty}</p>;
+
+  return (
+    <ul className="space-y-2 text-sm leading-6 text-zinc-700">
+      {items.map((item, index) => (
+        <li key={`${item}-${index}`} className="rounded-lg bg-zinc-50 px-3 py-2">
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function VideoNarrativeDiagnosisBlocks({ diagnosis, creatorProfile }: VideoNarrativeDiagnosisBlocksProps) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Block title="Diagnóstico">
+        <dl className="grid gap-3">
+          <Field label="Narrativa principal" value={diagnosis.mainNarrative} />
+          <Field label="O que o vídeo comunica" value={diagnosis.whatVideoCommunicates} />
+          <Field label="Intenção do criador" value={diagnosis.creatorIntent} />
+          <Field label="Diagnóstico estratégico" value={diagnosis.strategicReading} />
+          <Field label="Ponto forte" value={diagnosis.strength} />
+          <Field label="Ponto de atenção" value={diagnosis.weakness} />
+          <Field label="Ajuste recomendado" value={diagnosis.recommendedAdjustment} />
+          <Field label="Gancho sugerido" value={diagnosis.suggestedHook} />
+        </dl>
+      </Block>
+
+      <Block title="Potencial de marcas">
+        <List items={diagnosis.brandPotential.territories} />
+        {diagnosis.brandPotential.whyItFits ? (
+          <p className="mt-3 text-sm leading-6 text-zinc-700">{diagnosis.brandPotential.whyItFits}</p>
+        ) : null}
+      </Block>
+
+      <Block title="Blueprint">
+        <dl className="grid gap-3">
+          <Field label="O que postar" value={diagnosis.blueprint.whatToPost} />
+          <Field label="Por que seguir" value={diagnosis.blueprint.whyThisPath} />
+          <Field label="Como funcionar" value={diagnosis.blueprint.howItShouldWork} />
+        </dl>
+        <div className="mt-3">
+          <List items={diagnosis.blueprint.scenes} />
+        </div>
+      </Block>
+
+      <Block title="Direção de roteiro">
+        {diagnosis.scriptDirection.locked ? (
+          <p className="text-sm leading-6 text-zinc-600">Direção completa bloqueada neste nível de acesso.</p>
+        ) : (
+          <dl className="grid gap-3">
+            <Field label="Abertura" value={diagnosis.scriptDirection.opening} />
+            <Field label="Fechamento" value={diagnosis.scriptDirection.closing} />
+            <Field label="Tom" value={diagnosis.scriptDirection.tone} />
+            <div>
+              <dt className="mb-2 text-xs font-semibold uppercase text-zinc-500">Desenvolvimento</dt>
+              <List items={diagnosis.scriptDirection.development} />
+            </div>
+          </dl>
+        )}
+      </Block>
+
+      <Block title="Seções bloqueadas">
+        <List items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
+      </Block>
+
+      <Block title="Próximas ações">
+        <List items={diagnosis.nextActions.map((action) => `${action.label}: ${action.description ?? "Ação disponível."}`)} />
+      </Block>
+
+      <Block title="Sinais do criador">
+        <List items={diagnosis.creatorSignals.map((signal) => `${formatSignalLabel(signal.type)}: ${signal.value}`)} />
+      </Block>
+
+      <Block title="Resumo do perfil narrativo">
+        {creatorProfile ? (
+          <dl className="grid gap-3">
+            <Field label="Objetivos" value={creatorProfile.summary.strongestContentGoals.join(", ") || null} />
+            <Field label="Formatos" value={creatorProfile.summary.preferredFormats.join(", ") || null} />
+            <Field label="Ganchos" value={creatorProfile.summary.preferredHookDirections.join(", ") || null} />
+            <Field label="Territórios" value={creatorProfile.summary.preferredBrandTerritories.join(", ") || null} />
+            <Field label="Comercial" value={creatorProfile.summary.commercialPreferences.join(", ") || null} />
+            <Field label="Posicionamento" value={creatorProfile.summary.positioningSignals.join(", ") || null} />
+          </dl>
+        ) : (
+          <p className="text-sm leading-6 text-zinc-600">Sem perfil narrativo para este cenário.</p>
+        )}
+      </Block>
+
+      <Block title="Comparação com Instagram">
+        <dl className="grid gap-3">
+          <Field label="Resumo" value={diagnosis.instagramComparison.summary} />
+          <Field label="Narrativas próximas" value={diagnosis.instagramComparison.matchingNarratives.join(", ") || null} />
+          <Field label="Formatos próximos" value={diagnosis.instagramComparison.matchingFormats.join(", ") || null} />
+        </dl>
+        {diagnosis.instagramComparison.locked ? (
+          <p className="mt-3 text-sm leading-6 text-zinc-600">Comparação depende de conexão Instagram futura.</p>
+        ) : null}
+      </Block>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { VideoNarrativeLoadingBlock } from "./VideoNarrativeLoadingBlock";
+
+describe("VideoNarrativeLoadingBlock", () => {
+  it("renders title", () => {
+    render(<VideoNarrativeLoadingBlock title="Analisando" messages={["Um"]} />);
+
+    expect(screen.getByText("Analisando")).toBeInTheDocument();
+  });
+
+  it("renders all messages", () => {
+    render(<VideoNarrativeLoadingBlock title="Analisando" messages={["Identificando gancho", "Mapeando narrativa"]} />);
+
+    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+  });
+
+  it("handles empty messages", () => {
+    render(<VideoNarrativeLoadingBlock title="Analisando" messages={[]} />);
+
+    expect(screen.getByText("Sem etapas de carregamento para este estágio.")).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.tsx
@@ -1,0 +1,25 @@
+type VideoNarrativeLoadingBlockProps = {
+  title: string;
+  messages: string[];
+};
+
+export function VideoNarrativeLoadingBlock({ title, messages }: VideoNarrativeLoadingBlockProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+      <h3 className="text-sm font-semibold text-zinc-950">{title}</h3>
+      {messages.length > 0 ? (
+        <ul className="mt-4 grid gap-2">
+          {messages.map((message, index) => (
+            <li key={message} className="flex items-center gap-3 rounded-lg bg-white px-3 py-2 text-sm text-zinc-700">
+              <span className="h-2.5 w-2.5 rounded-full bg-zinc-950" aria-hidden="true" />
+              <span className="text-xs font-semibold uppercase text-zinc-500">{index + 1}</span>
+              <span>{message}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 text-sm leading-6 text-zinc-600">Sem etapas de carregamento para este estágio.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeProgress.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeProgress.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { VideoNarrativeProgress } from "./VideoNarrativeProgress";
+
+describe("VideoNarrativeProgress", () => {
+  it("renders Etapa X de Y", () => {
+    render(<VideoNarrativeProgress currentStep={2} totalSteps={6} label="Análise" />);
+
+    expect(screen.getByText("Etapa 2 de 6")).toBeInTheDocument();
+    expect(screen.getByText("Análise")).toBeInTheDocument();
+  });
+
+  it("clamps invalid step", () => {
+    render(<VideoNarrativeProgress currentStep={99} totalSteps={6} label="Ações" />);
+
+    expect(screen.getByText("Etapa 6 de 6")).toBeInTheDocument();
+  });
+
+  it("has aria-label", () => {
+    render(<VideoNarrativeProgress currentStep={1} totalSteps={6} label="Upload" />);
+
+    expect(screen.getByLabelText("Etapa 1 de 6: Upload")).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeProgress.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeProgress.tsx
@@ -1,0 +1,27 @@
+import { clampStep } from "./VideoNarrativeAppPreviewPrimitives";
+
+type VideoNarrativeProgressProps = {
+  currentStep: number;
+  totalSteps: number;
+  label: string;
+};
+
+export function VideoNarrativeProgress({ currentStep, totalSteps, label }: VideoNarrativeProgressProps) {
+  const safeTotal = Number.isFinite(totalSteps) && totalSteps > 0 ? Math.floor(totalSteps) : 1;
+  const safeStep = clampStep(currentStep, safeTotal);
+  const percent = Math.round((safeStep / safeTotal) * 100);
+
+  return (
+    <div aria-label={`Etapa ${safeStep} de ${safeTotal}: ${label}`} className="w-full">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase text-zinc-500">
+          Etapa {safeStep} de {safeTotal}
+        </p>
+        <p className="text-xs font-semibold text-zinc-600">{label}</p>
+      </div>
+      <div className="mt-2 h-2 rounded-full bg-zinc-100">
+        <div className="h-2 rounded-full bg-zinc-950" style={{ width: `${percent}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+import { VideoNarrativePromptCards } from "./VideoNarrativePromptCards";
+
+describe("VideoNarrativePromptCards", () => {
+  const lockedSections = buildVideoNarrativeAppPreviewScenario({ access: "free" }).diagnosis.lockedSections;
+
+  it("renders upgrade prompt when showUpgrade", () => {
+    render(<VideoNarrativePromptCards showUpgrade />);
+
+    expect(screen.getByText("Quer liberar diagnósticos completos?")).toBeInTheDocument();
+    expect(screen.getByText("Ver planos")).toBeInTheDocument();
+  });
+
+  it("renders Instagram prompt when showInstagram", () => {
+    render(<VideoNarrativePromptCards showInstagram />);
+
+    expect(screen.getByText("Quer deixar o diagnóstico mais preciso?")).toBeInTheDocument();
+    expect(screen.getByText("Conectar Instagram")).toBeInTheDocument();
+  });
+
+  it("renders lockedSections", () => {
+    render(<VideoNarrativePromptCards lockedSections={lockedSections} />);
+
+    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
+    expect(screen.getAllByText(/premium|Instagram/i).length).toBeGreaterThan(0);
+  });
+
+  it("does not render card when flags false and no locked sections", () => {
+    const { container } = render(<VideoNarrativePromptCards />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.tsx
@@ -1,0 +1,64 @@
+import type { VideoNarrativeDiagnosisLockedSection } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
+
+type VideoNarrativePromptCardsProps = {
+  lockedSections?: VideoNarrativeDiagnosisLockedSection[];
+  showUpgrade?: boolean;
+  showInstagram?: boolean;
+};
+
+function PromptCard({
+  title,
+  description,
+  cta,
+}: {
+  title: string;
+  description: string;
+  cta: string;
+}) {
+  return (
+    <article className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <h3 className="text-base font-semibold text-zinc-950">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-zinc-700">{description}</p>
+      <span className="mt-4 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white">{cta}</span>
+    </article>
+  );
+}
+
+export function VideoNarrativePromptCards({
+  lockedSections = [],
+  showUpgrade = false,
+  showInstagram = false,
+}: VideoNarrativePromptCardsProps) {
+  if (!showUpgrade && !showInstagram && lockedSections.length === 0) return null;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {showUpgrade ? (
+        <PromptCard
+          title="Quer liberar diagnósticos completos?"
+          description="Assinantes podem fazer novas análises e acessar ações mais profundas."
+          cta="Ver planos"
+        />
+      ) : null}
+      {showInstagram ? (
+        <PromptCard
+          title="Quer deixar o diagnóstico mais preciso?"
+          description="Conecte seu Instagram para comparar esse vídeo com o que já funciona no seu perfil."
+          cta="Conectar Instagram"
+        />
+      ) : null}
+      {lockedSections.length > 0 ? (
+        <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm md:col-span-2">
+          <h3 className="text-base font-semibold text-zinc-950">Seções bloqueadas</h3>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-zinc-700">
+            {lockedSections.map((section) => (
+              <li key={section.key} className="rounded-lg bg-zinc-50 px-3 py-2">
+                <span className="font-semibold text-zinc-900">{section.title}:</span> {section.message}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeQuizCard.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeQuizCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+import { VideoNarrativeQuizCard } from "./VideoNarrativeQuizCard";
+
+describe("VideoNarrativeQuizCard", () => {
+  const questions = buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" }).quiz.questions;
+
+  it("renders questions", () => {
+    render(<VideoNarrativeQuizCard questions={questions} />);
+
+    expect(screen.getAllByText(/Pergunta/).length).toBeGreaterThan(0);
+  });
+
+  it("renders options", () => {
+    render(<VideoNarrativeQuizCard questions={questions} />);
+
+    expect(screen.getAllByText(/Gerar identificação|Mais direta|Reels direto|Ainda não sei/).length).toBeGreaterThan(0);
+  });
+
+  it("renders learningSignalType badge", () => {
+    render(<VideoNarrativeQuizCard questions={questions} />);
+
+    expect(screen.getAllByText(/sinal:/i).length).toBeGreaterThan(0);
+  });
+
+  it("handles empty list", () => {
+    render(<VideoNarrativeQuizCard questions={[]} />);
+
+    expect(screen.getByText("Sem perguntas para este cenário.")).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeQuizCard.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeQuizCard.tsx
@@ -1,0 +1,41 @@
+import type { VideoNarrativeDiagnosisQuizQuestion } from "../../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
+import { formatSignalLabel } from "./VideoNarrativeAppPreviewPrimitives";
+
+type VideoNarrativeQuizCardProps = {
+  questions: VideoNarrativeDiagnosisQuizQuestion[];
+};
+
+export function VideoNarrativeQuizCard({ questions }: VideoNarrativeQuizCardProps) {
+  if (questions.length === 0) {
+    return (
+      <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+        <p className="text-sm leading-6 text-zinc-600">Sem perguntas para este cenário.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {questions.map((question, index) => (
+        <article key={question.id} className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Pergunta {index + 1}</p>
+          <h3 className="mt-1 text-base font-semibold text-zinc-950">{question.title}</h3>
+          <p className="mt-2 text-sm leading-6 text-zinc-600">{question.helper ?? question.reason}</p>
+          <div className="mt-4 grid gap-2">
+            {question.options.map((option) => (
+              <div key={option.id} className="rounded-lg border border-zinc-200 bg-white p-3">
+                <p className="text-sm font-semibold text-zinc-800">{option.label}</p>
+                {option.description ? <p className="mt-1 text-xs leading-5 text-zinc-500">{option.description}</p> : null}
+                {option.learningSignalType ? (
+                  <span className="mt-2 inline-flex rounded-full bg-zinc-900 px-2.5 py-1 text-xs font-semibold text-white">
+                    sinal: {formatSignalLabel(option.learningSignalType)}
+                  </span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { VideoNarrativeStageShell } from "./VideoNarrativeStageShell";
+
+describe("VideoNarrativeStageShell", () => {
+  it("renders eyebrow, title, subtitle and helper", () => {
+    render(
+      <VideoNarrativeStageShell
+        eyebrow="Etapa"
+        title="Título da etapa"
+        subtitle="Subtítulo"
+        helper="Ajuda"
+      />,
+    );
+
+    expect(screen.getByText("Etapa")).toBeInTheDocument();
+    expect(screen.getByText("Título da etapa")).toBeInTheDocument();
+    expect(screen.getByText("Subtítulo")).toBeInTheDocument();
+    expect(screen.getByText("Ajuda")).toBeInTheDocument();
+  });
+
+  it("renders children and footer", () => {
+    render(
+      <VideoNarrativeStageShell title="Título" footer={<button type="button">Continuar</button>}>
+        <p>Conteúdo</p>
+      </VideoNarrativeStageShell>,
+    );
+
+    expect(screen.getByText("Conteúdo")).toBeInTheDocument();
+    expect(screen.getByText("Continuar")).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+type VideoNarrativeStageShellProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string | null;
+  helper?: string | null;
+  children?: ReactNode;
+  footer?: ReactNode;
+};
+
+export function VideoNarrativeStageShell({
+  eyebrow,
+  title,
+  subtitle,
+  helper,
+  children,
+  footer,
+}: VideoNarrativeStageShellProps) {
+  return (
+    <section className="mx-auto w-full max-w-3xl rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-7">
+      {eyebrow ? <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">{eyebrow}</p> : null}
+      <h2 className="mt-2 text-2xl font-semibold tracking-normal text-zinc-950 sm:text-3xl">{title}</h2>
+      {subtitle ? <p className="mt-3 text-sm leading-6 text-zinc-700 sm:text-base">{subtitle}</p> : null}
+      {helper ? <p className="mt-2 text-sm leading-6 text-zinc-500">{helper}</p> : null}
+      {children ? <div className="mt-6">{children}</div> : null}
+      {footer ? <footer className="mt-6 border-t border-zinc-100 pt-5">{footer}</footer> : null}
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
@@ -63,8 +63,8 @@ describe("VideoNarrativeAppPreviewPage", () => {
 
     expect(screen.getAllByText("Marca").length).toBeGreaterThan(0);
     expect(screen.getByText("Seu diagnóstico está pronto")).toBeInTheDocument();
-    expect(screen.getAllByText("instagram_optimized").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("connected").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Instagram otimizado").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Conectado").length).toBeGreaterThan(0);
     expect(screen.getByText("Comparação com Instagram")).toBeInTheDocument();
   });
 

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -90,6 +90,8 @@ Já existe:
 - prompts de upgrade e Instagram foram definidos em MM32 sem conectar billing ou Instagram real;
 - internal app-first preview foi criado em MM33 para visualizar a jornada com cenários mockados;
 - a preview MM33 continua sem upload real, persistência, BoardShell, endpoint real ou Instagram real;
+- UI primitives foram criados em MM34 para deixar a preview mais próxima de app;
+- os primitives MM34 seguem isolados da rota real, sem upload real, persistência, BoardShell ou integração externa;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -755,6 +755,34 @@ O que não faz:
 - não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta Instagram real, billing, Stripe ou cobrança.
 
+### MM34 — Diagnosis and Quiz UI primitives
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/appPreview/VideoNarrativeStageShell.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeProgress.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeLoadingBlock.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeQuizCard.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativePromptCards.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.ts`
+
+O que faz:
+
+- cria primitives reutilizáveis para a preview app-first;
+- deixa quiz, diagnóstico, loading, progresso e prompts em componentes modulares;
+- melhora a sensação de app interno sem conectar a experiência ao produto real;
+- mantém `VideoNarrativeAppPreview` como composição de blocos testáveis.
+
+O que não faz:
+
+- não cria upload real, storage real, banco/tabela, analytics real ou persistência;
+- não altera endpoint real nem chama Gemini, OpenAI, endpoint ou rede;
+- não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta Instagram real, billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -240,8 +240,9 @@ Exemplos:
 30. MM31 — Creator Narrative Profile contract. Organiza sinais acumulados do criador sem persistência, banco ou Instagram real.
 31. MM32 — App-first flow state model. Define estados, transições, copy e prompts antes de qualquer UI real.
 32. MM33 — Internal app-first preview with mock. Permite sentir a experiência app-first em preview interna/admin-dev com cenários mockados, sem produto real.
-33. Teste real manual quando houver quota/billing disponível.
-34. Integração experimental futura no Board de Criação.
+33. MM34 — Diagnosis and Quiz UI primitives. Modulariza a preview interna em componentes reutilizáveis de shell, progresso, loading, quiz, diagnóstico e prompts.
+34. Teste real manual quando houver quota/billing disponível.
+35. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -300,6 +301,8 @@ MM31 adiciona `VideoNarrativeCreatorProfile` como contrato puro para agregar sin
 MM32 adiciona `VideoNarrativeAppFlowState` para modelar a experiência app-first antes da UI. A jornada cobre upload, análise, pergunta central, quiz, diagnóstico, CTAs e prompts de upgrade/Instagram sem alterar endpoint, criar upload real ou persistir respostas/sinais.
 
 MM33 adiciona `/dashboard/boards/video-narrative-app-preview` como preview interna protegida por flag e admin/dev. A experiência já pode ser sentida com cenários mockados, controles por query param, diagnóstico, quiz, perfil narrativo e prompts, mas continua fora do produto real, sem upload real, storage, banco, BoardShell, endpoint real ou persistência.
+
+MM34 adiciona primitives visuais em `components/videoUpload/appPreview/` para tornar a preview interna mais próxima de um app. A rota passa a compor shell, progresso, loading, quiz, diagnóstico e prompts com componentes testáveis, ainda sem upload real, endpoint alterado, persistência, BoardShell ou integração real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
Stacked sobre #830.

## Summary
- Adds modular UI primitives for the internal video narrative app-first preview.
- Refactors `VideoNarrativeAppPreview` to compose stage shell, progress, loading, quiz, diagnosis, and prompt blocks.
- Updates MM34 docs/readiness notes for the preview-only UI layer.

## Safety
- No endpoint changes.
- No real upload, storage, database, persistence, analytics, BoardShell wiring, navigation link, Gemini/OpenAI call, Instagram integration, Stripe, billing, or new dependency.
- Preview remains mock/query-param driven and internal.

## Validation
- `npm test -- --runInBand` primitives block: passed.
- `npm test -- --runInBand` app preview/page/scenario/flag block: passed.
- `npm test -- --runInBand` MM29-MM33 + endpoint mock block: passed.
- `npm test -- --runInBand` videoUpload/previews regressions: passed.
- `npm test -- --runInBand` NSE/Adaptive regressions: passed.
- `npm run typecheck`: passed.
- `git diff --check`: passed.
- `npm run build`: passed.