### PR TITLE
feat: add video narrative interactive app preview

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
@@ -1,0 +1,263 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { VideoNarrativeInteractiveAppPreview } from "./VideoNarrativeInteractiveAppPreview";
+import { buildVideoNarrativeAppPreviewScenario } from "./buildVideoNarrativeAppPreviewScenario";
+
+function renderInteractive() {
+  return render(<VideoNarrativeInteractiveAppPreview scenarioData={buildVideoNarrativeAppPreviewScenario()} />);
+}
+
+function answerAllQuizQuestions(container: HTMLElement) {
+  const articles = container.querySelectorAll("article");
+  articles.forEach((article) => {
+    const option = within(article as HTMLElement).getAllByRole("button")[0]!;
+    fireEvent.click(option);
+  });
+}
+
+describe("VideoNarrativeInteractiveAppPreview", () => {
+  it("renders welcome initially", () => {
+    renderInteractive();
+
+    expect(screen.getByText("Preview interativo app-first")).toBeInTheDocument();
+    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+  });
+
+  it("clicking Começar shows upload_video", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+
+    expect(screen.getByText("Suba seu vídeo")).toBeInTheDocument();
+  });
+
+  it("clicking upload shows analyzing_video", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+
+    expect(screen.getByText("Analisando seu vídeo")).toBeInTheDocument();
+  });
+
+  it("loading analysis shows messages", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+
+    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+  });
+
+  it("continue shows central question", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+
+    expect(screen.getByText("O que você quer entender sobre esse vídeo?")).toBeInTheDocument();
+  });
+
+  it("filling goal and continuing shows understanding_goal", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+
+    expect(screen.getByText("Entendendo sua dúvida")).toBeInTheDocument();
+  });
+
+  it("continue from understanding_goal shows adaptive quiz", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+
+    expect(screen.getByText("Algumas perguntas rápidas")).toBeInTheDocument();
+  });
+
+  it("answering quiz and completing shows building diagnosis", () => {
+    const { container } = renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    answerAllQuizQuestions(container);
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+
+    expect(screen.getByText("Montando seu diagnóstico")).toBeInTheDocument();
+  });
+
+  it("build diagnosis shows diagnosis_ready", () => {
+    const { container } = renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    answerAllQuizQuestions(container);
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+    fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
+
+    expect(screen.getByText("Seu diagnóstico está pronto")).toBeInTheDocument();
+  });
+
+  it("diagnosis_ready shows diagnosis, locked sections, profile summary and prompts", () => {
+    const { container } = renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    answerAllQuizQuestions(container);
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+    fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
+
+    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
+    expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ver planos" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Conectar Instagram" })).toBeInTheDocument();
+  });
+
+  it("clicking Ver planos shows upgrade prompt", () => {
+    const { container } = renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    answerAllQuizQuestions(container);
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+    fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
+    fireEvent.click(screen.getByRole("button", { name: "Ver planos" }));
+
+    expect(screen.getAllByText("Quer liberar diagnósticos completos?").length).toBeGreaterThan(0);
+  });
+
+  it("clicking Conectar Instagram shows Instagram prompt", () => {
+    const { container } = renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    answerAllQuizQuestions(container);
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+    fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
+    fireEvent.click(screen.getByRole("button", { name: "Conectar Instagram" }));
+
+    expect(screen.getAllByText("Quer deixar o diagnóstico mais preciso?").length).toBeGreaterThan(0);
+  });
+
+  it("reset returns to beginning", () => {
+    renderInteractive();
+
+    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reiniciar" }));
+
+    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+  });
+
+  it("does not call endpoint or fetch", () => {
+    const source = fs.readFileSync(path.join(__dirname, "VideoNarrativeInteractiveAppPreview.tsx"), "utf8");
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("app/api");
+    expect(source).not.toContain("route");
+  });
+
+  it("new interactive files do not import forbidden integrations", () => {
+    const files = [
+      path.join(__dirname, "VideoNarrativeInteractiveAppPreview.tsx"),
+      path.join(__dirname, "appPreview/useVideoNarrativeInteractivePreviewState.ts"),
+      path.join(__dirname, "appPreview/VideoNarrativeGoalInput.tsx"),
+      path.join(__dirname, "appPreview/VideoNarrativeInteractiveQuiz.tsx"),
+    ];
+    const forbidden = [
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "app/api",
+      "upload service",
+      "storage provider",
+      "analytics provider",
+      "ffmpeg",
+      "Stripe",
+      "billing",
+      "GoogleGenAI",
+      "BoardShell",
+      "PostCreationFunnelBoardShell",
+      "PostCreationFunnelState",
+    ];
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, "utf8");
+      const importLines = source
+        .split("\n")
+        .filter((line) => line.trim().startsWith("import"))
+        .join("\n");
+      for (const term of forbidden) {
+        expect(importLines).not.toContain(term);
+      }
+    }
+  });
+
+  it("does not render raw payload, API key or signed URL fields", () => {
+    const { container } = renderInteractive();
+    const text = container.textContent || "";
+
+    for (const forbidden of ["rawText", "inlineVideoBase64", "base64", "apiKey", "signedUrl", "videoUrl", "AIza"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps rendered language safe", () => {
+    const { container } = renderInteractive();
+    const text = container.textContent?.toLowerCase() || "";
+
+    for (const forbidden of [
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "score",
+      "nota",
+      "pontuação",
+      "acerto",
+      "gabarito",
+      "resposta correta",
+      "venceu",
+      "perdeu",
+      "treinado permanentemente",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import {
+  buildVideoNarrativeStrategicDiagnosis,
+  type VideoNarrativeDiagnosisQuizAnswer,
+} from "../../videoUpload/videoNarrativeDiagnosisLearningModel";
+import { buildVideoNarrativeDiagnosisQuiz } from "../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
+import { buildVideoNarrativeCreatorProfile } from "../../videoUpload/videoNarrativeCreatorProfileContract";
+import { VideoNarrativeDiagnosisBlocks } from "./appPreview/VideoNarrativeDiagnosisBlocks";
+import { VideoNarrativeGoalInput } from "./appPreview/VideoNarrativeGoalInput";
+import { VideoNarrativeInteractiveQuiz } from "./appPreview/VideoNarrativeInteractiveQuiz";
+import { VideoNarrativeLoadingBlock } from "./appPreview/VideoNarrativeLoadingBlock";
+import { VideoNarrativeProgress } from "./appPreview/VideoNarrativeProgress";
+import { VideoNarrativePromptCards } from "./appPreview/VideoNarrativePromptCards";
+import { VideoNarrativeStageShell } from "./appPreview/VideoNarrativeStageShell";
+import {
+  formatAccessLabel,
+  formatStageLabel,
+} from "./appPreview/VideoNarrativeAppPreviewPrimitives";
+import { useVideoNarrativeInteractivePreviewState } from "./appPreview/useVideoNarrativeInteractivePreviewState";
+import type { buildVideoNarrativeAppPreviewScenario } from "./buildVideoNarrativeAppPreviewScenario";
+
+type VideoNarrativeInteractiveAppPreviewData = ReturnType<typeof buildVideoNarrativeAppPreviewScenario>;
+
+type VideoNarrativeInteractiveAppPreviewProps = {
+  scenarioData: VideoNarrativeInteractiveAppPreviewData;
+};
+
+function toQuizAnswers(params: {
+  scenarioData: VideoNarrativeInteractiveAppPreviewData;
+  selectedAnswers: Record<string, string>;
+}): VideoNarrativeDiagnosisQuizAnswer[] {
+  return params.scenarioData.quiz.questions.flatMap((question) => {
+    const optionId = params.selectedAnswers[question.id];
+    const option = question.options.find((candidate) => candidate.id === optionId);
+    if (!option) return [];
+
+    return [
+      {
+        questionId: question.id,
+        key: question.key,
+        value: option.learningSignalValue ?? option.id,
+        label: option.label,
+      },
+    ];
+  });
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  disabled = false,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-zinc-300"
+    >
+      {children}
+    </button>
+  );
+}
+
+function SecondaryButton({ children, onClick }: { children: ReactNode; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarrativeInteractiveAppPreviewProps) {
+  const previewState = useVideoNarrativeInteractivePreviewState(scenarioData);
+  const { currentStage, flowState, actions, selectedQuizAnswers, creatorGoal } = previewState;
+
+  const derived = useMemo(() => {
+    const creatorQuestion = creatorGoal || scenarioData.scenario.creatorQuestion;
+    const quizAnswers = toQuizAnswers({ scenarioData, selectedAnswers: selectedQuizAnswers });
+    const diagnosis = buildVideoNarrativeStrategicDiagnosis({
+      accessLevel: scenarioData.accessLevel,
+      analysis: scenarioData.analysis,
+      seed: scenarioData.seed,
+      creatorQuestion,
+      quizAnswers,
+      instagramContext: {
+        connected: scenarioData.instagramConnected,
+        topNarratives: scenarioData.instagramConnected ? ["rotina orgânica -> produto -> continuidade"] : [],
+        topFormats: scenarioData.instagramConnected ? ["reel", "stories"] : [],
+        strongestMetricsSummary: scenarioData.instagramConnected
+          ? "Histórico simulado para comparação interna de preview."
+          : null,
+        brandTerritories: scenarioData.instagramConnected ? ["beleza", "autocuidado"] : [],
+      },
+    });
+    const quiz = buildVideoNarrativeDiagnosisQuiz({
+      analysis: scenarioData.analysis,
+      seed: scenarioData.seed,
+      diagnosis,
+      creatorQuestion,
+      accessLevel: scenarioData.accessLevel,
+      existingSignals: diagnosis.creatorSignals,
+    });
+    const creatorProfile = buildVideoNarrativeCreatorProfile({
+      creatorId: "video-narrative-interactive-preview-creator",
+      newSignals: diagnosis.creatorSignals,
+      diagnosisId: diagnosis.id,
+      createdAt: scenarioData.analysis.createdAt,
+    });
+
+    return { diagnosis, quiz, creatorProfile };
+  }, [creatorGoal, scenarioData, selectedQuizAnswers]);
+
+  function renderBody() {
+    if (currentStage === "upload_video") {
+      return (
+        <button
+          type="button"
+          onClick={actions.simulateVideoUpload}
+          className="flex min-h-36 w-full items-center justify-center rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-6 py-8 text-lg font-semibold text-zinc-950 hover:border-zinc-500 hover:bg-white"
+        >
+          + Subir vídeo
+        </button>
+      );
+    }
+
+    if (currentStage === "analyzing_video") {
+      return (
+        <div className="grid gap-5">
+          <VideoNarrativeLoadingBlock title="Analisando vídeo simulado" messages={flowState.copy.loadingMessages} />
+          <PrimaryButton onClick={actions.continueAfterVideoAnalysis}>Continuar</PrimaryButton>
+        </div>
+      );
+    }
+
+    if (currentStage === "asking_creator_goal") {
+      return <VideoNarrativeGoalInput initialValue={creatorGoal} onSubmit={actions.submitCreatorGoal} />;
+    }
+
+    if (currentStage === "understanding_goal") {
+      return (
+        <div className="grid gap-5">
+          {creatorGoal ? (
+            <p className="rounded-xl bg-zinc-50 p-4 text-sm leading-6 text-zinc-700">Objetivo informado: {creatorGoal}</p>
+          ) : null}
+          <VideoNarrativeLoadingBlock title="Entendendo objetivo" messages={flowState.copy.loadingMessages} />
+          <PrimaryButton onClick={actions.continueAfterUnderstandingGoal}>Continuar</PrimaryButton>
+        </div>
+      );
+    }
+
+    if (currentStage === "adaptive_quiz") {
+      return (
+        <VideoNarrativeInteractiveQuiz
+          questions={derived.quiz.questions}
+          selectedAnswers={selectedQuizAnswers}
+          onAnswer={actions.answerQuiz}
+          onComplete={actions.completeQuiz}
+        />
+      );
+    }
+
+    if (currentStage === "building_diagnosis") {
+      return (
+        <div className="grid gap-5">
+          <VideoNarrativeLoadingBlock title="Montando diagnóstico" messages={flowState.copy.loadingMessages} />
+          <PrimaryButton onClick={actions.buildDiagnosis}>Montar diagnóstico</PrimaryButton>
+        </div>
+      );
+    }
+
+    if (currentStage === "diagnosis_ready") {
+      return (
+        <div className="grid gap-4">
+          <div className="flex flex-wrap gap-2">
+            <SecondaryButton onClick={() => undefined}>Transformar em roteiro</SecondaryButton>
+            <SecondaryButton onClick={() => undefined}>Criar blueprint</SecondaryButton>
+            <SecondaryButton onClick={actions.requestUpgrade}>Ver planos</SecondaryButton>
+            <SecondaryButton onClick={actions.requestInstagramConnection}>Conectar Instagram</SecondaryButton>
+          </div>
+          <VideoNarrativeDiagnosisBlocks diagnosis={derived.diagnosis} creatorProfile={derived.creatorProfile} />
+        </div>
+      );
+    }
+
+    if (currentStage === "upgrade_prompt") {
+      return <VideoNarrativePromptCards lockedSections={derived.diagnosis.lockedSections} showUpgrade />;
+    }
+
+    if (currentStage === "instagram_optimization_prompt") {
+      return <VideoNarrativePromptCards showInstagram />;
+    }
+
+    if (currentStage === "completed") {
+      return (
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-sm leading-6 text-zinc-700">Preview concluído. Você pode reiniciar a jornada quando quiser.</p>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  function renderFooter() {
+    if (currentStage === "welcome") {
+      return <PrimaryButton onClick={actions.start}>Começar</PrimaryButton>;
+    }
+
+    if (currentStage === "diagnosis_ready") {
+      return (
+        <div className="flex flex-wrap gap-2">
+          <PrimaryButton onClick={actions.finish}>Concluir</PrimaryButton>
+          <SecondaryButton onClick={actions.reset}>Reiniciar</SecondaryButton>
+        </div>
+      );
+    }
+
+    if (currentStage === "upgrade_prompt" || currentStage === "instagram_optimization_prompt" || currentStage === "completed") {
+      return <SecondaryButton onClick={actions.reset}>Reiniciar</SecondaryButton>;
+    }
+
+    return <SecondaryButton onClick={actions.reset}>Reiniciar</SecondaryButton>;
+  }
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950 sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-6xl gap-5">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Análise Guiada de Vídeo</p>
+          <h1 className="mt-2 text-2xl font-semibold">Preview interativo app-first</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Jornada local com mocks. Sem upload real, endpoint call, Gemini, storage, banco ou persistência.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold text-zinc-600">
+            <span className="rounded-full bg-zinc-50 px-3 py-1">Cenário: {scenarioData.scenario.label}</span>
+            <span className="rounded-full bg-zinc-50 px-3 py-1">Acesso: {formatAccessLabel(scenarioData.accessLevel)}</span>
+            <span className="rounded-full bg-zinc-50 px-3 py-1">
+              Instagram: {scenarioData.instagramConnected ? "Conectado" : "Desconectado"}
+            </span>
+          </div>
+        </header>
+
+        <VideoNarrativeStageShell
+          eyebrow={formatStageLabel(currentStage)}
+          title={flowState.copy.title}
+          subtitle={flowState.copy.subtitle}
+          helper={flowState.copy.helper}
+          footer={renderFooter()}
+        >
+          <VideoNarrativeProgress
+            currentStep={flowState.progress.currentStep}
+            totalSteps={flowState.progress.totalSteps}
+            label={flowState.progress.label}
+          />
+          <div className="mt-6">{renderBody()}</div>
+        </VideoNarrativeStageShell>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { VideoNarrativeGoalInput } from "./VideoNarrativeGoalInput";
+
+describe("VideoNarrativeGoalInput", () => {
+  it("renders placeholder", () => {
+    render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    expect(screen.getByPlaceholderText("Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi.")).toBeInTheDocument();
+  });
+
+  it("starts with continue disabled", () => {
+    render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Continuar" })).toBeDisabled();
+  });
+
+  it("typing text enables continue", () => {
+    render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero melhorar o gancho" } });
+
+    expect(screen.getByRole("button", { name: "Continuar" })).toBeEnabled();
+  });
+
+  it("quick prompt fills text", () => {
+    render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Virar publi" }));
+
+    expect(screen.getByRole("textbox")).toHaveValue("Virar publi");
+  });
+
+  it("submit calls callback with text", () => {
+    const onSubmit = jest.fn();
+    render(<VideoNarrativeGoalInput onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Vale postar?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+
+    expect(onSubmit).toHaveBeenCalledWith("Vale postar?");
+  });
+
+  it("does not render sensitive terms from input", () => {
+    const { container } = render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: {
+        value:
+          "AIza123456789012345678901234 GEMINI_API_KEY=secret https://example.com/video.mp4?token=abc AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+    });
+
+    const text = container.textContent || "";
+    expect(text).not.toContain("AIza");
+    expect(text).not.toContain("GEMINI_API_KEY=secret");
+    expect(text).not.toContain("token=abc");
+    expect(screen.getByRole("textbox")).toHaveValue("[redigido] [redigido] [redigido] [redigido]");
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { sanitizeVideoNarrativeInteractivePreviewText } from "./useVideoNarrativeInteractivePreviewState";
+
+type VideoNarrativeGoalInputProps = {
+  initialValue?: string;
+  onSubmit: (goal: string) => void;
+};
+
+const QUICK_PROMPTS = [
+  "Vale postar?",
+  "Melhorar gancho",
+  "Virar publi",
+  "Entender narrativa",
+  "Encontrar marcas",
+];
+
+export function VideoNarrativeGoalInput({ initialValue = "", onSubmit }: VideoNarrativeGoalInputProps) {
+  const [value, setValue] = useState(() => sanitizeVideoNarrativeInteractivePreviewText(initialValue));
+  const safeValue = sanitizeVideoNarrativeInteractivePreviewText(value);
+
+  function updateValue(nextValue: string) {
+    setValue(sanitizeVideoNarrativeInteractivePreviewText(nextValue));
+  }
+
+  return (
+    <form
+      className="grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!safeValue) return;
+        onSubmit(safeValue);
+      }}
+    >
+      <textarea
+        value={value}
+        onChange={(event) => updateValue(event.currentTarget.value)}
+        rows={4}
+        placeholder="Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi."
+        className="min-h-32 rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm leading-6 text-zinc-950 outline-none transition focus:border-zinc-500"
+      />
+      <div className="flex flex-wrap gap-2">
+        {QUICK_PROMPTS.map((prompt) => (
+          <button
+            key={prompt}
+            type="button"
+            onClick={() => updateValue(prompt)}
+            className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700 hover:bg-zinc-100"
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
+      <button
+        type="submit"
+        disabled={!safeValue}
+        className="inline-flex w-fit rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-zinc-300"
+      >
+        Continuar
+      </button>
+    </form>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+import { VideoNarrativeInteractiveQuiz } from "./VideoNarrativeInteractiveQuiz";
+
+const scenario = buildVideoNarrativeAppPreviewScenario({ stage: "adaptive_quiz" });
+
+describe("VideoNarrativeInteractiveQuiz", () => {
+  it("renders questions", () => {
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={{}}
+        onAnswer={jest.fn()}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText(/Pergunta/).length).toBeGreaterThan(0);
+  });
+
+  it("selects option", () => {
+    const onAnswer = jest.fn();
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={{}}
+        onAnswer={onAnswer}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(scenario.quiz.questions[0]!.options[0]!.label) }));
+
+    expect(onAnswer).toHaveBeenCalledWith(scenario.quiz.questions[0]!.id, scenario.quiz.questions[0]!.options[0]!.id);
+  });
+
+  it("shows answered progress", () => {
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={{ [scenario.quiz.questions[0]!.id]: scenario.quiz.questions[0]!.options[0]!.id }}
+        onAnswer={jest.fn()}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(`1/${scenario.quiz.questions.length} perguntas respondidas`)).toBeInTheDocument();
+  });
+
+  it("keeps complete disabled until required questions are answered", () => {
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={{}}
+        onAnswer={jest.fn()}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Concluir quiz" })).toBeDisabled();
+  });
+
+  it("complete calls callback when ready", () => {
+    const onComplete = jest.fn();
+    const selectedAnswers = Object.fromEntries(
+      scenario.quiz.questions.map((question) => [question.id, question.options[0]!.id]),
+    );
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={selectedAnswers}
+        onAnswer={jest.fn()}
+        onComplete={onComplete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
+
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("shows learningSignalType on options", () => {
+    render(
+      <VideoNarrativeInteractiveQuiz
+        questions={scenario.quiz.questions}
+        selectedAnswers={{}}
+        onAnswer={jest.fn()}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText(/sinal:/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { VideoNarrativeDiagnosisQuizQuestion } from "../../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
+import { formatSignalLabel } from "./VideoNarrativeAppPreviewPrimitives";
+import type { VideoNarrativeInteractiveQuizAnswers } from "./useVideoNarrativeInteractivePreviewState";
+
+type VideoNarrativeInteractiveQuizProps = {
+  questions: VideoNarrativeDiagnosisQuizQuestion[];
+  selectedAnswers: VideoNarrativeInteractiveQuizAnswers;
+  onAnswer: (questionId: string, optionId: string) => void;
+  onComplete: () => void;
+};
+
+function countAnswered(questions: VideoNarrativeDiagnosisQuizQuestion[], selectedAnswers: VideoNarrativeInteractiveQuizAnswers) {
+  return questions.filter((question) => Boolean(selectedAnswers[question.id])).length;
+}
+
+function requiredComplete(questions: VideoNarrativeDiagnosisQuizQuestion[], selectedAnswers: VideoNarrativeInteractiveQuizAnswers) {
+  return questions.filter((question) => question.required).every((question) => Boolean(selectedAnswers[question.id]));
+}
+
+export function VideoNarrativeInteractiveQuiz({
+  questions,
+  selectedAnswers,
+  onAnswer,
+  onComplete,
+}: VideoNarrativeInteractiveQuizProps) {
+  const answered = countAnswered(questions, selectedAnswers);
+  const canComplete = questions.length > 0 && requiredComplete(questions, selectedAnswers);
+
+  if (questions.length === 0) {
+    return (
+      <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+        <p className="text-sm leading-6 text-zinc-600">Sem perguntas para este cenário.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      <p className="text-sm font-semibold text-zinc-700">
+        {answered}/{questions.length} perguntas respondidas
+      </p>
+      <div className="grid gap-3">
+        {questions.map((question, index) => (
+          <article key={question.id} className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Pergunta {index + 1}</p>
+            <h3 className="mt-1 text-base font-semibold text-zinc-950">{question.title}</h3>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">{question.helper ?? question.reason}</p>
+            <div className="mt-4 grid gap-2">
+              {question.options.map((option) => {
+                const selected = selectedAnswers[question.id] === option.id;
+
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => onAnswer(question.id, option.id)}
+                    className={
+                      selected
+                        ? "rounded-lg border border-zinc-950 bg-white p-3 text-left shadow-sm"
+                        : "rounded-lg border border-zinc-200 bg-white p-3 text-left hover:border-zinc-400"
+                    }
+                  >
+                    <span className="block text-sm font-semibold text-zinc-800">{option.label}</span>
+                    {option.description ? (
+                      <span className="mt-1 block text-xs leading-5 text-zinc-500">{option.description}</span>
+                    ) : null}
+                    {option.learningSignalType ? (
+                      <span className="mt-2 inline-flex rounded-full bg-zinc-900 px-2.5 py-1 text-xs font-semibold text-white">
+                        sinal: {formatSignalLabel(option.learningSignalType)}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </article>
+        ))}
+      </div>
+      <button
+        type="button"
+        disabled={!canComplete}
+        onClick={onComplete}
+        className="inline-flex w-fit rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-zinc-300"
+      >
+        Concluir quiz
+      </button>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.test.tsx
@@ -1,0 +1,219 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+import { useVideoNarrativeInteractivePreviewState } from "./useVideoNarrativeInteractivePreviewState";
+
+function Harness() {
+  const scenario = buildVideoNarrativeAppPreviewScenario();
+  const state = useVideoNarrativeInteractivePreviewState(scenario);
+  const requiredQuestions = scenario.quiz.questions.filter((question) => question.required);
+
+  return (
+    <div>
+      <p>stage:{state.currentStage}</p>
+      <p>hasVideo:{String(state.context.hasVideo)}</p>
+      <p>hasVideoAnalysis:{String(state.context.hasVideoAnalysis)}</p>
+      <p>hasDiagnosis:{String(state.context.hasDiagnosis)}</p>
+      <p>goal:{state.creatorGoal}</p>
+      <p>answers:{Object.keys(state.selectedQuizAnswers).length}</p>
+      <p>access:{state.accessLevel}</p>
+      <p>scenario:{state.selectedScenario}</p>
+      <p>instagram:{String(state.instagramConnected)}</p>
+      <button type="button" onClick={state.actions.start}>
+        start
+      </button>
+      <button type="button" onClick={state.actions.simulateVideoUpload}>
+        upload
+      </button>
+      <button type="button" onClick={state.actions.continueAfterVideoAnalysis}>
+        analysis-ready
+      </button>
+      <button type="button" onClick={() => state.actions.submitCreatorGoal("Melhorar gancho AIza123456789012345678901234")}>
+        submit-goal
+      </button>
+      <button type="button" onClick={() => state.actions.submitCreatorGoal("   ")}>
+        submit-empty-goal
+      </button>
+      <button type="button" onClick={state.actions.continueAfterUnderstandingGoal}>
+        goal-understood
+      </button>
+      <button type="button" onClick={() => state.actions.answerQuiz(requiredQuestions[0]!.id, requiredQuestions[0]!.options[0]!.id)}>
+        answer-one
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          requiredQuestions.forEach((question) => state.actions.answerQuiz(question.id, question.options[0]!.id));
+        }}
+      >
+        answer-all
+      </button>
+      <button type="button" onClick={state.actions.completeQuiz}>
+        complete-quiz
+      </button>
+      <button type="button" onClick={state.actions.buildDiagnosis}>
+        build-diagnosis
+      </button>
+      <button type="button" onClick={state.actions.requestUpgrade}>
+        upgrade
+      </button>
+      <button type="button" onClick={state.actions.requestInstagramConnection}>
+        instagram
+      </button>
+      <button type="button" onClick={state.actions.finish}>
+        finish
+      </button>
+      <button type="button" onClick={state.actions.reset}>
+        reset
+      </button>
+    </div>
+  );
+}
+
+describe("useVideoNarrativeInteractivePreviewState", () => {
+  it("starts in welcome", () => {
+    render(<Harness />);
+
+    expect(screen.getByText("stage:welcome")).toBeInTheDocument();
+  });
+
+  it("start changes to upload_video", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("start"));
+
+    expect(screen.getByText("stage:upload_video")).toBeInTheDocument();
+  });
+
+  it("simulateVideoUpload changes to analyzing_video and marks video", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("upload"));
+
+    expect(screen.getByText("stage:analyzing_video")).toBeInTheDocument();
+    expect(screen.getByText("hasVideo:true")).toBeInTheDocument();
+  });
+
+  it("continueAfterVideoAnalysis changes to asking_creator_goal and marks analysis", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("analysis-ready"));
+
+    expect(screen.getByText("stage:asking_creator_goal")).toBeInTheDocument();
+    expect(screen.getByText("hasVideoAnalysis:true")).toBeInTheDocument();
+  });
+
+  it("submitCreatorGoal with valid text changes to understanding_goal and stores sanitized goal", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("submit-goal"));
+
+    expect(screen.getByText("stage:understanding_goal")).toBeInTheDocument();
+    expect(screen.getByText("goal:Melhorar gancho [redigido]")).toBeInTheDocument();
+  });
+
+  it("submitCreatorGoal empty does not advance", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("submit-empty-goal"));
+
+    expect(screen.getByText("stage:welcome")).toBeInTheDocument();
+  });
+
+  it("continueAfterUnderstandingGoal changes to adaptive_quiz", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("goal-understood"));
+
+    expect(screen.getByText("stage:adaptive_quiz")).toBeInTheDocument();
+  });
+
+  it("answerQuiz saves local answer", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("answer-one"));
+
+    expect(screen.getByText("answers:1")).toBeInTheDocument();
+  });
+
+  it("completeQuiz does not advance before required answers", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("complete-quiz"));
+
+    expect(screen.getByText("stage:welcome")).toBeInTheDocument();
+  });
+
+  it("completeQuiz advances to building_diagnosis when required answers exist", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("answer-all"));
+    fireEvent.click(screen.getByText("complete-quiz"));
+
+    expect(screen.getByText("stage:building_diagnosis")).toBeInTheDocument();
+  });
+
+  it("buildDiagnosis changes to diagnosis_ready and marks diagnosis", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("build-diagnosis"));
+
+    expect(screen.getByText("stage:diagnosis_ready")).toBeInTheDocument();
+    expect(screen.getByText("hasDiagnosis:true")).toBeInTheDocument();
+  });
+
+  it("requestUpgrade changes to upgrade_prompt", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("upgrade"));
+
+    expect(screen.getByText("stage:upgrade_prompt")).toBeInTheDocument();
+  });
+
+  it("requestInstagramConnection changes to instagram_optimization_prompt", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("instagram"));
+
+    expect(screen.getByText("stage:instagram_optimization_prompt")).toBeInTheDocument();
+  });
+
+  it("finish changes to completed", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("finish"));
+
+    expect(screen.getByText("stage:completed")).toBeInTheDocument();
+  });
+
+  it("reset returns to welcome and clears goal and answers", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("submit-goal"));
+    fireEvent.click(screen.getByText("answer-one"));
+    fireEvent.click(screen.getByText("reset"));
+
+    expect(screen.getByText("stage:welcome")).toBeInTheDocument();
+    expect(screen.getByText("goal:")).toBeInTheDocument();
+    expect(screen.getByText("answers:0")).toBeInTheDocument();
+  });
+
+  it("reset preserves access, scenario and Instagram state", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("reset"));
+
+    expect(screen.getByText("access:free")).toBeInTheDocument();
+    expect(screen.getByText("scenario:skincare")).toBeInTheDocument();
+    expect(screen.getByText("instagram:false")).toBeInTheDocument();
+  });
+
+  it("does not use fetch, localStorage or setTimeout", () => {
+    const source = fs.readFileSync(path.join(__dirname, "useVideoNarrativeInteractivePreviewState.ts"), "utf8");
+
+    expect(source).not.toContain("fetch");
+    expect(source).not.toContain("localStorage");
+    expect(source).not.toContain("setTimeout");
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.ts
@@ -1,0 +1,208 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  buildVideoNarrativeAppFlowState,
+  type VideoNarrativeAppFlowContext,
+  type VideoNarrativeAppFlowStage,
+} from "../../../videoUpload/videoNarrativeAppFlowState";
+import type { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+
+type VideoNarrativeInteractivePreviewScenarioData = ReturnType<typeof buildVideoNarrativeAppPreviewScenario>;
+
+export type VideoNarrativeInteractiveQuizAnswers = Record<string, string>;
+
+export type VideoNarrativeInteractivePreviewState = {
+  currentStage: VideoNarrativeAppFlowStage;
+  context: VideoNarrativeAppFlowContext;
+  creatorGoal: string;
+  selectedQuizAnswers: VideoNarrativeInteractiveQuizAnswers;
+  selectedScenario: string;
+  accessLevel: VideoNarrativeInteractivePreviewScenarioData["accessLevel"];
+  instagramConnected: boolean;
+  flowState: ReturnType<typeof buildVideoNarrativeAppFlowState>;
+  canGoNext: boolean;
+  canGoBack: boolean;
+  actions: {
+    start: () => void;
+    simulateVideoUpload: () => void;
+    continueAfterVideoAnalysis: () => void;
+    submitCreatorGoal: (goal: string) => void;
+    continueAfterUnderstandingGoal: () => void;
+    answerQuiz: (questionId: string, optionId: string) => void;
+    completeQuiz: () => void;
+    buildDiagnosis: () => void;
+    finish: () => void;
+    requestUpgrade: () => void;
+    requestInstagramConnection: () => void;
+    reset: () => void;
+  };
+};
+
+const INTERACTIVE_STAGES: VideoNarrativeAppFlowStage[] = [
+  "welcome",
+  "upload_video",
+  "analyzing_video",
+  "asking_creator_goal",
+  "understanding_goal",
+  "adaptive_quiz",
+  "building_diagnosis",
+  "diagnosis_ready",
+  "upgrade_prompt",
+  "instagram_optimization_prompt",
+  "completed",
+];
+
+const SENSITIVE_PATTERNS = [
+  /AIza[0-9A-Za-z_-]{20,}/g,
+  /GEMINI_API_KEY\s*=\s*[^\s]+/gi,
+  /GOOGLE_GENAI_API_KEY\s*=\s*[^\s]+/gi,
+  /https?:\/\/[^\s]+(?:token|signature|X-Amz-Signature|X-Goog-Signature)=[^\s]+/gi,
+  /\b[A-Za-z0-9+/]{80,}={0,2}\b/g,
+];
+
+export function sanitizeVideoNarrativeInteractivePreviewText(value: string): string {
+  let safe = value;
+  for (const pattern of SENSITIVE_PATTERNS) {
+    safe = safe.replace(pattern, "[redigido]");
+  }
+  return safe.trim();
+}
+
+function buildContext(params: {
+  baseContext: VideoNarrativeAppFlowContext;
+  patch?: Partial<VideoNarrativeAppFlowContext>;
+}): VideoNarrativeAppFlowContext {
+  return {
+    ...params.baseContext,
+    ...params.patch,
+  };
+}
+
+function hasRequiredAnswers(
+  scenarioData: VideoNarrativeInteractivePreviewScenarioData,
+  answers: VideoNarrativeInteractiveQuizAnswers,
+): boolean {
+  return scenarioData.quiz.questions
+    .filter((question) => question.required)
+    .every((question) => Boolean(answers[question.id]));
+}
+
+export function useVideoNarrativeInteractivePreviewState(
+  scenarioData: VideoNarrativeInteractivePreviewScenarioData,
+): VideoNarrativeInteractivePreviewState {
+  const initialContext = useMemo(
+    () =>
+      buildContext({
+        baseContext: scenarioData.flowState.context,
+        patch: {
+          hasVideo: false,
+          hasVideoAnalysis: false,
+          hasCreatorGoal: false,
+          hasQuiz: false,
+          quizCompleted: false,
+          hasDiagnosis: false,
+          hasUsefulDiagnosis: false,
+          hasCreatorProfile: false,
+        },
+      }),
+    [scenarioData.flowState.context],
+  );
+
+  const [currentStage, setCurrentStage] = useState<VideoNarrativeAppFlowStage>(scenarioData.flowState.stage);
+  const [context, setContext] = useState<VideoNarrativeAppFlowContext>(
+    scenarioData.flowState.stage === "welcome" ? initialContext : scenarioData.flowState.context,
+  );
+  const [creatorGoal, setCreatorGoal] = useState("");
+  const [selectedQuizAnswers, setSelectedQuizAnswers] = useState<VideoNarrativeInteractiveQuizAnswers>({});
+
+  const flowState = useMemo(
+    () =>
+      buildVideoNarrativeAppFlowState({
+        stage: currentStage,
+        context,
+        updatedAt: scenarioData.analysis.createdAt,
+      }),
+    [context, currentStage, scenarioData.analysis.createdAt],
+  );
+
+  function moveTo(stage: VideoNarrativeAppFlowStage, patch?: Partial<VideoNarrativeAppFlowContext>) {
+    setCurrentStage(stage);
+    setContext((current) => buildContext({ baseContext: current, patch }));
+  }
+
+  const actions = {
+    start() {
+      moveTo("upload_video");
+    },
+    simulateVideoUpload() {
+      moveTo("analyzing_video", { hasVideo: true });
+    },
+    continueAfterVideoAnalysis() {
+      moveTo("asking_creator_goal", { hasVideo: true, hasVideoAnalysis: true });
+    },
+    submitCreatorGoal(goal: string) {
+      const safeGoal = sanitizeVideoNarrativeInteractivePreviewText(goal);
+      if (!safeGoal) return;
+      setCreatorGoal(safeGoal);
+      moveTo("understanding_goal", { hasCreatorGoal: true });
+    },
+    continueAfterUnderstandingGoal() {
+      moveTo("adaptive_quiz", { hasQuiz: true });
+    },
+    answerQuiz(questionId: string, optionId: string) {
+      setSelectedQuizAnswers((current) => ({
+        ...current,
+        [questionId]: optionId,
+      }));
+    },
+    completeQuiz() {
+      if (!hasRequiredAnswers(scenarioData, selectedQuizAnswers)) return;
+      moveTo("building_diagnosis", { hasQuiz: true, quizCompleted: true });
+    },
+    buildDiagnosis() {
+      moveTo("diagnosis_ready", {
+        hasDiagnosis: true,
+        hasUsefulDiagnosis: true,
+        hasCreatorProfile: true,
+        lockedSectionsCount: scenarioData.diagnosis.lockedSections.length,
+      });
+    },
+    finish() {
+      moveTo("completed");
+    },
+    requestUpgrade() {
+      moveTo("upgrade_prompt", {
+        hasDiagnosis: true,
+        hasUsefulDiagnosis: true,
+        lockedSectionsCount: scenarioData.diagnosis.lockedSections.length,
+      });
+    },
+    requestInstagramConnection() {
+      moveTo("instagram_optimization_prompt", {
+        hasDiagnosis: true,
+        hasUsefulDiagnosis: true,
+      });
+    },
+    reset() {
+      setCurrentStage("welcome");
+      setContext(initialContext);
+      setCreatorGoal("");
+      setSelectedQuizAnswers({});
+    },
+  };
+
+  return {
+    currentStage,
+    context,
+    creatorGoal,
+    selectedQuizAnswers,
+    selectedScenario: scenarioData.scenario.id,
+    accessLevel: scenarioData.accessLevel,
+    instagramConnected: scenarioData.instagramConnected,
+    flowState,
+    canGoNext: currentStage !== "completed",
+    canGoBack: currentStage !== "welcome",
+    actions,
+  };
+}

--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
@@ -45,6 +45,7 @@ export type VideoNarrativeAppPreviewScenarioParams = {
   stage?: string | string[] | null;
   access?: string | string[] | null;
   instagram?: string | string[] | null;
+  mode?: string | string[] | null;
 };
 
 export const VIDEO_NARRATIVE_APP_PREVIEW_SCENARIOS: VideoNarrativeAppPreviewScenarioDefinition[] = [

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
@@ -46,6 +46,34 @@ describe("VideoNarrativeAppPreviewPage", () => {
     expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
   });
 
+  it("mode=static keeps static preview", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(
+      await VideoNarrativeAppPreviewPage({
+        viewer: adminViewer,
+        searchParams: { mode: "static" },
+      }),
+    );
+
+    expect(screen.getByText("Experiência app-first com mock narrativo")).toBeInTheDocument();
+    expect(screen.queryByText("Preview interativo app-first")).not.toBeInTheDocument();
+  });
+
+  it("mode=interactive renders interactive preview", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(
+      await VideoNarrativeAppPreviewPage({
+        viewer: adminViewer,
+        searchParams: { mode: "interactive" },
+      }),
+    );
+
+    expect(screen.getByText("Preview interativo app-first")).toBeInTheDocument();
+    expect(screen.getByText("Começar")).toBeInTheDocument();
+  });
+
   it("query params alter scenario, stage, access and Instagram state", async () => {
     process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
 
@@ -68,6 +96,27 @@ describe("VideoNarrativeAppPreviewPage", () => {
     expect(screen.getByText("Comparação com Instagram")).toBeInTheDocument();
   });
 
+  it("query params keep working in interactive mode", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_APP_PREVIEW_ENABLED = "1";
+
+    render(
+      await VideoNarrativeAppPreviewPage({
+        viewer: adminViewer,
+        searchParams: {
+          scenario: "brand",
+          access: "premium",
+          instagram: "connected",
+          mode: "interactive",
+        },
+      }),
+    );
+
+    expect(screen.getByText("Preview interativo app-first")).toBeInTheDocument();
+    expect(screen.getByText("Cenário: Marca")).toBeInTheDocument();
+    expect(screen.getByText("Acesso: Premium")).toBeInTheDocument();
+    expect(screen.getByText("Instagram: Conectado")).toBeInTheDocument();
+  });
+
   it("does not call endpoint or fetch", () => {
     const pageSource = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
     const importLines = pageSource
@@ -77,7 +126,7 @@ describe("VideoNarrativeAppPreviewPage", () => {
 
     expect(pageSource).not.toContain("fetch(");
     expect(importLines).not.toContain("app/api");
-    expect(importLines).not.toContain("route");
+    expect(importLines).not.toContain("route.ts");
   });
 
   it("does not import Gemini SDK or provider real", () => {

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.tsx
@@ -1,4 +1,5 @@
 import { VideoNarrativeAppPreview } from "../components/videoUpload/VideoNarrativeAppPreview";
+import { VideoNarrativeInteractiveAppPreview } from "../components/videoUpload/VideoNarrativeInteractiveAppPreview";
 import { buildVideoNarrativeAppPreviewScenario } from "../components/videoUpload/buildVideoNarrativeAppPreviewScenario";
 import {
   canAccessInternalPreview,
@@ -13,6 +14,7 @@ type VideoNarrativeAppPreviewPageProps = {
     stage?: string | string[];
     access?: string | string[];
     instagram?: string | string[];
+    mode?: string | string[];
   };
   viewer?: InternalPreviewUser | null;
 };
@@ -47,5 +49,10 @@ export default async function VideoNarrativeAppPreviewPage({
   }
 
   const preview = buildVideoNarrativeAppPreviewScenario(searchParams);
+  const mode = Array.isArray(searchParams?.mode) ? searchParams?.mode[0] : searchParams?.mode;
+  if (mode === "interactive") {
+    return <VideoNarrativeInteractiveAppPreview scenarioData={preview} />;
+  }
+
   return <VideoNarrativeAppPreview preview={preview} />;
 }

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -92,6 +92,8 @@ Já existe:
 - a preview MM33 continua sem upload real, persistência, BoardShell, endpoint real ou Instagram real;
 - UI primitives foram criados em MM34 para deixar a preview mais próxima de app;
 - os primitives MM34 seguem isolados da rota real, sem upload real, persistência, BoardShell ou integração externa;
+- interactive app-first preview foi criado em MM35 para navegar pela jornada com estado local;
+- o modo `mode=interactive` continua sem upload real, endpoint call, persistência, BoardShell ou Gemini real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -783,6 +783,35 @@ O que não faz:
 - não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta Instagram real, billing, Stripe ou cobrança.
 
+### MM35 — Interactive app-first preview
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx`
+- `../components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx`
+- `../components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.ts`
+- `../components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.test.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeGoalInput.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx`
+
+O que faz:
+
+- adiciona `mode=interactive` em `/dashboard/boards/video-narrative-app-preview`;
+- simula a jornada app-first em estado local, de começar até diagnóstico e prompts;
+- permite digitar objetivo, selecionar respostas do quiz e avançar manualmente por loadings;
+- usa os helpers puros já existentes para recompor diagnóstico, quiz e perfil narrativo em memória.
+
+O que não faz:
+
+- não cria upload real, storage real, banco/tabela, analytics real ou persistência;
+- não altera endpoint real nem chama Gemini, OpenAI, endpoint ou rede;
+- não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta Instagram real, billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -241,8 +241,9 @@ Exemplos:
 31. MM32 — App-first flow state model. Define estados, transições, copy e prompts antes de qualquer UI real.
 32. MM33 — Internal app-first preview with mock. Permite sentir a experiência app-first em preview interna/admin-dev com cenários mockados, sem produto real.
 33. MM34 — Diagnosis and Quiz UI primitives. Modulariza a preview interna em componentes reutilizáveis de shell, progresso, loading, quiz, diagnóstico e prompts.
-34. Teste real manual quando houver quota/billing disponível.
-35. Integração experimental futura no Board de Criação.
+34. MM35 — Interactive app-first preview state. Permite navegar pela jornada em estado local via `mode=interactive`, sem depender de query params etapa por etapa.
+35. Teste real manual quando houver quota/billing disponível.
+36. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -303,6 +304,8 @@ MM32 adiciona `VideoNarrativeAppFlowState` para modelar a experiência app-first
 MM33 adiciona `/dashboard/boards/video-narrative-app-preview` como preview interna protegida por flag e admin/dev. A experiência já pode ser sentida com cenários mockados, controles por query param, diagnóstico, quiz, perfil narrativo e prompts, mas continua fora do produto real, sem upload real, storage, banco, BoardShell, endpoint real ou persistência.
 
 MM34 adiciona primitives visuais em `components/videoUpload/appPreview/` para tornar a preview interna mais próxima de um app. A rota passa a compor shell, progresso, loading, quiz, diagnóstico e prompts com componentes testáveis, ainda sem upload real, endpoint alterado, persistência, BoardShell ou integração real.
+
+MM35 adiciona `VideoNarrativeInteractiveAppPreview` e `useVideoNarrativeInteractivePreviewState` para transformar a preview em uma jornada navegável por estado local. `mode=interactive` simula upload, loadings, objetivo do criador, quiz, diagnóstico e prompts sem upload real, endpoint call, persistência, BoardShell, Gemini real ou integração externa.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
Stacked sobre #831.

## Summary
- Adds `mode=interactive` to the internal app-first video narrative preview.
- Adds local preview state with `useVideoNarrativeInteractivePreviewState`.
- Adds goal input and interactive quiz components for a navigable mock journey.
- Rebuilds diagnosis, quiz and creator profile locally from existing pure helpers when the creator goal/answers change.

## Safety
- No endpoint changes.
- No real upload, storage, database, persistence, analytics, BoardShell wiring, navigation link, Gemini/OpenAI call, Instagram integration, Stripe, billing, fetch, or new dependency.
- Interactive mode remains preview-only, internal/admin-dev, mock-driven and local-state only.

## Validation
- `npm test -- --runInBand` interactive preview block: passed.
- `npm test -- --runInBand` page/static preview/scenario/flag block: passed.
- `npm test -- --runInBand` MM29-MM34 + endpoint mock block: passed.
- `npm test -- --runInBand` videoUpload/previews regressions: passed.
- `npm test -- --runInBand` NSE/Adaptive regressions: passed.
- `npm run typecheck`: passed.
- `git diff --check`: passed.
- `npm run build`: passed.