### PR TITLE
feat: add mobile strategic profile mapping layer

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -110,6 +110,8 @@ Já existe:
 - MM42 materializa o presentation model na preview interna, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage e não cria UI pública;
 - strategic profile state contract foi criado em MM43 como camada segura de contrato/produto;
 - MM43 modela o Perfil Estratégico mobile como diagnóstico vivo do creator, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
+- strategic profile mapping layer foi criado em MM44 como camada segura de contrato/mapping;
+- MM44 monta um `MobileStrategicProfile` consumível pela futura UI, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1009,6 +1009,32 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing, Stripe, match real de marcas ou creators.
 
+### MM44 — Strategic Profile Mapping Layer
+
+Status: concluído.
+
+Arquivos principais:
+
+- `mobileStrategicProfileMapping.ts`
+- `mobileStrategicProfileMapping.test.ts`
+
+O que faz:
+
+- cria camada pura que transforma estado do Perfil + diagnóstico em um `MobileStrategicProfile`;
+- monta header, tabs internas, seções, ações, bridges de Mídia Kit/Comunidade e navegação mobile futura;
+- mantém o Perfil Estratégico como diagnóstico vivo do creator;
+- usa `VideoNarrativeDiagnosisPresentation` para alimentar a aba Diagnóstico;
+- traduz Comercial como leitura interna do diagnóstico, sem substituir Mídia Kit;
+- mantém Mídia Kit e Comunidade como recursos existentes, não recriados.
+
+O que não faz:
+
+- não cria UI, preview visual, nova navegação real, nova página de diagnóstico ou histórico visual;
+- não altera endpoint, NextAuth, `LoginClient`, navegação/sidebar, `ActivationPendingWidget`, Mídia Kit real, `MediaKitView` ou Comunidade real;
+- não cria persistência, banco/tabela, schema, Prisma, upload real ou storage real;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing, Stripe, match real de marcas ou creators.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -250,8 +250,9 @@ Exemplos:
 40. MM41 — Evolving Diagnosis Preview Scenarios. Conecta os contratos evolutivos ao builder mockado da preview interna, sem alterar UI visual.
 41. MM42 — Mobile Diagnosis UI Refactor. Materializa o presentation model na UI interna do diagnóstico, com layout mobile-first.
 42. MM43 — Strategic Profile State Contract. Modela o Perfil Estratégico mobile como diagnóstico vivo do creator, sem UI real.
-43. Teste real manual quando houver quota/billing disponível.
-44. Integração experimental futura no Board de Criação.
+43. MM44 — Strategic Profile Mapping Layer. Monta o modelo consumível do Perfil Estratégico mobile a partir do estado e do diagnóstico.
+44. Teste real manual quando houver quota/billing disponível.
+45. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -330,6 +331,8 @@ MM41 conecta a cadeia de contratos ao builder da preview interna. A preview pass
 MM42 é a primeira materialização visual do presentation model. A preview interna passa a renderizar o diagnóstico a partir de `VideoNarrativeDiagnosisPresentation`, com hero, cards prioritários, CTAs, seções e previews bloqueados em layout mobile-first. Os componentes não devem reconstruir lógica de tier diretamente; essa lógica permanece nas camadas MM39/MM40.
 
 MM43 adiciona `MobileStrategicProfileState` como contrato puro para a experiência mobile do Perfil Estratégico. O diagnóstico deixa de ser tratado como uma página isolada e passa a alimentar o Perfil: a análise de vídeo é uma ação temporária que atualiza o diagnóstico vivo do creator. O Perfil existe desde o login, mas pode estar em construção até a primeira leitura. Mídia Kit e Comunidade continuam sendo recursos existentes acessados pelo Perfil ou pela navegação futura; MM43 apenas modela disponibilidade, intenção e próximos passos, sem recriar Mídia Kit, `MediaKitView`, Comunidade, feed ou navegação real.
+
+MM44 adiciona `MobileStrategicProfile` como mapping puro acima de MM43. MM43 resolve os estados do Perfil; MM44 monta a estrutura consumível pela futura UI: header, tabs internas, seções, ações, bridges e navegação mobile futura. `VideoNarrativeDiagnosisPresentation` alimenta a aba Diagnóstico. A seção Comercial é uma tradução interna do diagnóstico para potencial comercial, não substitui Mídia Kit. Mídia Kit e Comunidade aparecem como bridges para recursos existentes, sem recriar `MediaKitView`, Comunidade, navegação real ou páginas públicas.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts
@@ -1,0 +1,475 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildMobileStrategicProfile,
+  type MobileStrategicProfile,
+} from "./mobileStrategicProfileMapping";
+import {
+  resolveMobileStrategicProfileState,
+  type MobileStrategicProfileState,
+} from "./mobileStrategicProfileStateContract";
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+
+const MAPPING_SOURCE_PATH = path.join(__dirname, "mobileStrategicProfileMapping.ts");
+
+function makePresentation(
+  accessLevel: VideoNarrativeDiagnosisPresentation["accessLevel"] = "free",
+): VideoNarrativeDiagnosisPresentation {
+  return {
+    id: `presentation-${accessLevel}`,
+    accessLevel,
+    hero: {
+      title: accessLevel === "instagram_optimized"
+        ? "Diagnóstico otimizado com contexto de Instagram"
+        : accessLevel === "premium"
+          ? "Seu mapa estratégico foi atualizado"
+          : "Primeira leitura do seu vídeo",
+      subtitle: "O Perfil da D2C é o diagnóstico vivo do creator.",
+      badge: {
+        id: "hero-badge",
+        label: accessLevel === "instagram_optimized" ? "Leitura mais precisa" : "Diagnóstico atualizado",
+        tone: accessLevel === "instagram_optimized" ? "instagram" : "neutral",
+      },
+      levelLabel: "Perfil em evolução",
+      nextLevelLabel: "Perfil estratégico",
+      precisionLabel: "Leitura de estado",
+    },
+    priorityCards: [
+      {
+        id: "main-reading",
+        title: "O que este vídeo comunica",
+        body: "Este vídeo comunica rotina, contexto e próximo passo.",
+        tone: "insight",
+        priority: "high",
+        locked: false,
+      },
+      {
+        id: "primary-adjustment",
+        title: "Ajuste mais importante",
+        body: "Abrir com a direção antes do contexto.",
+        tone: "action",
+        priority: "high",
+        locked: false,
+      },
+    ],
+    sections: [
+      {
+        id: "video_diagnosis",
+        title: "Diagnóstico do vídeo",
+        description: "Leitura prática do vídeo.",
+        visible: true,
+        collapsedByDefault: false,
+        cards: [
+          {
+            id: "video-main",
+            title: "Narrativa",
+            body: "Rotina com direção estratégica.",
+            tone: "insight",
+            priority: "high",
+            locked: false,
+          },
+        ],
+      },
+      {
+        id: "brand_opportunities",
+        title: "Oportunidades futuras de marca",
+        description: "Territórios possíveis e fit narrativo.",
+        visible: accessLevel !== "free",
+        collapsedByDefault: true,
+        cards: [
+          {
+            id: "brand-availability",
+            title: "Território possível",
+            body: "Oportunidade futura de marca por território e fit narrativo.",
+            tone: "opportunity",
+            priority: "medium",
+            locked: false,
+          },
+        ],
+      },
+      {
+        id: "collab_opportunities",
+        title: "Tipos de collab futuros",
+        description: "Caminhos possíveis por tipo de oportunidade futura.",
+        visible: accessLevel !== "free",
+        collapsedByDefault: true,
+        cards: [
+          {
+            id: "collab-availability",
+            title: "Tipo de collab futuro",
+            body: "Tipos de collab possíveis por formato, autoridade e ponte de audiência.",
+            tone: "opportunity",
+            priority: "medium",
+            locked: false,
+          },
+        ],
+      },
+      {
+        id: "instagram_precision",
+        title: "Precisão com Instagram",
+        description: "Contexto de Instagram para leitura mais precisa.",
+        visible: accessLevel === "instagram_optimized",
+        collapsedByDefault: true,
+        cards: [
+          {
+            id: "instagram-context",
+            title: "Leitura mais precisa",
+            body: "Leitura mais precisa por estado de Instagram conectado.",
+            tone: "insight",
+            priority: "high",
+            locked: false,
+          },
+        ],
+      },
+    ],
+    lockedPreviews: [],
+    primaryCTA: {
+      label: accessLevel === "free" ? "Desbloquear diagnóstico completo" : "Gerar próximo movimento estratégico",
+      action: accessLevel === "free" ? "upgrade" : "generate_next_strategic_move",
+      helper: "Próximo passo",
+    },
+    secondaryCTA: null,
+    badges: [],
+    readingTimeHint: "Leitura rápida",
+    createdAt: "2026-05-19T00:00:00.000Z",
+  };
+}
+
+function makeState(params: {
+  isAuthenticated?: boolean;
+  accessLevel?: VideoNarrativeDiagnosisPresentation["accessLevel"] | null;
+  diagnosisPresentation?: VideoNarrativeDiagnosisPresentation | null;
+  instagramConnected?: boolean;
+  hasPremiumAccess?: boolean;
+  hasMediaKit?: boolean;
+  mediaKitShareUrl?: string | null;
+  primaryIntent?: "view_profile" | "analyze_video";
+} = {}): MobileStrategicProfileState {
+  return resolveMobileStrategicProfileState({
+    isAuthenticated: params.isAuthenticated ?? true,
+    accessLevel: params.accessLevel,
+    diagnosisPresentation: params.diagnosisPresentation,
+    instagramConnected: params.instagramConnected,
+    hasPremiumAccess: params.hasPremiumAccess,
+    hasMediaKit: params.hasMediaKit,
+    mediaKitShareUrl: params.mediaKitShareUrl,
+    primaryIntent: params.primaryIntent,
+    userName: "Ana Creator",
+    userHandle: "@ana",
+  });
+}
+
+function build(params: {
+  state?: MobileStrategicProfileState;
+  presentation?: VideoNarrativeDiagnosisPresentation | null;
+  creatorBio?: string | null;
+  mediaKitShareUrl?: string | null;
+  mediaKitEditUrl?: string | null;
+  mediaKitPublicUrl?: string | null;
+  communityHref?: string | null;
+  loginHref?: string | null;
+}): MobileStrategicProfile {
+  return buildMobileStrategicProfile({
+    state: params.state ?? makeState(),
+    diagnosisPresentation: params.presentation,
+    creatorBio: params.creatorBio,
+    mediaKitShareUrl: params.mediaKitShareUrl,
+    mediaKitEditUrl: params.mediaKitEditUrl,
+    mediaKitPublicUrl: params.mediaKitPublicUrl,
+    communityHref: params.communityHref,
+    loginHref: params.loginHref,
+    profileHref: "/dashboard/profile",
+    analyzeVideoHref: "/dashboard/analyze",
+  });
+}
+
+function textOf(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("mobileStrategicProfileMapping", () => {
+  it("anonymous user builds authGate and does not build real diagnosis", () => {
+    const state = makeState({ isAuthenticated: false, primaryIntent: "view_profile" });
+    const result = build({ state, loginHref: "/login" });
+
+    expect(result.authGate.visible).toBe(true);
+    expect(result.authGate.description).toBe("Entre com Google para criar seu Perfil Estratégico.");
+    expect(result.authGate.action).toMatchObject({ href: "/login", intent: "view_profile" });
+    expect(result.sections).toEqual([]);
+    expect(result.tabs).toEqual([]);
+  });
+
+  it("anonymous with analyze_video intent builds login copy to analyze first video", () => {
+    const state = makeState({ isAuthenticated: false, primaryIntent: "analyze_video" });
+    const result = build({ state, loginHref: "/login?callbackUrl=/dashboard/analyze" });
+
+    expect(result.authGate.description).toBe("Entre com Google para analisar seu primeiro vídeo.");
+    expect(result.authGate.action).toMatchObject({ label: "Entrar para analisar vídeo" });
+  });
+
+  it("construction profile builds header, empty diagnosis section and Analisar primeiro vídeo action", () => {
+    const result = build({ state: makeState({ diagnosisPresentation: null, instagramConnected: false }) });
+
+    expect(result.constructionState.visible).toBe(true);
+    expect(result.header.identity.displayName).toBe("Ana Creator");
+    expect(result.header.statusPills.map((pill) => pill.label)).toContain("Perfil em construção");
+    expect(result.sections.find((section) => section.id === "diagnosis")).toMatchObject({
+      state: "construction",
+      title: "Diagnóstico",
+    });
+    expect(result.primaryActions[0]).toMatchObject({ label: "Analisar primeiro vídeo", intent: "analyze_video" });
+  });
+
+  it("construction profile does not show Media Kit Bridge as available", () => {
+    const result = build({ state: makeState({ diagnosisPresentation: null, instagramConnected: false }) });
+
+    expect(result.mediaKitBridge.state).not.toBe("available");
+    expect(result.mediaKitBridge.actions).toEqual([]);
+  });
+
+  it("first reading builds diagnosis and commercial tabs", () => {
+    const presentation = makePresentation("free");
+    const state = makeState({ accessLevel: "free", diagnosisPresentation: presentation, instagramConnected: false });
+    const result = build({ state, presentation });
+
+    expect(result.tabs.map((tab) => tab.id)).toEqual(["diagnosis", "commercial"]);
+    expect(result.activeTab).toBe("diagnosis");
+  });
+
+  it("first reading uses diagnosisPresentation for Diagnosis section", () => {
+    const presentation = makePresentation("free");
+    const state = makeState({ accessLevel: "free", diagnosisPresentation: presentation, instagramConnected: false });
+    const result = build({ state, presentation });
+    const diagnosis = result.sections.find((section) => section.id === "diagnosis");
+
+    expect(diagnosis?.cards).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "diagnosis-hero", title: "Primeira leitura do seu vídeo", source: "diagnosisPresentation" }),
+        expect.objectContaining({ id: "main-reading", source: "diagnosisPresentation" }),
+      ]),
+    );
+  });
+
+  it("free without Instagram creates secondary connect Instagram action", () => {
+    const presentation = makePresentation("free");
+    const state = makeState({ accessLevel: "free", diagnosisPresentation: presentation, instagramConnected: false });
+    const result = build({ state, presentation });
+
+    expect(result.primaryActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "connect-instagram", intent: "connect_instagram", priority: "secondary" }),
+      ]),
+    );
+  });
+
+  it("premium builds fuller Commercial section without brand promise", () => {
+    const presentation = makePresentation("premium");
+    const state = makeState({
+      accessLevel: "premium",
+      diagnosisPresentation: presentation,
+      hasPremiumAccess: true,
+      instagramConnected: false,
+    });
+    const result = build({ state, presentation });
+    const commercial = result.sections.find((section) => section.id === "commercial");
+    const text = textOf(commercial);
+
+    expect(commercial?.state).toBe("ready");
+    expect(text).toContain("oportunidade futura");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("marca garantida");
+    expect(text).not.toContain("patrocínio garantido");
+  });
+
+  it("instagram optimized builds more precise reading without promising performance", () => {
+    const presentation = makePresentation("instagram_optimized");
+    const state = makeState({
+      accessLevel: "instagram_optimized",
+      diagnosisPresentation: presentation,
+      instagramConnected: true,
+    });
+    const result = build({ state, presentation });
+    const text = textOf(result.sections.find((section) => section.id === "diagnosis"));
+
+    expect(result.sections.find((section) => section.id === "diagnosis")?.title).toContain("leitura mais precisa");
+    expect(text).toContain("leitura mais precisa");
+    expect(text).not.toContain("performance garantida");
+    expect(text).not.toContain("resultado garantido");
+  });
+
+  it("Media Kit Bridge is available only when state.mediaKitState is available", () => {
+    const presentation = makePresentation("instagram_optimized");
+    const availableState = makeState({
+      accessLevel: "instagram_optimized",
+      diagnosisPresentation: presentation,
+      instagramConnected: true,
+      hasMediaKit: true,
+    });
+    const unavailableState = makeState({
+      accessLevel: "free",
+      diagnosisPresentation: makePresentation("free"),
+      instagramConnected: false,
+      hasMediaKit: false,
+    });
+
+    expect(build({ state: availableState, presentation, mediaKitShareUrl: "/media-kit/me" }).mediaKitBridge.state).toBe("available");
+    expect(build({ state: unavailableState, presentation: makePresentation("free") }).mediaKitBridge.state).not.toBe("available");
+  });
+
+  it("Media Kit Bridge does not include internal diagnosis, QR Code or new MediaKitView", () => {
+    const presentation = makePresentation("instagram_optimized");
+    const state = makeState({
+      accessLevel: "instagram_optimized",
+      diagnosisPresentation: presentation,
+      instagramConnected: true,
+      hasMediaKit: true,
+    });
+    const result = build({
+      state,
+      presentation,
+      mediaKitShareUrl: "/media-kit/me",
+      mediaKitEditUrl: "/dashboard/media-kit",
+      mediaKitPublicUrl: "/mediakit/ana",
+    });
+    const text = textOf(result.mediaKitBridge);
+
+    expect(text).toContain("mídia kit existente");
+    expect(text).not.toContain("diagnóstico interno");
+    expect(text).not.toContain("qr code");
+    expect(text).not.toContain("mediakitview");
+  });
+
+  it("Community appears only as bridge and existing destination, without social surface modeling", () => {
+    const presentation = makePresentation("free");
+    const state = makeState({ accessLevel: "free", diagnosisPresentation: presentation });
+    const result = build({ state, presentation, communityHref: "/community" });
+    const text = textOf(result.communityBridge);
+
+    expect(result.communityBridge).toMatchObject({
+      visible: true,
+      label: "Comunidade",
+      href: "/community",
+      description: "Destino existente da Comunidade Data2Content.",
+    });
+    expect(text).not.toContain("comments");
+    expect(text).not.toContain("posts");
+    expect(text).not.toContain("creators");
+  });
+
+  it("navigation contains profile, central analyze_video and community", () => {
+    const result = build({ state: makeState({ diagnosisPresentation: null }) });
+
+    expect(result.navigation.items).toEqual([
+      expect.objectContaining({ id: "profile", role: "destination", active: true }),
+      expect.objectContaining({ id: "analyze_video", role: "central_action" }),
+      expect.objectContaining({ id: "community", role: "destination" }),
+    ]);
+  });
+
+  it("navigation does not contain media_kit, diagnosis or commercial as global tabs", () => {
+    const result = build({ state: makeState({ diagnosisPresentation: null }) });
+    const ids = result.navigation.items.map((item) => item.id);
+
+    expect(ids).not.toContain("media_kit");
+    expect(ids).not.toContain("diagnosis");
+    expect(ids).not.toContain("commercial");
+  });
+
+  it("does not create analyzed videos section", () => {
+    const presentation = makePresentation("premium");
+    const state = makeState({ accessLevel: "premium", diagnosisPresentation: presentation, hasPremiumAccess: true });
+    const result = build({ state, presentation });
+
+    expect(result.sections.map((section) => section.id)).not.toContain("videos");
+    expect(textOf(result)).not.toContain("vídeos analisados");
+  });
+
+  it("does not use signal or narrative counts as primary highlight", () => {
+    const presentation = makePresentation("premium");
+    const state = makeState({ accessLevel: "premium", diagnosisPresentation: presentation, hasPremiumAccess: true });
+    const result = build({ state, presentation, creatorBio: "18 sinais e 3 narrativas com percentual de perfil" });
+
+    const headerText = textOf(result.header);
+    expect(headerText).not.toContain("18 sinais");
+    expect(headerText).not.toContain("3 narrativas");
+    expect(headerText).not.toContain("percentual de perfil");
+  });
+
+  it("copies do not use forbidden terms", () => {
+    const presentation = makePresentation("premium");
+    const state = makeState({ accessLevel: "premium", diagnosisPresentation: presentation, hasPremiumAccess: true });
+    const result = build({ state, presentation });
+    const text = textOf(result);
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "18 sinais",
+      "3 narrativas",
+      "percentual de perfil",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("sanitizes dangerous text", () => {
+    const result = build({
+      state: makeState({ diagnosisPresentation: null }),
+      creatorBio: "score, ranking, match real, marca garantida e patrocínio garantido",
+    });
+
+    expect(result.header.identity.bio).toContain("leitura");
+    expect(result.header.identity.bio).toContain("mapa");
+    expect(result.header.identity.bio).toContain("indicação futura");
+    expect(result.header.identity.bio).not.toContain("score");
+    expect(result.header.identity.bio).not.toContain("match real");
+  });
+
+  it("does not import React components", () => {
+    const importLines = fs.readFileSync(MAPPING_SOURCE_PATH, "utf8")
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).not.toContain("React");
+    expect(importLines).not.toContain(".tsx");
+    expect(importLines).not.toContain("LoginClient");
+    expect(importLines).not.toContain("MediaKitView");
+  });
+
+  it("does not import forbidden integrations", () => {
+    const importLines = fs.readFileSync(MAPPING_SOURCE_PATH, "utf8")
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of ["fetch", "Prisma", "banco", "Gemini", "OpenAI", "Stripe", "SDK", "app/api", "storage"]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+
+  it("does not alter endpoint, LoginClient, NextAuth, MediaKitView, Community, real navigation or ActivationPendingWidget", () => {
+    const source = fs.readFileSync(MAPPING_SOURCE_PATH, "utf8");
+
+    for (const forbidden of [
+      "src/app/api/auth/[...nextauth]/route",
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "ActivationPendingWidget",
+      "Sidebar",
+      "route.ts",
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
@@ -1,0 +1,513 @@
+import {
+  sanitizeMobileStrategicProfileText,
+  type MobileStrategicProfileMediaKitState,
+  type MobileStrategicProfilePrimaryIntent,
+  type MobileStrategicProfileRecommendedAction,
+  type MobileStrategicProfileState,
+  type MobileStrategicProfileStatusPill,
+} from "./mobileStrategicProfileStateContract";
+import type {
+  VideoNarrativeDiagnosisPresentation,
+  VideoNarrativeDiagnosisPresentationCard,
+  VideoNarrativeDiagnosisPresentationSection,
+} from "./videoNarrativeDiagnosisPresentationModel";
+
+export interface MobileStrategicProfileInput {
+  state: MobileStrategicProfileState;
+  diagnosisPresentation?: VideoNarrativeDiagnosisPresentation | null;
+  creatorBio?: string | null;
+  mediaKitShareUrl?: string | null;
+  mediaKitEditUrl?: string | null;
+  mediaKitPublicUrl?: string | null;
+  communityHref?: string | null;
+  profileHref?: string | null;
+  analyzeVideoHref?: string | null;
+  loginHref?: string | null;
+  createdAt?: string | null;
+}
+
+export interface MobileStrategicProfileAuthGate {
+  visible: boolean;
+  title: string;
+  description: string;
+  action: MobileStrategicProfileAction | null;
+}
+
+export interface MobileStrategicProfileIdentity {
+  displayName: string;
+  displayHandle: string | null;
+  userImage: string | null;
+  bio: string | null;
+}
+
+export interface MobileStrategicProfileHeader {
+  title: string;
+  subtitle: string;
+  identity: MobileStrategicProfileIdentity;
+  statusPills: MobileStrategicProfileStatusPill[];
+  primaryActionLabel: string | null;
+  secondaryActionLabel: string | null;
+}
+
+export interface MobileStrategicProfileTab {
+  id: "diagnosis" | "commercial";
+  label: string;
+  active: boolean;
+}
+
+export interface MobileStrategicProfileSectionCard {
+  id: string;
+  title: string;
+  body: string;
+  tone: "neutral" | "diagnosis" | "commercial" | "action" | "locked";
+  source: "state" | "diagnosisPresentation" | "bridge";
+  locked: boolean;
+}
+
+export interface MobileStrategicProfileSection {
+  id: "diagnosis" | "commercial";
+  title: string;
+  description: string;
+  state: "hidden" | "construction" | "ready" | "limited";
+  cards: MobileStrategicProfileSectionCard[];
+}
+
+export interface MobileStrategicProfileAction {
+  id: string;
+  intent: MobileStrategicProfilePrimaryIntent | "copy_link" | "view_as_brand" | "edit_or_open_media_kit";
+  label: string;
+  description: string;
+  href: string | null;
+  priority: "primary" | "secondary";
+  disabled: boolean;
+}
+
+export interface MobileStrategicProfileMediaKitBridge {
+  state: MobileStrategicProfileMediaKitState | "hidden";
+  title: string | null;
+  description: string | null;
+  href: string | null;
+  actions: MobileStrategicProfileAction[];
+}
+
+export interface MobileStrategicProfileCommunityBridge {
+  visible: boolean;
+  label: "Comunidade";
+  href: string;
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationModel {
+  items: Array<{
+    id: "profile" | "analyze_video" | "community";
+    label: string;
+    href: string | null;
+    role: "destination" | "central_action";
+    active: boolean;
+  }>;
+}
+
+export interface MobileStrategicProfileConstructionState {
+  visible: boolean;
+  title: string;
+  description: string;
+  recommendedActionLabel: string | null;
+}
+
+export interface MobileStrategicProfile {
+  id: string;
+  state: MobileStrategicProfileState;
+  authGate: MobileStrategicProfileAuthGate;
+  header: MobileStrategicProfileHeader;
+  tabs: MobileStrategicProfileTab[];
+  activeTab: "diagnosis" | "commercial" | null;
+  sections: MobileStrategicProfileSection[];
+  primaryActions: MobileStrategicProfileAction[];
+  mediaKitBridge: MobileStrategicProfileMediaKitBridge;
+  communityBridge: MobileStrategicProfileCommunityBridge;
+  navigation: MobileStrategicProfileNavigationModel;
+  constructionState: MobileStrategicProfileConstructionState;
+  createdAt: string | null;
+}
+
+function clean(value: string | null | undefined, fallback = ""): string {
+  const sanitized = sanitizeMobileStrategicProfileText(value ?? "");
+  return sanitized.trim() || fallback;
+}
+
+function sentence(value: string, maxLength = 180): string {
+  const sanitized = clean(value).replace(/\s+/g, " ").trim();
+  if (sanitized.length <= maxLength) return sanitized;
+  return `${sanitized.slice(0, maxLength - 1).trim()}…`;
+}
+
+function href(value: string | null | undefined): string | null {
+  return clean(value) || null;
+}
+
+function profileAction(
+  params: Omit<MobileStrategicProfileAction, "id" | "label" | "description" | "href"> & {
+    id: string;
+    label: string;
+    description: string;
+    href?: string | null;
+  },
+): MobileStrategicProfileAction {
+  return {
+    id: clean(params.id),
+    intent: params.intent,
+    label: sentence(params.label, 72),
+    description: sentence(params.description, 150),
+    href: href(params.href),
+    priority: params.priority,
+    disabled: params.disabled,
+  };
+}
+
+function card(params: {
+  id: string;
+  title: string;
+  body: string;
+  tone: MobileStrategicProfileSectionCard["tone"];
+  source: MobileStrategicProfileSectionCard["source"];
+  locked?: boolean;
+}): MobileStrategicProfileSectionCard {
+  return {
+    id: clean(params.id),
+    title: sentence(params.title, 80),
+    body: sentence(params.body, 190),
+    tone: params.tone,
+    source: params.source,
+    locked: params.locked ?? false,
+  };
+}
+
+function mapActionHref(intent: MobileStrategicProfilePrimaryIntent, input: MobileStrategicProfileInput): string | null {
+  if (intent === "view_profile") return href(input.profileHref);
+  if (intent === "analyze_video") return href(input.analyzeVideoHref);
+  if (intent === "connect_instagram") return null;
+  if (intent === "share_media_kit") return href(input.mediaKitShareUrl ?? input.mediaKitPublicUrl);
+  if (intent === "upgrade") return null;
+  return null;
+}
+
+function actionFromState(action: MobileStrategicProfileRecommendedAction, input: MobileStrategicProfileInput): MobileStrategicProfileAction {
+  return profileAction({
+    id: action.id,
+    intent: action.intent,
+    label: action.label,
+    description: action.description,
+    href: action.id === "login" ? input.loginHref : mapActionHref(action.intent, input),
+    priority: action.priority,
+    disabled: action.disabled,
+  });
+}
+
+function buildAuthGate(input: MobileStrategicProfileInput): MobileStrategicProfileAuthGate {
+  const visible = input.state.profileAvailability === "auth_gate";
+  if (!visible) {
+    return {
+      visible: false,
+      title: "",
+      description: "",
+      action: null,
+    };
+  }
+
+  const loginAction = input.state.recommendedActions[0];
+  return {
+    visible: true,
+    title: sentence(input.state.summary.title),
+    description: sentence(input.state.summary.description),
+    action: loginAction ? actionFromState(loginAction, input) : null,
+  };
+}
+
+function buildHeader(input: MobileStrategicProfileInput): MobileStrategicProfileHeader {
+  const primaryAction = input.state.recommendedActions.find((item) => item.priority === "primary");
+  const secondaryAction = input.state.recommendedActions.find((item) => item.priority === "secondary" && !item.disabled);
+  const bio = clean(input.creatorBio) || input.state.summary.helper;
+
+  return {
+    title: input.state.profileAvailability === "auth_gate" ? "Perfil Estratégico" : input.state.displayName,
+    subtitle: sentence(input.state.summary.description),
+    identity: {
+      displayName: input.state.displayName,
+      displayHandle: input.state.displayHandle,
+      userImage: input.state.userImage,
+      bio: bio ? sentence(bio, 160) : null,
+    },
+    statusPills: input.state.statusPills,
+    primaryActionLabel: primaryAction?.label ?? null,
+    secondaryActionLabel: secondaryAction?.label ?? null,
+  };
+}
+
+function buildTabs(state: MobileStrategicProfileState): MobileStrategicProfileTab[] {
+  if (state.profileAvailability === "auth_gate") return [];
+
+  return [
+    { id: "diagnosis", label: "Diagnóstico", active: true },
+    { id: "commercial", label: "Comercial", active: false },
+  ];
+}
+
+function cardFromPresentation(
+  cardInput: VideoNarrativeDiagnosisPresentationCard,
+  tone: MobileStrategicProfileSectionCard["tone"],
+): MobileStrategicProfileSectionCard {
+  return card({
+    id: cardInput.id,
+    title: cardInput.title,
+    body: cardInput.body,
+    tone,
+    source: "diagnosisPresentation",
+    locked: cardInput.locked,
+  });
+}
+
+function sectionCardsFromPresentation(section: VideoNarrativeDiagnosisPresentationSection): MobileStrategicProfileSectionCard[] {
+  return section.cards.map((item) => cardFromPresentation(item, section.id.includes("brand") || section.id.includes("collab") ? "commercial" : "diagnosis"));
+}
+
+function buildDiagnosisSection(input: MobileStrategicProfileInput): MobileStrategicProfileSection | null {
+  const state = input.state;
+  const presentation = input.diagnosisPresentation;
+  if (state.profileAvailability === "auth_gate") return null;
+
+  if (state.profileAvailability === "construction" || !presentation) {
+    return {
+      id: "diagnosis",
+      title: "Diagnóstico",
+      description: "Seu Perfil Estratégico ainda está começando.",
+      state: "construction",
+      cards: [
+        card({
+          id: "diagnosis-empty",
+          title: "Perfil em construção",
+          body: "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo.",
+          tone: "action",
+          source: "state",
+        }),
+      ],
+    };
+  }
+
+  const cards: MobileStrategicProfileSectionCard[] = [
+    card({
+      id: "diagnosis-hero",
+      title: presentation.hero.title,
+      body: presentation.hero.subtitle,
+      tone: state.diagnosisState === "instagram_optimized" ? "diagnosis" : "neutral",
+      source: "diagnosisPresentation",
+    }),
+    ...presentation.priorityCards.map((item) => cardFromPresentation(item, "diagnosis")),
+    ...presentation.sections
+      .filter((section) => section.visible && !section.id.includes("brand") && !section.id.includes("collab") && section.id !== "subscription_unlocks")
+      .flatMap(sectionCardsFromPresentation),
+  ];
+
+  return {
+    id: "diagnosis",
+    title: state.diagnosisState === "instagram_optimized" ? "Diagnóstico vivo com leitura mais precisa" : "Diagnóstico vivo",
+    description: state.diagnosisState === "complete"
+      ? "Diagnóstico atualizado a partir do Perfil Estratégico."
+      : "Cada vídeo analisado atualiza este Perfil Estratégico.",
+    state: state.diagnosisState === "first_reading" || state.diagnosisState === "limited" ? "limited" : "ready",
+    cards,
+  };
+}
+
+function commercialCardsFromPresentation(presentation: VideoNarrativeDiagnosisPresentation | null | undefined): MobileStrategicProfileSectionCard[] {
+  if (!presentation) return [];
+
+  const commercialSections = presentation.sections.filter((section) =>
+    section.visible && (section.id === "brand_opportunities" || section.id === "collab_opportunities")
+  );
+
+  return commercialSections.flatMap(sectionCardsFromPresentation);
+}
+
+function buildCommercialSection(input: MobileStrategicProfileInput): MobileStrategicProfileSection | null {
+  const state = input.state;
+  if (state.profileAvailability === "auth_gate") return null;
+
+  if (state.profileAvailability === "construction") {
+    return {
+      id: "commercial",
+      title: "Potencial comercial",
+      description: "Esta camada fica mais útil depois da primeira análise.",
+      state: "limited",
+      cards: [
+        card({
+          id: "commercial-construction",
+          title: "Leitura comercial em construção",
+          body: "A D2C precisa da primeira leitura para entender territórios possíveis e próximos passos.",
+          tone: "commercial",
+          source: "state",
+        }),
+      ],
+    };
+  }
+
+  const commercialCards = commercialCardsFromPresentation(input.diagnosisPresentation);
+  const cards = commercialCards.length > 0
+    ? commercialCards
+    : [
+      card({
+        id: "commercial-initial",
+        title: "Potencial comercial",
+        body: state.diagnosisState === "first_reading" || state.diagnosisState === "limited"
+          ? "Leitura inicial de potencial comercial, sem promessa de marca ou campanha."
+          : "Tradução estratégica do diagnóstico para oportunidades futuras.",
+        tone: "commercial",
+        source: "state",
+      }),
+    ];
+
+  return {
+    id: "commercial",
+    title: "Potencial comercial",
+    description: state.diagnosisState === "complete" || state.diagnosisState === "instagram_optimized"
+      ? "Tradução interna do diagnóstico para oportunidades futuras."
+      : "Leitura inicial para orientar próximos passos comerciais.",
+    state: state.diagnosisState === "first_reading" || state.diagnosisState === "limited" ? "limited" : "ready",
+    cards,
+  };
+}
+
+function buildSections(input: MobileStrategicProfileInput): MobileStrategicProfileSection[] {
+  return [buildDiagnosisSection(input), buildCommercialSection(input)].filter((section): section is MobileStrategicProfileSection => Boolean(section));
+}
+
+function buildMediaKitBridge(input: MobileStrategicProfileInput): MobileStrategicProfileMediaKitBridge {
+  const state = input.state.mediaKitState;
+  if (input.state.profileAvailability === "auth_gate") {
+    return { state: "hidden", title: null, description: null, href: null, actions: [] };
+  }
+
+  if (state === "available") {
+    const shareHref = href(input.mediaKitShareUrl ?? input.mediaKitPublicUrl);
+    return {
+      state,
+      title: "Mídia Kit",
+      description: "Use o Mídia Kit existente para compartilhar seu perfil com marcas.",
+      href: shareHref,
+      actions: [
+        profileAction({
+          id: "media-kit-copy-link",
+          intent: "copy_link",
+          label: "Copiar link",
+          description: "Copiar o link do Mídia Kit existente.",
+          href: shareHref,
+          priority: "secondary",
+          disabled: !shareHref,
+        }),
+        profileAction({
+          id: "media-kit-view-brand",
+          intent: "view_as_brand",
+          label: "Ver como marca",
+          description: "Abrir a visão pública existente do Mídia Kit.",
+          href: href(input.mediaKitPublicUrl ?? input.mediaKitShareUrl),
+          priority: "secondary",
+          disabled: !href(input.mediaKitPublicUrl ?? input.mediaKitShareUrl),
+        }),
+        profileAction({
+          id: "media-kit-edit",
+          intent: "edit_or_open_media_kit",
+          label: "Abrir Mídia Kit",
+          description: "Abrir ou editar o recurso existente de Mídia Kit.",
+          href: href(input.mediaKitEditUrl ?? input.mediaKitShareUrl),
+          priority: "secondary",
+          disabled: !href(input.mediaKitEditUrl ?? input.mediaKitShareUrl),
+        }),
+      ],
+    };
+  }
+
+  if (state === "connect_instagram_required") {
+    return {
+      state,
+      title: "Mídia Kit",
+      description: "Conectar Instagram é o próximo passo para ativar o Mídia Kit existente.",
+      href: null,
+      actions: [],
+    };
+  }
+
+  return { state, title: null, description: null, href: null, actions: [] };
+}
+
+function buildCommunityBridge(input: MobileStrategicProfileInput): MobileStrategicProfileCommunityBridge {
+  return {
+    visible: input.state.profileAvailability !== "auth_gate",
+    label: "Comunidade",
+    href: href(input.communityHref) ?? "/dashboard/community",
+    description: "Destino existente da Comunidade Data2Content.",
+  };
+}
+
+function buildNavigation(input: MobileStrategicProfileInput): MobileStrategicProfileNavigationModel {
+  return {
+    items: [
+      {
+        id: "profile",
+        label: "Perfil",
+        href: href(input.profileHref),
+        role: "destination",
+        active: true,
+      },
+      {
+        id: "analyze_video",
+        label: "+",
+        href: href(input.analyzeVideoHref),
+        role: "central_action",
+        active: false,
+      },
+      {
+        id: "community",
+        label: "Comunidade",
+        href: href(input.communityHref) ?? "/dashboard/community",
+        role: "destination",
+        active: false,
+      },
+    ],
+  };
+}
+
+function buildConstructionState(input: MobileStrategicProfileInput): MobileStrategicProfileConstructionState {
+  const visible = input.state.profileAvailability === "construction";
+  return {
+    visible,
+    title: visible ? "Seu Perfil Estratégico ainda está começando." : "",
+    description: visible
+      ? "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo."
+      : "",
+    recommendedActionLabel: visible
+      ? input.state.recommendedActions.find((item) => item.intent === "analyze_video")?.label ?? "Analisar primeiro vídeo"
+      : null,
+  };
+}
+
+export function buildMobileStrategicProfile(input: MobileStrategicProfileInput): MobileStrategicProfile {
+  const tabs = buildTabs(input.state);
+  const primaryActions = input.state.recommendedActions
+    .filter((item) => item.id !== "community-future")
+    .map((item) => actionFromState(item, input));
+
+  return {
+    id: clean(`mobile-strategic-profile-${input.state.authState}-${input.state.profileAvailability}`),
+    state: input.state,
+    authGate: buildAuthGate(input),
+    header: buildHeader(input),
+    tabs,
+    activeTab: tabs[0]?.id ?? null,
+    sections: buildSections(input),
+    primaryActions,
+    mediaKitBridge: buildMediaKitBridge(input),
+    communityBridge: buildCommunityBridge(input),
+    navigation: buildNavigation(input),
+    constructionState: buildConstructionState(input),
+    createdAt: clean(input.createdAt) || input.state.createdAt || input.diagnosisPresentation?.createdAt || null,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #840.

MM44 adds a pure mapping layer that turns `MobileStrategicProfileState` + `VideoNarrativeDiagnosisPresentation` into a complete `MobileStrategicProfile` model for the future mobile Strategic Profile UI.

Changes:
- Adds `mobileStrategicProfileMapping.ts` with `buildMobileStrategicProfile(input)`.
- Models auth gate, profile header, internal tabs, diagnosis/commercial sections, primary actions, Media Kit bridge, Community bridge, construction state, and future mobile navigation.
- Keeps the Strategic Profile as the creator's living diagnosis.
- Uses `diagnosisPresentation` for the Diagnosis tab.
- Treats Commercial as an internal strategic translation, not a replacement for Media Kit.
- Treats Media Kit as an existing resource via bridge only, without changing `MediaKitView`.
- Treats Community as an existing navigation destination, without creating feed/chat/comments.
- Keeps future navigation to Profile / central analyze action / Community.
- Updates docs for MM44.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, schema, or Prisma changes.
- No endpoint changes.
- No `LoginClient` changes.
- No NextAuth changes.
- No `MediaKitView` changes.
- No real Community changes.
- No real navigation/sidebar changes.
- No real Instagram integration.
- No real billing or Stripe integration.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisPresentationModel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings outside this scope in `src/app/brand-report/[slug]` and `BrandNarrativeMatchesPanel`.