### PR TITLE
feat: add mobile strategic profile state contract

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -108,6 +108,8 @@ Já existe:
 - MM41 conecta diagnóstico evolutivo, regras de acesso e presentation model aos cenários mockados, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não muda UI pública;
 - mobile diagnosis UI refactor foi criado em MM42 como camada segura de UI interna/preview;
 - MM42 materializa o presentation model na preview interna, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não cria UI pública;
+- strategic profile state contract foi criado em MM43 como camada segura de contrato/produto;
+- MM43 modela o Perfil Estratégico mobile como diagnóstico vivo do creator, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -983,6 +983,32 @@ O que não faz:
 - não conecta Instagram real, BoardShell, navegação/menu, fluxo real ou `PostCreationFunnelState`;
 - não conecta billing, Stripe ou cobrança.
 
+### MM43 — Strategic Profile State Contract
+
+Status: concluído.
+
+Arquivos principais:
+
+- `mobileStrategicProfileStateContract.ts`
+- `mobileStrategicProfileStateContract.test.ts`
+
+O que faz:
+
+- cria contrato puro para os estados do Perfil Estratégico mobile;
+- define que o Perfil é o diagnóstico vivo do creator;
+- cobre usuário anônimo, conta criada só com Gmail, primeira leitura, premium e Instagram otimizado;
+- modela estado do Mídia Kit sem recriar Mídia Kit ou alterar `MediaKitView`;
+- modela Comunidade apenas como destino existente de navegação futura;
+- reaproveita a lógica existente de login/callback em etapa futura, sem recriar login com Google.
+
+O que não faz:
+
+- não cria UI, preview visual, nova página de diagnóstico, nova tela de login ou histórico visual;
+- não altera endpoint, NextAuth, `LoginClient`, navegação/sidebar, `ActivationPendingWidget`, Mídia Kit real, `MediaKitView` ou Comunidade real;
+- não cria persistência, banco/tabela, schema, Prisma, upload real ou storage real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing, Stripe, match real de marcas ou creators.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -249,8 +249,9 @@ Exemplos:
 39. MM40 — Diagnosis Presentation Model. Transforma diagnóstico evolutivo e regras de acesso em blocos de apresentação para futura UI mobile-first.
 40. MM41 — Evolving Diagnosis Preview Scenarios. Conecta os contratos evolutivos ao builder mockado da preview interna, sem alterar UI visual.
 41. MM42 — Mobile Diagnosis UI Refactor. Materializa o presentation model na UI interna do diagnóstico, com layout mobile-first.
-42. Teste real manual quando houver quota/billing disponível.
-43. Integração experimental futura no Board de Criação.
+42. MM43 — Strategic Profile State Contract. Modela o Perfil Estratégico mobile como diagnóstico vivo do creator, sem UI real.
+43. Teste real manual quando houver quota/billing disponível.
+44. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -327,6 +328,8 @@ MM40 adiciona `VideoNarrativeDiagnosisPresentation` como superfície de apresent
 MM41 conecta a cadeia de contratos ao builder da preview interna. A preview passa a carregar diagnóstico pontual, diagnóstico evolutivo, regras de acesso e presentation model em cada cenário mockado, mantendo tudo local e determinístico. A UI futura deve consumir `VideoNarrativeDiagnosisPresentation` em vez de reconstruir lógica de tier, bloqueio, oportunidade comercial ou precisão por Instagram dentro dos componentes.
 
 MM42 é a primeira materialização visual do presentation model. A preview interna passa a renderizar o diagnóstico a partir de `VideoNarrativeDiagnosisPresentation`, com hero, cards prioritários, CTAs, seções e previews bloqueados em layout mobile-first. Os componentes não devem reconstruir lógica de tier diretamente; essa lógica permanece nas camadas MM39/MM40.
+
+MM43 adiciona `MobileStrategicProfileState` como contrato puro para a experiência mobile do Perfil Estratégico. O diagnóstico deixa de ser tratado como uma página isolada e passa a alimentar o Perfil: a análise de vídeo é uma ação temporária que atualiza o diagnóstico vivo do creator. O Perfil existe desde o login, mas pode estar em construção até a primeira leitura. Mídia Kit e Comunidade continuam sendo recursos existentes acessados pelo Perfil ou pela navegação futura; MM43 apenas modela disponibilidade, intenção e próximos passos, sem recriar Mídia Kit, `MediaKitView`, Comunidade, feed ou navegação real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts
@@ -1,0 +1,335 @@
+import fs from "fs";
+import path from "path";
+import {
+  resolveMobileStrategicProfileState,
+  sanitizeMobileStrategicProfileText,
+  type MobileStrategicProfileState,
+} from "./mobileStrategicProfileStateContract";
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+
+const CONTRACT_SOURCE_PATH = path.join(__dirname, "mobileStrategicProfileStateContract.ts");
+
+function makePresentation(
+  accessLevel: VideoNarrativeDiagnosisPresentation["accessLevel"] = "free",
+): VideoNarrativeDiagnosisPresentation {
+  return {
+    id: `presentation-${accessLevel}`,
+    accessLevel,
+    hero: {
+      title: accessLevel === "free" ? "Primeira leitura do seu vídeo" : "Seu mapa estratégico foi atualizado",
+      subtitle: "Leitura estratégica para o Perfil.",
+      badge: {
+        id: "badge",
+        label: accessLevel === "instagram_optimized" ? "Leitura mais precisa" : "Diagnóstico atualizado",
+        tone: accessLevel === "instagram_optimized" ? "instagram" : "neutral",
+      },
+      levelLabel: "Perfil em evolução",
+      nextLevelLabel: "Perfil estratégico",
+      precisionLabel: "Leitura de estado",
+    },
+    priorityCards: [],
+    sections: [],
+    lockedPreviews: [],
+    primaryCTA: {
+      label: "Analisar vídeo",
+      action: accessLevel === "free" ? "upgrade" : "generate_next_strategic_move",
+      helper: "Próximo passo",
+    },
+    secondaryCTA: null,
+    badges: [],
+    readingTimeHint: "Leitura rápida",
+    createdAt: "2026-05-19T00:00:00.000Z",
+  };
+}
+
+function allText(state: MobileStrategicProfileState): string {
+  return JSON.stringify(state).toLowerCase();
+}
+
+describe("mobileStrategicProfileStateContract", () => {
+  it("anonymous with view_profile intent generates auth_gate and login action to create Perfil Estratégico", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: false,
+      primaryIntent: "view_profile",
+    });
+
+    expect(result.authState).toBe("anonymous");
+    expect(result.profileAvailability).toBe("auth_gate");
+    expect(result.diagnosisState).toBe("empty");
+    expect(result.mediaKitState).toBe("unavailable");
+    expect(result.summary.description).toBe("Entre com Google para criar seu Perfil Estratégico.");
+    expect(result.recommendedActions[0]).toMatchObject({
+      id: "login",
+      intent: "view_profile",
+      label: "Entrar para criar Perfil",
+    });
+  });
+
+  it("anonymous with analyze_video intent generates auth_gate and login action to analyze first video", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: false,
+      primaryIntent: "analyze_video",
+    });
+
+    expect(result.profileAvailability).toBe("auth_gate");
+    expect(result.summary.description).toBe("Entre com Google para analisar seu primeiro vídeo.");
+    expect(result.recommendedActions[0]).toMatchObject({
+      id: "login",
+      intent: "analyze_video",
+      label: "Entrar para analisar vídeo",
+    });
+  });
+
+  it("authenticated Gmail-only user generates Perfil em construção", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      userName: "Ana Creator",
+      instagramConnected: false,
+    });
+
+    expect(result.authState).toBe("authenticated");
+    expect(result.profileAvailability).toBe("construction");
+    expect(result.readinessState).toBe("first_diagnosis_pending");
+    expect(result.diagnosisState).toBe("empty");
+    expect(result.statusPills.map((pill) => pill.label)).toContain("Perfil em construção");
+    expect(result.summary.title).toBe("Seu Perfil Estratégico ainda está começando.");
+  });
+
+  it("authenticated user without diagnosis prioritizes Analisar primeiro vídeo", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+    });
+
+    expect(result.recommendedActions[0]).toMatchObject({
+      id: "analyze-first-video",
+      intent: "analyze_video",
+      label: "Analisar primeiro vídeo",
+      priority: "primary",
+    });
+  });
+
+  it("free user with first reading generates first_reading_ready", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "free",
+      diagnosisPresentation: makePresentation("free"),
+      instagramConnected: false,
+    });
+
+    expect(result.profileAvailability).toBe("active");
+    expect(result.readinessState).toBe("first_reading_ready");
+    expect(result.diagnosisState).toBe("first_reading");
+    expect(result.summary.title).toBe("Primeira leitura criada.");
+  });
+
+  it("free user without Instagram suggests connecting Instagram as secondary next step", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "free",
+      diagnosisPresentation: makePresentation("free"),
+      instagramConnected: false,
+    });
+
+    expect(result.recommendedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "connect-instagram",
+          intent: "connect_instagram",
+          priority: "secondary",
+        }),
+      ]),
+    );
+  });
+
+  it("premium user with diagnosis generates strategic_profile_active", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "premium",
+      hasPremiumAccess: true,
+      diagnosisPresentation: makePresentation("premium"),
+    });
+
+    expect(result.subscriptionState).toBe("premium");
+    expect(result.diagnosisState).toBe("complete");
+    expect(result.readinessState).toBe("strategic_profile_active");
+    expect(result.statusPills.map((pill) => pill.label)).toContain("Premium");
+  });
+
+  it("premium user without Instagram suggests connecting for precision", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "premium",
+      hasPremiumAccess: true,
+      diagnosisPresentation: makePresentation("premium"),
+      instagramConnected: false,
+    });
+
+    expect(allText(result)).toContain("aumentar a precisão");
+    expect(result.recommendedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "connect-instagram", intent: "connect_instagram" }),
+      ]),
+    );
+  });
+
+  it("instagram_optimized connected user generates instagram_optimized diagnosis state", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "instagram_optimized",
+      diagnosisPresentation: makePresentation("instagram_optimized"),
+      instagramConnected: true,
+    });
+
+    expect(result.diagnosisState).toBe("instagram_optimized");
+    expect(result.instagramState).toBe("connected");
+    expect(result.readinessState).toBe("strategic_profile_active");
+    expect(result.statusPills.map((pill) => pill.label)).toContain("Leitura mais precisa");
+  });
+
+  it("mediaKitState is available when hasMediaKit or mediaKitShareUrl exists", () => {
+    expect(resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      hasMediaKit: true,
+    }).mediaKitState).toBe("available");
+
+    expect(resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      mediaKitShareUrl: "https://data2content.test/media-kit/demo",
+    }).mediaKitState).toBe("available");
+  });
+
+  it("mediaKitState does not create a new Media Kit experience", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "instagram_optimized",
+      diagnosisPresentation: makePresentation("instagram_optimized"),
+      instagramConnected: true,
+      hasMediaKit: true,
+    });
+
+    expect(result.mediaKitState).toBe("available");
+    expect(allText(result)).toContain("mídia kit existente");
+    expect(allText(result)).not.toContain("novo card");
+    expect(allText(result)).not.toContain("mediakitview");
+  });
+
+  it("Comunidade is only modeled as a future existing destination without feed or chat", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      diagnosisPresentation: makePresentation("free"),
+      accessLevel: "free",
+    });
+    const communityAction = result.recommendedActions.find((item) => item.id === "community-future");
+
+    expect(communityAction).toMatchObject({
+      label: "Comunidade",
+      disabled: true,
+    });
+    expect(communityAction?.description).toContain("Destino existente de navegação futura");
+    expect(allText(result)).not.toContain("feed");
+    expect(allText(result)).not.toContain("comentários");
+  });
+
+  it("does not use signal or narrative counts as primary status", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "premium",
+      diagnosisPresentation: makePresentation("premium"),
+      hasPremiumAccess: true,
+    });
+    const statusText = result.statusPills.map((pill) => pill.label).join(" ").toLowerCase();
+
+    expect(statusText).not.toContain("18 sinais");
+    expect(statusText).not.toContain("3 narrativas");
+    expect(statusText).not.toContain("percentual");
+  });
+
+  it("copies do not use forbidden product terms", () => {
+    const result = resolveMobileStrategicProfileState({
+      isAuthenticated: true,
+      accessLevel: "free",
+      diagnosisPresentation: makePresentation("free"),
+      instagramConnected: false,
+      hasMediaKit: false,
+    });
+    const text = allText(result);
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "18 sinais",
+      "3 narrativas",
+      "percentual de perfil",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("sanitizes dangerous text", () => {
+    expect(sanitizeMobileStrategicProfileText(
+      "score, ranking, match real, marca garantida e patrocínio garantido",
+    )).toBe("leitura, mapa, indicação futura, território possível e oportunidade futura");
+  });
+
+  it("does not import React components", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).not.toContain("React");
+    expect(importLines).not.toContain(".tsx");
+    expect(importLines).not.toContain("LoginClient");
+    expect(importLines).not.toContain("MediaKitView");
+    expect(importLines).not.toContain("MediaKitSnapshot");
+  });
+
+  it("does not import forbidden integrations", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "fetch",
+      "Prisma",
+      "banco",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "SDK",
+      "app/api",
+      "storage",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+
+  it("does not alter endpoint, LoginClient, NextAuth, MediaKitView, Community, navigation or ActivationPendingWidget", () => {
+    const source = fs.readFileSync(CONTRACT_SOURCE_PATH, "utf8");
+
+    for (const forbidden of [
+      "src/app/api/auth/[...nextauth]/route",
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "ActivationPendingWidget",
+      "Sidebar",
+      "navigation",
+      "route.ts",
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.ts
@@ -1,0 +1,466 @@
+import type { VideoNarrativeDiagnosisAccessLevel } from "./videoNarrativeDiagnosisLearningModel";
+import {
+  sanitizeVideoNarrativeDiagnosisPresentationText,
+  type VideoNarrativeDiagnosisPresentation,
+} from "./videoNarrativeDiagnosisPresentationModel";
+
+export type MobileStrategicProfileAuthState = "anonymous" | "authenticated";
+export type MobileStrategicProfileAvailability = "auth_gate" | "construction" | "active";
+export type MobileStrategicProfileReadinessState =
+  | "account_only"
+  | "first_diagnosis_pending"
+  | "first_reading_ready"
+  | "instagram_connected"
+  | "strategic_profile_active";
+export type MobileStrategicProfileDiagnosisState =
+  | "empty"
+  | "first_reading"
+  | "limited"
+  | "complete"
+  | "instagram_optimized";
+export type MobileStrategicProfileMediaKitState =
+  | "unavailable"
+  | "connect_instagram_required"
+  | "available";
+export type MobileStrategicProfileInstagramState = "disconnected" | "connected" | "reconnect_required";
+export type MobileStrategicProfileSubscriptionState = "free" | "premium" | "trial" | "inactive";
+export type MobileStrategicProfilePrimaryIntent =
+  | "view_profile"
+  | "analyze_video"
+  | "connect_instagram"
+  | "share_media_kit"
+  | "upgrade"
+  | "continue_diagnosis";
+
+export interface MobileStrategicProfileRecommendedAction {
+  id: string;
+  intent: MobileStrategicProfilePrimaryIntent;
+  label: string;
+  description: string;
+  priority: "primary" | "secondary";
+  disabled: boolean;
+}
+
+export interface MobileStrategicProfileStatusPill {
+  id: string;
+  label: string;
+  tone: "neutral" | "construction" | "active" | "premium" | "instagram" | "warning";
+}
+
+export interface MobileStrategicProfileStateSummary {
+  title: string;
+  description: string;
+  helper: string | null;
+}
+
+export interface MobileStrategicProfileStateInput {
+  isAuthenticated: boolean;
+  userName?: string | null;
+  userHandle?: string | null;
+  userImage?: string | null;
+  instagramConnected?: boolean;
+  instagramUsername?: string | null;
+  hasMediaKit?: boolean;
+  mediaKitShareUrl?: string | null;
+  accessLevel?: VideoNarrativeDiagnosisAccessLevel | null;
+  planStatus?: string | null;
+  hasPremiumAccess?: boolean;
+  diagnosisPresentation?: VideoNarrativeDiagnosisPresentation | null;
+  primaryIntent?: MobileStrategicProfilePrimaryIntent;
+  createdAt?: string | null;
+}
+
+export interface MobileStrategicProfileState {
+  authState: MobileStrategicProfileAuthState;
+  profileAvailability: MobileStrategicProfileAvailability;
+  readinessState: MobileStrategicProfileReadinessState;
+  diagnosisState: MobileStrategicProfileDiagnosisState;
+  mediaKitState: MobileStrategicProfileMediaKitState;
+  instagramState: MobileStrategicProfileInstagramState;
+  subscriptionState: MobileStrategicProfileSubscriptionState;
+  primaryIntent: MobileStrategicProfilePrimaryIntent;
+  displayName: string;
+  displayHandle: string | null;
+  userImage: string | null;
+  statusPills: MobileStrategicProfileStatusPill[];
+  recommendedActions: MobileStrategicProfileRecommendedAction[];
+  summary: MobileStrategicProfileStateSummary;
+  createdAt: string | null;
+}
+
+function clean(value: string | null | undefined, fallback = ""): string {
+  const sanitized = sanitizeMobileStrategicProfileText(value ?? "");
+  return sanitized.trim() || fallback;
+}
+
+function sentence(value: string, maxLength = 160): string {
+  const sanitized = clean(value).replace(/\s+/g, " ").trim();
+  if (sanitized.length <= maxLength) return sanitized;
+  return `${sanitized.slice(0, maxLength - 1).trim()}…`;
+}
+
+function action(params: {
+  id: string;
+  intent: MobileStrategicProfilePrimaryIntent;
+  label: string;
+  description: string;
+  priority: "primary" | "secondary";
+  disabled?: boolean;
+}): MobileStrategicProfileRecommendedAction {
+  return {
+    id: clean(params.id),
+    intent: params.intent,
+    label: sentence(params.label, 64),
+    description: sentence(params.description, 150),
+    priority: params.priority,
+    disabled: params.disabled ?? false,
+  };
+}
+
+function pill(
+  id: string,
+  label: string,
+  tone: MobileStrategicProfileStatusPill["tone"],
+): MobileStrategicProfileStatusPill {
+  return {
+    id: clean(id),
+    label: sentence(label, 56),
+    tone,
+  };
+}
+
+function resolveSubscriptionState(input: MobileStrategicProfileStateInput): MobileStrategicProfileSubscriptionState {
+  const normalizedPlan = clean(input.planStatus).toLowerCase();
+  if (input.hasPremiumAccess || input.accessLevel === "premium" || input.accessLevel === "instagram_optimized") {
+    return "premium";
+  }
+  if (normalizedPlan.includes("trial")) return "trial";
+  if (normalizedPlan === "inactive" || normalizedPlan === "canceled" || normalizedPlan === "cancelled") return "inactive";
+  return "free";
+}
+
+function resolveInstagramState(input: MobileStrategicProfileStateInput): MobileStrategicProfileInstagramState {
+  const normalizedUsername = clean(input.instagramUsername);
+  if (input.instagramConnected) return "connected";
+  if (normalizedUsername) return "reconnect_required";
+  return "disconnected";
+}
+
+function resolveMediaKitState(input: MobileStrategicProfileStateInput): MobileStrategicProfileMediaKitState {
+  if (input.hasMediaKit || clean(input.mediaKitShareUrl)) return "available";
+  if (input.instagramConnected || input.instagramUsername) return "unavailable";
+  return "connect_instagram_required";
+}
+
+function resolveDiagnosisState(input: MobileStrategicProfileStateInput): MobileStrategicProfileDiagnosisState {
+  if (!input.diagnosisPresentation) return "empty";
+  if (input.accessLevel === "instagram_optimized" && input.instagramConnected) return "instagram_optimized";
+  if (input.hasPremiumAccess || input.accessLevel === "premium") return "complete";
+  if (input.accessLevel === "free") return "first_reading";
+  return input.diagnosisPresentation.accessLevel === "free" ? "first_reading" : "limited";
+}
+
+function resolveReadinessState(params: {
+  input: MobileStrategicProfileStateInput;
+  diagnosisState: MobileStrategicProfileDiagnosisState;
+  instagramState: MobileStrategicProfileInstagramState;
+  subscriptionState: MobileStrategicProfileSubscriptionState;
+}): MobileStrategicProfileReadinessState {
+  if (!params.input.isAuthenticated) return "account_only";
+  if (params.diagnosisState === "instagram_optimized" || params.subscriptionState === "premium") {
+    return "strategic_profile_active";
+  }
+  if (params.instagramState === "connected" && params.diagnosisState !== "empty") return "instagram_connected";
+  if (params.diagnosisState === "first_reading" || params.diagnosisState === "limited") return "first_reading_ready";
+  return "first_diagnosis_pending";
+}
+
+function defaultIntent(input: MobileStrategicProfileStateInput): MobileStrategicProfilePrimaryIntent {
+  if (input.primaryIntent) return input.primaryIntent;
+  if (!input.isAuthenticated) return "view_profile";
+  if (!input.diagnosisPresentation) return "analyze_video";
+  if (!input.instagramConnected) return "connect_instagram";
+  if (input.hasMediaKit || input.mediaKitShareUrl) return "share_media_kit";
+  return "view_profile";
+}
+
+function buildAnonymousSummary(intent: MobileStrategicProfilePrimaryIntent): MobileStrategicProfileStateSummary {
+  if (intent === "analyze_video") {
+    return {
+      title: "Entre para analisar seu primeiro vídeo",
+      description: "Entre com Google para analisar seu primeiro vídeo.",
+      helper: "O Perfil Estratégico nasce da primeira análise e evolui com novos vídeos.",
+    };
+  }
+
+  return {
+    title: "Crie seu Perfil Estratégico",
+    description: "Entre com Google para criar seu Perfil Estratégico.",
+    helper: "O Perfil da D2C é o diagnóstico vivo do creator. Cada vídeo analisado atualiza esse perfil.",
+  };
+}
+
+function buildAuthenticatedSummary(params: {
+  diagnosisState: MobileStrategicProfileDiagnosisState;
+  readinessState: MobileStrategicProfileReadinessState;
+  subscriptionState: MobileStrategicProfileSubscriptionState;
+  instagramState: MobileStrategicProfileInstagramState;
+  presentation: VideoNarrativeDiagnosisPresentation | null | undefined;
+}): MobileStrategicProfileStateSummary {
+  if (params.diagnosisState === "empty") {
+    return {
+      title: "Seu Perfil Estratégico ainda está começando.",
+      description: "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo.",
+      helper: "O vídeo analisado é temporário; o aprendizado fica organizado no Perfil.",
+    };
+  }
+
+  if (params.diagnosisState === "instagram_optimized") {
+    return {
+      title: "Diagnóstico vivo atualizado",
+      description: "Seu Perfil Estratégico está ativo com leitura mais precisa por estado de Instagram conectado.",
+      helper: "A leitura usa linguagem de estado e não promete performance.",
+    };
+  }
+
+  if (params.subscriptionState === "premium" || params.diagnosisState === "complete") {
+    return {
+      title: "Diagnóstico atualizado",
+      description: "Seu Perfil Estratégico conecta esta leitura aos próximos passos do creator.",
+      helper: params.instagramState === "connected"
+        ? "O Perfil segue evoluindo a cada análise."
+        : "Conectar Instagram pode aumentar a precisão da leitura em uma etapa futura.",
+    };
+  }
+
+  return {
+    title: "Primeira leitura criada.",
+    description: "A D2C já identificou uma direção inicial da sua narrativa.",
+    helper: params.presentation?.readingTimeHint
+      ? sentence(params.presentation.readingTimeHint, 96)
+      : "Novas análises ajudam o Perfil Estratégico a ficar mais completo.",
+  };
+}
+
+function buildStatusPills(params: {
+  profileAvailability: MobileStrategicProfileAvailability;
+  diagnosisState: MobileStrategicProfileDiagnosisState;
+  mediaKitState: MobileStrategicProfileMediaKitState;
+  instagramState: MobileStrategicProfileInstagramState;
+  subscriptionState: MobileStrategicProfileSubscriptionState;
+}): MobileStrategicProfileStatusPill[] {
+  if (params.profileAvailability === "auth_gate") {
+    return [pill("auth-gate", "Login necessário", "warning")];
+  }
+
+  const pills: MobileStrategicProfileStatusPill[] = [];
+  if (params.profileAvailability === "construction") {
+    pills.push(pill("profile-construction", "Perfil em construção", "construction"));
+  } else if (params.diagnosisState === "instagram_optimized") {
+    pills.push(pill("diagnosis-instagram", "Leitura mais precisa", "instagram"));
+  } else if (params.diagnosisState === "complete") {
+    pills.push(pill("diagnosis-complete", "Diagnóstico atualizado", "premium"));
+  } else {
+    pills.push(pill("first-reading", "Primeira leitura", "active"));
+  }
+
+  if (params.subscriptionState === "premium") pills.push(pill("premium", "Premium", "premium"));
+  if (params.instagramState === "connected") pills.push(pill("instagram-connected", "Instagram conectado", "instagram"));
+  if (params.mediaKitState === "available") pills.push(pill("media-kit", "Mídia Kit ativo", "active"));
+
+  return pills;
+}
+
+function buildRecommendedActions(params: {
+  input: MobileStrategicProfileStateInput;
+  primaryIntent: MobileStrategicProfilePrimaryIntent;
+  diagnosisState: MobileStrategicProfileDiagnosisState;
+  mediaKitState: MobileStrategicProfileMediaKitState;
+  instagramState: MobileStrategicProfileInstagramState;
+  subscriptionState: MobileStrategicProfileSubscriptionState;
+}): MobileStrategicProfileRecommendedAction[] {
+  if (!params.input.isAuthenticated) {
+    const label = params.primaryIntent === "analyze_video" ? "Entrar para analisar vídeo" : "Entrar para criar Perfil";
+    const description = params.primaryIntent === "analyze_video"
+      ? "Entre com Google para analisar seu primeiro vídeo."
+      : "Entre com Google para criar seu Perfil Estratégico.";
+
+    return [action({
+      id: "login",
+      intent: params.primaryIntent === "analyze_video" ? "analyze_video" : "view_profile",
+      label,
+      description,
+      priority: "primary",
+    })];
+  }
+
+  const actions: MobileStrategicProfileRecommendedAction[] = [];
+
+  if (params.diagnosisState === "empty") {
+    actions.push(action({
+      id: "analyze-first-video",
+      intent: "analyze_video",
+      label: "Analisar primeiro vídeo",
+      description: "Analise seu primeiro vídeo para começar o Perfil Estratégico.",
+      priority: "primary",
+    }));
+  } else {
+    actions.push(action({
+      id: "analyze-next-video",
+      intent: "analyze_video",
+      label: "Analisar vídeo",
+      description: "Use outro vídeo para atualizar o diagnóstico vivo do creator.",
+      priority: "primary",
+    }));
+  }
+
+  if (params.instagramState !== "connected") {
+    actions.push(action({
+      id: "connect-instagram",
+      intent: "connect_instagram",
+      label: "Conectar Instagram",
+      description: params.subscriptionState === "premium"
+        ? "Conecte Instagram para aumentar a precisão da leitura em uma etapa futura."
+        : "Conecte Instagram para completar o contexto do Perfil.",
+      priority: "secondary",
+    }));
+  }
+
+  if (params.mediaKitState === "available") {
+    actions.push(action({
+      id: "share-media-kit",
+      intent: "share_media_kit",
+      label: "Compartilhar Mídia Kit",
+      description: "Use o Mídia Kit existente como recurso de compartilhamento.",
+      priority: params.diagnosisState === "instagram_optimized" ? "secondary" : "primary",
+    }));
+  } else if (params.mediaKitState === "connect_instagram_required") {
+    actions.push(action({
+      id: "prepare-media-kit",
+      intent: "connect_instagram",
+      label: "Preparar Mídia Kit",
+      description: "Conectar Instagram é o próximo passo para ativar o Mídia Kit existente.",
+      priority: "secondary",
+    }));
+  }
+
+  if (params.subscriptionState === "free" && params.diagnosisState !== "empty") {
+    actions.push(action({
+      id: "upgrade",
+      intent: "upgrade",
+      label: "Ver diagnóstico completo",
+      description: "Desbloqueie uma leitura mais completa do Perfil Estratégico.",
+      priority: "secondary",
+    }));
+  }
+
+  actions.push(action({
+    id: "community-future",
+    intent: "continue_diagnosis",
+    label: "Comunidade",
+    description: "Destino existente de navegação futura, sem recriar experiências sociais neste contrato.",
+    priority: "secondary",
+    disabled: true,
+  }));
+
+  return actions;
+}
+
+export function sanitizeMobileStrategicProfileText(value: string): string {
+  const replacements: Array<[RegExp, string]> = [
+    [/viralizar garantido/gi, "crescer com consistência"],
+    [/patroc[ií]nio garantido/gi, "oportunidade futura"],
+    [/marca garantida/gi, "território possível"],
+    [/publi garantida/gi, "possibilidade comercial"],
+    [/match real/gi, "indicação futura"],
+    [/match comprovado/gi, "fit narrativo"],
+    [/resultado garantido/gi, "próximo passo"],
+    [/\bviralizar\b/gi, "crescer com consistência"],
+    [/\bscore\b/gi, "leitura"],
+    [/\bnota\b/gi, "leitura"],
+    [/\bpontos\b/gi, "sinais"],
+    [/\branking\b/gi, "mapa"],
+    [/\bgabarito\b/gi, "direção"],
+    [/\bgarantido\b/gi, "possível"],
+    [/\bcerteza\b/gi, "leitura"],
+    [/\bcomprovado\b/gi, "observado"],
+    [/\b18 sinais\b/gi, "sinais do Perfil"],
+    [/\b3 narrativas\b/gi, "direções narrativas"],
+    [/\bpercentual de perfil\b/gi, "estado do Perfil"],
+  ];
+
+  const locallySanitized = replacements.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    value,
+  );
+
+  return sanitizeVideoNarrativeDiagnosisPresentationText(locallySanitized);
+}
+
+export function resolveMobileStrategicProfileState(
+  input: MobileStrategicProfileStateInput,
+): MobileStrategicProfileState {
+  const primaryIntent = defaultIntent(input);
+  const authState: MobileStrategicProfileAuthState = input.isAuthenticated ? "authenticated" : "anonymous";
+  const instagramState = resolveInstagramState(input);
+  const mediaKitState = input.isAuthenticated ? resolveMediaKitState(input) : "unavailable";
+  const subscriptionState = resolveSubscriptionState(input);
+  const diagnosisState = input.isAuthenticated ? resolveDiagnosisState(input) : "empty";
+  const profileAvailability: MobileStrategicProfileAvailability = !input.isAuthenticated
+    ? "auth_gate"
+    : diagnosisState === "empty"
+      ? "construction"
+      : "active";
+  const readinessState = resolveReadinessState({
+    input,
+    diagnosisState,
+    instagramState,
+    subscriptionState,
+  });
+  const summary = !input.isAuthenticated
+    ? buildAnonymousSummary(primaryIntent)
+    : buildAuthenticatedSummary({
+      diagnosisState,
+      readinessState,
+      subscriptionState,
+      instagramState,
+      presentation: input.diagnosisPresentation,
+    });
+  const statusPills = buildStatusPills({
+    profileAvailability,
+    diagnosisState,
+    mediaKitState,
+    instagramState,
+    subscriptionState,
+  });
+  const recommendedActions = buildRecommendedActions({
+    input,
+    primaryIntent,
+    diagnosisState,
+    mediaKitState,
+    instagramState,
+    subscriptionState,
+  });
+
+  return {
+    authState,
+    profileAvailability,
+    readinessState,
+    diagnosisState,
+    mediaKitState,
+    instagramState,
+    subscriptionState,
+    primaryIntent,
+    displayName: clean(input.userName, "Creator"),
+    displayHandle: clean(input.userHandle) || clean(input.instagramUsername) || null,
+    userImage: clean(input.userImage) || null,
+    statusPills,
+    recommendedActions,
+    summary: {
+      title: sentence(summary.title, 96),
+      description: sentence(summary.description, 180),
+      helper: summary.helper ? sentence(summary.helper, 180) : null,
+    },
+    createdAt: clean(input.createdAt) || input.diagnosisPresentation?.createdAt || null,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #839.

MM43 adds a pure state contract for the mobile Strategic Profile, positioning the profile as the creator's living diagnosis.

Changes:
- Adds `mobileStrategicProfileStateContract.ts` with `resolveMobileStrategicProfileState(input)`.
- Models auth, profile availability, readiness, diagnosis, Instagram, Media Kit, subscription, status pills, recommended actions, and summary copy.
- Covers anonymous, Gmail-only/account-only, first reading, premium, and Instagram optimized states.
- Treats Media Kit as an existing resource only, without recreating or changing `MediaKitView`.
- Treats Community as an existing future navigation destination, without creating feed/chat/comments.
- Updates docs for MM43.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, schema, or Prisma changes.
- No endpoint changes.
- No `LoginClient` changes.
- No NextAuth changes.
- No `MediaKitView` changes.
- No real Community changes.
- No real navigation/sidebar changes.
- No real Instagram integration.
- No real billing or Stripe integration.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeAccessTierDiagnosisRules.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeEvolvingDiagnosisContract.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings outside this scope in `src/app/brand-report/[slug]/page.tsx` and `src/app/dashboard/boards/components/BrandNarrativeMatchesPanel.tsx`.