### PR TITLE
feat: refactor video narrative mobile diagnosis UI

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx
@@ -64,10 +64,10 @@ describe("VideoNarrativeAppPreview", () => {
   it("renders diagnosis blocks in diagnosis_ready", () => {
     render(<VideoNarrativeAppPreview preview={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready" })} />);
 
-    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
-    expect(screen.getByText("Potencial comercial")).toBeInTheDocument();
-    expect(screen.getByText("Blueprint")).toBeInTheDocument();
-    expect(screen.getByText("Próximas ações")).toBeInTheDocument();
+    expect(screen.getByText("Primeira leitura do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByText("O que este vídeo comunica")).toBeInTheDocument();
+    expect(screen.getByText("Ajuste mais importante")).toBeInTheDocument();
+    expect(screen.getByText("Próximo movimento")).toBeInTheDocument();
   });
 
   it("renders locked sections for free access", () => {
@@ -77,8 +77,8 @@ describe("VideoNarrativeAppPreview", () => {
       />,
     );
 
-    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
-    expect(screen.getAllByText(/premium|Instagram/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Próximas camadas do diagnóstico")).toBeInTheDocument();
+    expect(screen.getAllByText(/diagnóstico completo|Instagram/i).length).toBeGreaterThan(0);
   });
 
   it("renders creator profile summary", () => {
@@ -88,8 +88,39 @@ describe("VideoNarrativeAppPreview", () => {
       />,
     );
 
-    expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
-    expect(screen.getByText("Territórios")).toBeInTheDocument();
+    expect(screen.getByText("Evolução do creator")).toBeInTheDocument();
+    expect(screen.getByText("Território de marca possível")).toBeInTheDocument();
+  });
+
+  it("renders premium presentation with Instagram lock", () => {
+    render(
+      <VideoNarrativeAppPreview
+        preview={buildVideoNarrativeAppPreviewScenario({
+          stage: "diagnosis_ready",
+          access: "premium",
+          instagram: "disconnected",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Diagnóstico completo")).toBeInTheDocument();
+    expect(screen.getByText("Seu mapa estratégico foi atualizado")).toBeInTheDocument();
+    expect(screen.getAllByText("Leitura mais precisa com Instagram").length).toBeGreaterThan(0);
+  });
+
+  it("renders instagram optimized presentation with precision section", () => {
+    render(
+      <VideoNarrativeAppPreview
+        preview={buildVideoNarrativeAppPreviewScenario({
+          stage: "diagnosis_ready",
+          access: "instagram_optimized",
+          instagram: "connected",
+        })}
+      />,
+    );
+
+    expect(screen.getAllByText("Leitura mais precisa").length).toBeGreaterThan(0);
+    expect(screen.getByText("Precisão com Instagram")).toBeInTheDocument();
   });
 
   it("renders upgrade prompt", () => {

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.tsx
@@ -208,7 +208,11 @@ export function VideoNarrativeAppPreview({ preview }: VideoNarrativeAppPreviewPr
         </VideoNarrativeStageShell>
 
         {flowState.stage === "diagnosis_ready" ? (
-          <VideoNarrativeDiagnosisBlocks diagnosis={preview.diagnosis} creatorProfile={preview.creatorProfile} />
+          <VideoNarrativeDiagnosisBlocks
+            diagnosis={preview.diagnosis}
+            creatorProfile={preview.creatorProfile}
+            presentation={preview.diagnosisPresentation}
+          />
         ) : null}
       </div>
     </main>

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx
@@ -137,10 +137,10 @@ describe("VideoNarrativeInteractiveAppPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Concluir quiz" }));
     fireEvent.click(screen.getByRole("button", { name: "Montar diagnóstico" }));
 
-    expect(screen.getAllByText("Narrativa principal").length).toBeGreaterThan(0);
-    expect(screen.getByText("Leitura estratégica")).toBeInTheDocument();
-    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
-    expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Primeira leitura do seu vídeo")).toBeInTheDocument();
+    expect(screen.getByText("O que este vídeo comunica")).toBeInTheDocument();
+    expect(screen.getByText("Ajuste mais importante")).toBeInTheDocument();
+    expect(screen.getByText("Próximas camadas do diagnóstico")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ver planos" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Conectar Instagram" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Criar versão para publi" })).toBeInTheDocument();

--- a/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx
@@ -7,6 +7,9 @@ import {
 } from "../../videoUpload/videoNarrativeDiagnosisLearningModel";
 import { buildVideoNarrativeDiagnosisQuiz } from "../../videoUpload/videoNarrativeDiagnosisQuizBuilder";
 import { buildVideoNarrativeCreatorProfile } from "../../videoUpload/videoNarrativeCreatorProfileContract";
+import { buildVideoNarrativeAccessTierDiagnosisRules } from "../../videoUpload/videoNarrativeAccessTierDiagnosisRules";
+import { buildVideoNarrativeDiagnosisPresentation } from "../../videoUpload/videoNarrativeDiagnosisPresentationModel";
+import { buildVideoNarrativeEvolvingDiagnosis } from "../../videoUpload/videoNarrativeEvolvingDiagnosisContract";
 import { VideoNarrativeDiagnosisBlocks } from "./appPreview/VideoNarrativeDiagnosisBlocks";
 import { VideoNarrativeGoalInput } from "./appPreview/VideoNarrativeGoalInput";
 import { VideoNarrativeInteractiveQuiz } from "./appPreview/VideoNarrativeInteractiveQuiz";
@@ -117,8 +120,30 @@ export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarra
       diagnosisId: diagnosis.id,
       createdAt: scenarioData.analysis.createdAt,
     });
+    const evolvingDiagnosis = buildVideoNarrativeEvolvingDiagnosis({
+      diagnosis,
+      creatorProfile,
+      accessLevel: scenarioData.accessLevel,
+      instagramConnected: scenarioData.instagramConnected,
+      analyzedVideosCount: scenarioData.accessLevel === "instagram_optimized" && scenarioData.instagramConnected
+        ? 5
+        : scenarioData.accessLevel === "premium"
+          ? 3
+          : 1,
+      createdAt: scenarioData.analysis.createdAt,
+    });
+    const accessRules = buildVideoNarrativeAccessTierDiagnosisRules({
+      evolvingDiagnosis,
+      accessLevel: scenarioData.accessLevel,
+      instagramConnected: scenarioData.instagramConnected,
+    });
+    const diagnosisPresentation = buildVideoNarrativeDiagnosisPresentation({
+      diagnosis,
+      evolvingDiagnosis,
+      accessRules,
+    });
 
-    return { diagnosis, quiz, creatorProfile };
+    return { diagnosis, quiz, creatorProfile, diagnosisPresentation };
   }, [creatorGoal, scenarioData, selectedQuizAnswers]);
 
   function renderBody() {
@@ -195,7 +220,11 @@ export function VideoNarrativeInteractiveAppPreview({ scenarioData }: VideoNarra
             <SecondaryButton onClick={actions.requestUpgrade}>Ver planos</SecondaryButton>
             <SecondaryButton onClick={actions.requestInstagramConnection}>Conectar Instagram</SecondaryButton>
           </div>
-          <VideoNarrativeDiagnosisBlocks diagnosis={derived.diagnosis} creatorProfile={derived.creatorProfile} />
+          <VideoNarrativeDiagnosisBlocks
+            diagnosis={derived.diagnosis}
+            creatorProfile={derived.creatorProfile}
+            presentation={derived.diagnosisPresentation}
+          />
         </div>
       );
     }

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx
@@ -1,100 +1,180 @@
+import fs from "fs";
+import path from "path";
 import { render, screen } from "@testing-library/react";
 import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
 import { VideoNarrativeDiagnosisBlocks } from "./VideoNarrativeDiagnosisBlocks";
 
 describe("VideoNarrativeDiagnosisBlocks", () => {
-  const preview = buildVideoNarrativeAppPreviewScenario({
+  const instagramPreview = buildVideoNarrativeAppPreviewScenario({
     stage: "diagnosis_ready",
     scenario: "brand",
     access: "instagram_optimized",
     instagram: "connected",
   });
 
-  function renderBlocks() {
+  function renderBlocks(preview = instagramPreview) {
     return render(
-      <VideoNarrativeDiagnosisBlocks diagnosis={preview.diagnosis} creatorProfile={preview.creatorProfile} />,
+      <VideoNarrativeDiagnosisBlocks
+        diagnosis={preview.diagnosis}
+        creatorProfile={preview.creatorProfile}
+        presentation={preview.diagnosisPresentation}
+      />,
     );
   }
 
-  it("renders main narrative", () => {
+  it("renders hero from diagnosisPresentation", () => {
     renderBlocks();
-    expect(screen.getAllByText("Narrativa principal").length).toBeGreaterThan(0);
+
+    expect(screen.getByText("Diagnóstico otimizado com contexto de Instagram")).toBeInTheDocument();
+    expect(screen.getAllByText("Leitura mais precisa").length).toBeGreaterThan(0);
   });
 
-  it("renders what video communicates", () => {
+  it("renders readingTimeHint", () => {
     renderBlocks();
-    expect(screen.getByText("O que o vídeo comunica")).toBeInTheDocument();
+
+    expect(screen.getByText("Tempo de leitura")).toBeInTheDocument();
+    expect(screen.getByText("Leitura completa: 2 a 3 minutos")).toBeInTheDocument();
   });
 
-  it("renders creator intent", () => {
+  it("renders badges", () => {
     renderBlocks();
-    expect(screen.getByText("Intenção do criador")).toBeInTheDocument();
+
+    expect(screen.getByText("Instagram optimized")).toBeInTheDocument();
+    expect(screen.getByText("Território de marca possível")).toBeInTheDocument();
   });
 
-  it("renders strength, weakness and adjustment", () => {
-    const weakHookPreview = buildVideoNarrativeAppPreviewScenario({
+  it("renders priority cards", () => {
+    renderBlocks();
+
+    expect(screen.getByText("O que este vídeo comunica")).toBeInTheDocument();
+    expect(screen.getByText("Ajuste mais importante")).toBeInTheDocument();
+    expect(screen.getByText("O que revelou sobre o creator")).toBeInTheDocument();
+    expect(screen.getByText("Próximo movimento")).toBeInTheDocument();
+  });
+
+  it("renders primaryCTA", () => {
+    renderBlocks();
+
+    expect(screen.getByText("Gerar próximo movimento estratégico")).toBeInTheDocument();
+  });
+
+  it("renders secondaryCTA when available", () => {
+    renderBlocks();
+
+    expect(screen.getByText("Criar variação de roteiro")).toBeInTheDocument();
+  });
+
+  it("renders visible sections", () => {
+    renderBlocks();
+
+    expect(screen.getByText("Diagnóstico do vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Evolução do creator")).toBeInTheDocument();
+    expect(screen.getByText("Precisão com Instagram")).toBeInTheDocument();
+  });
+
+  it("renders lockedPreviews", () => {
+    renderBlocks(buildVideoNarrativeAppPreviewScenario({
       stage: "diagnosis_ready",
-      scenario: "weak-hook",
+      access: "free",
+      scenario: "brand",
+    }));
+
+    expect(screen.getByText("Próximas camadas do diagnóstico")).toBeInTheDocument();
+    expect(screen.getAllByText("Mapa estratégico completo").length).toBeGreaterThan(0);
+  });
+
+  it("free shows first free reading and unlock CTA", () => {
+    renderBlocks(buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      access: "free",
+    }));
+
+    expect(screen.getByText("Primeira leitura gratuita")).toBeInTheDocument();
+    expect(screen.getAllByText("Desbloquear diagnóstico completo").length).toBeGreaterThan(0);
+  });
+
+  it("premium shows complete diagnosis and Instagram lock", () => {
+    renderBlocks(buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
       access: "premium",
+      instagram: "disconnected",
+    }));
+
+    expect(screen.getByText("Diagnóstico completo")).toBeInTheDocument();
+    expect(screen.getByText("Seu mapa estratégico foi atualizado")).toBeInTheDocument();
+    expect(screen.getAllByText("Leitura mais precisa com Instagram").length).toBeGreaterThan(0);
+  });
+
+  it("brand scenario does not promise real match or guaranteed brand", () => {
+    const { container } = renderBlocks(buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      scenario: "brand",
+      access: "premium",
+    }));
+    const text = container.textContent?.toLowerCase() || "";
+
+    expect(text).toContain("oportunidade futura");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("marca garantida");
+    expect(text).not.toContain("garantido");
+    expect(text).not.toContain("comprovado");
+    expect(text).not.toContain("certeza");
+  });
+
+  it("collab scenario does not suggest real creator names", () => {
+    const { container } = renderBlocks(buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      scenario: "collab",
+      access: "premium",
+    }));
+    const text = container.textContent?.toLowerCase() || "";
+
+    expect(text).toContain("tipo de collab");
+    expect(text).not.toContain("creator famoso");
+    expect(text).not.toContain("match real");
+  });
+
+  it("keeps fallback rendering for legacy diagnosis props", () => {
+    const preview = buildVideoNarrativeAppPreviewScenario({
+      stage: "diagnosis_ready",
+      scenario: "brand",
     });
-    render(<VideoNarrativeDiagnosisBlocks diagnosis={weakHookPreview.diagnosis} />);
+    render(<VideoNarrativeDiagnosisBlocks diagnosis={preview.diagnosis} creatorProfile={preview.creatorProfile} />);
 
-    expect(screen.getByText("Ponto forte")).toBeInTheDocument();
-    expect(screen.getByText("Ponto de atenção")).toBeInTheDocument();
-    expect(screen.getByText("Ajuste recomendado")).toBeInTheDocument();
-  });
-
-  it("renders suggested hook", () => {
-    renderBlocks();
-    expect(screen.getByText("Gancho sugerido")).toBeInTheDocument();
-  });
-
-  it("renders brand potential", () => {
-    renderBlocks();
-    expect(screen.getByText("Potencial comercial")).toBeInTheDocument();
-    expect(screen.getByText("Marcas e territórios")).toBeInTheDocument();
-  });
-
-  it("renders blueprint", () => {
-    renderBlocks();
-    expect(screen.getByText("Blueprint")).toBeInTheDocument();
-  });
-
-  it("renders blueprint scenes", () => {
-    renderBlocks();
-    expect(screen.getByText("Cenas")).toBeInTheDocument();
-  });
-
-  it("renders lockedSections", () => {
-    render(
-      <VideoNarrativeDiagnosisBlocks
-        diagnosis={buildVideoNarrativeAppPreviewScenario({ stage: "diagnosis_ready", access: "free" }).diagnosis}
-      />,
-    );
-
-    expect(screen.getByText("Seções bloqueadas")).toBeInTheDocument();
-    expect(screen.getAllByText(/premium|Instagram/i).length).toBeGreaterThan(0);
-  });
-
-  it("renders nextActions", () => {
-    renderBlocks();
-    expect(screen.getByText("Próximas ações")).toBeInTheDocument();
-  });
-
-  it("renders creatorSignals", () => {
-    renderBlocks();
     expect(screen.getByText("Aprendizado sobre o criador")).toBeInTheDocument();
-    expect(screen.getByText("Sinais do criador")).toBeInTheDocument();
-  });
-
-  it("renders creatorProfile summary", () => {
-    renderBlocks();
     expect(screen.getByText("Resumo do perfil narrativo")).toBeInTheDocument();
-    expect(screen.getByText("Territórios")).toBeInTheDocument();
   });
 
-  it("renders instagramComparison", () => {
-    renderBlocks();
-    expect(screen.getByText("Comparação com Instagram")).toBeInTheDocument();
+  it("does not import forbidden integrations", () => {
+    const files = [
+      path.join(__dirname, "VideoNarrativeDiagnosisBlocks.tsx"),
+      path.join(__dirname, "VideoNarrativeDiagnosisPresentationBlocks.tsx"),
+    ];
+    const forbidden = [
+      "OpenAI",
+      "fetch",
+      "Prisma",
+      "banco",
+      "app/api",
+      "storage",
+      "analytics",
+      "ffmpeg",
+      "Stripe",
+      "billing",
+      "GoogleGenAI",
+      "BoardShell",
+      "PostCreationFunnelState",
+    ];
+
+    files.forEach((file) => {
+      const importLines = fs.readFileSync(file, "utf8")
+        .split("\n")
+        .filter((line) => line.trim().startsWith("import"))
+        .join("\n");
+
+      forbidden.forEach((term) => {
+        expect(importLines).not.toContain(term);
+      });
+    });
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx
@@ -1,11 +1,14 @@
 import type { VideoNarrativeCreatorProfile } from "../../../videoUpload/videoNarrativeCreatorProfileContract";
+import type { VideoNarrativeDiagnosisPresentation } from "../../../videoUpload/videoNarrativeDiagnosisPresentationModel";
 import type { VideoNarrativeStrategicDiagnosis } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
 import { formatSignalLabel } from "./VideoNarrativeAppPreviewPrimitives";
+import { VideoNarrativeDiagnosisPresentationBlocks } from "./VideoNarrativeDiagnosisPresentationBlocks";
 import type { ReactNode } from "react";
 
 type VideoNarrativeDiagnosisBlocksProps = {
   diagnosis: VideoNarrativeStrategicDiagnosis;
   creatorProfile?: VideoNarrativeCreatorProfile | null;
+  presentation?: VideoNarrativeDiagnosisPresentation | null;
 };
 
 const FINAL_ACTIONS = [
@@ -75,7 +78,15 @@ function ActionPills() {
   );
 }
 
-export function VideoNarrativeDiagnosisBlocks({ diagnosis, creatorProfile }: VideoNarrativeDiagnosisBlocksProps) {
+export function VideoNarrativeDiagnosisBlocks({
+  diagnosis,
+  creatorProfile,
+  presentation,
+}: VideoNarrativeDiagnosisBlocksProps) {
+  if (presentation) {
+    return <VideoNarrativeDiagnosisPresentationBlocks presentation={presentation} />;
+  }
+
   return (
     <div className="grid gap-4 lg:grid-cols-2">
       <Block title="Narrativa principal" eyebrow="Hero do diagnóstico" wide>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisPresentationBlocks.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisPresentationBlocks.tsx
@@ -1,0 +1,185 @@
+import type {
+  VideoNarrativeDiagnosisPresentation,
+  VideoNarrativeDiagnosisPresentationBadge,
+  VideoNarrativeDiagnosisPresentationCard,
+  VideoNarrativeDiagnosisPresentationCTA,
+  VideoNarrativeDiagnosisPresentationSection,
+  VideoNarrativeDiagnosisPresentationTone,
+} from "../../../videoUpload/videoNarrativeDiagnosisPresentationModel";
+
+type VideoNarrativeDiagnosisPresentationBlocksProps = {
+  presentation: VideoNarrativeDiagnosisPresentation;
+};
+
+const TONE_STYLES: Record<VideoNarrativeDiagnosisPresentationTone, string> = {
+  insight: "border-zinc-200 bg-white",
+  action: "border-zinc-300 bg-zinc-50",
+  opportunity: "border-emerald-200 bg-emerald-50/60",
+  unlock: "border-amber-200 bg-amber-50/70",
+  warning: "border-rose-200 bg-rose-50/70",
+};
+
+const BADGE_STYLES: Record<VideoNarrativeDiagnosisPresentationBadge["tone"], string> = {
+  neutral: "border-zinc-200 bg-zinc-50 text-zinc-700",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  premium: "border-zinc-300 bg-zinc-950 text-white",
+  instagram: "border-sky-200 bg-sky-50 text-sky-800",
+  warning: "border-amber-200 bg-amber-50 text-amber-800",
+};
+
+function Badge({ badge }: { badge: VideoNarrativeDiagnosisPresentationBadge }) {
+  return (
+    <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${BADGE_STYLES[badge.tone]}`}>
+      {badge.label}
+    </span>
+  );
+}
+
+function PresentationCard({ card }: { card: VideoNarrativeDiagnosisPresentationCard }) {
+  return (
+    <article
+      className={`rounded-2xl border p-4 shadow-sm ${TONE_STYLES[card.tone]} ${
+        card.priority === "high" ? "ring-1 ring-zinc-200" : ""
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-zinc-950">{card.title}</h3>
+        {card.locked ? (
+          <span className="shrink-0 rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-zinc-600">
+            Bloqueado
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-2 text-sm leading-6 text-zinc-700">{card.body}</p>
+    </article>
+  );
+}
+
+function CTAButton({ cta, secondary = false }: { cta: VideoNarrativeDiagnosisPresentationCTA; secondary?: boolean }) {
+  return (
+    <button
+      type="button"
+      className={
+        secondary
+          ? "rounded-xl border border-zinc-200 bg-white px-4 py-3 text-left text-sm font-semibold text-zinc-800 shadow-sm"
+          : "rounded-xl bg-zinc-950 px-4 py-3 text-left text-sm font-semibold text-white shadow-sm"
+      }
+    >
+      <span>{cta.label}</span>
+      {cta.helper ? (
+        <span className={secondary ? "mt-1 block text-xs font-medium leading-5 text-zinc-500" : "mt-1 block text-xs font-medium leading-5 text-zinc-300"}>
+          {cta.helper}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function SectionBlock({ section }: { section: VideoNarrativeDiagnosisPresentationSection }) {
+  const open = section.id === "video_diagnosis" || section.id === "creator_evolution";
+
+  return (
+    <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-zinc-950">{section.title}</h3>
+          <p className="mt-1 text-sm leading-6 text-zinc-600">{section.description}</p>
+        </div>
+        {!open && section.collapsedByDefault ? (
+          <span className="rounded-full bg-zinc-50 px-3 py-1 text-xs font-semibold text-zinc-500">Compacto</span>
+        ) : null}
+      </div>
+      <div className={open ? "mt-4 grid gap-3 md:grid-cols-2" : "mt-4 grid gap-3"}>
+        {section.cards.map((card) => (
+          <PresentationCard key={card.id} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function VideoNarrativeDiagnosisPresentationBlocks({
+  presentation,
+}: VideoNarrativeDiagnosisPresentationBlocksProps) {
+  return (
+    <section className="grid gap-4" aria-label="Diagnóstico estratégico do vídeo">
+      <article className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-6">
+        <div className="flex flex-wrap gap-2">
+          <Badge badge={presentation.hero.badge} />
+          {presentation.badges.map((badge) => (
+            <Badge key={badge.id} badge={badge} />
+          ))}
+        </div>
+
+        <div className="mt-5 grid gap-5 lg:grid-cols-[1.4fr_0.8fr]">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-normal text-zinc-950 sm:text-3xl">
+              {presentation.hero.title}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-zinc-700 sm:text-base">{presentation.hero.subtitle}</p>
+          </div>
+          <dl className="grid gap-3 rounded-2xl bg-zinc-50 p-4 text-sm">
+            <div>
+              <dt className="font-semibold text-zinc-500">Nível atual</dt>
+              <dd className="mt-1 text-zinc-950">{presentation.hero.levelLabel}</dd>
+            </div>
+            {presentation.hero.nextLevelLabel ? (
+              <div>
+                <dt className="font-semibold text-zinc-500">Próximo nível</dt>
+                <dd className="mt-1 text-zinc-950">{presentation.hero.nextLevelLabel}</dd>
+              </div>
+            ) : null}
+            <div>
+              <dt className="font-semibold text-zinc-500">Precisão</dt>
+              <dd className="mt-1 text-zinc-950">{presentation.hero.precisionLabel}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-zinc-500">Tempo de leitura</dt>
+              <dd className="mt-1 text-zinc-950">{presentation.readingTimeHint}</dd>
+            </div>
+          </dl>
+        </div>
+      </article>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {presentation.priorityCards.map((card) => (
+          <PresentationCard key={card.id} card={card} />
+        ))}
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <CTAButton cta={presentation.primaryCTA} />
+        {presentation.secondaryCTA ? <CTAButton cta={presentation.secondaryCTA} secondary /> : null}
+      </div>
+
+      <div className="grid gap-4">
+        {presentation.sections
+          .filter((section) => section.visible)
+          .map((section) => (
+            <SectionBlock key={section.id} section={section} />
+          ))}
+      </div>
+
+      {presentation.lockedPreviews.length > 0 ? (
+        <section className="rounded-2xl border border-zinc-200 bg-zinc-50 p-5 shadow-sm">
+          <h3 className="text-base font-semibold text-zinc-950">Próximas camadas do diagnóstico</h3>
+          <p className="mt-1 text-sm leading-6 text-zinc-600">
+            Sua primeira leitura já ajuda; o diagnóstico fica mais estratégico com mais contexto.
+          </p>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {presentation.lockedPreviews.map((preview, index) => (
+              <article key={`${preview.id}-${index}`} className="rounded-2xl border border-zinc-200 bg-white p-4">
+                <h4 className="text-sm font-semibold text-zinc-950">{preview.title}</h4>
+                <p className="mt-2 text-sm leading-6 text-zinc-700">{preview.description}</p>
+                <p className="mt-2 text-xs font-medium leading-5 text-zinc-500">{preview.reason}</p>
+                <span className="mt-3 inline-flex rounded-lg bg-zinc-950 px-3 py-2 text-xs font-semibold text-white">
+                  {preview.ctaLabel}
+                </span>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -106,6 +106,8 @@ Já existe:
 - MM40 transforma diagnóstico evolutivo e regras de acesso em blocos estruturados para futura UI, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI real;
 - evolving diagnosis preview scenarios foi criado em MM41 como camada segura de preview/mock;
 - MM41 conecta diagnóstico evolutivo, regras de acesso e presentation model aos cenários mockados, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI pública;
+- mobile diagnosis UI refactor foi criado em MM42 como camada segura de UI interna/preview;
+- MM42 materializa o presentation model na preview interna, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não cria UI pública;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -957,6 +957,32 @@ O que não faz:
 - não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta billing, Stripe ou cobrança.
 
+### MM42 — Mobile Diagnosis UI Refactor
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/appPreview/VideoNarrativeDiagnosisPresentationBlocks.tsx`
+- `../components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.tsx`
+- `../components/videoUpload/VideoNarrativeAppPreview.tsx`
+- `../components/videoUpload/VideoNarrativeInteractiveAppPreview.tsx`
+
+O que faz:
+
+- refatora a UI interna do diagnóstico para consumir `VideoNarrativeDiagnosisPresentation`;
+- troca a sensação de relatório por um painel estratégico mobile-first;
+- renderiza hero, cards prioritários, CTAs, seções, badges e previews bloqueados;
+- diferencia visualmente `free`, `premium` e `instagram_optimized` na preview interna;
+- mantém a experiência mockada e interna.
+
+O que não faz:
+
+- não cria persistência, banco/tabela, endpoint, UI pública, upload real, storage real ou analytics real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
+- não conecta billing, Stripe ou cobrança.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -248,8 +248,9 @@ Exemplos:
 38. MM39 — Access Tier Diagnosis Rules. Define regras de acesso e valor por camada para free, premium e Instagram conectado.
 39. MM40 — Diagnosis Presentation Model. Transforma diagnóstico evolutivo e regras de acesso em blocos de apresentação para futura UI mobile-first.
 40. MM41 — Evolving Diagnosis Preview Scenarios. Conecta os contratos evolutivos ao builder mockado da preview interna, sem alterar UI visual.
-41. Teste real manual quando houver quota/billing disponível.
-42. Integração experimental futura no Board de Criação.
+41. MM42 — Mobile Diagnosis UI Refactor. Materializa o presentation model na UI interna do diagnóstico, com layout mobile-first.
+42. Teste real manual quando houver quota/billing disponível.
+43. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -324,6 +325,8 @@ MM39 adiciona `VideoNarrativeAccessTierDiagnosisRules` para explicitar as regras
 MM40 adiciona `VideoNarrativeDiagnosisPresentation` como superfície de apresentação pura acima de MM38 e MM39. MM38 define o diagnóstico evolutivo, MM39 define as regras de acesso e MM40 organiza o que a futura UI deve renderizar como hero, cards prioritários, seções, previews bloqueados, badges e CTAs. Componentes React futuros devem consumir essa camada para evitar lógica de copy, paywall e priorização espalhada na UI.
 
 MM41 conecta a cadeia de contratos ao builder da preview interna. A preview passa a carregar diagnóstico pontual, diagnóstico evolutivo, regras de acesso e presentation model em cada cenário mockado, mantendo tudo local e determinístico. A UI futura deve consumir `VideoNarrativeDiagnosisPresentation` em vez de reconstruir lógica de tier, bloqueio, oportunidade comercial ou precisão por Instagram dentro dos componentes.
+
+MM42 é a primeira materialização visual do presentation model. A preview interna passa a renderizar o diagnóstico a partir de `VideoNarrativeDiagnosisPresentation`, com hero, cards prioritários, CTAs, seções e previews bloqueados em layout mobile-first. Os componentes não devem reconstruir lógica de tier diretamente; essa lógica permanece nas camadas MM39/MM40.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
## Summary

Stacked over #838.

MM42 refactors the internal video narrative app preview diagnosis surface to consume `VideoNarrativeDiagnosisPresentation` instead of rendering the diagnosis as a technical report.

Changes:
- Adds `VideoNarrativeDiagnosisPresentationBlocks` for the mobile-first diagnosis presentation.
- Updates `VideoNarrativeDiagnosisBlocks` to delegate to the presentation blocks when `diagnosisPresentation` is available, while keeping the previous fallback compatible.
- Updates the static and interactive previews to pass `diagnosisPresentation` through.
- Recomputes evolving diagnosis, access rules, and presentation in the interactive preview state path so the final diagnosis screen uses the same presentation model.
- Updates tests and docs for MM42.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, or Prisma changes.
- No endpoint changes.
- No public UI changes outside the internal preview.
- No real Instagram integration.
- No real billing or Stripe integration.
- No brand or creator real matching.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/VideoNarrativeDiagnosisBlocks.test.tsx src/app/dashboard/boards/components/videoUpload/VideoNarrativeAppPreview.test.tsx src/app/dashboard/boards/components/videoUpload/VideoNarrativeInteractiveAppPreview.test.tsx src/app/dashboard/boards/components/videoUpload/buildVideoNarrativeAppPreviewScenario.test.ts src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings in unrelated files: `src/app/brand-report/[slug]/page.tsx` and `src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.tsx`.