### PR TITLE
feat: add video narrative evolving diagnosis contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -98,6 +98,8 @@ Já existe:
 - a preview MM36 segue mock/local-state; a próxima etapa pode revisar visualmente no navegador ou preparar integração controlada com fluxo real;
 - browser UX QA checklist foi criada em MM37 para orientar revisão visual/funcional da preview interativa;
 - a próxima etapa deve considerar os achados da QA antes de qualquer upload real, BoardShell, paywall ou integração real;
+- evolving creator diagnosis contract foi criado em MM38 como camada segura de produto sobre o diagnóstico pontual;
+- MM38 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint e não muda upload/storage;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -861,6 +861,30 @@ O que não faz:
 - não conecta BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta Instagram real, billing, Stripe ou cobrança.
 
+### MM38 — Evolving Creator Diagnosis Contract
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeEvolvingDiagnosisContract.ts`
+- `videoNarrativeEvolvingDiagnosisContract.test.ts`
+
+O que faz:
+
+- cria um contrato puro para diagnóstico evolutivo do creator;
+- conecta o diagnóstico pontual de vídeo ao mapa estratégico do creator;
+- modela nível atual, próximo nível, impacto no perfil, sinais desbloqueados, sinais pendentes, próximos sinais e oportunidades futuras;
+- diferencia `free`, `premium` e `instagram_optimized` sem billing real;
+- mantém marca/collab como oportunidade futura, sem match real.
+
+O que não faz:
+
+- não cria persistência, banco/tabela, endpoint, UI, preview, upload real, storage real ou analytics real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -244,8 +244,9 @@ Exemplos:
 34. MM35 — Interactive app-first preview state. Permite navegar pela jornada em estado local via `mode=interactive`, sem depender de query params etapa por etapa.
 35. MM36 — Interactive preview UX refinement. Lapida copy, quiz, diagnóstico, CTAs e prompts antes de conectar upload real ou BoardShell.
 36. MM37 — Browser UX QA checklist. Cria roteiro manual e testável para revisar a experiência no navegador antes de upload, BoardShell ou paywall.
-37. Teste real manual quando houver quota/billing disponível.
-38. Integração experimental futura no Board de Criação.
+37. MM38 — Evolving Creator Diagnosis Contract. Modela a camada evolutiva acima do diagnóstico pontual, sem persistência ou match real.
+38. Teste real manual quando houver quota/billing disponível.
+39. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -312,6 +313,8 @@ MM35 adiciona `VideoNarrativeInteractiveAppPreview` e `useVideoNarrativeInteract
 MM36 refina a UX da preview interativa. A experiência fica mais clara na primeira tela, o upload simulado ganha CTA central, os loadings usam mensagens mais estratégicas, o quiz parece conversa guiada e o diagnóstico passa a priorizar narrativa, leitura estratégica, potencial comercial, blueprint, ações e aprendizado do criador. A fase continua mock/local-state, sem upload real, endpoint call, persistência, BoardShell ou Gemini real.
 
 MM37 cria uma checklist de QA visual/funcional para testar a preview interativa no navegador. O roteiro cobre URLs, cenários, acessos, mobile-first, segurança visual, critérios por etapa e registro de achados antes de integrar upload, BoardShell, paywall ou qualquer fluxo real.
+
+MM38 adiciona `VideoNarrativeEvolvingDiagnosis` como camada acima de `VideoNarrativeStrategicDiagnosis`. O diagnóstico estratégico continua sendo a leitura pontual do vídeo; a nova camada organiza esse valor em torno da evolução do creator, com nível atual, próximo nível, impacto no perfil, sinais desbloqueados, sinais pendentes e oportunidades futuras. Ela usa o `VideoNarrativeCreatorProfile` como contexto, mas não persiste sinais, não substitui o profile contract e não cria match real de marcas ou creators.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts
@@ -1,0 +1,349 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildVideoNarrativeEvolvingDiagnosis,
+  sanitizeVideoNarrativeEvolvingDiagnosisText,
+  type VideoNarrativeEvolvingDiagnosis,
+} from "./videoNarrativeEvolvingDiagnosisContract";
+import {
+  buildVideoNarrativeCreatorProfile,
+  createEmptyVideoNarrativeCreatorProfile,
+  type VideoNarrativeCreatorProfile,
+} from "./videoNarrativeCreatorProfileContract";
+import type {
+  VideoNarrativeDiagnosisCreatorSignal,
+  VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+
+const CONTRACT_SOURCE_PATH = path.join(__dirname, "videoNarrativeEvolvingDiagnosisContract.ts");
+
+function signal(
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+  value: string,
+  confidence: VideoNarrativeDiagnosisCreatorSignal["confidence"] = "medium",
+): VideoNarrativeDiagnosisCreatorSignal {
+  return {
+    id: `${type}-${value}`,
+    type,
+    value,
+    source: "diagnosis_inference",
+    confidence,
+    evidence: `Evidência para ${value}`,
+    shouldPersistLater: false,
+  };
+}
+
+function makeDiagnosis(overrides: Partial<VideoNarrativeStrategicDiagnosis> = {}): VideoNarrativeStrategicDiagnosis {
+  return {
+    id: "diagnosis-1",
+    accessLevel: "free",
+    mainNarrative: "rotina de produto com potencial comercial",
+    whatVideoCommunicates: "Esse vídeo comunica uma rotina com território narrativo de cuidado.",
+    creatorIntent: "Quero saber se vale postar e se pode virar publi",
+    strategicReading: "Pelo vídeo e pelo objetivo declarado, o melhor caminho é tornar o gancho mais direto.",
+    strength: "Mostra contexto real de uso.",
+    weakness: "A abertura poderia ser mais clara.",
+    recommendedAdjustment: "Abrir com a transformação principal antes do passo a passo.",
+    suggestedHook: "Abrir com o resultado antes da rotina.",
+    brandPotential: {
+      enabled: true,
+      territories: ["skincare", "bem-estar", "rotina prática"],
+      whyItFits: "Existe fit narrativo com rotina e cuidado.",
+      locked: false,
+    },
+    blueprint: {
+      whatToPost: "Reel de rotina com antes/depois narrativo.",
+      whyThisPath: "A narrativa fica mais fácil de entender.",
+      howItShouldWork: "Abrir com resultado, mostrar processo e fechar com convite para salvar.",
+      scenes: ["resultado", "processo", "fechamento"],
+      locked: false,
+    },
+    scriptDirection: {
+      opening: "Comece mostrando o resultado final.",
+      development: ["mostrar contexto", "explicar decisão"],
+      closing: "Fechar com próximo passo.",
+      tone: "consultivo",
+      locked: false,
+    },
+    nextActions: [
+      { id: "improve-hook", label: "Melhorar gancho", description: null, locked: false },
+    ],
+    lockedSections: [],
+    creatorSignals: [
+      signal("content_goal", "validar antes de postar"),
+      signal("commercial_preference", "atrair marcas"),
+      signal("brand_territory", "skincare"),
+    ],
+    instagramComparison: {
+      connected: false,
+      summary: null,
+      matchingNarratives: [],
+      matchingFormats: [],
+      locked: true,
+    },
+    createdAt: "2026-05-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function profileFromSignals(
+  signals: VideoNarrativeDiagnosisCreatorSignal[],
+  existingProfile: VideoNarrativeCreatorProfile | null = null,
+): VideoNarrativeCreatorProfile {
+  return buildVideoNarrativeCreatorProfile({
+    creatorId: "creator-1",
+    existingProfile,
+    newSignals: signals,
+    diagnosisId: "diagnosis-1",
+    createdAt: "2026-05-18T00:00:00.000Z",
+  });
+}
+
+function recurringProfile(): VideoNarrativeCreatorProfile {
+  const first = profileFromSignals([
+    signal("content_goal", "validar antes de postar", "high"),
+    signal("hook_preference", "abertura direta", "high"),
+    signal("format_preference", "reels direto", "medium"),
+    signal("brand_territory", "skincare", "high"),
+    signal("commercial_preference", "atrair marcas", "medium"),
+    signal("collab_preference", "autoridade complementar", "medium"),
+  ]);
+
+  return profileFromSignals([
+    signal("content_goal", "validar antes de postar", "high"),
+    signal("hook_preference", "abertura direta", "high"),
+    signal("format_preference", "reels direto", "medium"),
+    signal("brand_territory", "skincare", "high"),
+    signal("commercial_preference", "atrair marcas", "medium"),
+    signal("collab_preference", "autoridade complementar", "medium"),
+  ], first);
+}
+
+function stringify(value: VideoNarrativeEvolvingDiagnosis): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("videoNarrativeEvolvingDiagnosisContract", () => {
+  it("cria diagnóstico evolutivo gratuito útil a partir de um diagnóstico estratégico", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis(),
+      accessLevel: "free",
+    });
+
+    expect(evolving.accessLevel).toBe("free");
+    expect(evolving.videoDiagnosisId).toBe("diagnosis-1");
+    expect(evolving.currentLevel.id).toBeTruthy();
+    expect(evolving.profileImpact.summary).toContain("primeira leitura");
+    expect(evolving.unlockedSignals.length).toBeGreaterThan(0);
+  });
+
+  it("free gera subscriptionUnlocks para evolução completa, marca/collab e análise aprofundada", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis(),
+      accessLevel: "free",
+    });
+    const text = stringify(evolving);
+
+    expect(evolving.subscriptionUnlocks.length).toBeGreaterThanOrEqual(3);
+    expect(text).toContain("evolução completa");
+    expect(text).toContain("potencial comercial");
+    expect(text).toContain("collab");
+    expect(text).toContain("padrões recorrentes");
+  });
+
+  it("premium gera profileImpact mais completo que free", () => {
+    const profile = recurringProfile();
+    const free = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis(),
+      creatorProfile: profile,
+      accessLevel: "free",
+    });
+    const premium = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ accessLevel: "premium" }),
+      creatorProfile: profile,
+      accessLevel: "premium",
+    });
+
+    expect(premium.profileImpact.depth).toBe("deep");
+    expect(premium.profileImpact.usefulSignalsCount).toBeGreaterThan(free.profileImpact.usefulSignalsCount);
+    expect(premium.unlockedSignals.length).toBeGreaterThan(free.unlockedSignals.length);
+  });
+
+  it("instagram optimized conectado marca leitura como mais precisa", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ accessLevel: "instagram_optimized" }),
+      creatorProfile: recurringProfile(),
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+    });
+
+    expect(evolving.accessSummary.precision).toBe("instagram_contextual");
+    expect(evolving.accessSummary.message).toContain("mais precisa");
+    expect(evolving.instagramUnlocks).toHaveLength(0);
+  });
+
+  it("sem Instagram conectado cria instagramUnlocks claros", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ accessLevel: "premium" }),
+      accessLevel: "premium",
+      instagramConnected: false,
+    });
+
+    expect(evolving.instagramUnlocks.map((unlock) => unlock.id)).toContain("unlock-instagram-comparison");
+    expect(evolving.instagramUnlocks.map((unlock) => unlock.id)).toContain("unlock-performance-precision");
+  });
+
+  it("usa Creator Narrative Profile para detectar padrões recorrentes", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ accessLevel: "premium" }),
+      creatorProfile: recurringProfile(),
+      accessLevel: "premium",
+    });
+
+    expect(evolving.recurringPatterns.length).toBeGreaterThan(0);
+    expect(evolving.profileImpact.recurringSignalsCount).toBeGreaterThan(0);
+  });
+
+  it("nível estratégico não depende apenas de analyzedVideosCount", () => {
+    const manyVideosWithoutSignals = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ creatorSignals: [], brandPotential: { enabled: false, territories: [], whyItFits: null, locked: true } }),
+      creatorProfile: createEmptyVideoNarrativeCreatorProfile(),
+      accessLevel: "premium",
+      analyzedVideosCount: 99,
+    });
+    const fewVideosWithSignals = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({ accessLevel: "instagram_optimized" }),
+      creatorProfile: recurringProfile(),
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+      analyzedVideosCount: 1,
+    });
+
+    expect(manyVideosWithoutSignals.currentLevel.id).toBe("first_reading");
+    expect(fewVideosWithSignals.currentLevel.position).toBeGreaterThan(manyVideosWithoutSignals.currentLevel.position);
+  });
+
+  it("gera currentLevel e nextLevel coerentes", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis(),
+      accessLevel: "free",
+    });
+
+    expect(evolving.currentLevel.position).toBeGreaterThanOrEqual(1);
+    expect(evolving.nextLevel?.position).toBe(evolving.currentLevel.position + 1);
+  });
+
+  it("gera pendingSignals quando faltam formato, performance, marca ou collab", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({
+        creatorSignals: [signal("content_goal", "validar pauta")],
+        brandPotential: { enabled: false, territories: [], whyItFits: null, locked: true },
+      }),
+      accessLevel: "free",
+      instagramConnected: false,
+    });
+    const pendingIds = evolving.pendingSignals.map((pending) => pending.id);
+
+    expect(pendingIds).toContain("pending-format-preference");
+    expect(pendingIds).toContain("pending-performance-context");
+    expect(pendingIds).toContain("pending-brand-territory");
+    expect(pendingIds).toContain("pending-collab-preference");
+  });
+
+  it("gera nextSignalsToUnlock com ações claras", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({
+        creatorSignals: [signal("content_goal", "validar pauta")],
+        brandPotential: { enabled: false, territories: [], whyItFits: null, locked: true },
+      }),
+      accessLevel: "free",
+    });
+
+    expect(evolving.nextSignalsToUnlock.length).toBeGreaterThan(0);
+    evolving.nextSignalsToUnlock.forEach((item) => {
+      expect(item.label).toContain("Desbloquear");
+      expect(item.action.length).toBeGreaterThan(10);
+    });
+  });
+
+  it("gera opportunities de marca/collab sem prometer match real", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({
+        creatorSignals: [
+          ...makeDiagnosis().creatorSignals,
+          signal("collab_preference", "autoridade complementar"),
+        ],
+      }),
+      accessLevel: "premium",
+    });
+
+    expect(evolving.opportunities.some((item) => item.type === "brand_territory")).toBe(true);
+    expect(evolving.opportunities.some((item) => item.type === "collab_type")).toBe(true);
+    expect(evolving.opportunities.every((item) => item.realMatchAvailable === false)).toBe(true);
+    expect(stringify(evolving)).not.toContain("match real disponível");
+  });
+
+  it("não sugere nomes reais de creators", () => {
+    const evolving = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis: makeDiagnosis({
+        creatorIntent: "Quero fazer collab com Creator Famoso",
+        creatorSignals: [signal("collab_preference", "Creator Famoso")],
+      }),
+      accessLevel: "premium",
+    });
+
+    expect(stringify(evolving)).not.toContain("creator famoso");
+    expect(evolving.opportunities.filter((item) => item.type === "collab_type").length).toBeGreaterThan(0);
+  });
+
+  it("sanitiza textos perigosos", () => {
+    const text = sanitizeVideoNarrativeEvolvingDiagnosisText(
+      "AIza1234567890abc GEMINI_API_KEY=secret abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 https://x.test/file?token=abc marca garantida score venceu",
+    );
+
+    expect(text).toContain("[redigido]");
+    expect(text).not.toContain("AIza");
+    expect(text).not.toContain("GEMINI_API_KEY");
+    expect(text).not.toContain("token=abc");
+    expect(text.toLowerCase()).not.toContain("marca garantida");
+    expect(text.toLowerCase()).not.toContain("score");
+    expect(text.toLowerCase()).not.toContain("venceu");
+  });
+
+  it("não importa fetch, Prisma, banco, Gemini, OpenAI, Stripe ou SDK externo", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+
+    [
+      "fetch",
+      "Prisma",
+      "banco",
+      "@google/genai",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "stripe",
+      "firebase",
+      "supabase",
+    ].forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("não altera endpoint, UI ou preview", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+
+    [
+      "route.ts",
+      "VideoNarrativeAppPreview",
+      "VideoNarrativeInteractiveAppPreview",
+      "React",
+      "BoardShell",
+      "PostCreationFunnelState",
+      "components/",
+      "app/api",
+    ].forEach((term) => {
+      expect(source).not.toContain(term);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.ts
@@ -1,0 +1,766 @@
+import {
+  sanitizeVideoNarrativeDiagnosisText,
+  type VideoNarrativeDiagnosisAccessLevel,
+  type VideoNarrativeDiagnosisCreatorSignal,
+  type VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+import type {
+  VideoNarrativeCreatorProfile,
+  VideoNarrativeCreatorProfileSignal,
+  VideoNarrativeCreatorProfileSignalCategory,
+} from "./videoNarrativeCreatorProfileContract";
+
+export type VideoNarrativeCreatorStrategicLevelId =
+  | "first_reading"
+  | "initial_patterns"
+  | "narrative_in_formation"
+  | "commercial_potential_mapped"
+  | "strategically_mapped_creator";
+
+export interface VideoNarrativeCreatorStrategicLevel {
+  id: VideoNarrativeCreatorStrategicLevelId;
+  label: string;
+  description: string;
+  position: number;
+}
+
+export interface VideoNarrativeCreatorProfileImpact {
+  summary: string;
+  depth: "limited" | "moderate" | "deep" | "instagram_contextual";
+  usefulSignalsCount: number;
+  recurringSignalsCount: number;
+  newSignalsCount: number;
+  recurringPatternsCount: number;
+  profileSignalsUsed: boolean;
+}
+
+export interface VideoNarrativeUnlockedSignal {
+  id: string;
+  label: string;
+  category: VideoNarrativeCreatorProfileSignalCategory | VideoNarrativeDiagnosisCreatorSignal["type"];
+  value: string;
+  source: "current_video" | "creator_profile";
+  recurrenceCount: number;
+}
+
+export interface VideoNarrativePendingSignal {
+  id: string;
+  label: string;
+  category:
+    | VideoNarrativeCreatorProfileSignalCategory
+    | "performance_context"
+    | "instagram_context";
+  reason: string;
+  unlockPath: "answer_more_quiz" | "analyze_more_videos" | "upgrade" | "connect_instagram";
+}
+
+export interface VideoNarrativeNextSignalToUnlock {
+  id: string;
+  label: string;
+  action: string;
+  expectedSignal:
+    | VideoNarrativeCreatorProfileSignalCategory
+    | "performance_context"
+    | "instagram_context";
+}
+
+export interface VideoNarrativeEvolvingDiagnosisOpportunity {
+  id: string;
+  type: "brand_territory" | "collab_type" | "content_pattern" | "performance_context";
+  label: string;
+  description: string;
+  confidence: "low" | "medium" | "high";
+  realMatchAvailable: false;
+  requiresPremium: boolean;
+  requiresInstagram: boolean;
+}
+
+export interface VideoNarrativeEvolvingDiagnosisUnlock {
+  id: string;
+  label: string;
+  description: string;
+  reason: "requires_premium" | "requires_instagram_connection" | "requires_more_context";
+}
+
+export interface VideoNarrativeEvolvingDiagnosisAccessSummary {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  isLimited: boolean;
+  instagramConnected: boolean;
+  precision: "initial" | "profile_based" | "instagram_contextual";
+  message: string;
+}
+
+export interface VideoNarrativeEvolvingDiagnosisInput {
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+  creatorProfile?: VideoNarrativeCreatorProfile | null;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+  analyzedVideosCount?: number;
+  createdAt?: string | null;
+}
+
+export interface VideoNarrativeEvolvingDiagnosis {
+  id: string;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  videoDiagnosisId: string;
+  currentLevel: VideoNarrativeCreatorStrategicLevel;
+  nextLevel: VideoNarrativeCreatorStrategicLevel | null;
+  profileImpact: VideoNarrativeCreatorProfileImpact;
+  unlockedSignals: VideoNarrativeUnlockedSignal[];
+  pendingSignals: VideoNarrativePendingSignal[];
+  nextSignalsToUnlock: VideoNarrativeNextSignalToUnlock[];
+  recurringPatterns: string[];
+  opportunities: VideoNarrativeEvolvingDiagnosisOpportunity[];
+  subscriptionUnlocks: VideoNarrativeEvolvingDiagnosisUnlock[];
+  instagramUnlocks: VideoNarrativeEvolvingDiagnosisUnlock[];
+  accessSummary: VideoNarrativeEvolvingDiagnosisAccessSummary;
+  createdAt: string | null;
+}
+
+export const VIDEO_NARRATIVE_CREATOR_STRATEGIC_LEVELS: VideoNarrativeCreatorStrategicLevel[] = [
+  {
+    id: "first_reading",
+    label: "Primeira leitura",
+    description: "Primeira leitura estratégica do vídeo e dos sinais iniciais do creator.",
+    position: 1,
+  },
+  {
+    id: "initial_patterns",
+    label: "Padrões iniciais",
+    description: "Primeiros padrões de objetivo, formato ou gancho começam a aparecer.",
+    position: 2,
+  },
+  {
+    id: "narrative_in_formation",
+    label: "Narrativa em formação",
+    description: "O mapa estratégico já conecta objetivos, formatos e preferências narrativas.",
+    position: 3,
+  },
+  {
+    id: "commercial_potential_mapped",
+    label: "Potencial comercial mapeado",
+    description: "Territórios narrativos e oportunidades comerciais futuras ficam mais claros.",
+    position: 4,
+  },
+  {
+    id: "strategically_mapped_creator",
+    label: "Creator estrategicamente mapeado",
+    description: "O mapa estratégico combina recorrência, variedade e contexto para orientar decisões futuras.",
+    position: 5,
+  },
+];
+
+const CATEGORY_LABELS: Partial<Record<VideoNarrativeCreatorProfileSignalCategory, string>> = {
+  content_goals: "objetivo de conteúdo",
+  creative_preferences: "preferência criativa",
+  commercial_preferences: "preferência comercial",
+  recurring_pains: "dor recorrente",
+  hook_preferences: "preferência de gancho",
+  format_preferences: "preferência de formato",
+  brand_territories: "território de marca",
+  collab_preferences: "preferência de collab",
+  production_constraints: "restrição de produção",
+  audience_relationship: "relação com audiência",
+  positioning_signals: "sinal de posicionamento",
+  instagram_patterns: "padrão de Instagram",
+  unknown: "sinal em análise",
+};
+
+const BLOCKED_TERMS = [
+  "viralizar garantido",
+  "treinado permanentemente",
+  "resposta correta",
+  "patrocínio garantido",
+  "marca garantida",
+  "match comprovado",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "score",
+  "nota",
+  "pontuação",
+  "pontos",
+  "moedas",
+  "ranking",
+  "acerto",
+  "gabarito",
+  "venceu",
+  "perdeu",
+];
+
+function levelById(id: VideoNarrativeCreatorStrategicLevelId): VideoNarrativeCreatorStrategicLevel {
+  const level = VIDEO_NARRATIVE_CREATOR_STRATEGIC_LEVELS.find((item) => item.id === id);
+  if (level) return level;
+
+  return {
+    id: "first_reading",
+    label: "Primeira leitura",
+    description: "Primeira leitura estratégica do vídeo e dos sinais iniciais do creator.",
+    position: 1,
+  };
+}
+
+function nextLevelFor(level: VideoNarrativeCreatorStrategicLevel): VideoNarrativeCreatorStrategicLevel | null {
+  return VIDEO_NARRATIVE_CREATOR_STRATEGIC_LEVELS.find((item) => item.position === level.position + 1) ?? null;
+}
+
+function normalize(value: string | null | undefined): string {
+  return sanitizeVideoNarrativeEvolvingDiagnosisText(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function slug(value: string): string {
+  return normalize(value).replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item";
+}
+
+function clean(value: string | null | undefined): string | null {
+  const sanitized = sanitizeVideoNarrativeEvolvingDiagnosisText(value ?? "");
+  return sanitized ? sanitized : null;
+}
+
+function unique(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = normalize(value);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function usefulProfileSignals(profile?: VideoNarrativeCreatorProfile | null): VideoNarrativeCreatorProfileSignal[] {
+  return (profile?.signals ?? []).filter((signal) =>
+    signal.value.trim() &&
+    signal.status !== "archived" &&
+    signal.status !== "weak",
+  );
+}
+
+function hasCategory(
+  signals: VideoNarrativeCreatorProfileSignal[],
+  category: VideoNarrativeCreatorProfileSignalCategory,
+): boolean {
+  return signals.some((signal) => signal.category === category);
+}
+
+function diagnosisSignalsForCategory(
+  signals: VideoNarrativeDiagnosisCreatorSignal[],
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+): boolean {
+  return signals.some((signal) => signal.type === type && signal.value.trim());
+}
+
+function hasAnySignal(params: {
+  profileSignals: VideoNarrativeCreatorProfileSignal[];
+  diagnosisSignals: VideoNarrativeDiagnosisCreatorSignal[];
+  profileCategory: VideoNarrativeCreatorProfileSignalCategory;
+  diagnosisType: VideoNarrativeDiagnosisCreatorSignal["type"];
+}): boolean {
+  return hasCategory(params.profileSignals, params.profileCategory) ||
+    diagnosisSignalsForCategory(params.diagnosisSignals, params.diagnosisType);
+}
+
+function computeLevel(input: {
+  usefulSignalsCount: number;
+  recurringSignalsCount: number;
+  categoriesCount: number;
+  hasContentGoal: boolean;
+  hasHookPreference: boolean;
+  hasFormatPreference: boolean;
+  hasBrandTerritory: boolean;
+  hasCollabPreference: boolean;
+  hasCommercialSignal: boolean;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  analyzedVideosCount: number;
+}): VideoNarrativeCreatorStrategicLevel {
+  if (input.usefulSignalsCount === 0) return levelById("first_reading");
+
+  const hasNarrativeBase =
+    input.hasContentGoal &&
+    (input.hasHookPreference || input.hasFormatPreference) &&
+    input.categoriesCount >= 3;
+  const hasCommercialBase =
+    input.hasBrandTerritory &&
+    input.hasCommercialSignal &&
+    input.recurringSignalsCount >= 1 &&
+    input.categoriesCount >= 4;
+  const hasStrategicBase =
+    hasCommercialBase &&
+    input.hasCollabPreference &&
+    input.recurringSignalsCount >= 3 &&
+    input.categoriesCount >= 6 &&
+    input.usefulSignalsCount >= 7 &&
+    input.accessLevel === "instagram_optimized" &&
+    input.instagramConnected;
+
+  if (hasStrategicBase) return levelById("strategically_mapped_creator");
+  if (hasCommercialBase && input.accessLevel !== "free") return levelById("commercial_potential_mapped");
+  if (hasNarrativeBase) return levelById("narrative_in_formation");
+  if (input.usefulSignalsCount >= 2 || (input.analyzedVideosCount >= 2 && input.categoriesCount >= 2)) {
+    return levelById("initial_patterns");
+  }
+
+  return levelById("first_reading");
+}
+
+function buildUnlockedSignals(params: {
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+  profileSignals: VideoNarrativeCreatorProfileSignal[];
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+}): VideoNarrativeUnlockedSignal[] {
+  const fromDiagnosis = params.diagnosis.creatorSignals.slice(0, params.accessLevel === "free" ? 1 : 4).map((signal) => ({
+    id: `current-${signal.type}-${slug(safeUnlockedSignalValue(signal.type, signal.value))}`,
+    label: sanitizeVideoNarrativeEvolvingDiagnosisText(`Sinal do vídeo: ${safeUnlockedSignalValue(signal.type, signal.value)}`),
+    category: signal.type,
+    value: safeUnlockedSignalValue(signal.type, signal.value),
+    source: "current_video" as const,
+    recurrenceCount: 1,
+  }));
+
+  const profileLimit = params.accessLevel === "free" ? 1 : 6;
+  const fromProfile = params.profileSignals.slice(0, profileLimit).map((signal) => ({
+    id: `profile-${signal.id}`,
+    label: sanitizeVideoNarrativeEvolvingDiagnosisText(`${CATEGORY_LABELS[signal.category] ?? "sinal"}: ${safeUnlockedProfileValue(signal.category, signal.value)}`),
+    category: signal.category,
+    value: safeUnlockedProfileValue(signal.category, signal.value),
+    source: "creator_profile" as const,
+    recurrenceCount: signal.recurrenceCount,
+  }));
+
+  return [...fromDiagnosis, ...fromProfile].filter((signal) => signal.value);
+}
+
+function safeUnlockedSignalValue(
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+  value: string,
+): string {
+  if (type === "collab_preference") return "tipo de collab futura";
+  return sanitizeVideoNarrativeEvolvingDiagnosisText(value);
+}
+
+function safeUnlockedProfileValue(
+  category: VideoNarrativeCreatorProfileSignalCategory,
+  value: string,
+): string {
+  if (category === "collab_preferences") return "tipo de collab futura";
+  return sanitizeVideoNarrativeEvolvingDiagnosisText(value);
+}
+
+function buildPendingSignals(params: {
+  hasFormatPreference: boolean;
+  hasBrandTerritory: boolean;
+  hasCollabPreference: boolean;
+  instagramConnected: boolean;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+}): VideoNarrativePendingSignal[] {
+  const pending: VideoNarrativePendingSignal[] = [];
+
+  if (!params.hasFormatPreference) {
+    pending.push({
+      id: "pending-format-preference",
+      label: "Preferência de formato",
+      category: "format_preferences",
+      reason: "Ainda falta entender quais formatos o creator tende a repetir com mais intenção.",
+      unlockPath: "answer_more_quiz",
+    });
+  }
+
+  if (!params.hasBrandTerritory) {
+    pending.push({
+      id: "pending-brand-territory",
+      label: "Território de marca",
+      category: "brand_territories",
+      reason: "O fit narrativo comercial ainda precisa de mais sinais antes de orientar oportunidades futuras.",
+      unlockPath: params.accessLevel === "free" ? "upgrade" : "analyze_more_videos",
+    });
+  }
+
+  if (!params.hasCollabPreference) {
+    pending.push({
+      id: "pending-collab-preference",
+      label: "Tipo de collab",
+      category: "collab_preferences",
+      reason: "Ainda falta mapear que tipo de colaboração combinaria com a narrativa do creator.",
+      unlockPath: params.accessLevel === "free" ? "upgrade" : "analyze_more_videos",
+    });
+  }
+
+  if (!params.instagramConnected) {
+    pending.push({
+      id: "pending-performance-context",
+      label: "Contexto de performance",
+      category: "performance_context",
+      reason: "A leitura de performance depende de contexto futuro do Instagram para ficar mais precisa.",
+      unlockPath: "connect_instagram",
+    });
+  }
+
+  return pending.map((signal) => ({
+    ...signal,
+    label: sanitizeVideoNarrativeEvolvingDiagnosisText(signal.label),
+    reason: sanitizeVideoNarrativeEvolvingDiagnosisText(signal.reason),
+  }));
+}
+
+function buildNextSignalsToUnlock(pendingSignals: VideoNarrativePendingSignal[]): VideoNarrativeNextSignalToUnlock[] {
+  return pendingSignals.slice(0, 4).map((signal) => ({
+    id: `next-${signal.id}`,
+    label: sanitizeVideoNarrativeEvolvingDiagnosisText(`Desbloquear ${signal.label.toLowerCase()}`),
+    action: sanitizeVideoNarrativeEvolvingDiagnosisText(actionForUnlockPath(signal.unlockPath)),
+    expectedSignal: signal.category,
+  }));
+}
+
+function actionForUnlockPath(path: VideoNarrativePendingSignal["unlockPath"]): string {
+  if (path === "connect_instagram") return "Conectar Instagram para comparar com contexto futuro de performance.";
+  if (path === "upgrade") return "Liberar leitura premium para aprofundar o mapa estratégico.";
+  if (path === "analyze_more_videos") return "Analisar mais vídeos para confirmar recorrência e variedade.";
+  return "Responder perguntas rápidas para completar o diagnóstico.";
+}
+
+function buildRecurringPatterns(profileSignals: VideoNarrativeCreatorProfileSignal[]): string[] {
+  return unique(
+    profileSignals
+      .filter((signal) => signal.recurrenceCount >= 2)
+      .map((signal) =>
+        sanitizeVideoNarrativeEvolvingDiagnosisText(`${CATEGORY_LABELS[signal.category] ?? "sinal"} recorrente: ${signal.value}`),
+      ),
+  ).slice(0, 6);
+}
+
+function buildOpportunities(params: {
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+  profileSignals: VideoNarrativeCreatorProfileSignal[];
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeEvolvingDiagnosisOpportunity[] {
+  const opportunities: VideoNarrativeEvolvingDiagnosisOpportunity[] = [];
+  const brandTerritories = unique([
+    ...params.diagnosis.brandPotential.territories,
+    ...(params.profileSignals
+      .filter((signal) => signal.category === "brand_territories")
+      .map((signal) => signal.value)),
+  ]).slice(0, params.accessLevel === "free" ? 2 : 5);
+
+  brandTerritories.forEach((territory) => {
+    opportunities.push({
+      id: `brand-${slug(territory)}`,
+      type: "brand_territory",
+      label: sanitizeVideoNarrativeEvolvingDiagnosisText(`Território de marca possível: ${territory}`),
+      description: sanitizeVideoNarrativeEvolvingDiagnosisText(
+        "Indica fit narrativo como oportunidade futura; depende de performance real e contexto comercial para maior precisão.",
+      ),
+      confidence: params.accessLevel === "free" ? "low" : "medium",
+      realMatchAvailable: false,
+      requiresPremium: params.accessLevel === "free",
+      requiresInstagram: false,
+    });
+  });
+
+  const hasCollabSignal = params.profileSignals.some((signal) => signal.category === "collab_preferences") ||
+    params.diagnosis.creatorSignals.some((signal) => signal.type === "collab_preference");
+  if (hasCollabSignal || params.diagnosis.creatorIntent?.toLowerCase().includes("collab")) {
+    [
+      "complementary_authority",
+      "practical_application",
+      "audience_bridge",
+      "format_contrast",
+      "brand_safe_collab",
+    ].slice(0, params.accessLevel === "free" ? 2 : 5).forEach((type) => {
+      opportunities.push({
+        id: `collab-${type}`,
+        type: "collab_type",
+        label: sanitizeVideoNarrativeEvolvingDiagnosisText(`Tipo de collab futuro: ${type.replace(/_/g, " ")}`),
+        description: sanitizeVideoNarrativeEvolvingDiagnosisText(
+          "Indica um caminho de colaboração futura sem sugerir nomes reais de creators ou criar match real.",
+        ),
+        confidence: "low",
+        realMatchAvailable: false,
+        requiresPremium: params.accessLevel === "free",
+        requiresInstagram: false,
+      });
+    });
+  }
+
+  if (params.instagramConnected && params.accessLevel === "instagram_optimized") {
+    opportunities.push({
+      id: "performance-context-future",
+      type: "performance_context",
+      label: "Comparação futura com Instagram disponível no contexto",
+      description: "A leitura pode considerar contexto futuro/mockado de Instagram, sem afirmar uso de dados reais nesta fase.",
+      confidence: "medium",
+      realMatchAvailable: false,
+      requiresPremium: false,
+      requiresInstagram: false,
+    });
+  }
+
+  return opportunities;
+}
+
+function buildSubscriptionUnlocks(accessLevel: VideoNarrativeDiagnosisAccessLevel): VideoNarrativeEvolvingDiagnosisUnlock[] {
+  if (accessLevel !== "free") return [];
+
+  return [
+    {
+      id: "unlock-complete-evolution",
+      label: "Evolução completa entre vídeos",
+      description: "Libera leitura mais profunda do mapa estratégico conforme novos vídeos geram sinais recorrentes.",
+      reason: "requires_premium",
+    },
+    {
+      id: "unlock-commercial-map",
+      label: "Potencial comercial completo",
+      description: "Aprofunda territórios de marca e oportunidades futuras sem criar match real.",
+      reason: "requires_premium",
+    },
+    {
+      id: "unlock-collab-map",
+      label: "Tipos de collab possíveis",
+      description: "Organiza caminhos de colaboração futura sem sugerir creators reais.",
+      reason: "requires_premium",
+    },
+    {
+      id: "unlock-deeper-patterns",
+      label: "Padrões recorrentes mais profundos",
+      description: "Mostra mais sinais, variedade e recorrência do perfil narrativo.",
+      reason: "requires_premium",
+    },
+  ];
+}
+
+function buildInstagramUnlocks(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeEvolvingDiagnosisUnlock[] {
+  if (params.instagramConnected) return [];
+
+  return [
+    {
+      id: "unlock-instagram-comparison",
+      label: "Comparação com Instagram",
+      description: "Conecta o diagnóstico ao contexto futuro de conteúdos e formatos do perfil.",
+      reason: "requires_instagram_connection",
+    },
+    {
+      id: "unlock-performance-precision",
+      label: "Precisão por performance",
+      description: "Ajuda a entender quais sinais narrativos combinam melhor com o histórico do perfil.",
+      reason: "requires_instagram_connection",
+    },
+  ];
+}
+
+function buildAccessSummary(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  profileSignalsUsed: boolean;
+}): VideoNarrativeEvolvingDiagnosisAccessSummary {
+  if (params.accessLevel === "instagram_optimized" && params.instagramConnected) {
+    return {
+      accessLevel: params.accessLevel,
+      isLimited: false,
+      instagramConnected: true,
+      precision: "instagram_contextual",
+      message: "Leitura mais precisa com contexto futuro/mockado de Instagram disponível, sem usar dados reais nesta fase.",
+    };
+  }
+
+  if (params.accessLevel === "premium") {
+    return {
+      accessLevel: params.accessLevel,
+      isLimited: false,
+      instagramConnected: params.instagramConnected,
+      precision: params.profileSignalsUsed ? "profile_based" : "initial",
+      message: "Mapa estratégico premium liberado sem depender de Instagram real.",
+    };
+  }
+
+  return {
+    accessLevel: params.accessLevel,
+    isLimited: true,
+    instagramConnected: params.instagramConnected,
+    precision: "initial",
+    message: "Primeira leitura útil e limitada; a evolução completa do mapa estratégico fica desbloqueável.",
+  };
+}
+
+function buildProfileImpact(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  usefulSignalsCount: number;
+  recurringSignalsCount: number;
+  newSignalsCount: number;
+  recurringPatternsCount: number;
+  profileSignalsUsed: boolean;
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+}): VideoNarrativeCreatorProfileImpact {
+  const depth: VideoNarrativeCreatorProfileImpact["depth"] =
+    params.accessLevel === "instagram_optimized" && params.instagramConnected
+      ? "instagram_contextual"
+      : params.accessLevel === "premium"
+        ? "deep"
+        : params.accessLevel === "instagram_optimized"
+          ? "deep"
+          : "limited";
+
+  const firstReading = clean(params.diagnosis.mainNarrative ?? params.diagnosis.whatVideoCommunicates) ??
+    "primeira leitura estratégica";
+  const adjustment = clean(params.diagnosis.recommendedAdjustment);
+  const summary =
+    params.accessLevel === "free"
+      ? `Este vídeo adiciona uma primeira leitura ao mapa estratégico: ${firstReading}${adjustment ? `. Ajuste principal: ${adjustment}` : ""}.`
+      : `Este vídeo atualiza o mapa estratégico com ${params.newSignalsCount} sinais do diagnóstico, ${params.usefulSignalsCount} sinais úteis no perfil e ${params.recurringSignalsCount} sinais recorrentes.`;
+
+  return {
+    summary: sanitizeVideoNarrativeEvolvingDiagnosisText(summary),
+    depth,
+    usefulSignalsCount: params.accessLevel === "free"
+      ? Math.min(params.usefulSignalsCount, 2)
+      : params.usefulSignalsCount,
+    recurringSignalsCount: params.accessLevel === "free"
+      ? Math.min(params.recurringSignalsCount, 1)
+      : params.recurringSignalsCount,
+    newSignalsCount: params.accessLevel === "free"
+      ? Math.min(params.newSignalsCount, 1)
+      : params.newSignalsCount,
+    recurringPatternsCount: params.accessLevel === "free"
+      ? Math.min(params.recurringPatternsCount, 1)
+      : params.recurringPatternsCount,
+    profileSignalsUsed: params.profileSignalsUsed,
+  };
+}
+
+export function sanitizeVideoNarrativeEvolvingDiagnosisText(value: string): string {
+  let sanitized = sanitizeVideoNarrativeDiagnosisText(value);
+  sanitized = sanitized.replace(/\bAIza[0-9A-Za-z_-]{8,}/g, "[redigido]");
+  sanitized = sanitized.replace(/\b(?:GEMINI_API_KEY|GOOGLE_GENAI_API_KEY|API_KEY)=\S+/g, "[redigido]");
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/]{120,}={0,2}\b/g, "[redigido]");
+  sanitized = sanitized.replace(/\bhttps?:\/\/\S*(?:\?|&)(?:token|signature|sig|X-Amz-Signature|Expires)=\S*/gi, "[redigido]");
+
+  BLOCKED_TERMS.forEach((term) => {
+    sanitized = sanitized.replace(new RegExp(term.replace(/\s+/g, "\\s+"), "gi"), "[redigido]");
+  });
+
+  return sanitized.trim();
+}
+
+export function buildVideoNarrativeEvolvingDiagnosis(
+  input: VideoNarrativeEvolvingDiagnosisInput,
+): VideoNarrativeEvolvingDiagnosis {
+  const profileSignals = usefulProfileSignals(input.creatorProfile);
+  const diagnosisSignals = input.diagnosis.creatorSignals.filter((signal) => signal.value.trim());
+  const instagramConnected = Boolean(input.instagramConnected);
+  const analyzedVideosCount = Math.max(0, input.analyzedVideosCount ?? 0);
+  const categories = new Set(profileSignals.map((signal) => signal.category));
+  diagnosisSignals.forEach((signal) => categories.add(signal.type as VideoNarrativeCreatorProfileSignalCategory));
+
+  const hasContentGoal = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "content_goals",
+    diagnosisType: "content_goal",
+  });
+  const hasHookPreference = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "hook_preferences",
+    diagnosisType: "hook_preference",
+  });
+  const hasFormatPreference = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "format_preferences",
+    diagnosisType: "format_preference",
+  });
+  const hasBrandTerritory = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "brand_territories",
+    diagnosisType: "brand_territory",
+  }) || input.diagnosis.brandPotential.territories.length > 0;
+  const hasCollabPreference = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "collab_preferences",
+    diagnosisType: "collab_preference",
+  });
+  const hasCommercialSignal = hasAnySignal({
+    profileSignals,
+    diagnosisSignals,
+    profileCategory: "commercial_preferences",
+    diagnosisType: "commercial_preference",
+  }) || input.diagnosis.brandPotential.enabled;
+
+  const recurringSignalsCount = profileSignals.filter((signal) => signal.recurrenceCount >= 2).length;
+  const usefulSignalsCount = profileSignals.length + diagnosisSignals.length;
+  const currentLevel = computeLevel({
+    usefulSignalsCount,
+    recurringSignalsCount,
+    categoriesCount: categories.size,
+    hasContentGoal,
+    hasHookPreference,
+    hasFormatPreference,
+    hasBrandTerritory,
+    hasCollabPreference,
+    hasCommercialSignal,
+    accessLevel: input.accessLevel,
+    instagramConnected,
+    analyzedVideosCount,
+  });
+  const recurringPatterns = buildRecurringPatterns(profileSignals);
+  const unlockedSignals = buildUnlockedSignals({
+    diagnosis: input.diagnosis,
+    profileSignals,
+    accessLevel: input.accessLevel,
+  });
+  const pendingSignals = buildPendingSignals({
+    hasFormatPreference,
+    hasBrandTerritory,
+    hasCollabPreference,
+    instagramConnected,
+    accessLevel: input.accessLevel,
+  });
+
+  return {
+    id: `evolving-diagnosis-${input.diagnosis.id}`,
+    accessLevel: input.accessLevel,
+    videoDiagnosisId: input.diagnosis.id,
+    currentLevel,
+    nextLevel: nextLevelFor(currentLevel),
+    profileImpact: buildProfileImpact({
+      accessLevel: input.accessLevel,
+      instagramConnected,
+      usefulSignalsCount,
+      recurringSignalsCount,
+      newSignalsCount: diagnosisSignals.length,
+      recurringPatternsCount: recurringPatterns.length,
+      profileSignalsUsed: profileSignals.length > 0,
+      diagnosis: input.diagnosis,
+    }),
+    unlockedSignals,
+    pendingSignals,
+    nextSignalsToUnlock: buildNextSignalsToUnlock(pendingSignals),
+    recurringPatterns: input.accessLevel === "free" ? recurringPatterns.slice(0, 1) : recurringPatterns,
+    opportunities: buildOpportunities({
+      diagnosis: input.diagnosis,
+      profileSignals,
+      accessLevel: input.accessLevel,
+      instagramConnected,
+    }),
+    subscriptionUnlocks: buildSubscriptionUnlocks(input.accessLevel),
+    instagramUnlocks: buildInstagramUnlocks({
+      accessLevel: input.accessLevel,
+      instagramConnected,
+    }),
+    accessSummary: buildAccessSummary({
+      accessLevel: input.accessLevel,
+      instagramConnected,
+      profileSignalsUsed: profileSignals.length > 0,
+    }),
+    createdAt: input.createdAt ?? input.diagnosis.createdAt ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked on #834.

This PR adds MM38, a pure contract for the evolving creator diagnosis layer above the per-video strategic diagnosis.

It introduces:

- `VideoNarrativeEvolvingDiagnosis`
- `VideoNarrativeCreatorStrategicLevel` and level ids
- `VideoNarrativeCreatorProfileImpact`
- unlocked/pending/next signals
- future opportunities for brand territories and collab types
- subscription and Instagram unlock summaries
- deterministic `buildVideoNarrativeEvolvingDiagnosis`
- sanitization for sensitive text and unsafe promise/game language

The model connects `VideoNarrativeStrategicDiagnosis` with `VideoNarrativeCreatorProfile` without persistence. It treats brand/collab as future opportunities only, with no real match, no creator names, no provider call, and no external integration.

## Guardrails

- No UI changes
- No preview changes
- No endpoint changes
- No real upload or storage
- No persistence or database/table changes
- No Gemini/OpenAI calls or SDK imports
- No fetch/network calls
- No Instagram real integration
- No brand/creator real match
- No Stripe/billing/cobrança integration

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisQuizBuilder.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeAppFlowState.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`