### PR TITLE
feat: add mobile strategic profile preview UI

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -1,0 +1,176 @@
+import fs from "fs";
+import path from "path";
+import { render, screen, within } from "@testing-library/react";
+import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
+import {
+  buildMobileStrategicProfilePreviewFixture,
+  type MobileStrategicProfilePreviewFixtureState,
+} from "./buildMobileStrategicProfilePreviewFixture";
+
+const SOURCE_PATH = path.join(__dirname, "MobileStrategicProfilePreview.tsx");
+
+function renderState(state: MobileStrategicProfilePreviewFixtureState) {
+  const fixture = buildMobileStrategicProfilePreviewFixture({ state });
+  return render(<MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} />);
+}
+
+function renderedText(container: HTMLElement): string {
+  return container.textContent?.toLowerCase() ?? "";
+}
+
+describe("MobileStrategicProfilePreview", () => {
+  it("auth gate renders Perfil Estratégico copy", () => {
+    renderState("anonymous_view_profile");
+
+    expect(screen.getByText("Crie seu Perfil Estratégico")).toBeInTheDocument();
+    expect(screen.getByText("Entre com Google para criar seu Perfil Estratégico.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Entrar para criar Perfil" })).toBeInTheDocument();
+  });
+
+  it("auth gate for analyze_video renders first video copy", () => {
+    renderState("anonymous_analyze_video");
+
+    expect(screen.getByText("Entre para analisar seu primeiro vídeo")).toBeInTheDocument();
+    expect(screen.getByText("Entre com Google para analisar seu primeiro vídeo.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Entrar para analisar vídeo" })).toBeInTheDocument();
+  });
+
+  it("construction profile renders Analisar primeiro vídeo CTA", () => {
+    renderState("account_only");
+
+    expect(screen.getAllByText("Perfil em construção").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Analisar primeiro vídeo").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Seu Perfil Estratégico ainda está começando.").length).toBeGreaterThan(0);
+  });
+
+  it("construction profile does not show Media Kit available", () => {
+    const { container } = renderState("account_only");
+    const text = renderedText(container);
+
+    expect(text).not.toContain("mídia kit ativo");
+    expect(text).not.toContain("copiar link");
+    expect(text).not.toContain("ver como marca");
+  });
+
+  it("first reading renders Diagnosis and Analisar vídeo CTA", () => {
+    renderState("first_reading_free");
+
+    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Comercial").length).toBeGreaterThan(0);
+    expect(screen.getByText("O que este vídeo comunica")).toBeInTheDocument();
+    expect(screen.getAllByText("Analisar vídeo").length).toBeGreaterThan(0);
+  });
+
+  it("premium renders Commercial section without brand promise", () => {
+    const { container } = renderState("premium_without_instagram");
+    const text = renderedText(container);
+
+    expect(screen.getAllByText("Potencial comercial").length).toBeGreaterThan(0);
+    expect(text).toContain("oportunidade futura");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("marca garantida");
+    expect(text).not.toContain("patrocínio garantido");
+  });
+
+  it("instagram optimized renders more precise reading and Instagram connected", () => {
+    renderState("instagram_optimized");
+
+    expect(screen.getAllByText("Leitura mais precisa").length).toBeGreaterThan(0);
+    expect(screen.getByText("Instagram conectado")).toBeInTheDocument();
+  });
+
+  it("Media Kit Bridge available renders visual buttons without changing MediaKitView", () => {
+    const { container } = renderState("media_kit_available");
+    const text = renderedText(container);
+
+    expect(screen.getAllByText("Mídia Kit").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Copiar link" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ver como marca" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Abrir Mídia Kit" })).toBeInTheDocument();
+    expect(text).not.toContain("mediakitview");
+    expect(text).not.toContain("qr code");
+    expect(text).not.toContain("diagnóstico interno");
+  });
+
+  it("Community appears only as destination/nav, without social surfaces", () => {
+    const { container } = renderState("first_reading_free");
+    const text = renderedText(container);
+
+    expect(screen.getAllByText("Comunidade").length).toBeGreaterThan(0);
+    expect(screen.getByText("Destino existente da Comunidade Data2Content.")).toBeInTheDocument();
+    expect(text).not.toContain("feed");
+    expect(text).not.toContain("chat");
+    expect(text).not.toContain("comments");
+    expect(text).not.toContain("comentários");
+  });
+
+  it("bottom nav renders Perfil, + and Comunidade", () => {
+    renderState("first_reading_free");
+    const nav = screen.getByLabelText("Navegação mobile futura");
+
+    expect(within(nav).getByText("Perfil")).toBeInTheDocument();
+    expect(within(nav).getByText("+")).toBeInTheDocument();
+    expect(within(nav).getByText("Comunidade")).toBeInTheDocument();
+  });
+
+  it("bottom nav does not render Mídia Kit, Diagnóstico or Comercial as global tabs", () => {
+    renderState("media_kit_available");
+    const nav = screen.getByLabelText("Navegação mobile futura");
+
+    expect(within(nav).queryByText("Mídia Kit")).not.toBeInTheDocument();
+    expect(within(nav).queryByText("Diagnóstico")).not.toBeInTheDocument();
+    expect(within(nav).queryByText("Comercial")).not.toBeInTheDocument();
+  });
+
+  it("does not render forbidden terms", () => {
+    const { container } = renderState("media_kit_available");
+    const text = renderedText(container);
+
+    for (const forbidden of [
+      "api_key",
+      "apikey",
+      "base64",
+      "signedurl",
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "18 sinais",
+      "3 narrativas",
+      "percentual de perfil",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import forbidden app or integration dependencies", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "fetch",
+      "Prisma",
+      "banco",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "SDK",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -1,0 +1,311 @@
+import type {
+  MobileStrategicProfile,
+  MobileStrategicProfileAction,
+  MobileStrategicProfileSection,
+  MobileStrategicProfileSectionCard,
+} from "../../../videoUpload/mobileStrategicProfileMapping";
+import {
+  MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
+  type MobileStrategicProfilePreviewFixtureState,
+} from "./buildMobileStrategicProfilePreviewFixture";
+
+type MobileStrategicProfilePreviewProps = {
+  profile: MobileStrategicProfile;
+  activeState?: MobileStrategicProfilePreviewFixtureState;
+};
+
+const CARD_TONE: Record<MobileStrategicProfileSectionCard["tone"], string> = {
+  neutral: "border-zinc-200 bg-white",
+  diagnosis: "border-sky-100 bg-sky-50/70",
+  commercial: "border-emerald-100 bg-emerald-50/70",
+  action: "border-zinc-200 bg-zinc-50",
+  locked: "border-amber-100 bg-amber-50/70",
+};
+
+function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePreviewFixtureState }) {
+  return (
+    <nav className="flex gap-2 overflow-x-auto pb-1" aria-label="Estados do Perfil Estratégico">
+      {MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES.map((state) => (
+        <a
+          key={state}
+          href={`/dashboard/boards/mobile-strategic-profile-preview?state=${state}`}
+          className={
+            state === activeState
+              ? "shrink-0 rounded-full bg-zinc-950 px-3 py-1.5 text-xs font-semibold text-white"
+              : "shrink-0 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700"
+          }
+        >
+          {state.replaceAll("_", " ")}
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+function ActionButton({ action }: { action: MobileStrategicProfileAction }) {
+  return (
+    <button
+      type="button"
+      disabled={action.disabled}
+      className={
+        action.priority === "primary"
+          ? "rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-zinc-300"
+          : "rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+      }
+    >
+      {action.label}
+    </button>
+  );
+}
+
+function AuthGate({ profile }: { profile: MobileStrategicProfile }) {
+  const gate = profile.authGate;
+
+  return (
+    <section className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
+      <div className="mx-auto grid max-w-5xl gap-5">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Perfil Estratégico</p>
+          <h1 className="mt-2 text-2xl font-semibold">Perfil Estratégico mobile</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            O Perfil da D2C é o diagnóstico vivo do creator. Cada vídeo analisado atualiza esse perfil.
+          </p>
+        </header>
+
+        <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
+          <div className="min-h-[680px] rounded-[1.5rem] bg-white px-5 py-5">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-zinc-950">Perfil Estratégico</span>
+              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">D2C</span>
+            </div>
+            <div className="mt-24 grid place-items-center text-center">
+              <div className="grid h-20 w-20 place-items-center rounded-full bg-zinc-950 text-2xl font-semibold text-white">
+                D2C
+              </div>
+              <h2 className="mt-6 text-2xl font-semibold text-zinc-950">{gate.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-zinc-600">{gate.description}</p>
+              {gate.action ? (
+                <div className="mt-6">
+                  <ActionButton action={gate.action} />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProfileHeader({ profile }: { profile: MobileStrategicProfile }) {
+  const identity = profile.header.identity;
+  const initials = identity.displayName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase() || "D2";
+
+  return (
+    <header className="px-5 pt-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-semibold text-zinc-950">{identity.displayHandle ?? "Perfil Estratégico"}</p>
+          <p className="text-xs text-zinc-500">Diagnóstico vivo</p>
+        </div>
+        <button type="button" className="grid h-9 w-9 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white">
+          +
+        </button>
+      </div>
+
+      <div className="mt-6 flex items-start gap-4">
+        <div className="grid h-20 w-20 shrink-0 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white">
+          {identity.userImage ? <span>{initials}</span> : initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-xl font-semibold text-zinc-950">{identity.displayName}</h2>
+          {identity.displayHandle ? <p className="mt-0.5 text-sm text-zinc-500">{identity.displayHandle}</p> : null}
+          {identity.bio ? <p className="mt-2 text-sm leading-6 text-zinc-700">{identity.bio}</p> : null}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {profile.header.statusPills.map((pill) => (
+          <span key={pill.id} className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-700">
+            {pill.label}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {profile.primaryActions.slice(0, 2).map((action) => (
+          <ActionButton key={action.id} action={action} />
+        ))}
+      </div>
+    </header>
+  );
+}
+
+function Tabs({ profile }: { profile: MobileStrategicProfile }) {
+  return (
+    <div className="mx-5 mt-5 grid grid-cols-2 rounded-full bg-zinc-100 p-1">
+      {profile.tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          className={
+            tab.active
+              ? "rounded-full bg-white px-3 py-2 text-sm font-semibold text-zinc-950 shadow-sm"
+              : "rounded-full px-3 py-2 text-sm font-semibold text-zinc-500"
+          }
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SectionCard({ card }: { card: MobileStrategicProfileSectionCard }) {
+  return (
+    <article className={`rounded-2xl border p-4 ${CARD_TONE[card.tone]}`}>
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="text-sm font-semibold text-zinc-950">{card.title}</h4>
+        {card.locked ? <span className="rounded-full bg-white px-2 py-1 text-xs font-semibold text-zinc-500">Bloqueado</span> : null}
+      </div>
+      <p className="mt-2 text-sm leading-6 text-zinc-700">{card.body}</p>
+    </article>
+  );
+}
+
+function ProfileSection({ section }: { section: MobileStrategicProfileSection }) {
+  return (
+    <section className="px-5">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-zinc-950">{section.title}</h3>
+          <p className="mt-1 text-sm leading-6 text-zinc-600">{section.description}</p>
+        </div>
+        {section.state === "limited" || section.state === "construction" ? (
+          <span className="shrink-0 rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-500">
+            {section.state === "construction" ? "Em construção" : "Inicial"}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 grid gap-3">
+        {section.cards.slice(0, 5).map((card) => (
+          <SectionCard key={card.id} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function MediaKitBridge({ profile }: { profile: MobileStrategicProfile }) {
+  const bridge = profile.mediaKitBridge;
+  if (bridge.state === "hidden" || bridge.state === "unavailable" || !bridge.title || !bridge.description) return null;
+
+  return (
+    <section className="mx-5 rounded-2xl border border-zinc-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-zinc-950">{bridge.title}</h3>
+          <p className="mt-1 text-sm leading-6 text-zinc-600">{bridge.description}</p>
+        </div>
+        <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">
+          {bridge.state === "available" ? "Ativo" : "Instagram"}
+        </span>
+      </div>
+      {bridge.actions.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {bridge.actions.map((action) => (
+            <ActionButton key={action.id} action={action} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function BottomNav({ profile }: { profile: MobileStrategicProfile }) {
+  return (
+    <nav className="sticky bottom-0 mt-6 grid grid-cols-3 border-t border-zinc-200 bg-white px-4 py-3" aria-label="Navegação mobile futura">
+      {profile.navigation.items.map((item) => (
+        <a
+          key={item.id}
+          href={item.href ?? "#"}
+          className={
+            item.role === "central_action"
+              ? "mx-auto grid h-12 w-12 place-items-center rounded-full bg-zinc-950 text-lg font-semibold text-white"
+              : item.active
+                ? "text-center text-xs font-semibold text-zinc-950"
+                : "text-center text-xs font-semibold text-zinc-500"
+          }
+        >
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+export function MobileStrategicProfilePreview({
+  profile,
+  activeState,
+}: MobileStrategicProfilePreviewProps) {
+  if (profile.authGate.visible) return <AuthGate profile={profile} />;
+
+  return (
+    <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
+      <div className="mx-auto grid max-w-5xl gap-5">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Perfil Estratégico</p>
+          <h1 className="mt-2 text-2xl font-semibold">Perfil Estratégico mobile</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            O Perfil da D2C é o diagnóstico vivo do creator. Cada vídeo analisado atualiza esse perfil.
+          </p>
+          <div className="mt-4">
+            <StateSwitcher activeState={activeState} />
+          </div>
+        </header>
+
+        <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
+          <div className="min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
+            <ProfileHeader profile={profile} />
+            <Tabs profile={profile} />
+
+            <div className="mt-5 grid gap-5 pb-2">
+              {profile.constructionState.visible ? (
+                <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+                  <h3 className="text-base font-semibold text-zinc-950">{profile.constructionState.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">{profile.constructionState.description}</p>
+                  {profile.constructionState.recommendedActionLabel ? (
+                    <span className="mt-3 inline-flex rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white">
+                      {profile.constructionState.recommendedActionLabel}
+                    </span>
+                  ) : null}
+                </section>
+              ) : null}
+
+              {profile.sections.map((section) => (
+                <ProfileSection key={section.id} section={section} />
+              ))}
+
+              <MediaKitBridge profile={profile} />
+
+              {profile.communityBridge.visible ? (
+                <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+                  <h3 className="text-base font-semibold text-zinc-950">{profile.communityBridge.label}</h3>
+                  <p className="mt-1 text-sm leading-6 text-zinc-600">{profile.communityBridge.description}</p>
+                </section>
+              ) : null}
+            </div>
+
+            <BottomNav profile={profile} />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.test.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.test.ts
@@ -1,0 +1,92 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildMobileStrategicProfilePreviewFixture,
+  MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
+} from "./buildMobileStrategicProfilePreviewFixture";
+
+const SOURCE_PATH = path.join(__dirname, "buildMobileStrategicProfilePreviewFixture.ts");
+
+describe("buildMobileStrategicProfilePreviewFixture", () => {
+  it("generates anonymous_view_profile", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "anonymous_view_profile" });
+
+    expect(result.id).toBe("anonymous_view_profile");
+    expect(result.profile.authGate.visible).toBe(true);
+    expect(result.profile.authGate.description).toBe("Entre com Google para criar seu Perfil Estratégico.");
+  });
+
+  it("generates anonymous_analyze_video", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "anonymous_analyze_video" });
+
+    expect(result.id).toBe("anonymous_analyze_video");
+    expect(result.profile.authGate.visible).toBe(true);
+    expect(result.profile.authGate.description).toBe("Entre com Google para analisar seu primeiro vídeo.");
+  });
+
+  it("generates account_only", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "account_only" });
+
+    expect(result.id).toBe("account_only");
+    expect(result.profile.state.profileAvailability).toBe("construction");
+    expect(result.profile.constructionState.visible).toBe(true);
+  });
+
+  it("generates first_reading_free", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "first_reading_free" });
+
+    expect(result.id).toBe("first_reading_free");
+    expect(result.profile.state.diagnosisState).toBe("first_reading");
+    expect(result.profile.sections.map((section) => section.id)).toContain("diagnosis");
+  });
+
+  it("generates premium_without_instagram", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "premium_without_instagram" });
+
+    expect(result.id).toBe("premium_without_instagram");
+    expect(result.profile.state.diagnosisState).toBe("complete");
+    expect(result.profile.state.instagramState).toBe("disconnected");
+  });
+
+  it("generates instagram_optimized", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "instagram_optimized" });
+
+    expect(result.id).toBe("instagram_optimized");
+    expect(result.profile.state.diagnosisState).toBe("instagram_optimized");
+    expect(result.profile.state.instagramState).toBe("connected");
+  });
+
+  it("generates media_kit_available", () => {
+    const result = buildMobileStrategicProfilePreviewFixture({ state: "media_kit_available" });
+
+    expect(result.id).toBe("media_kit_available");
+    expect(result.profile.mediaKitBridge.state).toBe("available");
+    expect(result.profile.mediaKitBridge.actions.map((action) => action.label)).toEqual(
+      expect.arrayContaining(["Copiar link", "Ver como marca", "Abrir Mídia Kit"]),
+    );
+  });
+
+  it("lists all required states", () => {
+    expect(MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES).toEqual([
+      "anonymous_view_profile",
+      "anonymous_analyze_video",
+      "account_only",
+      "first_reading_free",
+      "premium_without_instagram",
+      "instagram_optimized",
+      "media_kit_available",
+    ]);
+  });
+
+  it("does not import forbidden integrations", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of ["LoginClient", "NextAuth", "MediaKitView", "fetch", "Prisma", "Gemini", "OpenAI", "Stripe", "SDK"]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.ts
@@ -1,0 +1,192 @@
+import {
+  resolveMobileStrategicProfileState,
+  type MobileStrategicProfilePrimaryIntent,
+} from "../../../videoUpload/mobileStrategicProfileStateContract";
+import {
+  buildMobileStrategicProfile,
+  type MobileStrategicProfile,
+} from "../../../videoUpload/mobileStrategicProfileMapping";
+import type { VideoNarrativeDiagnosisAccessLevel } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+
+export type MobileStrategicProfilePreviewFixtureState =
+  | "anonymous_view_profile"
+  | "anonymous_analyze_video"
+  | "account_only"
+  | "first_reading_free"
+  | "premium_without_instagram"
+  | "instagram_optimized"
+  | "media_kit_available";
+
+export const MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES: MobileStrategicProfilePreviewFixtureState[] = [
+  "anonymous_view_profile",
+  "anonymous_analyze_video",
+  "account_only",
+  "first_reading_free",
+  "premium_without_instagram",
+  "instagram_optimized",
+  "media_kit_available",
+];
+
+export interface MobileStrategicProfilePreviewFixture {
+  id: MobileStrategicProfilePreviewFixtureState;
+  label: string;
+  profile: MobileStrategicProfile;
+}
+
+function first(value?: string | string[] | null): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function resolveFixtureState(value?: string | string[] | null): MobileStrategicProfilePreviewFixtureState {
+  const id = first(value);
+  return MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES.find((state) => state === id) ?? "first_reading_free";
+}
+
+function scenarioFor(access: VideoNarrativeDiagnosisAccessLevel, instagram: "connected" | "disconnected") {
+  return buildVideoNarrativeAppPreviewScenario({
+    stage: "diagnosis_ready",
+    scenario: access === "premium" ? "brand" : "skincare",
+    access,
+    instagram,
+  });
+}
+
+function buildAnonymousFixture(params: {
+  id: MobileStrategicProfilePreviewFixtureState;
+  label: string;
+  intent: MobileStrategicProfilePrimaryIntent;
+}): MobileStrategicProfilePreviewFixture {
+  const state = resolveMobileStrategicProfileState({
+    isAuthenticated: false,
+    primaryIntent: params.intent,
+    userName: "Creator",
+  });
+
+  return {
+    id: params.id,
+    label: params.label,
+    profile: buildMobileStrategicProfile({
+      state,
+      loginHref: "/login",
+      profileHref: "/dashboard/profile",
+      analyzeVideoHref: "/dashboard/boards/mobile-strategic-profile-preview?state=account_only",
+      communityHref: "/dashboard/community",
+      createdAt: "2026-05-19T00:00:00.000Z",
+    }),
+  };
+}
+
+function buildAuthenticatedFixture(params: {
+  id: MobileStrategicProfilePreviewFixtureState;
+  label: string;
+  accessLevel?: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected?: boolean;
+  hasPremiumAccess?: boolean;
+  hasMediaKit?: boolean;
+  mediaKitShareUrl?: string | null;
+}): MobileStrategicProfilePreviewFixture {
+  const preview = params.accessLevel
+    ? scenarioFor(params.accessLevel, params.instagramConnected ? "connected" : "disconnected")
+    : null;
+  const state = resolveMobileStrategicProfileState({
+    isAuthenticated: true,
+    userName: "Ana Creator",
+    userHandle: "@ana.creator",
+    userImage: null,
+    instagramConnected: params.instagramConnected ?? false,
+    instagramUsername: params.instagramConnected ? "@ana.creator" : null,
+    accessLevel: params.accessLevel ?? null,
+    hasPremiumAccess: params.hasPremiumAccess ?? false,
+    diagnosisPresentation: preview?.diagnosisPresentation ?? null,
+    hasMediaKit: params.hasMediaKit ?? false,
+    mediaKitShareUrl: params.mediaKitShareUrl ?? null,
+    createdAt: "2026-05-19T00:00:00.000Z",
+  });
+
+  return {
+    id: params.id,
+    label: params.label,
+    profile: buildMobileStrategicProfile({
+      state,
+      diagnosisPresentation: preview?.diagnosisPresentation ?? null,
+      creatorBio: "Diagnóstico vivo em evolução para posicionamento, narrativa e próximo passo.",
+      mediaKitShareUrl: params.mediaKitShareUrl ?? null,
+      mediaKitEditUrl: params.hasMediaKit ? "/dashboard/media-kit" : null,
+      mediaKitPublicUrl: params.hasMediaKit ? "/mediakit/ana-preview" : null,
+      profileHref: "/dashboard/profile",
+      analyzeVideoHref: "/dashboard/boards/video-narrative-app-preview",
+      communityHref: "/dashboard/community",
+      createdAt: "2026-05-19T00:00:00.000Z",
+    }),
+  };
+}
+
+export function buildMobileStrategicProfilePreviewFixture(params: {
+  state?: string | string[] | null;
+} = {}): MobileStrategicProfilePreviewFixture {
+  const selected = resolveFixtureState(params.state);
+
+  if (selected === "anonymous_view_profile") {
+    return buildAnonymousFixture({
+      id: selected,
+      label: "Anônimo — Perfil",
+      intent: "view_profile",
+    });
+  }
+
+  if (selected === "anonymous_analyze_video") {
+    return buildAnonymousFixture({
+      id: selected,
+      label: "Anônimo — Analisar vídeo",
+      intent: "analyze_video",
+    });
+  }
+
+  if (selected === "account_only") {
+    return buildAuthenticatedFixture({
+      id: selected,
+      label: "Conta criada",
+    });
+  }
+
+  if (selected === "premium_without_instagram") {
+    return buildAuthenticatedFixture({
+      id: selected,
+      label: "Premium sem Instagram",
+      accessLevel: "premium",
+      hasPremiumAccess: true,
+      instagramConnected: false,
+    });
+  }
+
+  if (selected === "instagram_optimized") {
+    return buildAuthenticatedFixture({
+      id: selected,
+      label: "Instagram otimizado",
+      accessLevel: "instagram_optimized",
+      hasPremiumAccess: true,
+      instagramConnected: true,
+    });
+  }
+
+  if (selected === "media_kit_available") {
+    return buildAuthenticatedFixture({
+      id: selected,
+      label: "Mídia Kit ativo",
+      accessLevel: "instagram_optimized",
+      hasPremiumAccess: true,
+      instagramConnected: true,
+      hasMediaKit: true,
+      mediaKitShareUrl: "/mediakit/ana-preview",
+    });
+  }
+
+  return buildAuthenticatedFixture({
+    id: "first_reading_free",
+    label: "Primeira leitura free",
+    accessLevel: "free",
+    instagramConnected: false,
+  });
+}

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
@@ -1,0 +1,86 @@
+import fs from "fs";
+import path from "path";
+import { render, screen } from "@testing-library/react";
+import MobileStrategicProfilePreviewPage from "./page";
+
+const originalFlag = process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED;
+const adminViewer = { role: "admin" };
+const commonViewer = { role: "user" };
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (originalFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED;
+    return;
+  }
+  process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = originalFlag;
+});
+
+describe("MobileStrategicProfilePreviewPage", () => {
+  it("blocks preview when flag is off", async () => {
+    process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = "0";
+
+    render(await MobileStrategicProfilePreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Preview interno bloqueado")).toBeInTheDocument();
+    expect(screen.getByText(/NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1/)).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Perfil Estratégico")).not.toBeInTheDocument();
+  });
+
+  it("blocks preview without admin/dev", async () => {
+    process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = "1";
+
+    render(await MobileStrategicProfilePreviewPage({ viewer: commonViewer }));
+
+    expect(screen.getByText("Preview interno restrito a usuários admin/dev.")).toBeInTheDocument();
+    expect(screen.queryByText("Preview interno — Perfil Estratégico")).not.toBeInTheDocument();
+  });
+
+  it("renders preview with flag on and admin/dev", async () => {
+    process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = "1";
+
+    render(await MobileStrategicProfilePreviewPage({ viewer: adminViewer }));
+
+    expect(screen.getByText("Preview interno — Perfil Estratégico")).toBeInTheDocument();
+    expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
+    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+  });
+
+  it("state query selects fixture", async () => {
+    process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = "1";
+
+    render(
+      await MobileStrategicProfilePreviewPage({
+        viewer: adminViewer,
+        searchParams: { state: "media_kit_available" },
+      }),
+    );
+
+    expect(screen.getAllByText("Mídia Kit").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Copiar link" })).toBeInTheDocument();
+  });
+
+  it("does not import forbidden integrations or real UI surfaces", () => {
+    const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "ActivationPendingWidget",
+      "Sidebar",
+      "fetch",
+      "Prisma",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "SDK",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
@@ -1,0 +1,49 @@
+import { MobileStrategicProfilePreview } from "../components/videoUpload/appPreview/MobileStrategicProfilePreview";
+import { buildMobileStrategicProfilePreviewFixture } from "../components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture";
+import {
+  canAccessInternalPreview,
+  getCurrentInternalPreviewUser,
+  type InternalPreviewUser,
+} from "../internalPreviewAccess";
+import { isMobileStrategicProfilePreviewEnabled } from "../videoUpload/mobileStrategicProfilePreviewFeatureFlag";
+
+type MobileStrategicProfilePreviewPageProps = {
+  searchParams?: {
+    state?: string | string[];
+  };
+  viewer?: InternalPreviewUser | null;
+};
+
+function BlockedInternalPreview({ reason }: { reason: "flag" | "permission" }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-6 py-10 text-zinc-950">
+      <section className="mx-auto max-w-3xl rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno bloqueado</p>
+        <h1 className="mt-2 text-2xl font-semibold">Perfil Estratégico mobile</h1>
+        <p className="mt-3 text-sm leading-6 text-zinc-700">
+          {reason === "flag"
+            ? "Preview bloqueado por flag. Ative NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1 para visualizar esta rota."
+            : "Preview interno restrito a usuários admin/dev."}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function MobileStrategicProfilePreviewPage({
+  searchParams,
+  viewer,
+}: MobileStrategicProfilePreviewPageProps = {}) {
+  if (!isMobileStrategicProfilePreviewEnabled()) {
+    return <BlockedInternalPreview reason="flag" />;
+  }
+
+  const currentUser = viewer === undefined ? await getCurrentInternalPreviewUser() : viewer;
+  if (!canAccessInternalPreview(currentUser)) {
+    return <BlockedInternalPreview reason="permission" />;
+  }
+
+  const fixture = buildMobileStrategicProfilePreviewFixture({ state: searchParams?.state });
+
+  return <MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} />;
+}

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -112,6 +112,8 @@ Já existe:
 - MM43 modela o Perfil Estratégico mobile como diagnóstico vivo do creator, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
 - strategic profile mapping layer foi criado em MM44 como camada segura de contrato/mapping;
 - MM44 monta um `MobileStrategicProfile` consumível pela futura UI, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
+- strategic profile preview UI foi criado em MM45 como camada segura de UI interna/preview;
+- MM45 materializa visualmente o Perfil Estratégico mobile em preview interna, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1035,6 +1035,34 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing, Stripe, match real de marcas ou creators.
 
+### MM45 — Strategic Profile Preview UI
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx`
+- `../components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.ts`
+- `../mobile-strategic-profile-preview/page.tsx`
+- `mobileStrategicProfilePreviewFeatureFlag.ts`
+
+O que faz:
+
+- cria a primeira UI interna do Perfil Estratégico mobile;
+- consome `MobileStrategicProfile` em vez de reconstruir lógica de estado ou tier;
+- renderiza auth gate visual, Perfil em construção, primeira leitura, premium, Instagram otimizado e Mídia Kit Bridge;
+- usa estrutura familiar de perfil social sem copiar métricas de rede social;
+- mantém Mídia Kit e Comunidade como recursos existentes, não recriados;
+- expõe preview interna por flag `NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1` e acesso admin/dev.
+
+O que não faz:
+
+- não altera endpoint, NextAuth, `LoginClient`, navegação/sidebar, `ActivationPendingWidget`, Mídia Kit real, `MediaKitView` ou Comunidade real;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing, Stripe, match real de marcas ou creators;
+- não cria histórico de vídeos analisados.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -251,8 +251,9 @@ Exemplos:
 41. MM42 — Mobile Diagnosis UI Refactor. Materializa o presentation model na UI interna do diagnóstico, com layout mobile-first.
 42. MM43 — Strategic Profile State Contract. Modela o Perfil Estratégico mobile como diagnóstico vivo do creator, sem UI real.
 43. MM44 — Strategic Profile Mapping Layer. Monta o modelo consumível do Perfil Estratégico mobile a partir do estado e do diagnóstico.
-44. Teste real manual quando houver quota/billing disponível.
-45. Integração experimental futura no Board de Criação.
+44. MM45 — Strategic Profile Preview UI. Materializa a primeira preview interna visual do Perfil Estratégico mobile.
+45. Teste real manual quando houver quota/billing disponível.
+46. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -333,6 +334,8 @@ MM42 é a primeira materialização visual do presentation model. A preview inte
 MM43 adiciona `MobileStrategicProfileState` como contrato puro para a experiência mobile do Perfil Estratégico. O diagnóstico deixa de ser tratado como uma página isolada e passa a alimentar o Perfil: a análise de vídeo é uma ação temporária que atualiza o diagnóstico vivo do creator. O Perfil existe desde o login, mas pode estar em construção até a primeira leitura. Mídia Kit e Comunidade continuam sendo recursos existentes acessados pelo Perfil ou pela navegação futura; MM43 apenas modela disponibilidade, intenção e próximos passos, sem recriar Mídia Kit, `MediaKitView`, Comunidade, feed ou navegação real.
 
 MM44 adiciona `MobileStrategicProfile` como mapping puro acima de MM43. MM43 resolve os estados do Perfil; MM44 monta a estrutura consumível pela futura UI: header, tabs internas, seções, ações, bridges e navegação mobile futura. `VideoNarrativeDiagnosisPresentation` alimenta a aba Diagnóstico. A seção Comercial é uma tradução interna do diagnóstico para potencial comercial, não substitui Mídia Kit. Mídia Kit e Comunidade aparecem como bridges para recursos existentes, sem recriar `MediaKitView`, Comunidade, navegação real ou páginas públicas.
+
+MM45 é a primeira materialização visual do Perfil Estratégico. A UI interna consome `MobileStrategicProfile` e não reconstrói lógica de estado, tier, Mídia Kit ou Comunidade. O Perfil substitui a ideia de uma página isolada de diagnóstico: a análise de vídeo segue como ação temporária para atualizar o Perfil. A preview usa formato mobile-first com header de perfil, tabs internas, ações, Mídia Kit Bridge e navegação mockada Perfil / + / Comunidade, sem alterar navegação real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfilePreviewFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfilePreviewFeatureFlag.ts
@@ -1,0 +1,5 @@
+export function isMobileStrategicProfilePreviewEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  return env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED === "1";
+}


### PR DESCRIPTION
## Summary

Stacked over #841.

MM45 adds the first internal mobile Strategic Profile preview UI consuming `MobileStrategicProfile`.

Changes:
- Adds `MobileStrategicProfilePreview.tsx`.
- Adds fixtures for anonymous, account-only, first reading, premium, Instagram optimized, and Media Kit available states.
- Adds internal preview route at `/dashboard/boards/mobile-strategic-profile-preview` behind `NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1` and admin/dev access.
- Renders a mobile-first profile shell with profile header, status pills, CTAs, Diagnosis/Commercial tabs, diagnosis cards, Media Kit bridge, Community bridge, and bottom nav mock for Profile / + / Community.
- Keeps Media Kit as an existing resource bridge only, without changing `MediaKitView`.
- Keeps Community as an existing destination only, without creating feed/chat/posts/comments.
- Updates docs for MM45.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, schema, or Prisma changes.
- No endpoint changes.
- No `LoginClient` changes.
- No NextAuth changes.
- No `MediaKitView` changes.
- No real Community changes.
- No real navigation/sidebar changes.
- No real Instagram integration.
- No real billing or Stripe integration.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings outside this scope in `brand-report/[slug]` and `BrandNarrativeMatchesPanel`.