### PR TITLE
feat: add video narrative access tier diagnosis rules

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -100,6 +100,8 @@ Já existe:
 - a próxima etapa deve considerar os achados da QA antes de qualquer upload real, BoardShell, paywall ou integração real;
 - evolving creator diagnosis contract foi criado em MM38 como camada segura de produto sobre o diagnóstico pontual;
 - MM38 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint e não muda upload/storage;
+- access tier diagnosis rules foi criado em MM39 para separar valor free, premium e Instagram conectado;
+- MM39 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda billing real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -885,6 +885,30 @@ O que não faz:
 - não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta billing, Stripe ou cobrança.
 
+### MM39 — Access Tier Diagnosis Rules
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeAccessTierDiagnosisRules.ts`
+- `videoNarrativeAccessTierDiagnosisRules.test.ts`
+
+O que faz:
+
+- cria regras puras para diferenciar diagnóstico `free`, `premium` e `instagram_optimized`;
+- separa valor gratuito, valor de assinatura e valor de Instagram conectado;
+- modela disponibilidade de marca/collab sem match real;
+- prepara a futura camada de apresentação sem criar UI;
+- centraliza a lógica de acesso para evitar espalhar paywall/copy pelos componentes.
+
+O que não faz:
+
+- não cria persistência, banco/tabela, endpoint, UI, preview, upload real, storage real ou analytics real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -245,8 +245,9 @@ Exemplos:
 35. MM36 — Interactive preview UX refinement. Lapida copy, quiz, diagnóstico, CTAs e prompts antes de conectar upload real ou BoardShell.
 36. MM37 — Browser UX QA checklist. Cria roteiro manual e testável para revisar a experiência no navegador antes de upload, BoardShell ou paywall.
 37. MM38 — Evolving Creator Diagnosis Contract. Modela a camada evolutiva acima do diagnóstico pontual, sem persistência ou match real.
-38. Teste real manual quando houver quota/billing disponível.
-39. Integração experimental futura no Board de Criação.
+38. MM39 — Access Tier Diagnosis Rules. Define regras de acesso e valor por camada para free, premium e Instagram conectado.
+39. Teste real manual quando houver quota/billing disponível.
+40. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -315,6 +316,8 @@ MM36 refina a UX da preview interativa. A experiência fica mais clara na primei
 MM37 cria uma checklist de QA visual/funcional para testar a preview interativa no navegador. O roteiro cobre URLs, cenários, acessos, mobile-first, segurança visual, critérios por etapa e registro de achados antes de integrar upload, BoardShell, paywall ou qualquer fluxo real.
 
 MM38 adiciona `VideoNarrativeEvolvingDiagnosis` como camada acima de `VideoNarrativeStrategicDiagnosis`. O diagnóstico estratégico continua sendo a leitura pontual do vídeo; a nova camada organiza esse valor em torno da evolução do creator, com nível atual, próximo nível, impacto no perfil, sinais desbloqueados, sinais pendentes e oportunidades futuras. Ela usa o `VideoNarrativeCreatorProfile` como contexto, mas não persiste sinais, não substitui o profile contract e não cria match real de marcas ou creators.
+
+MM39 adiciona `VideoNarrativeAccessTierDiagnosisRules` para explicitar as regras de acesso e valor por camada. MM38 define o diagnóstico evolutivo; MM39 define o que fica visível, limitado, bloqueado ou sugerido em `free`, `premium` e `instagram_optimized`. Essa camada deve ser usada futuramente pela apresentação/UI para não espalhar lógica de paywall, disponibilidade comercial, collab e precisão por Instagram pelos componentes.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts
@@ -1,0 +1,322 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildVideoNarrativeAccessTierDiagnosisRules,
+  sanitizeVideoNarrativeAccessTierDiagnosisRulesText,
+  type VideoNarrativeAccessTierDiagnosisRules,
+} from "./videoNarrativeAccessTierDiagnosisRules";
+import {
+  buildVideoNarrativeEvolvingDiagnosis,
+  type VideoNarrativeEvolvingDiagnosis,
+} from "./videoNarrativeEvolvingDiagnosisContract";
+import {
+  buildVideoNarrativeCreatorProfile,
+  type VideoNarrativeCreatorProfile,
+} from "./videoNarrativeCreatorProfileContract";
+import type {
+  VideoNarrativeDiagnosisCreatorSignal,
+  VideoNarrativeDiagnosisAccessLevel,
+  VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+
+const RULES_SOURCE_PATH = path.join(__dirname, "videoNarrativeAccessTierDiagnosisRules.ts");
+
+function signal(
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+  value: string,
+  confidence: VideoNarrativeDiagnosisCreatorSignal["confidence"] = "medium",
+): VideoNarrativeDiagnosisCreatorSignal {
+  return {
+    id: `${type}-${value}`,
+    type,
+    value,
+    source: "diagnosis_inference",
+    confidence,
+    evidence: `Evidência para ${value}`,
+    shouldPersistLater: false,
+  };
+}
+
+function makeDiagnosis(overrides: Partial<VideoNarrativeStrategicDiagnosis> = {}): VideoNarrativeStrategicDiagnosis {
+  return {
+    id: "access-rules-diagnosis",
+    accessLevel: "premium",
+    mainNarrative: "rotina de cuidado com fit narrativo comercial",
+    whatVideoCommunicates: "Esse vídeo comunica rotina, contexto e oportunidade futura.",
+    creatorIntent: "Quero saber se isso pode virar publi ou collab",
+    strategicReading: "Pelo vídeo, o caminho é transformar a rotina em mapa estratégico.",
+    strength: "Mostra contexto real.",
+    weakness: "A abertura ainda pode ficar mais clara.",
+    recommendedAdjustment: "Abrir com o resultado antes da rotina.",
+    suggestedHook: "Comece pelo resultado.",
+    brandPotential: {
+      enabled: true,
+      territories: ["skincare", "bem-estar"],
+      whyItFits: "Existe fit narrativo com cuidado e rotina.",
+      locked: false,
+    },
+    blueprint: {
+      whatToPost: "Reel com rotina e resultado.",
+      whyThisPath: "A narrativa fica mais clara.",
+      howItShouldWork: "Abrir com resultado, mostrar processo e fechar com próximo passo.",
+      scenes: ["resultado", "processo"],
+      locked: false,
+    },
+    scriptDirection: {
+      opening: "Comece pelo resultado.",
+      development: ["contexto", "processo"],
+      closing: "Próximo passo.",
+      tone: "consultivo",
+      locked: false,
+    },
+    nextActions: [{ id: "script", label: "Gerar roteiro", description: null, locked: false }],
+    lockedSections: [],
+    creatorSignals: [
+      signal("content_goal", "validar antes de postar"),
+      signal("brand_territory", "skincare"),
+      signal("commercial_preference", "atrair marcas"),
+      signal("collab_preference", "tipo complementar"),
+      signal("format_preference", "reels direto"),
+    ],
+    instagramComparison: {
+      connected: false,
+      summary: null,
+      matchingNarratives: [],
+      matchingFormats: [],
+      locked: true,
+    },
+    createdAt: "2026-05-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function profile(): VideoNarrativeCreatorProfile {
+  const first = buildVideoNarrativeCreatorProfile({
+    creatorId: "creator-1",
+    diagnosisId: "d1",
+    createdAt: "2026-05-17T00:00:00.000Z",
+    newSignals: [
+      signal("content_goal", "validar antes de postar", "high"),
+      signal("hook_preference", "abertura direta", "high"),
+      signal("format_preference", "reels direto", "medium"),
+      signal("brand_territory", "skincare", "high"),
+      signal("commercial_preference", "atrair marcas", "medium"),
+      signal("collab_preference", "tipo complementar", "medium"),
+    ],
+  });
+
+  return buildVideoNarrativeCreatorProfile({
+    existingProfile: first,
+    diagnosisId: "d2",
+    createdAt: "2026-05-18T00:00:00.000Z",
+    newSignals: [
+      signal("content_goal", "validar antes de postar", "high"),
+      signal("hook_preference", "abertura direta", "high"),
+      signal("format_preference", "reels direto", "medium"),
+      signal("brand_territory", "skincare", "high"),
+      signal("commercial_preference", "atrair marcas", "medium"),
+      signal("collab_preference", "tipo complementar", "medium"),
+    ],
+  });
+}
+
+function evolving(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+  withSignals?: boolean;
+  diagnosis?: VideoNarrativeStrategicDiagnosis;
+}): VideoNarrativeEvolvingDiagnosis {
+  return buildVideoNarrativeEvolvingDiagnosis({
+    diagnosis: params.diagnosis ?? makeDiagnosis({ accessLevel: params.accessLevel }),
+    creatorProfile: params.withSignals === false ? null : profile(),
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+    analyzedVideosCount: 3,
+  });
+}
+
+function rules(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+  withSignals?: boolean;
+  diagnosis?: VideoNarrativeStrategicDiagnosis;
+}): VideoNarrativeAccessTierDiagnosisRules {
+  return buildVideoNarrativeAccessTierDiagnosisRules({
+    evolvingDiagnosis: evolving(params),
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+  });
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("videoNarrativeAccessTierDiagnosisRules", () => {
+  it("free mostra apenas seções essenciais e bloqueia mapa completo", () => {
+    const result = rules({ accessLevel: "free" });
+
+    expect(result.valueLayer).toBe("first_reading");
+    expect(result.visibleSections.map((section) => section.key)).toContain("main_video_reading");
+    expect(result.visibleSections.map((section) => section.key)).toContain("primary_adjustment");
+    expect(result.canShowFullProfileImpact).toBe(false);
+    expect(result.lockedSections.map((section) => section.key)).toContain("full_profile_impact");
+  });
+
+  it("free cria CTA de desbloquear diagnóstico completo", () => {
+    const result = rules({ accessLevel: "free" });
+
+    expect(result.primaryCTA.action).toBe("upgrade");
+    expect(result.primaryCTA.label).toBe("Desbloquear diagnóstico completo");
+    expect(result.shouldTeaseSubscription).toBe(true);
+  });
+
+  it("free limita marca/collab a teaser quando houver oportunidade", () => {
+    const result = rules({ accessLevel: "free" });
+
+    expect(result.commercialAvailability.state).toBe("teaser_only");
+    expect(result.collabAvailability.state).toBe("teaser_only");
+    expect(result.canShowFullBrandOpportunities).toBe(false);
+    expect(result.canShowFullCollabOpportunities).toBe(false);
+  });
+
+  it("premium libera mapa estratégico, sinais e padrões recorrentes", () => {
+    const result = rules({ accessLevel: "premium" });
+
+    expect(result.valueLayer).toBe("strategic_map");
+    expect(result.canShowFullProfileImpact).toBe(true);
+    expect(result.canShowFullRecurringPatterns).toBe(true);
+    expect(result.visibleSections.map((section) => section.key)).toContain("unlocked_signals");
+    expect(result.visibleSections.map((section) => section.key)).toContain("recurring_patterns");
+  });
+
+  it("premium libera oportunidades estratégicas de marca/collab sem match real", () => {
+    const result = rules({ accessLevel: "premium" });
+
+    expect(result.commercialAvailability.state).toBe("strategic_available");
+    expect(result.collabAvailability.state).toBe("strategic_available");
+    expect(result.commercialAvailability.realMatchAvailable).toBe(false);
+    expect(result.collabAvailability.realMatchAvailable).toBe(false);
+    expect(stringify(result)).not.toContain("match real disponível");
+  });
+
+  it("premium sem Instagram cria CTA ou motivo para conectar Instagram", () => {
+    const result = rules({ accessLevel: "premium", instagramConnected: false });
+
+    expect(result.primaryCTA.action).toBe("connect_instagram");
+    expect(result.primaryCTA.label).toBe("Conectar Instagram para aumentar precisão");
+    expect(result.instagramReasons.map((reason) => reason.id)).toContain("instagram_precision");
+    expect(result.shouldTeaseInstagramConnection).toBe(true);
+  });
+
+  it("instagram optimized conectado libera precisão contextual", () => {
+    const result = rules({ accessLevel: "instagram_optimized", instagramConnected: true });
+
+    expect(result.valueLayer).toBe("instagram_precision");
+    expect(result.canShowInstagramPrecision).toBe(true);
+    expect(result.primaryCTA.action).toBe("generate_next_strategic_move");
+    expect(result.visibleSections.map((section) => section.key)).toContain("instagram_precision");
+  });
+
+  it("instagram optimized conectado não afirma uso de dados reais", () => {
+    const result = rules({ accessLevel: "instagram_optimized", instagramConnected: true });
+    const text = stringify(result);
+
+    expect(text).toContain("contexto futuro");
+    expect(text).not.toContain("dados reais foram usados");
+    expect(text).not.toContain("usou dados reais");
+  });
+
+  it("commercialAvailability muda corretamente entre free, premium e instagram_optimized", () => {
+    expect(rules({ accessLevel: "free" }).commercialAvailability.state).toBe("teaser_only");
+    expect(rules({ accessLevel: "premium" }).commercialAvailability.state).toBe("strategic_available");
+    expect(rules({
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+    }).commercialAvailability.state).toBe("instagram_precision_available");
+  });
+
+  it("collabAvailability muda corretamente entre free, premium e instagram_optimized", () => {
+    expect(rules({ accessLevel: "free" }).collabAvailability.state).toBe("teaser_only");
+    expect(rules({ accessLevel: "premium" }).collabAvailability.state).toBe("strategic_available");
+    expect(rules({
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+    }).collabAvailability.state).toBe("instagram_precision_available");
+  });
+
+  it("não sugere nomes reais de creators", () => {
+    const result = rules({
+      accessLevel: "premium",
+      diagnosis: makeDiagnosis({
+        creatorIntent: "Quero collab com Creator Famoso",
+        creatorSignals: [signal("collab_preference", "Creator Famoso")],
+      }),
+    });
+
+    expect(stringify(result)).not.toContain("creator famoso");
+  });
+
+  it("não promete marca, publi, match ou resultado garantido", () => {
+    const result = rules({ accessLevel: "premium" });
+    const text = stringify(result);
+
+    expect(text).not.toContain("marca garantida");
+    expect(text).not.toContain("publi garantida");
+    expect(text).not.toContain("match comprovado");
+    expect(text).not.toContain("resultado garantido");
+    expect(text).not.toContain("garantido");
+    expect(text).not.toContain("certeza");
+    expect(text).not.toContain("comprovado");
+  });
+
+  it("sanitiza textos perigosos", () => {
+    const text = sanitizeVideoNarrativeAccessTierDiagnosisRulesText(
+      "AIza1234567890abc GEMINI_API_KEY=secret abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 https://x.test/file?token=abc score venceu garantido",
+    ).toLowerCase();
+
+    expect(text).toContain("[redigido]");
+    expect(text).not.toContain("AIza");
+    expect(text).not.toContain("gemini_api_key");
+    expect(text).not.toContain("token=abc");
+    expect(text).not.toContain("score");
+    expect(text).not.toContain("venceu");
+  });
+
+  it("não importa fetch, Prisma, banco, Gemini, OpenAI, Stripe ou SDK externo", () => {
+    const source = fs.readFileSync(RULES_SOURCE_PATH, "utf8");
+
+    [
+      "fetch",
+      "Prisma",
+      "banco",
+      "@google/genai",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "stripe",
+      "firebase",
+      "supabase",
+    ].forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("não altera endpoint, UI ou preview", () => {
+    const source = fs.readFileSync(RULES_SOURCE_PATH, "utf8");
+
+    [
+      "route.ts",
+      "VideoNarrativeAppPreview",
+      "VideoNarrativeInteractiveAppPreview",
+      "React",
+      "BoardShell",
+      "PostCreationFunnelState",
+      "components/",
+      "app/api",
+    ].forEach((term) => {
+      expect(source).not.toContain(term);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.ts
@@ -1,0 +1,521 @@
+import {
+  sanitizeVideoNarrativeEvolvingDiagnosisText,
+  type VideoNarrativeEvolvingDiagnosis,
+  type VideoNarrativeEvolvingDiagnosisOpportunity,
+} from "./videoNarrativeEvolvingDiagnosisContract";
+import type { VideoNarrativeDiagnosisAccessLevel } from "./videoNarrativeDiagnosisLearningModel";
+
+export type VideoNarrativeAccessTierValueLayer =
+  | "first_reading"
+  | "strategic_map"
+  | "instagram_precision";
+
+export type VideoNarrativeAccessTierSectionKey =
+  | "main_video_reading"
+  | "primary_adjustment"
+  | "first_creator_signal"
+  | "limited_profile_impact"
+  | "full_profile_impact"
+  | "unlocked_signals"
+  | "pending_signals"
+  | "next_signals"
+  | "recurring_patterns"
+  | "brand_opportunities"
+  | "collab_opportunities"
+  | "script_blueprint_depth"
+  | "instagram_precision"
+  | "performance_comparison";
+
+export interface VideoNarrativeAccessTierVisibleSection {
+  key: VideoNarrativeAccessTierSectionKey;
+  label: string;
+  description: string;
+  limited: boolean;
+}
+
+export interface VideoNarrativeAccessTierLockedSection {
+  key: VideoNarrativeAccessTierSectionKey;
+  label: string;
+  reason: VideoNarrativeAccessTierUpgradeReason | VideoNarrativeAccessTierInstagramReason;
+  message: string;
+}
+
+export type VideoNarrativeAccessTierPrimaryCTAAction =
+  | "upgrade"
+  | "connect_instagram"
+  | "generate_next_strategic_move";
+
+export interface VideoNarrativeAccessTierPrimaryCTA {
+  label: string;
+  action: VideoNarrativeAccessTierPrimaryCTAAction;
+  helper: string;
+}
+
+export interface VideoNarrativeAccessTierUpgradeReason {
+  id:
+    | "complete_strategic_map"
+    | "full_recurring_patterns"
+    | "full_brand_opportunities"
+    | "full_collab_opportunities"
+    | "script_blueprint_depth";
+  label: string;
+  description: string;
+}
+
+export interface VideoNarrativeAccessTierInstagramReason {
+  id:
+    | "instagram_precision"
+    | "performance_comparison"
+    | "audience_validated_formats";
+  label: string;
+  description: string;
+}
+
+export type VideoNarrativeAccessTierAvailabilityState =
+  | "teaser_only"
+  | "strategic_available"
+  | "instagram_precision_available"
+  | "unavailable";
+
+export interface VideoNarrativeAccessTierCommercialAvailability {
+  state: VideoNarrativeAccessTierAvailabilityState;
+  hasSignals: boolean;
+  label: string;
+  description: string;
+  realMatchAvailable: false;
+}
+
+export interface VideoNarrativeAccessTierCollabAvailability {
+  state: VideoNarrativeAccessTierAvailabilityState;
+  hasSignals: boolean;
+  label: string;
+  description: string;
+  realMatchAvailable: false;
+}
+
+export interface VideoNarrativeAccessTierDiagnosisRulesInput {
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+}
+
+export interface VideoNarrativeAccessTierDiagnosisRules {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  valueLayer: VideoNarrativeAccessTierValueLayer;
+  visibleSections: VideoNarrativeAccessTierVisibleSection[];
+  lockedSections: VideoNarrativeAccessTierLockedSection[];
+  primaryCTA: VideoNarrativeAccessTierPrimaryCTA;
+  upgradeReasons: VideoNarrativeAccessTierUpgradeReason[];
+  instagramReasons: VideoNarrativeAccessTierInstagramReason[];
+  commercialAvailability: VideoNarrativeAccessTierCommercialAvailability;
+  collabAvailability: VideoNarrativeAccessTierCollabAvailability;
+  canShowFullProfileImpact: boolean;
+  canShowFullRecurringPatterns: boolean;
+  canShowFullBrandOpportunities: boolean;
+  canShowFullCollabOpportunities: boolean;
+  canShowInstagramPrecision: boolean;
+  shouldTeaseSubscription: boolean;
+  shouldTeaseInstagramConnection: boolean;
+}
+
+function clean(value: string): string {
+  return sanitizeVideoNarrativeAccessTierDiagnosisRulesText(value);
+}
+
+export function sanitizeVideoNarrativeAccessTierDiagnosisRulesText(value: string): string {
+  return sanitizeVideoNarrativeEvolvingDiagnosisText(value);
+}
+
+function hasOpportunities(
+  diagnosis: VideoNarrativeEvolvingDiagnosis,
+  type: VideoNarrativeEvolvingDiagnosisOpportunity["type"],
+): boolean {
+  return diagnosis.opportunities.some((opportunity) => opportunity.type === type);
+}
+
+function visibleSection(
+  key: VideoNarrativeAccessTierSectionKey,
+  label: string,
+  description: string,
+  limited: boolean,
+): VideoNarrativeAccessTierVisibleSection {
+  return {
+    key,
+    label: clean(label),
+    description: clean(description),
+    limited,
+  };
+}
+
+function upgradeReason(
+  id: VideoNarrativeAccessTierUpgradeReason["id"],
+  label: string,
+  description: string,
+): VideoNarrativeAccessTierUpgradeReason {
+  return {
+    id,
+    label: clean(label),
+    description: clean(description),
+  };
+}
+
+function instagramReason(
+  id: VideoNarrativeAccessTierInstagramReason["id"],
+  label: string,
+  description: string,
+): VideoNarrativeAccessTierInstagramReason {
+  return {
+    id,
+    label: clean(label),
+    description: clean(description),
+  };
+}
+
+function lockedSection(
+  key: VideoNarrativeAccessTierSectionKey,
+  label: string,
+  reason: VideoNarrativeAccessTierUpgradeReason | VideoNarrativeAccessTierInstagramReason,
+  message: string,
+): VideoNarrativeAccessTierLockedSection {
+  return {
+    key,
+    label: clean(label),
+    reason,
+    message: clean(message),
+  };
+}
+
+function buildUpgradeReasons(accessLevel: VideoNarrativeDiagnosisAccessLevel): VideoNarrativeAccessTierUpgradeReason[] {
+  if (accessLevel !== "free") return [];
+
+  return [
+    upgradeReason(
+      "complete_strategic_map",
+      "Mapa estratégico completo",
+      "Libera a leitura completa entre vídeos, sinais e próximos movimentos.",
+    ),
+    upgradeReason(
+      "full_recurring_patterns",
+      "Padrões recorrentes completos",
+      "Mostra mais recorrência e variedade do creator ao longo das análises.",
+    ),
+    upgradeReason(
+      "full_brand_opportunities",
+      "Oportunidades futuras de marca",
+      "Aprofunda territórios de marca e fit narrativo sem criar match real.",
+    ),
+    upgradeReason(
+      "full_collab_opportunities",
+      "Tipos de collab possíveis",
+      "Organiza tipos de colaboração futura sem sugerir creators reais.",
+    ),
+    upgradeReason(
+      "script_blueprint_depth",
+      "Blueprint e roteiro completos",
+      "Aprofunda os caminhos de execução quando o diagnóstico base tiver material suficiente.",
+    ),
+  ];
+}
+
+function buildInstagramReasons(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeAccessTierInstagramReason[] {
+  if (params.accessLevel === "instagram_optimized" && params.instagramConnected) return [];
+
+  return [
+    instagramReason(
+      "instagram_precision",
+      "Leitura mais precisa com Instagram",
+      "Adiciona contexto futuro de Instagram para calibrar a leitura sem prometer performance.",
+    ),
+    instagramReason(
+      "performance_comparison",
+      "Comparação com performance",
+      "Ajuda a comparar narrativa e formato com sinais futuros do perfil.",
+    ),
+    instagramReason(
+      "audience_validated_formats",
+      "Formatos validados pela audiência",
+      "Ajuda a entender quais formatos e narrativas parecem mais coerentes com o histórico futuro.",
+    ),
+  ];
+}
+
+function buildVisibleSections(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  hasBrandSignals: boolean;
+  hasCollabSignals: boolean;
+}): VideoNarrativeAccessTierVisibleSection[] {
+  if (params.accessLevel === "free") {
+    const sections = [
+      visibleSection(
+        "main_video_reading",
+        "Leitura principal do vídeo",
+        "Mostra a primeira leitura estratégica que já ajuda a entender o vídeo.",
+        false,
+      ),
+      visibleSection(
+        "primary_adjustment",
+        "Ajuste principal",
+        "Mostra o ajuste mais importante para deixar a direção do conteúdo mais clara.",
+        false,
+      ),
+      visibleSection(
+        "first_creator_signal",
+        "Primeiro sinal do mapa",
+        "Mostra o primeiro sinal útil para o mapa estratégico do creator.",
+        true,
+      ),
+      visibleSection(
+        "limited_profile_impact",
+        "Impacto limitado no perfil",
+        "Resume como esse vídeo começa a alimentar o mapa estratégico.",
+        true,
+      ),
+    ];
+
+    if (params.hasBrandSignals) {
+      sections.push(visibleSection(
+        "brand_opportunities",
+        "Teaser de território de marca",
+        "Mostra indício de oportunidade futura sem match real.",
+        true,
+      ));
+    }
+
+    if (params.hasCollabSignals) {
+      sections.push(visibleSection(
+        "collab_opportunities",
+        "Teaser de tipo de collab",
+        "Mostra indício de colaboração futura sem sugerir creators reais.",
+        true,
+      ));
+    }
+
+    return sections;
+  }
+
+  const sections = [
+    visibleSection("main_video_reading", "Leitura principal do vídeo", "Mantém a leitura estratégica do vídeo.", false),
+    visibleSection("full_profile_impact", "Impacto completo no perfil", "Mostra como o vídeo altera o mapa estratégico.", false),
+    visibleSection("unlocked_signals", "Sinais desbloqueados", "Mostra sinais já identificados no diagnóstico e no perfil.", false),
+    visibleSection("pending_signals", "Sinais pendentes", "Mostra o que ainda precisa ser observado.", false),
+    visibleSection("next_signals", "Próximos sinais", "Mostra os próximos sinais a desbloquear.", false),
+    visibleSection("recurring_patterns", "Padrões recorrentes", "Mostra padrões que começam a se repetir.", false),
+    visibleSection("brand_opportunities", "Oportunidades futuras de marca", "Mostra territórios e fit narrativo sem match real.", false),
+    visibleSection("collab_opportunities", "Tipos de collab possíveis", "Mostra tipos de colaboração futura sem nomes reais.", false),
+  ];
+
+  if (params.accessLevel === "instagram_optimized" && params.instagramConnected) {
+    sections.push(visibleSection(
+      "instagram_precision",
+      "Precisão contextual com Instagram",
+      "Mostra camada de precisão contextual futura sem afirmar uso de dados reais nesta fase.",
+      false,
+    ));
+  }
+
+  return sections;
+}
+
+function buildLockedSections(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  upgradeReasons: VideoNarrativeAccessTierUpgradeReason[];
+  instagramReasons: VideoNarrativeAccessTierInstagramReason[];
+}): VideoNarrativeAccessTierLockedSection[] {
+  const locked: VideoNarrativeAccessTierLockedSection[] = [];
+
+  if (params.accessLevel === "free") {
+    params.upgradeReasons.forEach((reason) => {
+      const keyByReason: Record<VideoNarrativeAccessTierUpgradeReason["id"], VideoNarrativeAccessTierSectionKey> = {
+        complete_strategic_map: "full_profile_impact",
+        full_recurring_patterns: "recurring_patterns",
+        full_brand_opportunities: "brand_opportunities",
+        full_collab_opportunities: "collab_opportunities",
+        script_blueprint_depth: "script_blueprint_depth",
+      };
+      locked.push(lockedSection(
+        keyByReason[reason.id],
+        reason.label,
+        reason,
+        "Disponível no diagnóstico completo para aprofundar o mapa estratégico.",
+      ));
+    });
+  }
+
+  if (!params.instagramConnected) {
+    params.instagramReasons.forEach((reason) => {
+      const key = reason.id === "instagram_precision"
+        ? "instagram_precision"
+        : reason.id === "performance_comparison"
+          ? "performance_comparison"
+          : "recurring_patterns";
+      locked.push(lockedSection(
+        key,
+        reason.label,
+        reason,
+        "Disponível com conexão de Instagram para adicionar contexto futuro de precisão.",
+      ));
+    });
+  }
+
+  return locked;
+}
+
+function buildPrimaryCTA(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeAccessTierPrimaryCTA {
+  if (params.accessLevel === "free") {
+    return {
+      label: "Desbloquear diagnóstico completo",
+      action: "upgrade",
+      helper: clean("A primeira leitura já é útil; o diagnóstico completo aprofunda o mapa estratégico."),
+    };
+  }
+
+  if (!params.instagramConnected) {
+    return {
+      label: "Conectar Instagram para aumentar precisão",
+      action: "connect_instagram",
+      helper: clean("Premium vende profundidade estratégica; Instagram adiciona contexto futuro de precisão."),
+    };
+  }
+
+  return {
+    label: "Gerar próximo movimento estratégico",
+    action: "generate_next_strategic_move",
+    helper: clean("Usa o mapa estratégico e contexto futuro de Instagram sem prometer performance."),
+  };
+}
+
+function availabilityDescription(params: {
+  kind: "brand" | "collab";
+  state: VideoNarrativeAccessTierAvailabilityState;
+}): string {
+  if (params.state === "unavailable") {
+    return params.kind === "brand"
+      ? "Ainda não há sinal suficiente para território de marca."
+      : "Ainda não há sinal suficiente para tipo de collab.";
+  }
+  if (params.state === "teaser_only") {
+    return params.kind === "brand"
+      ? "Mostra apenas teaser de território de marca possível, sem match real."
+      : "Mostra apenas teaser de tipo de collab possível, sem creators reais.";
+  }
+  if (params.state === "instagram_precision_available") {
+    return params.kind === "brand"
+      ? "Mostra oportunidade futura com contexto de precisão do Instagram, sem match real."
+      : "Mostra tipo de collab com maior contexto futuro, sem match real ou nomes reais.";
+  }
+  return params.kind === "brand"
+    ? "Mostra oportunidade estratégica de marca por território e fit narrativo, sem match real."
+    : "Mostra tipos de collab possíveis sem match, chat, notificação ou nomes reais.";
+}
+
+function resolveAvailabilityState(params: {
+  hasSignals: boolean;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeAccessTierAvailabilityState {
+  if (!params.hasSignals) return "unavailable";
+  if (params.accessLevel === "free") return "teaser_only";
+  if (params.accessLevel === "instagram_optimized" && params.instagramConnected) {
+    return "instagram_precision_available";
+  }
+  return "strategic_available";
+}
+
+function buildCommercialAvailability(params: {
+  hasSignals: boolean;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeAccessTierCommercialAvailability {
+  const state = resolveAvailabilityState(params);
+
+  return {
+    state,
+    hasSignals: params.hasSignals,
+    label: clean(state === "unavailable" ? "Sem território de marca suficiente" : "Território de marca e fit narrativo"),
+    description: clean(availabilityDescription({ kind: "brand", state })),
+    realMatchAvailable: false,
+  };
+}
+
+function buildCollabAvailability(params: {
+  hasSignals: boolean;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+}): VideoNarrativeAccessTierCollabAvailability {
+  const state = resolveAvailabilityState(params);
+
+  return {
+    state,
+    hasSignals: params.hasSignals,
+    label: clean(state === "unavailable" ? "Sem tipo de collab suficiente" : "Tipo de collab futuro"),
+    description: clean(availabilityDescription({ kind: "collab", state })),
+    realMatchAvailable: false,
+  };
+}
+
+function sanitizeRules(rules: VideoNarrativeAccessTierDiagnosisRules): VideoNarrativeAccessTierDiagnosisRules {
+  return JSON.parse(sanitizeVideoNarrativeEvolvingDiagnosisText(JSON.stringify(rules))) as VideoNarrativeAccessTierDiagnosisRules;
+}
+
+export function buildVideoNarrativeAccessTierDiagnosisRules(
+  input: VideoNarrativeAccessTierDiagnosisRulesInput,
+): VideoNarrativeAccessTierDiagnosisRules {
+  const instagramConnected = Boolean(input.instagramConnected);
+  const hasBrandSignals = hasOpportunities(input.evolvingDiagnosis, "brand_territory");
+  const hasCollabSignals = hasOpportunities(input.evolvingDiagnosis, "collab_type");
+  const canShowInstagramPrecision = input.accessLevel === "instagram_optimized" && instagramConnected;
+  const upgradeReasons = buildUpgradeReasons(input.accessLevel);
+  const instagramReasons = buildInstagramReasons({ accessLevel: input.accessLevel, instagramConnected });
+  const valueLayer: VideoNarrativeAccessTierValueLayer = canShowInstagramPrecision
+    ? "instagram_precision"
+    : input.accessLevel === "free"
+      ? "first_reading"
+      : "strategic_map";
+
+  const rules: VideoNarrativeAccessTierDiagnosisRules = {
+    accessLevel: input.accessLevel,
+    valueLayer,
+    visibleSections: buildVisibleSections({
+      accessLevel: input.accessLevel,
+      instagramConnected,
+      hasBrandSignals,
+      hasCollabSignals,
+    }),
+    lockedSections: buildLockedSections({
+      accessLevel: input.accessLevel,
+      instagramConnected,
+      upgradeReasons,
+      instagramReasons,
+    }),
+    primaryCTA: buildPrimaryCTA({ accessLevel: input.accessLevel, instagramConnected }),
+    upgradeReasons,
+    instagramReasons,
+    commercialAvailability: buildCommercialAvailability({
+      hasSignals: hasBrandSignals,
+      accessLevel: input.accessLevel,
+      instagramConnected,
+    }),
+    collabAvailability: buildCollabAvailability({
+      hasSignals: hasCollabSignals,
+      accessLevel: input.accessLevel,
+      instagramConnected,
+    }),
+    canShowFullProfileImpact: input.accessLevel !== "free",
+    canShowFullRecurringPatterns: input.accessLevel !== "free",
+    canShowFullBrandOpportunities: input.accessLevel !== "free" && hasBrandSignals,
+    canShowFullCollabOpportunities: input.accessLevel !== "free" && hasCollabSignals,
+    canShowInstagramPrecision,
+    shouldTeaseSubscription: input.accessLevel === "free" && upgradeReasons.length > 0,
+    shouldTeaseInstagramConnection: !instagramConnected && instagramReasons.length > 0,
+  };
+
+  return sanitizeRules(rules);
+}


### PR DESCRIPTION
## Summary

Stacked on #835.

This PR adds MM39, a pure access/value rules layer for the evolving video narrative diagnosis.

It introduces:

- `VideoNarrativeAccessTierDiagnosisRules`
- visible and locked section modeling
- primary CTA modeling by tier
- upgrade and Instagram precision reasons
- commercial and collab availability states
- deterministic `buildVideoNarrativeAccessTierDiagnosisRules`
- sanitization helper reusing the evolving diagnosis contract

The rules distinguish `free`, `premium`, and `instagram_optimized` without adding UI, endpoint logic, persistence, billing, provider calls, or real Instagram integration.

## Guardrails

- No UI changes
- No preview changes
- No endpoint changes
- No real upload or storage
- No persistence or database/table changes
- No Gemini/OpenAI calls or SDK imports
- No fetch/network calls
- No Instagram real integration
- No brand/creator real match
- No Stripe/billing/cobrança integration
- No navigation/menu link added

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`