### PR TITLE
feat: add video narrative diagnosis presentation model

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -102,6 +102,8 @@ Já existe:
 - MM38 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint e não muda upload/storage;
 - access tier diagnosis rules foi criado em MM39 para separar valor free, premium e Instagram conectado;
 - MM39 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda billing real;
+- diagnosis presentation model foi criado em MM40 como camada segura de produto/apresentação;
+- MM40 transforma diagnóstico evolutivo e regras de acesso em blocos estruturados para futura UI, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -909,6 +909,30 @@ O que não faz:
 - não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta billing, Stripe ou cobrança.
 
+### MM40 — Diagnosis Presentation Model
+
+Status: concluído.
+
+Arquivos principais:
+
+- `videoNarrativeDiagnosisPresentationModel.ts`
+- `videoNarrativeDiagnosisPresentationModel.test.ts`
+
+O que faz:
+
+- cria uma camada pura de apresentação para o diagnóstico evolutivo;
+- transforma diagnóstico, regras de acesso e mapa evolutivo em hero, cards prioritários, seções, previews bloqueados, badges e CTAs;
+- prepara uma futura UI mobile-first sem criar componentes React;
+- mantém a superfície curta e escaneável, com profundidade organizada em seções;
+- diferencia `free`, `premium` e `instagram_optimized` sem billing real.
+
+O que não faz:
+
+- não cria persistência, banco/tabela, endpoint, UI, preview, upload real, storage real ou analytics real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -246,8 +246,9 @@ Exemplos:
 36. MM37 — Browser UX QA checklist. Cria roteiro manual e testável para revisar a experiência no navegador antes de upload, BoardShell ou paywall.
 37. MM38 — Evolving Creator Diagnosis Contract. Modela a camada evolutiva acima do diagnóstico pontual, sem persistência ou match real.
 38. MM39 — Access Tier Diagnosis Rules. Define regras de acesso e valor por camada para free, premium e Instagram conectado.
-39. Teste real manual quando houver quota/billing disponível.
-40. Integração experimental futura no Board de Criação.
+39. MM40 — Diagnosis Presentation Model. Transforma diagnóstico evolutivo e regras de acesso em blocos de apresentação para futura UI mobile-first.
+40. Teste real manual quando houver quota/billing disponível.
+41. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -318,6 +319,8 @@ MM37 cria uma checklist de QA visual/funcional para testar a preview interativa 
 MM38 adiciona `VideoNarrativeEvolvingDiagnosis` como camada acima de `VideoNarrativeStrategicDiagnosis`. O diagnóstico estratégico continua sendo a leitura pontual do vídeo; a nova camada organiza esse valor em torno da evolução do creator, com nível atual, próximo nível, impacto no perfil, sinais desbloqueados, sinais pendentes e oportunidades futuras. Ela usa o `VideoNarrativeCreatorProfile` como contexto, mas não persiste sinais, não substitui o profile contract e não cria match real de marcas ou creators.
 
 MM39 adiciona `VideoNarrativeAccessTierDiagnosisRules` para explicitar as regras de acesso e valor por camada. MM38 define o diagnóstico evolutivo; MM39 define o que fica visível, limitado, bloqueado ou sugerido em `free`, `premium` e `instagram_optimized`. Essa camada deve ser usada futuramente pela apresentação/UI para não espalhar lógica de paywall, disponibilidade comercial, collab e precisão por Instagram pelos componentes.
+
+MM40 adiciona `VideoNarrativeDiagnosisPresentation` como superfície de apresentação pura acima de MM38 e MM39. MM38 define o diagnóstico evolutivo, MM39 define as regras de acesso e MM40 organiza o que a futura UI deve renderizar como hero, cards prioritários, seções, previews bloqueados, badges e CTAs. Componentes React futuros devem consumir essa camada para evitar lógica de copy, paywall e priorização espalhada na UI.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts
@@ -1,0 +1,359 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildVideoNarrativeDiagnosisPresentation,
+  sanitizeVideoNarrativeDiagnosisPresentationText,
+  type VideoNarrativeDiagnosisPresentation,
+} from "./videoNarrativeDiagnosisPresentationModel";
+import {
+  buildVideoNarrativeAccessTierDiagnosisRules,
+} from "./videoNarrativeAccessTierDiagnosisRules";
+import {
+  buildVideoNarrativeEvolvingDiagnosis,
+  type VideoNarrativeEvolvingDiagnosis,
+} from "./videoNarrativeEvolvingDiagnosisContract";
+import {
+  buildVideoNarrativeCreatorProfile,
+  type VideoNarrativeCreatorProfile,
+} from "./videoNarrativeCreatorProfileContract";
+import type {
+  VideoNarrativeDiagnosisAccessLevel,
+  VideoNarrativeDiagnosisCreatorSignal,
+  VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+
+const PRESENTATION_SOURCE_PATH = path.join(__dirname, "videoNarrativeDiagnosisPresentationModel.ts");
+
+function signal(
+  type: VideoNarrativeDiagnosisCreatorSignal["type"],
+  value: string,
+  confidence: VideoNarrativeDiagnosisCreatorSignal["confidence"] = "medium",
+): VideoNarrativeDiagnosisCreatorSignal {
+  return {
+    id: `${type}-${value}`,
+    type,
+    value,
+    source: "diagnosis_inference",
+    confidence,
+    evidence: `Evidência para ${value}`,
+    shouldPersistLater: false,
+  };
+}
+
+function makeDiagnosis(overrides: Partial<VideoNarrativeStrategicDiagnosis> = {}): VideoNarrativeStrategicDiagnosis {
+  return {
+    id: "presentation-diagnosis",
+    accessLevel: "premium",
+    mainNarrative: "rotina de cuidado com território de marca possível",
+    whatVideoCommunicates: "rotina, contexto e oportunidade futura de conteúdo",
+    creatorIntent: "Quero entender se esse vídeo vira uma oportunidade comercial",
+    strategicReading: "O vídeo funciona melhor quando a rotina vira direção estratégica.",
+    strength: "Mostra contexto real e fácil de entender.",
+    weakness: "A abertura ainda demora para revelar o benefício.",
+    recommendedAdjustment: "abrir com o resultado antes da rotina",
+    suggestedHook: "Comece pelo resultado e depois mostre o processo.",
+    brandPotential: {
+      enabled: true,
+      territories: ["skincare", "bem-estar"],
+      whyItFits: "Existe fit narrativo com cuidado e rotina.",
+      locked: false,
+    },
+    blueprint: {
+      whatToPost: "Reel com rotina e resultado.",
+      whyThisPath: "A narrativa fica mais clara.",
+      howItShouldWork: "Abrir com resultado, mostrar processo e fechar com próximo passo.",
+      scenes: ["resultado", "processo"],
+      locked: false,
+    },
+    scriptDirection: {
+      opening: "Comece pelo resultado.",
+      development: ["contexto", "processo"],
+      closing: "Próximo passo.",
+      tone: "consultivo",
+      locked: false,
+    },
+    nextActions: [{ id: "script", label: "Gerar roteiro", description: null, locked: false }],
+    lockedSections: [],
+    creatorSignals: [
+      signal("content_goal", "validar antes de postar", "high"),
+      signal("brand_territory", "skincare", "high"),
+      signal("commercial_preference", "atrair marcas", "medium"),
+      signal("collab_preference", "tipo complementar", "medium"),
+      signal("format_preference", "reels direto", "medium"),
+      signal("hook_preference", "abertura direta", "high"),
+    ],
+    instagramComparison: {
+      connected: false,
+      summary: null,
+      matchingNarratives: [],
+      matchingFormats: [],
+      locked: true,
+    },
+    createdAt: "2026-05-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeProfile(): VideoNarrativeCreatorProfile {
+  const firstProfile = buildVideoNarrativeCreatorProfile({
+    creatorId: "creator-1",
+    diagnosisId: "presentation-d1",
+    createdAt: "2026-05-17T00:00:00.000Z",
+    newSignals: [
+      signal("content_goal", "validar antes de postar", "high"),
+      signal("hook_preference", "abertura direta", "high"),
+      signal("format_preference", "reels direto", "medium"),
+      signal("brand_territory", "skincare", "high"),
+      signal("commercial_preference", "atrair marcas", "medium"),
+      signal("collab_preference", "tipo complementar", "medium"),
+    ],
+  });
+
+  return buildVideoNarrativeCreatorProfile({
+    existingProfile: firstProfile,
+    diagnosisId: "presentation-d2",
+    createdAt: "2026-05-18T00:00:00.000Z",
+    newSignals: [
+      signal("content_goal", "validar antes de postar", "high"),
+      signal("hook_preference", "abertura direta", "high"),
+      signal("format_preference", "reels direto", "medium"),
+      signal("brand_territory", "skincare", "high"),
+      signal("commercial_preference", "atrair marcas", "medium"),
+      signal("collab_preference", "tipo complementar", "medium"),
+    ],
+  });
+}
+
+function makePresentation(params: {
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+  diagnosis?: VideoNarrativeStrategicDiagnosis;
+}): VideoNarrativeDiagnosisPresentation {
+  const diagnosis = params.diagnosis ?? makeDiagnosis({ accessLevel: params.accessLevel });
+  const evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis = buildVideoNarrativeEvolvingDiagnosis({
+    diagnosis,
+    creatorProfile: makeProfile(),
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+    analyzedVideosCount: 4,
+    createdAt: "2026-05-18T00:00:00.000Z",
+  });
+  const accessRules = buildVideoNarrativeAccessTierDiagnosisRules({
+    evolvingDiagnosis,
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+  });
+
+  return buildVideoNarrativeDiagnosisPresentation({
+    diagnosis,
+    evolvingDiagnosis,
+    accessRules,
+  });
+}
+
+function textOf(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("videoNarrativeDiagnosisPresentationModel", () => {
+  it("free gera hero de primeira leitura gratuita", () => {
+    const result = makePresentation({ accessLevel: "free" });
+
+    expect(result.hero.title).toBe("Primeira leitura do seu vídeo");
+    expect(result.hero.badge.label).toBe("Primeira leitura gratuita");
+    expect(result.hero.precisionLabel).toBe("Leitura inicial, sem performance do Instagram");
+  });
+
+  it("free gera de 3 a 5 priorityCards curtos", () => {
+    const result = makePresentation({ accessLevel: "free" });
+
+    expect(result.priorityCards.length).toBeGreaterThanOrEqual(3);
+    expect(result.priorityCards.length).toBeLessThanOrEqual(5);
+    result.priorityCards.forEach((card) => {
+      expect(card.title.length).toBeLessThanOrEqual(72);
+      expect(card.body.length).toBeLessThanOrEqual(170);
+    });
+  });
+
+  it("free transforma mapa completo, marca, collab e Instagram em lockedPreviews quando apropriado", () => {
+    const result = makePresentation({ accessLevel: "free", instagramConnected: false });
+    const titles = result.lockedPreviews.map((preview) => preview.title);
+
+    expect(titles).toContain("Mapa estratégico completo");
+    expect(titles).toContain("Oportunidades futuras de marca");
+    expect(titles).toContain("Tipos de collab possíveis");
+    expect(titles).toContain("Leitura mais precisa com Instagram");
+  });
+
+  it("free mantém valor real e não fica vazio", () => {
+    const result = makePresentation({ accessLevel: "free" });
+
+    expect(result.priorityCards[0]?.body).toContain("Este vídeo comunica");
+    expect(result.sections.map((section) => section.id)).toContain("video_diagnosis");
+    expect(result.primaryCTA.label).toBe("Desbloquear diagnóstico completo");
+  });
+
+  it("premium gera hero de diagnóstico completo e mapa estratégico", () => {
+    const result = makePresentation({ accessLevel: "premium" });
+
+    expect(result.hero.title).toBe("Seu mapa estratégico foi atualizado");
+    expect(result.hero.badge.label).toBe("Diagnóstico completo");
+    expect(result.hero.precisionLabel).toBe("Mapa estratégico baseado nos sinais do creator");
+  });
+
+  it("premium mostra creator_evolution e strategic_level", () => {
+    const result = makePresentation({ accessLevel: "premium" });
+    const sectionIds = result.sections.map((section) => section.id);
+
+    expect(sectionIds).toContain("creator_evolution");
+    expect(sectionIds).toContain("strategic_level");
+  });
+
+  it("premium mostra brand e collab como oportunidades futuras sem match real", () => {
+    const result = makePresentation({ accessLevel: "premium" });
+    const text = textOf(result);
+
+    expect(result.sections.map((section) => section.id)).toContain("brand_opportunities");
+    expect(result.sections.map((section) => section.id)).toContain("collab_opportunities");
+    expect(text).toContain("oportunidade futura");
+    expect(text).not.toContain("match real");
+  });
+
+  it("premium sem Instagram mantém instagram_precision bloqueado", () => {
+    const result = makePresentation({ accessLevel: "premium", instagramConnected: false });
+
+    expect(result.sections.map((section) => section.id)).not.toContain("instagram_precision");
+    expect(result.lockedPreviews.map((preview) => preview.id)).toContain("locked-instagram_precision");
+  });
+
+  it("instagram optimized conectado gera hero de leitura mais precisa", () => {
+    const result = makePresentation({ accessLevel: "instagram_optimized", instagramConnected: true });
+
+    expect(result.hero.title).toBe("Diagnóstico otimizado com contexto de Instagram");
+    expect(result.hero.badge.label).toBe("Leitura mais precisa");
+  });
+
+  it("instagram optimized conectado mostra seção instagram_precision", () => {
+    const result = makePresentation({ accessLevel: "instagram_optimized", instagramConnected: true });
+
+    expect(result.sections.map((section) => section.id)).toContain("instagram_precision");
+  });
+
+  it("primaryCTA respeita accessRules", () => {
+    const free = makePresentation({ accessLevel: "free" });
+    const premium = makePresentation({ accessLevel: "premium", instagramConnected: false });
+
+    expect(free.primaryCTA.label).toBe("Desbloquear diagnóstico completo");
+    expect(free.primaryCTA.action).toBe("upgrade");
+    expect(premium.primaryCTA.label).toBe("Conectar Instagram para aumentar precisão");
+    expect(premium.primaryCTA.action).toBe("connect_instagram");
+  });
+
+  it("secondaryCTA é coerente com accessLevel e Instagram", () => {
+    expect(makePresentation({ accessLevel: "free" }).secondaryCTA?.label).toBe("Conectar Instagram depois");
+    expect(makePresentation({ accessLevel: "premium", instagramConnected: false }).secondaryCTA?.label).toBe("Analisar mais um vídeo");
+    expect(makePresentation({
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+    }).secondaryCTA?.label).toBe("Criar variação de roteiro");
+  });
+
+  it("cards têm textos curtos", () => {
+    const result = makePresentation({ accessLevel: "instagram_optimized", instagramConnected: true });
+    const cards = [
+      ...result.priorityCards,
+      ...result.sections.flatMap((section) => section.cards),
+    ];
+
+    cards.forEach((card) => {
+      expect(card.body.length).toBeLessThanOrEqual(170);
+    });
+  });
+
+  it("não sugere nomes reais de creators", () => {
+    const result = makePresentation({
+      accessLevel: "premium",
+      diagnosis: makeDiagnosis({
+        creatorIntent: "Quero collab com Creator Famoso",
+        creatorSignals: [signal("collab_preference", "Creator Famoso", "high")],
+      }),
+    });
+
+    expect(textOf(result)).not.toContain("creator famoso");
+  });
+
+  it("não promete marca, publi, match ou performance", () => {
+    const result = makePresentation({ accessLevel: "instagram_optimized", instagramConnected: true });
+    const text = textOf(result);
+
+    expect(text).not.toContain("marca garantida");
+    expect(text).not.toContain("publi garantida");
+    expect(text).not.toContain("patrocínio garantido");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("performance garantida");
+    expect(text).not.toContain("garantido");
+    expect(text).not.toContain("certeza");
+    expect(text).not.toContain("comprovado");
+    expect(text).not.toContain("viralizar");
+  });
+
+  it("sanitiza textos perigosos", () => {
+    const dangerousText = "AIza1234567890abc GEMINI_API_KEY=secret https://x.test/file?token=abc score venceu garantido match real viralizar";
+    const sanitized = sanitizeVideoNarrativeDiagnosisPresentationText(dangerousText).toLowerCase();
+    const result = makePresentation({
+      accessLevel: "free",
+      diagnosis: makeDiagnosis({
+        whatVideoCommunicates: dangerousText,
+        recommendedAdjustment: dangerousText,
+      }),
+    });
+    const text = textOf(result);
+
+    expect(sanitized).toContain("[redigido]");
+    expect(text).not.toContain("AIza");
+    expect(text).not.toContain("gemini_api_key");
+    expect(text).not.toContain("token=abc");
+    expect(text).not.toContain("score");
+    expect(text).not.toContain("venceu");
+    expect(text).not.toContain("garantido");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("viralizar");
+  });
+
+  it("não importa fetch, Prisma, banco, Gemini, OpenAI, Stripe ou SDK externo", () => {
+    const source = fs.readFileSync(PRESENTATION_SOURCE_PATH, "utf8");
+
+    [
+      "fetch",
+      "Prisma",
+      "banco",
+      "@google/genai",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "stripe",
+      "firebase",
+      "supabase",
+    ].forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+
+  it("não altera endpoint, UI ou preview", () => {
+    const source = fs.readFileSync(PRESENTATION_SOURCE_PATH, "utf8");
+
+    [
+      "route.ts",
+      "VideoNarrativeAppPreview",
+      "VideoNarrativeInteractiveAppPreview",
+      "React",
+      "BoardShell",
+      "PostCreationFunnelState",
+      "components/",
+      "app/api",
+    ].forEach((term) => {
+      expect(source).not.toContain(term);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.ts
@@ -1,0 +1,524 @@
+import type {
+  VideoNarrativeAccessTierDiagnosisRules,
+  VideoNarrativeAccessTierPrimaryCTAAction,
+} from "./videoNarrativeAccessTierDiagnosisRules";
+import { sanitizeVideoNarrativeAccessTierDiagnosisRulesText } from "./videoNarrativeAccessTierDiagnosisRules";
+import type { VideoNarrativeEvolvingDiagnosis } from "./videoNarrativeEvolvingDiagnosisContract";
+import type {
+  VideoNarrativeDiagnosisAccessLevel,
+  VideoNarrativeStrategicDiagnosis,
+} from "./videoNarrativeDiagnosisLearningModel";
+
+export type VideoNarrativeDiagnosisPresentationPriority = "high" | "medium" | "low";
+
+export type VideoNarrativeDiagnosisPresentationTone =
+  | "insight"
+  | "action"
+  | "unlock"
+  | "opportunity"
+  | "warning";
+
+export interface VideoNarrativeDiagnosisPresentationBadge {
+  id: string;
+  label: string;
+  tone: "neutral" | "success" | "premium" | "instagram" | "warning";
+}
+
+export interface VideoNarrativeDiagnosisHeroBlock {
+  title: string;
+  subtitle: string;
+  badge: VideoNarrativeDiagnosisPresentationBadge;
+  levelLabel: string;
+  nextLevelLabel: string | null;
+  precisionLabel: string;
+}
+
+export interface VideoNarrativeDiagnosisPresentationCard {
+  id: string;
+  title: string;
+  body: string;
+  tone: VideoNarrativeDiagnosisPresentationTone;
+  priority: VideoNarrativeDiagnosisPresentationPriority;
+  locked: boolean;
+}
+
+export type VideoNarrativeDiagnosisPresentationSectionId =
+  | "video_diagnosis"
+  | "creator_evolution"
+  | "strategic_level"
+  | "next_signals"
+  | "brand_opportunities"
+  | "collab_opportunities"
+  | "instagram_precision"
+  | "subscription_unlocks";
+
+export interface VideoNarrativeDiagnosisPresentationSection {
+  id: VideoNarrativeDiagnosisPresentationSectionId;
+  title: string;
+  description: string;
+  cards: VideoNarrativeDiagnosisPresentationCard[];
+  collapsedByDefault: boolean;
+  visible: boolean;
+}
+
+export interface VideoNarrativeDiagnosisPresentationCTA {
+  label: string;
+  action:
+    | VideoNarrativeAccessTierPrimaryCTAAction
+    | "connect_instagram_later"
+    | "analyze_another_video"
+    | "create_script_variation";
+  helper: string | null;
+}
+
+export interface VideoNarrativeDiagnosisPresentationLockedPreview {
+  id: string;
+  title: string;
+  description: string;
+  reason: string;
+  ctaLabel: string;
+}
+
+export interface VideoNarrativeDiagnosisPresentationInput {
+  diagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+  accessRules: VideoNarrativeAccessTierDiagnosisRules;
+}
+
+export interface VideoNarrativeDiagnosisPresentation {
+  id: string;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  hero: VideoNarrativeDiagnosisHeroBlock;
+  priorityCards: VideoNarrativeDiagnosisPresentationCard[];
+  sections: VideoNarrativeDiagnosisPresentationSection[];
+  lockedPreviews: VideoNarrativeDiagnosisPresentationLockedPreview[];
+  primaryCTA: VideoNarrativeDiagnosisPresentationCTA;
+  secondaryCTA: VideoNarrativeDiagnosisPresentationCTA | null;
+  badges: VideoNarrativeDiagnosisPresentationBadge[];
+  readingTimeHint: string;
+  createdAt: string | null;
+}
+
+function clean(value: string | null | undefined): string {
+  return sanitizeVideoNarrativeDiagnosisPresentationText(value ?? "");
+}
+
+function firstText(values: Array<string | null | undefined>, fallback: string): string {
+  return clean(values.find((value) => value?.trim()) ?? fallback);
+}
+
+function sentence(value: string, maxLength = 150): string {
+  const sanitized = clean(value).replace(/\s+/g, " ").trim();
+  if (sanitized.length <= maxLength) return sanitized;
+  return `${sanitized.slice(0, maxLength - 1).trim()}…`;
+}
+
+function card(params: {
+  id: string;
+  title: string;
+  body: string;
+  tone: VideoNarrativeDiagnosisPresentationTone;
+  priority: VideoNarrativeDiagnosisPresentationPriority;
+  locked?: boolean;
+}): VideoNarrativeDiagnosisPresentationCard {
+  return {
+    id: clean(params.id),
+    title: sentence(params.title, 72),
+    body: sentence(params.body, 170),
+    tone: params.tone,
+    priority: params.priority,
+    locked: params.locked ?? false,
+  };
+}
+
+function badge(
+  id: string,
+  label: string,
+  tone: VideoNarrativeDiagnosisPresentationBadge["tone"],
+): VideoNarrativeDiagnosisPresentationBadge {
+  return { id: clean(id), label: sentence(label, 48), tone };
+}
+
+function section(params: {
+  id: VideoNarrativeDiagnosisPresentationSectionId;
+  title: string;
+  description: string;
+  cards: VideoNarrativeDiagnosisPresentationCard[];
+  collapsedByDefault?: boolean;
+  visible?: boolean;
+}): VideoNarrativeDiagnosisPresentationSection {
+  return {
+    id: params.id,
+    title: sentence(params.title, 80),
+    description: sentence(params.description, 150),
+    cards: params.cards,
+    collapsedByDefault: params.collapsedByDefault ?? true,
+    visible: params.visible ?? true,
+  };
+}
+
+function buildHero(input: VideoNarrativeDiagnosisPresentationInput): VideoNarrativeDiagnosisHeroBlock {
+  const accessLevel = input.accessRules.accessLevel;
+  const levelLabel = input.evolvingDiagnosis.currentLevel.label;
+  const nextLevelLabel = input.evolvingDiagnosis.nextLevel?.label ?? null;
+
+  if (accessLevel === "instagram_optimized" && input.accessRules.canShowInstagramPrecision) {
+    return {
+      title: "Diagnóstico otimizado com contexto de Instagram",
+      subtitle: sentence("A leitura combina o mapa estratégico com contexto futuro de Instagram nesta simulação."),
+      badge: badge("instagram-precision", "Leitura mais precisa", "instagram"),
+      levelLabel,
+      nextLevelLabel,
+      precisionLabel: "Contexto futuro de Instagram disponível nesta simulação",
+    };
+  }
+
+  if (accessLevel === "premium") {
+    return {
+      title: "Seu mapa estratégico foi atualizado",
+      subtitle: sentence("O diagnóstico conecta este vídeo aos sinais do creator e aos próximos movimentos."),
+      badge: badge("premium-complete", "Diagnóstico completo", "premium"),
+      levelLabel,
+      nextLevelLabel,
+      precisionLabel: "Mapa estratégico baseado nos sinais do creator",
+    };
+  }
+
+  return {
+    title: "Primeira leitura do seu vídeo",
+    subtitle: sentence("Sua primeira leitura já mostra direção, ajuste e um sinal inicial do mapa do creator."),
+    badge: badge("free-first-reading", "Primeira leitura gratuita", "neutral"),
+    levelLabel,
+    nextLevelLabel,
+    precisionLabel: "Leitura inicial, sem performance do Instagram",
+  };
+}
+
+function buildPriorityCards(input: VideoNarrativeDiagnosisPresentationInput): VideoNarrativeDiagnosisPresentationCard[] {
+  const diagnosis = input.diagnosis;
+  const evolving = input.evolvingDiagnosis;
+  const cards = [
+    card({
+      id: "main-reading",
+      title: "O que este vídeo comunica",
+      body: `Este vídeo comunica ${firstText([diagnosis.whatVideoCommunicates, diagnosis.mainNarrative], "uma direção narrativa em construção")}.`,
+      tone: "insight",
+      priority: "high",
+    }),
+    card({
+      id: "primary-adjustment",
+      title: "Ajuste mais importante",
+      body: `O ajuste mais importante é ${firstText([diagnosis.recommendedAdjustment, diagnosis.weakness], "deixar a abertura mais clara")}.`,
+      tone: "action",
+      priority: "high",
+    }),
+    card({
+      id: "creator-reveal",
+      title: "O que revelou sobre o creator",
+      body: firstText([
+        evolving.unlockedSignals[0]?.label,
+        evolving.profileImpact.summary,
+      ], "Este vídeo revelou um primeiro sinal para o mapa estratégico."),
+      tone: "insight",
+      priority: "high",
+    }),
+    card({
+      id: "next-move",
+      title: "Próximo movimento",
+      body: firstText([
+        evolving.nextSignalsToUnlock[0]?.action,
+        input.accessRules.primaryCTA.helper,
+      ], "O próximo movimento é transformar a leitura em direção prática."),
+      tone: "action",
+      priority: "high",
+    }),
+  ];
+
+  const opportunity = input.accessRules.commercialAvailability.hasSignals
+    ? input.evolvingDiagnosis.opportunities.find((item) => item.type === "brand_territory")
+    : input.evolvingDiagnosis.opportunities.find((item) => item.type === "collab_type");
+
+  if (opportunity) {
+    cards.push(card({
+      id: "future-opportunity",
+      title: opportunity.type === "brand_territory" ? "Oportunidade futura de marca" : "Oportunidade futura de collab",
+      body: opportunity.label,
+      tone: "opportunity",
+      priority: "medium",
+      locked: input.accessRules.accessLevel === "free",
+    }));
+  }
+
+  return cards.slice(0, 5);
+}
+
+function buildSections(input: VideoNarrativeDiagnosisPresentationInput): VideoNarrativeDiagnosisPresentationSection[] {
+  const diagnosis = input.diagnosis;
+  const evolving = input.evolvingDiagnosis;
+  const rules = input.accessRules;
+
+  const sections: VideoNarrativeDiagnosisPresentationSection[] = [
+    section({
+      id: "video_diagnosis",
+      title: "Diagnóstico do vídeo",
+      description: "A leitura prática do vídeo, com narrativa, ajuste e gancho.",
+      collapsedByDefault: false,
+      cards: [
+        card({ id: "video-main", title: "Narrativa", body: firstText([diagnosis.mainNarrative], "Narrativa em construção."), tone: "insight", priority: "high" }),
+        card({ id: "video-hook", title: "Gancho", body: firstText([diagnosis.suggestedHook], "A abertura pode ficar mais clara."), tone: "action", priority: "medium" }),
+      ],
+    }),
+    section({
+      id: "creator_evolution",
+      title: "Evolução do creator",
+      description: "Como este vídeo alimenta o mapa estratégico.",
+      visible: rules.canShowFullProfileImpact || rules.accessLevel === "free",
+      cards: [
+        card({ id: "profile-impact", title: "Impacto no perfil", body: evolving.profileImpact.summary, tone: "insight", priority: "high", locked: !rules.canShowFullProfileImpact }),
+        ...evolving.unlockedSignals.slice(0, rules.accessLevel === "free" ? 1 : 4).map((signal, index) =>
+          card({ id: `unlocked-signal-${index}`, title: "Sinal revelado", body: signal.label, tone: "insight", priority: "medium" }),
+        ),
+      ],
+    }),
+    section({
+      id: "strategic_level",
+      title: "Nível estratégico",
+      description: "Onde o creator está no mapa e qual é o próximo nível.",
+      visible: rules.canShowFullProfileImpact,
+      cards: [
+        card({ id: "current-level", title: evolving.currentLevel.label, body: evolving.currentLevel.description, tone: "insight", priority: "medium" }),
+        card({ id: "next-level", title: "Próximo nível", body: evolving.nextLevel?.description ?? "O mapa estratégico já está em estágio avançado.", tone: "action", priority: "medium" }),
+      ],
+    }),
+    section({
+      id: "next_signals",
+      title: "Próximos sinais",
+      description: "O que a D2C ainda precisa entender para melhorar a leitura.",
+      visible: rules.accessLevel !== "free",
+      cards: evolving.nextSignalsToUnlock.slice(0, 4).map((item, index) =>
+        card({ id: `next-signal-${index}`, title: item.label, body: item.action, tone: "action", priority: "medium" }),
+      ),
+    }),
+    section({
+      id: "brand_opportunities",
+      title: "Oportunidades futuras de marca",
+      description: "Territórios possíveis e fit narrativo como oportunidade futura.",
+      visible: rules.canShowFullBrandOpportunities || (rules.accessLevel === "free" && rules.commercialAvailability.hasSignals),
+      cards: [
+        card({
+          id: "brand-availability",
+          title: rules.commercialAvailability.label,
+          body: safeAvailabilityDescription("brand", rules.commercialAvailability.state),
+          tone: "opportunity",
+          priority: "medium",
+          locked: !rules.canShowFullBrandOpportunities,
+        }),
+      ],
+    }),
+    section({
+      id: "collab_opportunities",
+      title: "Tipos de collab futuros",
+      description: "Caminhos de colaboração possíveis por tipo de oportunidade futura.",
+      visible: rules.canShowFullCollabOpportunities || (rules.accessLevel === "free" && rules.collabAvailability.hasSignals),
+      cards: [
+        card({
+          id: "collab-availability",
+          title: rules.collabAvailability.label,
+          body: safeAvailabilityDescription("collab", rules.collabAvailability.state),
+          tone: "opportunity",
+          priority: "medium",
+          locked: !rules.canShowFullCollabOpportunities,
+        }),
+      ],
+    }),
+    section({
+      id: "instagram_precision",
+      title: "Precisão com Instagram",
+      description: "Como o contexto futuro de Instagram deixa a leitura mais precisa.",
+      visible: rules.canShowInstagramPrecision,
+      cards: [
+        card({
+          id: "instagram-context",
+          title: "Leitura mais precisa",
+          body: "Com Instagram, essa leitura fica mais precisa por contexto futuro de perfil e performance.",
+          tone: "insight",
+          priority: "high",
+        }),
+      ],
+    }),
+    section({
+      id: "subscription_unlocks",
+      title: "O que desbloqueia",
+      description: "Previews elegantes do que fica disponível em camadas mais profundas.",
+      visible: rules.lockedSections.length > 0,
+      cards: rules.lockedSections.slice(0, 4).map((locked, index) =>
+        card({ id: `locked-section-${index}`, title: locked.label, body: locked.message, tone: "unlock", priority: "low", locked: true }),
+      ),
+    }),
+  ];
+
+  return sections.filter((item) => item.visible);
+}
+
+function buildLockedPreviews(input: VideoNarrativeDiagnosisPresentationInput): VideoNarrativeDiagnosisPresentationLockedPreview[] {
+  return input.accessRules.lockedSections.map((locked) => ({
+    id: clean(`locked-${locked.key}`),
+    title: sentence(locked.label, 80),
+    description: sentence(`${lockedPreviewDescription(locked.key)} Sua primeira leitura já ajuda, mas a D2C fica mais estratégica com mais contexto.`, 190),
+    reason: sentence(lockedPreviewReason(locked.key), 150),
+    ctaLabel: input.accessRules.accessLevel === "free" ? "Desbloquear diagnóstico completo" : "Conectar Instagram",
+  }));
+}
+
+function buildPrimaryCTA(accessRules: VideoNarrativeAccessTierDiagnosisRules): VideoNarrativeDiagnosisPresentationCTA {
+  return {
+    label: sentence(accessRules.primaryCTA.label, 64),
+    action: accessRules.primaryCTA.action,
+    helper: sentence(accessRules.primaryCTA.helper, 120),
+  };
+}
+
+function buildSecondaryCTA(accessRules: VideoNarrativeAccessTierDiagnosisRules): VideoNarrativeDiagnosisPresentationCTA | null {
+  if (accessRules.accessLevel === "free") {
+    return {
+      label: "Conectar Instagram depois",
+      action: "connect_instagram_later",
+      helper: "Você pode manter a primeira leitura e adicionar contexto depois.",
+    };
+  }
+
+  if (accessRules.accessLevel === "premium" && accessRules.shouldTeaseInstagramConnection) {
+    return {
+      label: "Analisar mais um vídeo",
+      action: "analyze_another_video",
+      helper: "Mais vídeos ajudam a fortalecer o mapa estratégico.",
+    };
+  }
+
+  if (accessRules.accessLevel === "instagram_optimized" && accessRules.canShowInstagramPrecision) {
+    return {
+      label: "Criar variação de roteiro",
+      action: "create_script_variation",
+      helper: "Transforme a leitura em uma nova direção de execução.",
+    };
+  }
+
+  return null;
+}
+
+function buildBadges(input: VideoNarrativeDiagnosisPresentationInput & {
+  heroPrecisionLabel: string;
+}): VideoNarrativeDiagnosisPresentationBadge[] {
+  const badges = [
+    input.accessRules.accessLevel === "free"
+      ? badge("access-free", "Free", "neutral")
+      : input.accessRules.accessLevel === "premium"
+        ? badge("access-premium", "Premium", "premium")
+        : badge("access-instagram", "Instagram optimized", "instagram"),
+    badge("current-level", input.evolvingDiagnosis.currentLevel.label, "neutral"),
+    badge("precision", input.heroPrecisionLabel, "neutral"),
+  ];
+
+  if (input.accessRules.commercialAvailability.hasSignals) {
+    badges.push(badge("brand-availability", "Território de marca possível", "success"));
+  }
+  if (input.accessRules.collabAvailability.hasSignals) {
+    badges.push(badge("collab-availability", "Tipo de collab futuro", "success"));
+  }
+
+  return badges.filter((item) => item.label);
+}
+
+function readingTimeHint(accessLevel: VideoNarrativeDiagnosisAccessLevel): string {
+  if (accessLevel === "free") return "Leitura rápida: 30 segundos";
+  if (accessLevel === "premium") return "Leitura estratégica: 2 minutos";
+  return "Leitura completa: 2 a 3 minutos";
+}
+
+export function sanitizeVideoNarrativeDiagnosisPresentationText(value: string): string {
+  const replacements: Array<[RegExp, string]> = [
+    [/viralizar garantido/gi, "crescer com consistência"],
+    [/patroc[ií]nio garantido/gi, "oportunidade futura"],
+    [/marca garantida/gi, "território possível"],
+    [/publi garantida/gi, "possibilidade comercial"],
+    [/match real/gi, "indicação futura"],
+    [/match comprovado/gi, "fit narrativo"],
+    [/resultado garantido/gi, "próximo movimento"],
+    [/\bviralizar\b/gi, "crescer com consistência"],
+    [/\bscore\b/gi, "leitura"],
+    [/\bnota\b/gi, "leitura"],
+    [/\bpontos\b/gi, "sinais"],
+    [/\branking\b/gi, "mapa"],
+    [/\bgabarito\b/gi, "direção"],
+    [/\bgarantido\b/gi, "possível"],
+    [/\bcerteza\b/gi, "leitura"],
+    [/\bcomprovado\b/gi, "observado"],
+  ];
+
+  return replacements.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    sanitizeVideoNarrativeAccessTierDiagnosisRulesText(value),
+  );
+}
+
+function safeAvailabilityDescription(
+  kind: "brand" | "collab",
+  state: "teaser_only" | "strategic_available" | "instagram_precision_available" | "unavailable",
+): string {
+  if (kind === "brand") {
+    if (state === "unavailable") return "A D2C ainda precisa entender melhor o território de marca possível.";
+    if (state === "teaser_only") return "Existe indício de território de marca possível, ainda em formato de teaser.";
+    if (state === "instagram_precision_available") {
+      return "Território de marca possível com contexto futuro de Instagram para leitura mais precisa.";
+    }
+    return "Oportunidade futura de marca por território e fit narrativo.";
+  }
+
+  if (state === "unavailable") return "A D2C ainda precisa entender melhor o tipo de collab futuro.";
+  if (state === "teaser_only") return "Existe indício de tipo de collab futuro, ainda em formato de teaser.";
+  if (state === "instagram_precision_available") {
+    return "Tipo de collab futuro com contexto futuro de Instagram para leitura mais precisa.";
+  }
+  return "Tipos de collab possíveis por formato, autoridade e ponte de audiência.";
+}
+
+function lockedPreviewDescription(key: string): string {
+  if (key === "brand_opportunities") return "Mostra territórios de marca possíveis e fit narrativo com mais profundidade.";
+  if (key === "collab_opportunities") return "Organiza tipos de collab futuros sem sugerir creators reais.";
+  if (key === "instagram_precision" || key === "performance_comparison") {
+    return "Adiciona contexto futuro de Instagram para deixar a leitura mais precisa.";
+  }
+  if (key === "full_profile_impact") return "Mostra o mapa estratégico completo e o impacto do vídeo no creator.";
+  if (key === "recurring_patterns") return "Mostra padrões recorrentes mais profundos entre vídeos.";
+  return "Aprofunda esta parte do diagnóstico em uma camada mais estratégica.";
+}
+
+function lockedPreviewReason(key: string): string {
+  if (key === "instagram_precision" || key === "performance_comparison") {
+    return "Precisa de conexão futura de Instagram para adicionar contexto de precisão.";
+  }
+  return "Disponível em uma camada mais completa do diagnóstico.";
+}
+
+export function buildVideoNarrativeDiagnosisPresentation(
+  input: VideoNarrativeDiagnosisPresentationInput,
+): VideoNarrativeDiagnosisPresentation {
+  const hero = buildHero(input);
+  const presentationInput = { ...input, heroPrecisionLabel: hero.precisionLabel } as VideoNarrativeDiagnosisPresentationInput & {
+    heroPrecisionLabel: string;
+  };
+
+  return {
+    id: clean(`diagnosis-presentation-${input.evolvingDiagnosis.id}`),
+    accessLevel: input.accessRules.accessLevel,
+    hero,
+    priorityCards: buildPriorityCards(input),
+    sections: buildSections(input),
+    lockedPreviews: buildLockedPreviews(input),
+    primaryCTA: buildPrimaryCTA(input.accessRules),
+    secondaryCTA: buildSecondaryCTA(input.accessRules),
+    badges: buildBadges(presentationInput),
+    readingTimeHint: readingTimeHint(input.accessRules.accessLevel),
+    createdAt: input.evolvingDiagnosis.createdAt ?? input.diagnosis.createdAt ?? null,
+  };
+}


### PR DESCRIPTION
Stacked sobre #836.

## Resumo
- adiciona `VideoNarrativeDiagnosisPresentation` como camada pura de apresentação acima de `VideoNarrativeStrategicDiagnosis`, `VideoNarrativeEvolvingDiagnosis` e `VideoNarrativeAccessTierDiagnosisRules`
- modela hero, priorityCards, sections, lockedPreviews, badges, primaryCTA, secondaryCTA e readingTimeHint
- diferencia `free`, `premium` e `instagram_optimized` sem billing real
- mantém marca/collab como oportunidade futura, sem match real ou nomes reais de creators

## Guardrails
- sem UI/preview alterada
- sem endpoint alterado
- sem upload/storage real
- sem persistência/banco/tabela
- sem Gemini/OpenAI/fetch
- sem Instagram real
- sem billing/Stripe real

## Validações
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeCreatorProfileContract.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`