### PR TITLE
feat: add evolving diagnosis preview scenarios

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts
@@ -3,6 +3,10 @@ import path from "path";
 import { buildVideoNarrativeAppPreviewScenario } from "./buildVideoNarrativeAppPreviewScenario";
 
 describe("buildVideoNarrativeAppPreviewScenario", () => {
+  function stringify(value: unknown): string {
+    return JSON.stringify(value).toLowerCase();
+  }
+
   it("builds the default skincare scenario", () => {
     const preview = buildVideoNarrativeAppPreviewScenario();
 
@@ -10,6 +14,27 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
     expect(preview.scenario.creatorQuestion).toBe("Quero saber se vale postar");
     expect(preview.analysis.id).toContain("skincare");
     expect(preview.seed.analysisId).toBe(preview.analysis.id);
+  });
+
+  it("returns evolvingDiagnosis", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario();
+
+    expect(preview.evolvingDiagnosis.videoDiagnosisId).toBe(preview.diagnosis.id);
+    expect(preview.evolvingDiagnosis.unlockedSignals.length).toBeGreaterThan(0);
+  });
+
+  it("returns accessRules", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario();
+
+    expect(preview.accessRules.accessLevel).toBe(preview.accessLevel);
+    expect(preview.accessRules.visibleSections.length).toBeGreaterThan(0);
+  });
+
+  it("returns diagnosisPresentation", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario();
+
+    expect(preview.diagnosisPresentation.accessLevel).toBe(preview.accessLevel);
+    expect(preview.diagnosisPresentation.priorityCards.length).toBeGreaterThan(0);
   });
 
   it("builds the brand scenario with brand question", () => {
@@ -31,6 +56,26 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
     expect(buildVideoNarrativeAppPreviewScenario().accessLevel).toBe("free");
   });
 
+  it("free scenario generates first_reading value layer", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "free" });
+
+    expect(preview.evolvingDiagnosis.accessLevel).toBe("free");
+    expect(preview.accessRules.valueLayer).toBe("first_reading");
+  });
+
+  it("free scenario generates first reading presentation hero", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "free" });
+
+    expect(preview.diagnosisPresentation.hero.title).toBe("Primeira leitura do seu vídeo");
+    expect(preview.diagnosisPresentation.hero.badge.label).toBe("Primeira leitura gratuita");
+  });
+
+  it("free scenario generates locked presentation previews", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "free" });
+
+    expect(preview.diagnosisPresentation.lockedPreviews.length).toBeGreaterThan(0);
+  });
+
   it("uses disconnected Instagram by default", () => {
     expect(buildVideoNarrativeAppPreviewScenario().instagramConnected).toBe(false);
   });
@@ -42,11 +87,58 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
     expect(preview.flowState.context.accessLevel).toBe("premium");
   });
 
+  it("premium scenario generates strategic_map value layer", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "premium" });
+
+    expect(preview.evolvingDiagnosis.accessLevel).toBe("premium");
+    expect(preview.accessRules.valueLayer).toBe("strategic_map");
+  });
+
+  it("premium scenario generates complete diagnosis presentation hero", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({ access: "premium" });
+
+    expect(preview.diagnosisPresentation.hero.title).toBe("Seu mapa estratégico foi atualizado");
+    expect(preview.diagnosisPresentation.hero.badge.label).toBe("Diagnóstico completo");
+  });
+
+  it("premium disconnected scenario keeps instagram_precision locked", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      access: "premium",
+      instagram: "disconnected",
+    });
+
+    expect(preview.diagnosisPresentation.sections.map((section) => section.id)).not.toContain("instagram_precision");
+    expect(preview.diagnosisPresentation.lockedPreviews.map((previewItem) => previewItem.id)).toContain(
+      "locked-instagram_precision",
+    );
+  });
+
   it("respects instagram_optimized access", () => {
     const preview = buildVideoNarrativeAppPreviewScenario({ access: "instagram_optimized" });
 
     expect(preview.accessLevel).toBe("instagram_optimized");
     expect(preview.flowState.context.accessLevel).toBe("instagram_optimized");
+  });
+
+  it("instagram_optimized connected scenario generates instagram_precision value layer", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      access: "instagram_optimized",
+      instagram: "connected",
+    });
+
+    expect(preview.evolvingDiagnosis.accessLevel).toBe("instagram_optimized");
+    expect(preview.accessRules.valueLayer).toBe("instagram_precision");
+  });
+
+  it("instagram_optimized connected scenario includes instagram_precision presentation section", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      access: "instagram_optimized",
+      instagram: "connected",
+    });
+
+    expect(preview.diagnosisPresentation.hero.badge.label).toBe("Leitura mais precisa");
+    expect(preview.diagnosisPresentation.sections.map((section) => section.id)).toContain("instagram_precision");
+    expect(stringify(preview.diagnosisPresentation)).not.toContain("dados reais");
   });
 
   it("respects connected Instagram", () => {
@@ -122,11 +214,53 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
     expect(preview.creatorProfile.signals.length).toBeGreaterThan(0);
   });
 
+  it("brand scenario generates future brand opportunity without real match", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      scenario: "brand",
+      access: "premium",
+    });
+    const text = stringify(preview.diagnosisPresentation);
+
+    expect(preview.diagnosisPresentation.sections.map((section) => section.id)).toContain("brand_opportunities");
+    expect(text).toContain("oportunidade futura");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("garantido");
+    expect(text).not.toContain("comprovado");
+    expect(text).not.toContain("certeza");
+  });
+
+  it("collab scenario generates future collab opportunity without real creator names", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      scenario: "collab",
+      access: "premium",
+    });
+    const text = stringify(preview.diagnosisPresentation);
+
+    expect(preview.diagnosisPresentation.sections.map((section) => section.id)).toContain("collab_opportunities");
+    expect(text).toContain("tipo de collab");
+    expect(text).not.toContain("creator famoso");
+    expect(text).not.toContain("match real");
+  });
+
   it("unclear scenario generates missing context quiz or context question", () => {
     const preview = buildVideoNarrativeAppPreviewScenario({ scenario: "unclear", stage: "adaptive_quiz" });
     const keys = preview.quiz.questions.map((question) => question.key);
 
     expect(keys.some((key) => key === "missing_context" || key === "narrative_preference")).toBe(true);
+  });
+
+  it("keeps existing scenarios resolving by query params", () => {
+    [
+      "skincare",
+      "backstage",
+      "brand",
+      "weak-hook",
+      "collab",
+      "ad-adaptation",
+      "unclear",
+    ].forEach((scenario) => {
+      expect(buildVideoNarrativeAppPreviewScenario({ scenario }).scenario.id).toBe(scenario);
+    });
   });
 
   it("does not import forbidden integrations", () => {
@@ -153,5 +287,25 @@ describe("buildVideoNarrativeAppPreviewScenario", () => {
     ]) {
       expect(importLines).not.toContain(forbidden);
     }
+  });
+
+  it("does not alter endpoint or visual UI", () => {
+    const source = fs.readFileSync(path.join(__dirname, "buildVideoNarrativeAppPreviewScenario.ts"), "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    [
+      "route.ts",
+      "app/api",
+      "VideoNarrativeDiagnosisBlocks",
+      "VideoNarrativeAppPreview",
+      "VideoNarrativeInteractiveAppPreview",
+      "React",
+      "tsx",
+    ].forEach((forbidden) => {
+      expect(importLines).not.toContain(forbidden);
+    });
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
+++ b/src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts
@@ -10,6 +10,9 @@ import {
 } from "../../videoUpload/videoNarrativeDiagnosisLearningModel";
 import { buildVideoNarrativeDiagnosisQuiz } from "../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
 import { buildVideoNarrativeCreatorProfile } from "../../videoUpload/videoNarrativeCreatorProfileContract";
+import { buildVideoNarrativeEvolvingDiagnosis } from "../../videoUpload/videoNarrativeEvolvingDiagnosisContract";
+import { buildVideoNarrativeAccessTierDiagnosisRules } from "../../videoUpload/videoNarrativeAccessTierDiagnosisRules";
+import { buildVideoNarrativeDiagnosisPresentation } from "../../videoUpload/videoNarrativeDiagnosisPresentationModel";
 import {
   buildVideoNarrativeAppFlowState,
   type VideoNarrativeAppFlowAccessLevel,
@@ -192,6 +195,15 @@ function buildInstagramContext(connected: boolean): VideoNarrativeInstagramConte
   };
 }
 
+function analyzedVideosCountForPreview(params: {
+  accessLevel: VideoNarrativeAppPreviewAccess;
+  instagramConnected: boolean;
+}): number {
+  if (params.accessLevel === "instagram_optimized" && params.instagramConnected) return 5;
+  if (params.accessLevel === "premium") return 3;
+  return 1;
+}
+
 export function buildVideoNarrativeAppPreviewScenario(params: VideoNarrativeAppPreviewScenarioParams = {}) {
   const scenario = resolveScenario(params.scenario);
   const stage = resolveStage(params.stage);
@@ -233,6 +245,24 @@ export function buildVideoNarrativeAppPreviewScenario(params: VideoNarrativeAppP
     diagnosisId: diagnosis.id,
     createdAt: analysis.createdAt,
   });
+  const evolvingDiagnosis = buildVideoNarrativeEvolvingDiagnosis({
+    diagnosis,
+    creatorProfile,
+    accessLevel: toDiagnosisAccessLevel(accessLevel),
+    instagramConnected,
+    analyzedVideosCount: analyzedVideosCountForPreview({ accessLevel, instagramConnected }),
+    createdAt: analysis.createdAt,
+  });
+  const accessRules = buildVideoNarrativeAccessTierDiagnosisRules({
+    evolvingDiagnosis,
+    accessLevel: toDiagnosisAccessLevel(accessLevel),
+    instagramConnected,
+  });
+  const diagnosisPresentation = buildVideoNarrativeDiagnosisPresentation({
+    diagnosis,
+    evolvingDiagnosis,
+    accessRules,
+  });
   const hasUsefulDiagnosis = hasUsefulVideoNarrativeStrategicDiagnosis(diagnosis);
   const flowState = buildVideoNarrativeAppFlowState({
     stage,
@@ -255,6 +285,9 @@ export function buildVideoNarrativeAppPreviewScenario(params: VideoNarrativeAppP
     diagnosis,
     quiz,
     creatorProfile,
+    evolvingDiagnosis,
+    accessRules,
+    diagnosisPresentation,
     primaryAction: getPostCreationVideoSeedPrimaryAction(seed),
     accessLevel,
     instagramConnected,

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -104,6 +104,8 @@ Já existe:
 - MM39 não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda billing real;
 - diagnosis presentation model foi criado em MM40 como camada segura de produto/apresentação;
 - MM40 transforma diagnóstico evolutivo e regras de acesso em blocos estruturados para futura UI, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI real;
+- evolving diagnosis preview scenarios foi criado em MM41 como camada segura de preview/mock;
+- MM41 conecta diagnóstico evolutivo, regras de acesso e presentation model aos cenários mockados, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI pública;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -933,6 +933,30 @@ O que não faz:
 - não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta billing, Stripe ou cobrança.
 
+### MM41 — Evolving Diagnosis Preview Scenarios
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/buildVideoNarrativeAppPreviewScenario.ts`
+- `../components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts`
+
+O que faz:
+
+- conecta diagnóstico evolutivo, regras de acesso e presentation model ao builder da preview interna;
+- retorna `evolvingDiagnosis`, `accessRules` e `diagnosisPresentation` junto dos cenários mockados;
+- mantém tudo local, mockado e determinístico;
+- prepara a futura UI mobile-first sem alterar visual ainda;
+- garante cenários `free`, `premium` e `instagram_optimized` conectados aos novos contratos.
+
+O que não faz:
+
+- não cria persistência, banco/tabela, endpoint, UI pública, preview visual nova, upload real, storage real ou analytics real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -247,8 +247,9 @@ Exemplos:
 37. MM38 — Evolving Creator Diagnosis Contract. Modela a camada evolutiva acima do diagnóstico pontual, sem persistência ou match real.
 38. MM39 — Access Tier Diagnosis Rules. Define regras de acesso e valor por camada para free, premium e Instagram conectado.
 39. MM40 — Diagnosis Presentation Model. Transforma diagnóstico evolutivo e regras de acesso em blocos de apresentação para futura UI mobile-first.
-40. Teste real manual quando houver quota/billing disponível.
-41. Integração experimental futura no Board de Criação.
+40. MM41 — Evolving Diagnosis Preview Scenarios. Conecta os contratos evolutivos ao builder mockado da preview interna, sem alterar UI visual.
+41. Teste real manual quando houver quota/billing disponível.
+42. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -321,6 +322,8 @@ MM38 adiciona `VideoNarrativeEvolvingDiagnosis` como camada acima de `VideoNarra
 MM39 adiciona `VideoNarrativeAccessTierDiagnosisRules` para explicitar as regras de acesso e valor por camada. MM38 define o diagnóstico evolutivo; MM39 define o que fica visível, limitado, bloqueado ou sugerido em `free`, `premium` e `instagram_optimized`. Essa camada deve ser usada futuramente pela apresentação/UI para não espalhar lógica de paywall, disponibilidade comercial, collab e precisão por Instagram pelos componentes.
 
 MM40 adiciona `VideoNarrativeDiagnosisPresentation` como superfície de apresentação pura acima de MM38 e MM39. MM38 define o diagnóstico evolutivo, MM39 define as regras de acesso e MM40 organiza o que a futura UI deve renderizar como hero, cards prioritários, seções, previews bloqueados, badges e CTAs. Componentes React futuros devem consumir essa camada para evitar lógica de copy, paywall e priorização espalhada na UI.
+
+MM41 conecta a cadeia de contratos ao builder da preview interna. A preview passa a carregar diagnóstico pontual, diagnóstico evolutivo, regras de acesso e presentation model em cada cenário mockado, mantendo tudo local e determinístico. A UI futura deve consumir `VideoNarrativeDiagnosisPresentation` em vez de reconstruir lógica de tier, bloqueio, oportunidade comercial ou precisão por Instagram dentro dos componentes.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
Stacked sobre #837.

## Resumo
- conecta `VideoNarrativeEvolvingDiagnosis`, `VideoNarrativeAccessTierDiagnosisRules` e `VideoNarrativeDiagnosisPresentation` ao builder da preview interna
- mantém os cenários mockados determinísticos e adiciona `evolvingDiagnosis`, `accessRules` e `diagnosisPresentation` ao retorno
- usa `analyzedVideosCount` simulado por tier: free, premium e instagram_optimized conectado
- preserva a UI visual atual; os novos blocos ainda não são renderizados

## Guardrails
- sem UI visual alterada
- sem endpoint alterado
- sem upload/storage real
- sem persistência/banco/tabela
- sem Gemini/OpenAI/fetch
- sem Instagram real
- sem billing/Stripe real

## Validações
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run build`