### PR TITLE
feat: refine video narrative interactive preview UX

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
@@ -44,8 +44,8 @@ describe("VideoNarrativeAppPreview", () => {
   it("renders loading messages in analyzing_video", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "analyzing_video" })} />);
 
-    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
-    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Lendo a abertura")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando a narrativa principal")).toBeInTheDocument();
   });
 
   it("renders central question in asking_creator_goal", () => {
@@ -65,7 +65,7 @@ describe("VideoNarrativeAppPreview", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />);
 
     expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
-    expect(screen.getByText("Potencial de marcas")).toBeInTheDocument();
+    expect(screen.getByText("Potencial comercial")).toBeInTheDocument();
     expect(screen.getByText("Blueprint")).toBeInTheDocument();
     expect(screen.getByText("Próximas ações")).toBeInTheDocument();
   });
@@ -95,7 +95,7 @@ describe("VideoNarrativeAppPreview", () => {
   it("renders upgrade prompt", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "upgrade_prompt" })} />);
 
-    expect(screen.getAllByText("Quer liberar diagnósticos completos?").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Quer diagnósticos mais completos?").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Ver planos").length).toBeGreaterThan(0);
   });
 
@@ -106,7 +106,7 @@ describe("VideoNarrativeAppPreview", () => {
       />,
     );
 
-    expect(screen.getAllByText("Quer deixar o diagnóstico mais preciso?").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Quer um diagnóstico mais preciso?").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Conectar Instagram").length).toBeGreaterThan(0);
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
@@ -21,22 +21,24 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
     renderInteractive();
 
     expect(screen.getByText("Preview interativo app-first")).toBeInTheDocument();
-    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Descubra a narrativa do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Começar análise" })).toBeInTheDocument();
   });
 
-  it("clicking Começar shows upload_video", () => {
+  it("clicking Começar análise shows upload_video", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
 
     expect(screen.getByText("Suba seu vídeo")).toBeInTheDocument();
+    expect(screen.getAllByText("Na preview interna, o upload é simulado por cenário mockado.").length).toBeGreaterThan(0);
   });
 
   it("clicking upload shows analyzing_video", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
 
     expect(screen.getByText("Analisando seu vídeo")).toBeInTheDocument();
   });
@@ -44,40 +46,45 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
   it("loading analysis shows messages", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
 
-    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
-    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Lendo a abertura")).toBeInTheDocument();
+    expect(screen.getByText("Identificando cenas e contexto")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando a narrativa principal")).toBeInTheDocument();
+    expect(screen.getByText("Separando conteúdo bruto de direção estratégica")).toBeInTheDocument();
   });
 
   it("continue shows central question", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
     expect(screen.getByText("O que você quer entender sobre esse vídeo?")).toBeInTheDocument();
+    expect(screen.getByText("Quanto mais claro for seu objetivo, melhor fica o diagnóstico.")).toBeInTheDocument();
   });
 
   it("filling goal and continuing shows understanding_goal", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
     expect(screen.getByText("Entendendo sua dúvida")).toBeInTheDocument();
+    expect(screen.getByText("Cruzando sua dúvida com a narrativa do vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Identificando o que ainda falta entender")).toBeInTheDocument();
   });
 
   it("continue from understanding_goal shows adaptive quiz", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -89,8 +96,8 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
   it("answering quiz and completing shows building diagnosis", () => {
     const { container } = renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -104,8 +111,8 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
   it("build diagnosis shows diagnosis_ready", () => {
     const { container } = renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -120,8 +127,8 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
   it("diagnosis_ready shows diagnosis, locked sections, profile summary and prompts", () => {
     const { container } = renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -130,18 +137,20 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
     fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
 
-    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Narrativa principal").length).toBeGreaterThan(0);
+    expect(screen.getByText("Leitura estratégica")).toBeInTheDocument();
     expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
     expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ver planos" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Conectar Instagram" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Criar versão para publi" })).toBeInTheDocument();
   });
 
   it("clicking Ver planos shows upgrade prompt", () => {
     const { container } = renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -151,14 +160,14 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
     fireEvent.click(screen.getByRole("button", { name: "Ver planos" }));
 
-    expect(screen.getAllByText("Quer liberar diagnósticos completos?").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Quer diagnósticos mais completos?").length).toBeGreaterThan(0);
   });
 
   it("clicking Conectar Instagram shows Instagram prompt", () => {
     const { container } = renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -168,21 +177,21 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
     fireEvent.click(screen.getByRole("button", { name: "Conectar Instagram" }));
 
-    expect(screen.getAllByText("Quer deixar o diagnóstico mais preciso?").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Quer um diagnóstico mais preciso?").length).toBeGreaterThan(0);
   });
 
   it("reset returns to beginning", () => {
     renderInteractive();
 
-    fireEvent.click(screen.getByRole("button", { name: "Começar" }));
-    fireEvent.click(screen.getByRole("button", { name: "+ Subir vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Começar análise" }));
+    fireEvent.click(screen.getByRole("button", { name: /Subir vídeo/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Quero entender a narrativa" } });
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
     fireEvent.click(screen.getByRole("button", { name: "Reiniciar" }));
 
-    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Descubra a narrativa do seu vídeo")).toBeInTheDocument();
   });
 
   it("does not call endpoint or fetch", () => {

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
@@ -124,13 +124,19 @@ export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarra
   function renderBody() {
     if (currentStage === "upload_video") {
       return (
-        <button
-          type="button"
-          onClick={actions.simulateVideoUpload}
-          className="flex min-h-36 w-full items-center justify-center rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-6 py-8 text-lg font-semibold text-zinc-950 hover:border-zinc-500 hover:bg-white"
-        >
-          + Subir vídeo
-        </button>
+        <div className="grid gap-4">
+          <button
+            type="button"
+            onClick={actions.simulateVideoUpload}
+            className="flex min-h-52 w-full flex-col items-center justify-center rounded-3xl border border-dashed border-zinc-300 bg-zinc-50 px-6 py-10 text-zinc-950 hover:border-zinc-500 hover:bg-white"
+          >
+            <span className="grid h-14 w-14 place-items-center rounded-full bg-zinc-950 text-3xl font-semibold text-white">+</span>
+            <span className="mt-4 text-xl font-semibold">Subir vídeo</span>
+            <span className="mt-2 max-w-sm text-sm leading-6 text-zinc-600">
+              Na preview interna, o upload é simulado por cenário mockado.
+            </span>
+          </button>
+        </div>
       );
     }
 
@@ -185,6 +191,7 @@ export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarra
           <div className="flex flex-wrap gap-2">
             <SecondaryButton onClick={() => undefined}>Transformar em roteiro</SecondaryButton>
             <SecondaryButton onClick={() => undefined}>Criar blueprint</SecondaryButton>
+            <SecondaryButton onClick={() => undefined}>Criar versão para publi</SecondaryButton>
             <SecondaryButton onClick={actions.requestUpgrade}>Ver planos</SecondaryButton>
             <SecondaryButton onClick={actions.requestInstagramConnection}>Conectar Instagram</SecondaryButton>
           </div>
@@ -214,7 +221,7 @@ export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarra
 
   function renderFooter() {
     if (currentStage === "welcome") {
-      return <PrimaryButton onClick={actions.start}>Começar</PrimaryButton>;
+      return <PrimaryButton onClick={actions.start}>Começar análise</PrimaryButton>;
     }
 
     if (currentStage === "diagnosis_ready") {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
@@ -18,7 +18,7 @@ describe("VideoNarrativeDiagnosisBlocks", () => {
 
   it("renders main narrative", () => {
     renderBlocks();
-    expect(screen.getByText("Narrativa principal")).toBeInTheDocument();
+    expect(screen.getAllByText("Narrativa principal").length).toBeGreaterThan(0);
   });
 
   it("renders what video communicates", () => {
@@ -51,7 +51,8 @@ describe("VideoNarrativeDiagnosisBlocks", () => {
 
   it("renders brand potential", () => {
     renderBlocks();
-    expect(screen.getByText("Potencial de marcas")).toBeInTheDocument();
+    expect(screen.getByText("Potencial comercial")).toBeInTheDocument();
+    expect(screen.getByText("Marcas e territórios")).toBeInTheDocument();
   });
 
   it("renders blueprint", () => {
@@ -59,10 +60,9 @@ describe("VideoNarrativeDiagnosisBlocks", () => {
     expect(screen.getByText("Blueprint")).toBeInTheDocument();
   });
 
-  it("renders scriptDirection when unlocked", () => {
+  it("renders blueprint scenes", () => {
     renderBlocks();
-    expect(screen.getByText("Direção de roteiro")).toBeInTheDocument();
-    expect(screen.getByText("Abertura")).toBeInTheDocument();
+    expect(screen.getByText("Cenas")).toBeInTheDocument();
   });
 
   it("renders lockedSections", () => {
@@ -83,6 +83,7 @@ describe("VideoNarrativeDiagnosisBlocks", () => {
 
   it("renders creatorSignals", () => {
     renderBlocks();
+    expect(screen.getByText("Aprendizado sobre o criador")).toBeInTheDocument();
     expect(screen.getByText("Sinais do criador")).toBeInTheDocument();
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
@@ -8,22 +8,43 @@ type VideoNarrativeDiagnosisBlocksProps = {
   creatorProfile?: VideoNarrativeCreatorProfile | null;
 };
 
-function Block({ title, children }: { title: string; children: ReactNode }) {
+const FINAL_ACTIONS = [
+  "Transformar em roteiro",
+  "Criar blueprint",
+  "Criar versão para publi",
+  "Conectar Instagram",
+  "Ver planos",
+];
+
+function Block({
+  title,
+  eyebrow,
+  children,
+  wide = false,
+}: {
+  title: string;
+  eyebrow?: string;
+  children: ReactNode;
+  wide?: boolean;
+}) {
   return (
-    <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-      <h3 className="text-base font-semibold text-zinc-950">{title}</h3>
-      <div className="mt-3">{children}</div>
+    <section className={wide ? "rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm lg:col-span-2" : "rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm"}>
+      {eyebrow ? <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">{eyebrow}</p> : null}
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950">{title}</h3>
+      <div className="mt-4">{children}</div>
     </section>
   );
 }
 
-function Field({ label, value }: { label: string; value?: string | null }) {
+function Field({ label, value, large = false }: { label: string; value?: string | null; large?: boolean }) {
   if (!value) return null;
 
   return (
-    <div className="rounded-lg bg-zinc-50 p-3">
+    <div className={large ? "rounded-2xl bg-zinc-50 p-4" : "rounded-xl bg-zinc-50 p-3"}>
       <dt className="text-xs font-semibold uppercase text-zinc-500">{label}</dt>
-      <dd className="mt-1 text-sm leading-6 text-zinc-900">{value}</dd>
+      <dd className={large ? "mt-2 text-base leading-7 text-zinc-950" : "mt-1 text-sm leading-6 text-zinc-900"}>
+        {value}
+      </dd>
     </div>
   );
 }
@@ -34,7 +55,7 @@ function List({ items, empty = "Sem dados para este bloco." }: { items: string[]
   return (
     <ul className="space-y-2 text-sm leading-6 text-zinc-700">
       {items.map((item, index) => (
-        <li key={`${item}-${index}`} className="rounded-lg bg-zinc-50 px-3 py-2">
+        <li key={`${item}-${index}`} className="rounded-xl bg-zinc-50 px-3 py-2">
           {item}
         </li>
       ))}
@@ -42,81 +63,99 @@ function List({ items, empty = "Sem dados para este bloco." }: { items: string[]
   );
 }
 
+function ActionPills() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {FINAL_ACTIONS.map((action) => (
+        <span key={action} className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm font-semibold text-zinc-700">
+          {action}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function VideoNarrativeDiagnosisBlocks({ diagnosis, creatorProfile }: VideoNarrativeDiagnosisBlocksProps) {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
-      <Block title="Diagnóstico">
-        <dl className="grid gap-3">
-          <Field label="Narrativa principal" value={diagnosis.mainNarrative} />
-          <Field label="O que o vídeo comunica" value={diagnosis.whatVideoCommunicates} />
-          <Field label="Intenção do criador" value={diagnosis.creatorIntent} />
-          <Field label="Diagnóstico estratégico" value={diagnosis.strategicReading} />
-          <Field label="Ponto forte" value={diagnosis.strength} />
-          <Field label="Ponto de atenção" value={diagnosis.weakness} />
-          <Field label="Ajuste recomendado" value={diagnosis.recommendedAdjustment} />
-          <Field label="Gancho sugerido" value={diagnosis.suggestedHook} />
+      <Block title="Narrativa principal" eyebrow="Hero do diagnóstico" wide>
+        <dl className="grid gap-3 md:grid-cols-3">
+          <Field label="Narrativa principal" value={diagnosis.mainNarrative} large />
+          <Field label="O que o vídeo comunica" value={diagnosis.whatVideoCommunicates} large />
+          <Field label="Intenção do criador" value={diagnosis.creatorIntent} large />
         </dl>
       </Block>
 
-      <Block title="Potencial de marcas">
+      <Block title="Leitura estratégica" wide>
+        <dl className="grid gap-3 md:grid-cols-2">
+          <Field label="Diagnóstico estratégico" value={diagnosis.strategicReading} large />
+          <Field label="Ponto forte" value={diagnosis.strength} />
+          <Field label="Ponto de atenção" value={diagnosis.weakness} />
+          <Field label="Ajuste recomendado" value={diagnosis.recommendedAdjustment} />
+        </dl>
+      </Block>
+
+      <Block title="Gancho">
+        <dl className="grid gap-3">
+          <Field label="Gancho sugerido" value={diagnosis.suggestedHook} large />
+        </dl>
+      </Block>
+
+      <Block title="Potencial comercial">
+        <p className="mb-2 text-xs font-semibold uppercase text-zinc-500">Marcas e territórios</p>
         <List items={diagnosis.brandPotential.territories} />
         {diagnosis.brandPotential.whyItFits ? (
-          <p className="mt-3 text-sm leading-6 text-zinc-700">{diagnosis.brandPotential.whyItFits}</p>
+          <p className="mt-3 rounded-xl bg-zinc-50 p-3 text-sm leading-6 text-zinc-700">{diagnosis.brandPotential.whyItFits}</p>
         ) : null}
       </Block>
 
       <Block title="Blueprint">
         <dl className="grid gap-3">
           <Field label="O que postar" value={diagnosis.blueprint.whatToPost} />
-          <Field label="Por que seguir" value={diagnosis.blueprint.whyThisPath} />
-          <Field label="Como funcionar" value={diagnosis.blueprint.howItShouldWork} />
+          <Field label="Por que esse caminho" value={diagnosis.blueprint.whyThisPath} />
+          <Field label="Como funciona" value={diagnosis.blueprint.howItShouldWork} />
         </dl>
         <div className="mt-3">
+          <p className="mb-2 text-xs font-semibold uppercase text-zinc-500">Cenas</p>
           <List items={diagnosis.blueprint.scenes} />
         </div>
       </Block>
 
-      <Block title="Direção de roteiro">
-        {diagnosis.scriptDirection.locked ? (
-          <p className="text-sm leading-6 text-zinc-600">Direção completa bloqueada neste nível de acesso.</p>
-        ) : (
-          <dl className="grid gap-3">
-            <Field label="Abertura" value={diagnosis.scriptDirection.opening} />
-            <Field label="Fechamento" value={diagnosis.scriptDirection.closing} />
-            <Field label="Tom" value={diagnosis.scriptDirection.tone} />
-            <div>
-              <dt className="mb-2 text-xs font-semibold uppercase text-zinc-500">Desenvolvimento</dt>
-              <List items={diagnosis.scriptDirection.development} />
+      <Block title="Próximas ações">
+        <ActionPills />
+        <div className="mt-4">
+          <List items={diagnosis.nextActions.map((action) => `${action.label}: ${action.description ?? "Ação disponível."}`)} />
+        </div>
+      </Block>
+
+      <Block title="Aprendizado sobre o criador" wide>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <h4 className="text-sm font-semibold text-zinc-950">Sinais do criador</h4>
+            <div className="mt-3">
+              <List items={diagnosis.creatorSignals.map((signal) => `${formatSignalLabel(signal.type)}: ${signal.value}`)} />
             </div>
-          </dl>
-        )}
+          </div>
+          <div>
+            <h4 className="text-sm font-semibold text-zinc-950">Resumo do perfil narrativo</h4>
+            {creatorProfile ? (
+              <dl className="mt-3 grid gap-3">
+                <Field label="Objetivos" value={creatorProfile.summary.strongestContentGoals.join(", ") || null} />
+                <Field label="Formatos" value={creatorProfile.summary.preferredFormats.join(", ") || null} />
+                <Field label="Ganchos" value={creatorProfile.summary.preferredHookDirections.join(", ") || null} />
+                <Field label="Territórios" value={creatorProfile.summary.preferredBrandTerritories.join(", ") || null} />
+                <Field label="Comercial" value={creatorProfile.summary.commercialPreferences.join(", ") || null} />
+                <Field label="Posicionamento" value={creatorProfile.summary.positioningSignals.join(", ") || null} />
+              </dl>
+            ) : (
+              <p className="mt-3 text-sm leading-6 text-zinc-600">Sem perfil narrativo para este cenário.</p>
+            )}
+          </div>
+        </div>
       </Block>
 
       <Block title="Seções bloqueadas">
         <List items={diagnosis.lockedSections.map((section) => `${section.title}: ${section.message}`)} />
-      </Block>
-
-      <Block title="Próximas ações">
-        <List items={diagnosis.nextActions.map((action) => `${action.label}: ${action.description ?? "Ação disponível."}`)} />
-      </Block>
-
-      <Block title="Sinais do criador">
-        <List items={diagnosis.creatorSignals.map((signal) => `${formatSignalLabel(signal.type)}: ${signal.value}`)} />
-      </Block>
-
-      <Block title="Resumo do perfil narrativo">
-        {creatorProfile ? (
-          <dl className="grid gap-3">
-            <Field label="Objetivos" value={creatorProfile.summary.strongestContentGoals.join(", ") || null} />
-            <Field label="Formatos" value={creatorProfile.summary.preferredFormats.join(", ") || null} />
-            <Field label="Ganchos" value={creatorProfile.summary.preferredHookDirections.join(", ") || null} />
-            <Field label="Territórios" value={creatorProfile.summary.preferredBrandTerritories.join(", ") || null} />
-            <Field label="Comercial" value={creatorProfile.summary.commercialPreferences.join(", ") || null} />
-            <Field label="Posicionamento" value={creatorProfile.summary.positioningSignals.join(", ") || null} />
-          </dl>
-        ) : (
-          <p className="text-sm leading-6 text-zinc-600">Sem perfil narrativo para este cenário.</p>
-        )}
       </Block>
 
       <Block title="Comparação com Instagram">

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx
@@ -30,6 +30,12 @@ describe("VideoNarrativeGoalInput", () => {
     expect(screen.getByRole("textbox")).toHaveValue("Virar publi");
   });
 
+  it("renders quick prompt for next content ideas", () => {
+    render(<VideoNarrativeGoalInput onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Criar próximos conteúdos" })).toBeInTheDocument();
+  });
+
   it("submit calls callback with text", () => {
     const onSubmit = jest.fn();
     render(<VideoNarrativeGoalInput onSubmit={onSubmit} />);

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.tsx
@@ -14,6 +14,7 @@ const QUICK_PROMPTS = [
   "Virar publi",
   "Entender narrativa",
   "Encontrar marcas",
+  "Criar próximos conteúdos",
 ];
 
 export function VideoNarrativeGoalInput({ initialValue = "", onSubmit }: VideoNarrativeGoalInputProps) {
@@ -33,13 +34,16 @@ export function VideoNarrativeGoalInput({ initialValue = "", onSubmit }: VideoNa
         onSubmit(safeValue);
       }}
     >
-      <textarea
-        value={value}
-        onChange={(event) => updateValue(event.currentTarget.value)}
-        rows={4}
-        placeholder="Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi."
-        className="min-h-32 rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm leading-6 text-zinc-950 outline-none transition focus:border-zinc-500"
-      />
+      <label className="grid gap-2">
+        <span className="text-sm font-semibold text-zinc-900">Sua dúvida ou objetivo</span>
+        <textarea
+          value={value}
+          onChange={(event) => updateValue(event.currentTarget.value)}
+          rows={4}
+          placeholder="Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi."
+          className="min-h-32 rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm leading-6 text-zinc-950 outline-none transition focus:border-zinc-500"
+        />
+      </label>
       <div className="flex flex-wrap gap-2">
         {QUICK_PROMPTS.map((prompt) => (
           <button

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx
@@ -44,7 +44,9 @@ describe("VideoNarrativeInteractiveQuiz", () => {
       />,
     );
 
-    expect(screen.getByText(`1/${scenario.quiz.questions.length} perguntas respondidas`)).toBeInTheDocument();
+    expect(screen.getByTestId("quiz-local-state-note")).toHaveTextContent(
+      `1/${scenario.quiz.questions.length} respondidas. Respostas salvas apenas nesta preview.`,
+    );
   });
 
   it("keeps complete disabled until required questions are answered", () => {
@@ -89,6 +91,6 @@ describe("VideoNarrativeInteractiveQuiz", () => {
       />,
     );
 
-    expect(screen.getAllByText(/sinal:/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/aprende:/).length).toBeGreaterThan(0);
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx
@@ -38,15 +38,17 @@ export function VideoNarrativeInteractiveQuiz({
 
   return (
     <div className="grid gap-4">
-      <p className="text-sm font-semibold text-zinc-700">
-        {answered}/{questions.length} perguntas respondidas
+      <p className="text-sm font-semibold text-zinc-700" data-testid="quiz-local-state-note">
+        {answered}/{questions.length} respondidas. Respostas salvas apenas nesta preview.
       </p>
       <div className="grid gap-3">
         {questions.map((question, index) => (
-          <article key={question.id} className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
-            <p className="text-xs font-semibold uppercase text-zinc-500">Pergunta {index + 1}</p>
+          <article key={question.id} className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+            <p className="text-xs font-semibold uppercase text-zinc-500">
+              Pergunta {index + 1} de {questions.length}
+            </p>
             <h3 className="mt-1 text-base font-semibold text-zinc-950">{question.title}</h3>
-            <p className="mt-2 text-sm leading-6 text-zinc-600">{question.helper ?? question.reason}</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">{question.reason}</p>
             <div className="mt-4 grid gap-2">
               {question.options.map((option) => {
                 const selected = selectedAnswers[question.id] === option.id;
@@ -58,17 +60,18 @@ export function VideoNarrativeInteractiveQuiz({
                     onClick={() => onAnswer(question.id, option.id)}
                     className={
                       selected
-                        ? "rounded-lg border border-zinc-950 bg-white p-3 text-left shadow-sm"
-                        : "rounded-lg border border-zinc-200 bg-white p-3 text-left hover:border-zinc-400"
+                        ? "rounded-xl border border-zinc-950 bg-white p-4 text-left shadow-sm ring-2 ring-zinc-950/10"
+                        : "rounded-xl border border-zinc-200 bg-white p-4 text-left hover:border-zinc-400"
                     }
+                    aria-pressed={selected}
                   >
                     <span className="block text-sm font-semibold text-zinc-800">{option.label}</span>
                     {option.description ? (
                       <span className="mt-1 block text-xs leading-5 text-zinc-500">{option.description}</span>
                     ) : null}
                     {option.learningSignalType ? (
-                      <span className="mt-2 inline-flex rounded-full bg-zinc-900 px-2.5 py-1 text-xs font-semibold text-white">
-                        sinal: {formatSignalLabel(option.learningSignalType)}
+                      <span className="mt-2 inline-flex rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-600">
+                        aprende: {formatSignalLabel(option.learningSignalType)}
                       </span>
                     ) : null}
                   </button>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.test.tsx
@@ -9,10 +9,10 @@ describe("VideoNarrativeLoadingBlock", () => {
   });
 
   it("renders all messages", () => {
-    render(<VideoNarrativeLoadingBlock title="Analisando" messages={["Identificando gancho", "Mapeando narrativa"]} />);
+    render(<VideoNarrativeLoadingBlock title="Analisando" messages={["Lendo a abertura", "Mapeando a narrativa principal"]} />);
 
-    expect(screen.getByText("Identificando gancho")).toBeInTheDocument();
-    expect(screen.getByText("Mapeando narrativa")).toBeInTheDocument();
+    expect(screen.getByText("Lendo a abertura")).toBeInTheDocument();
+    expect(screen.getByText("Mapeando a narrativa principal")).toBeInTheDocument();
   });
 
   it("handles empty messages", () => {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.tsx
@@ -5,12 +5,12 @@ type VideoNarrativeLoadingBlockProps = {
 
 export function VideoNarrativeLoadingBlock({ title, messages }: VideoNarrativeLoadingBlockProps) {
   return (
-    <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
-      <h3 className="text-sm font-semibold text-zinc-950">{title}</h3>
+    <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-5">
+      <h3 className="text-base font-semibold text-zinc-950">{title}</h3>
       {messages.length > 0 ? (
         <ul className="mt-4 grid gap-2">
           {messages.map((message, index) => (
-            <li key={message} className="flex items-center gap-3 rounded-lg bg-white px-3 py-2 text-sm text-zinc-700">
+            <li key={message} className="flex items-center gap-3 rounded-xl bg-white px-3 py-3 text-sm text-zinc-700">
               <span className="h-2.5 w-2.5 rounded-full bg-zinc-950" aria-hidden="true" />
               <span className="text-xs font-semibold uppercase text-zinc-500">{index + 1}</span>
               <span>{message}</span>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.test.tsx
@@ -8,14 +8,15 @@ describe("VideoNarrativePromptCards", () => {
   it("renders upgrade prompt when showUpgrade", () => {
     render(<VideoNarrativePromptCards showUpgrade />);
 
-    expect(screen.getByText("Quer liberar diagnósticos completos?")).toBeInTheDocument();
+    expect(screen.getByText("Quer diagnósticos mais completos?")).toBeInTheDocument();
+    expect(screen.getByText(/liberar roteiro, versão para publi/)).toBeInTheDocument();
     expect(screen.getByText("Ver planos")).toBeInTheDocument();
   });
 
   it("renders Instagram prompt when showInstagram", () => {
     render(<VideoNarrativePromptCards showInstagram />);
 
-    expect(screen.getByText("Quer deixar o diagnóstico mais preciso?")).toBeInTheDocument();
+    expect(screen.getByText("Quer um diagnóstico mais preciso?")).toBeInTheDocument();
     expect(screen.getByText("Conectar Instagram")).toBeInTheDocument();
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.tsx
@@ -16,8 +16,8 @@ function PromptCard({
   cta: string;
 }) {
   return (
-    <article className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-      <h3 className="text-base font-semibold text-zinc-950">{title}</h3>
+    <article className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-zinc-950">{title}</h3>
       <p className="mt-2 text-sm leading-6 text-zinc-700">{description}</p>
       <span className="mt-4 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-semibold text-white">{cta}</span>
     </article>
@@ -35,14 +35,14 @@ export function VideoNarrativePromptCards({
     <div className="grid gap-4 md:grid-cols-2">
       {showUpgrade ? (
         <PromptCard
-          title="Quer liberar diagnósticos completos?"
-          description="Assinantes podem fazer novas análises e acessar ações mais profundas."
+          title="Quer diagnósticos mais completos?"
+          description="Assinantes podem fazer novas análises e liberar roteiro, versão para publi, ações completas e próximos conteúdos."
           cta="Ver planos"
         />
       ) : null}
       {showInstagram ? (
         <PromptCard
-          title="Quer deixar o diagnóstico mais preciso?"
+          title="Quer um diagnóstico mais preciso?"
           description="Conecte seu Instagram para comparar esse vídeo com o que já funciona no seu perfil."
           cta="Conectar Instagram"
         />

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.tsx
@@ -18,9 +18,9 @@ export function VideoNarrativeStageShell({
   footer,
 }: VideoNarrativeStageShellProps) {
   return (
-    <section className="mx-auto w-full max-w-3xl rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-7">
+    <section className="mx-auto w-full max-w-3xl rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-8">
       {eyebrow ? <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">{eyebrow}</p> : null}
-      <h2 className="mt-2 text-2xl font-semibold tracking-normal text-zinc-950 sm:text-3xl">{title}</h2>
+      <h2 className="mt-2 text-3xl font-semibold tracking-normal text-zinc-950 sm:text-4xl">{title}</h2>
       {subtitle ? <p className="mt-3 text-sm leading-6 text-zinc-700 sm:text-base">{subtitle}</p> : null}
       {helper ? <p className="mt-2 text-sm leading-6 text-zinc-500">{helper}</p> : null}
       {children ? <div className="mt-6">{children}</div> : null}

--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
@@ -72,7 +72,7 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
   it("analyzing_video stage has loading messages", () => {
     const preview = buildVideoNarrativeAppPreviewScenario({ stage: "analyzing_video" });
 
-    expect(preview.flowState.copy.loadingMessages).toContain("Identificando gancho");
+    expect(preview.flowState.copy.loadingMessages).toContain("Lendo a abertura");
   });
 
   it("asking_creator_goal stage has central question", () => {

--- a/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
+++ b/src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx
@@ -43,7 +43,7 @@ describe("VideoNarrativeAppPreviewPage", () => {
 
     expect(screen.getByText("Preview interno — Análise Guiada de Vídeo")).toBeInTheDocument();
     expect(screen.getByText("Experiência app-first com mock narrativo")).toBeInTheDocument();
-    expect(screen.getByText("Entenda a narrativa do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Descubra a narrativa do seu vídeo")).toBeInTheDocument();
   });
 
   it("mode=static keeps static preview", async () => {
@@ -71,7 +71,7 @@ describe("VideoNarrativeAppPreviewPage", () => {
     );
 
     expect(screen.getByText("Preview interativo app-first")).toBeInTheDocument();
-    expect(screen.getByText("Começar")).toBeInTheDocument();
+    expect(screen.getByText("Começar análise")).toBeInTheDocument();
   });
 
   it("query params alter scenario, stage, access and Instagram state", async () => {

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -94,6 +94,8 @@ Já existe:
 - os primitives MM34 seguem isolados da rota real, sem upload real, persistência, BoardShell ou integração externa;
 - interactive app-first preview foi criado em MM35 para navegar pela jornada com estado local;
 - o modo `mode=interactive` continua sem upload real, endpoint call, persistência, BoardShell ou Gemini real;
+- interactive preview UX refinement foi concluído em MM36 para lapidar copy, quiz, diagnóstico, CTAs e prompts;
+- a preview MM36 segue mock/local-state; a próxima etapa pode revisar visualmente no navegador ou preparar integração controlada com fluxo real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -812,6 +812,32 @@ O que não faz:
 - não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta Instagram real, billing, Stripe ou cobrança.
 
+### MM36 — Interactive preview UX refinement
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativePromptCards.tsx`
+- `videoNarrativeAppFlowState.ts`
+
+O que faz:
+
+- refina copy de boas-vindas, upload simulado, loadings, pergunta central e prompts;
+- deixa o quiz com sensação de conversa guiada, opções maiores e sinal aprendido discreto;
+- reorganiza o diagnóstico em blocos de narrativa, leitura estratégica, gancho, potencial comercial, blueprint, ações e aprendizado;
+- torna CTAs finais mais diretos para roteiro, blueprint, versão para publi, Instagram e planos.
+
+O que não faz:
+
+- não cria upload real, storage real, banco/tabela, analytics real ou persistência;
+- não altera endpoint real nem chama Gemini, OpenAI, endpoint ou rede;
+- não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta Instagram real, billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -242,8 +242,9 @@ Exemplos:
 32. MM33 — Internal app-first preview with mock. Permite sentir a experiência app-first em preview interna/admin-dev com cenários mockados, sem produto real.
 33. MM34 — Diagnosis and Quiz UI primitives. Modulariza a preview interna em componentes reutilizáveis de shell, progresso, loading, quiz, diagnóstico e prompts.
 34. MM35 — Interactive app-first preview state. Permite navegar pela jornada em estado local via `mode=interactive`, sem depender de query params etapa por etapa.
-35. Teste real manual quando houver quota/billing disponível.
-36. Integração experimental futura no Board de Criação.
+35. MM36 — Interactive preview UX refinement. Lapida copy, quiz, diagnóstico, CTAs e prompts antes de conectar upload real ou BoardShell.
+36. Teste real manual quando houver quota/billing disponível.
+37. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -306,6 +307,8 @@ MM33 adiciona `/dashboard/boards/video-narrative-app-preview` como preview inter
 MM34 adiciona primitives visuais em `components/videoUpload/appPreview/` para tornar a preview interna mais próxima de um app. A rota passa a compor shell, progresso, loading, quiz, diagnóstico e prompts com componentes testáveis, ainda sem upload real, endpoint alterado, persistência, BoardShell ou integração real.
 
 MM35 adiciona `VideoNarrativeInteractiveAppPreview` e `useVideoNarrativeInteractivePreviewState` para transformar a preview em uma jornada navegável por estado local. `mode=interactive` simula upload, loadings, objetivo do criador, quiz, diagnóstico e prompts sem upload real, endpoint call, persistência, BoardShell, Gemini real ou integração externa.
+
+MM36 refina a UX da preview interativa. A experiência fica mais clara na primeira tela, o upload simulado ganha CTA central, os loadings usam mensagens mais estratégicas, o quiz parece conversa guiada e o diagnóstico passa a priorizar narrativa, leitura estratégica, potencial comercial, blueprint, ações e aprendizado do criador. A fase continua mock/local-state, sem upload real, endpoint call, persistência, BoardShell ou Gemini real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts
@@ -59,7 +59,7 @@ describe("videoNarrativeAppFlowState", () => {
   it("initial state has start CTA", () => {
     const state = createInitialVideoNarrativeAppFlowState();
 
-    expect(state.copy.ctas.some((cta) => cta.label === "Começar")).toBe(true);
+    expect(state.copy.ctas.some((cta) => cta.label === "Começar análise")).toBe(true);
   });
 
   it("transitions start to upload_video", () => {
@@ -101,8 +101,10 @@ describe("videoNarrativeAppFlowState", () => {
   it("analyzing_video includes analysis loading messages", () => {
     const messages = flowTo("analyzing_video").copy.loadingMessages;
 
-    expect(messages).toContain("Identificando gancho");
-    expect(messages).toContain("Mapeando narrativa");
+    expect(messages).toContain("Lendo a abertura");
+    expect(messages).toContain("Identificando cenas e contexto");
+    expect(messages).toContain("Mapeando a narrativa principal");
+    expect(messages).toContain("Separando conteúdo bruto de direção estratégica");
   });
 
   it("video_analysis_ready goes to asking_creator_goal", () => {
@@ -132,7 +134,8 @@ describe("videoNarrativeAppFlowState", () => {
   it("understanding_goal includes goal loading messages", () => {
     const messages = flowTo("understanding_goal").copy.loadingMessages;
 
-    expect(messages).toContain("Cruzando seu objetivo com a narrativa do vídeo");
+    expect(messages).toContain("Cruzando sua dúvida com a narrativa do vídeo");
+    expect(messages).toContain("Identificando o que ainda falta entender");
     expect(messages).toContain("Preparando perguntas estratégicas");
   });
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.ts
@@ -229,11 +229,12 @@ export function getVideoNarrativeAppFlowCopy(
 ): VideoNarrativeAppFlowCopy {
   if (stage === "welcome") {
     return copy({
-      title: "Entenda a narrativa do seu vídeo",
-      subtitle: "Envie um vídeo e receba um diagnóstico com narrativa, gancho, marcas potenciais e próximos passos.",
-      helper: null,
+      title: "Descubra a narrativa do seu vídeo",
+      subtitle:
+        "Envie um vídeo, conte sua dúvida e receba um diagnóstico com gancho, narrativa, marcas potenciais e próximos passos.",
+      helper: "A experiência é guiada do upload ao diagnóstico final.",
       loadingMessages: [],
-      ctas: [cta({ id: "start", label: "Começar", action: "continue", primary: true })],
+      ctas: [cta({ id: "start", label: "Começar análise", action: "continue", primary: true })],
     });
   }
 
@@ -241,7 +242,7 @@ export function getVideoNarrativeAppFlowCopy(
     return copy({
       title: "Suba seu vídeo",
       subtitle: "Escolha um vídeo para a D2C analisar a narrativa.",
-      helper: "Você poderá explicar sua dúvida depois do envio.",
+      helper: "Na preview interna, o upload é simulado por cenário mockado.",
       loadingMessages: [],
       ctas: [cta({ id: "select-video", label: "Subir vídeo", action: "select_video", primary: true })],
     });
@@ -253,10 +254,11 @@ export function getVideoNarrativeAppFlowCopy(
       subtitle: null,
       helper: null,
       loadingMessages: [
-        "Identificando gancho",
-        "Lendo cenas e contexto",
-        "Mapeando narrativa",
+        "Lendo a abertura",
+        "Identificando cenas e contexto",
+        "Mapeando a narrativa principal",
         "Buscando sinais de marca",
+        "Separando conteúdo bruto de direção estratégica",
       ],
       ctas: [],
     });
@@ -266,7 +268,7 @@ export function getVideoNarrativeAppFlowCopy(
     return copy({
       title: "O que você quer entender sobre esse vídeo?",
       subtitle: "Escreva sua dúvida, objetivo ou incômodo.",
-      helper: "Ex: quero saber se vale postar, se o gancho está bom ou se pode virar publi.",
+      helper: "Quanto mais claro for seu objetivo, melhor fica o diagnóstico.",
       loadingMessages: [],
       ctas: [cta({ id: "submit-goal", label: "Continuar", action: "submit_goal", primary: true })],
     });
@@ -278,9 +280,9 @@ export function getVideoNarrativeAppFlowCopy(
       subtitle: null,
       helper: null,
       loadingMessages: [
-        "Cruzando seu objetivo com a narrativa do vídeo",
+        "Cruzando sua dúvida com a narrativa do vídeo",
+        "Identificando o que ainda falta entender",
         "Preparando perguntas estratégicas",
-        "Organizando o caminho do diagnóstico",
       ],
       ctas: [],
     });
@@ -335,7 +337,8 @@ export function getVideoNarrativeAppFlowCopy(
   if (stage === "upgrade_prompt") {
     return copy({
       title: "Quer liberar diagnósticos completos?",
-      subtitle: "Assinantes podem fazer novas análises e acessar ações mais profundas.",
+      subtitle:
+        "Assinantes podem fazer novas análises e liberar roteiro, versão para publi, ações completas e próximos conteúdos.",
       helper: null,
       loadingMessages: [],
       ctas: [cta({ id: "upgrade", label: "Ver planos", action: "upgrade", primary: true })],
@@ -344,7 +347,7 @@ export function getVideoNarrativeAppFlowCopy(
 
   if (stage === "instagram_optimization_prompt") {
     return copy({
-      title: "Quer deixar o diagnóstico mais preciso?",
+      title: "Quer um diagnóstico mais preciso?",
       subtitle: "Conecte seu Instagram para comparar esse vídeo com o que já funciona no seu perfil.",
       helper: null,
       loadingMessages: [],


### PR DESCRIPTION
## Summary

Stacked on #832.

This PR refines the internal interactive app-first video narrative preview UX while keeping it mock/local-state only:

- updates welcome, upload, loading, goal, upgrade, and Instagram prompt copy
- strengthens the simulated upload step and guided goal input
- improves the interactive quiz hierarchy with question progress, selected state, and softer learning-signal labels
- reorganizes the diagnosis into clearer app-first sections: hero, strategic reading, hook, commercial potential, blueprint, next actions, creator learning, locked sections, and Instagram comparison
- updates MM36 docs/readiness notes

## Guardrails

- No endpoint changes
- No real upload or storage
- No database/table or persistence
- No BoardShell or PostCreationFunnelState wiring
- No Gemini/OpenAI calls or SDK imports
- No fetch/network calls in the preview path
- No Instagram real integration
- No Stripe/billing/cobrança integration
- No navigation/menu link added

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/useVideoNarrativeInteractivePreviewState.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeGoalInput.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeInteractiveQuiz.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativePromptCards.test.tsx src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/video-narrative-app-preview/page.test.tsx src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAppPreviewFeatureFlag.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeAppPreviewPrimitives.test.ts src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeProgress.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeStageShell.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeLoadingBlock.test.tsx src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeQuizCard.test.tsx src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisQuizBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts src/app/api/internal/video-narrative/analyze/route.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeEndpointMockMode.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeObservabilityEvents.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePayloadValidation.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeMockProvider.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePipeline.test.ts src/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.test.ts`
- videoUpload/previews regressions
- NSE/Adaptive V2 regressions
- `npm run typecheck`
- `git diff --check`
- `npm run build`