### PR TITLE
feat: add mobile strategic profile media kit modal bridge

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.test.tsx
@@ -1,0 +1,147 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MobileStrategicProfileMediaKitModal } from "./MobileStrategicProfileMediaKitModal";
+import { buildMobileStrategicProfilePreviewFixture } from "./buildMobileStrategicProfilePreviewFixture";
+
+const SOURCE_PATH = path.join(__dirname, "MobileStrategicProfileMediaKitModal.tsx");
+
+function mediaKitProfile() {
+  return buildMobileStrategicProfilePreviewFixture({ state: "media_kit_available" }).profile;
+}
+
+function connectRequiredProfile() {
+  return buildMobileStrategicProfilePreviewFixture({ state: "account_only" }).profile;
+}
+
+function dialogText(): string {
+  return screen.getByRole("dialog").textContent?.toLowerCase() ?? "";
+}
+
+describe("MobileStrategicProfileMediaKitModal", () => {
+  it("does not appear by default", () => {
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open={false} onClose={jest.fn()} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders available Media Kit content with creator identity and link", () => {
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open onClose={jest.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Compartilhar Mídia Kit" })).toBeInTheDocument();
+    expect(screen.getByText("Ana Creator")).toBeInTheDocument();
+    expect(screen.getByText("@ana.creator")).toBeInTheDocument();
+    expect(screen.getByText("/mediakit/ana-preview")).toBeInTheDocument();
+    expect(screen.getByText("Mídia Kit ativo")).toBeInTheDocument();
+  });
+
+  it("renders local visual actions without clipboard, share API or navigation side effects", () => {
+    const clipboard = { writeText: jest.fn() };
+    const share = jest.fn();
+    const open = jest.fn();
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: clipboard });
+    Object.defineProperty(navigator, "share", { configurable: true, value: share });
+    window.open = open;
+
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open onClose={jest.fn()} />);
+
+    for (const label of ["Copiar link", "Compartilhar", "Ver como marca", "Abrir Mídia Kit"]) {
+      fireEvent.click(screen.getByRole("button", { name: label }));
+    }
+
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+    expect(share).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("closes with the close button", () => {
+    const onClose = jest.fn();
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Fechar" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles available bridge without a safe link", () => {
+    const sourceProfile = mediaKitProfile();
+    const profile = {
+      ...sourceProfile,
+      mediaKitBridge: {
+        ...sourceProfile.mediaKitBridge,
+        href: null,
+      },
+    };
+
+    render(<MobileStrategicProfileMediaKitModal profile={profile} open onClose={jest.fn()} />);
+
+    expect(screen.getByText("O link do Mídia Kit existente ainda não está disponível nesta preview.")).toBeInTheDocument();
+    for (const label of ["Copiar link", "Compartilhar", "Ver como marca", "Abrir Mídia Kit"]) {
+      expect(screen.getByRole("button", { name: label })).toBeDisabled();
+    }
+  });
+
+  it("shows connect Instagram required copy without changing real Instagram", () => {
+    render(<MobileStrategicProfileMediaKitModal profile={connectRequiredProfile()} open onClose={jest.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Ativar Mídia Kit" })).toBeInTheDocument();
+    expect(screen.getByText("Conectar Instagram é o próximo passo para ativar o Mídia Kit existente.")).toBeInTheDocument();
+    expect(screen.getByText(/não conecta Instagram de verdade/)).toBeInTheDocument();
+  });
+
+  it("does not show internal diagnosis, quiz, pending signals or weak points", () => {
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open onClose={jest.fn()} />);
+    const text = dialogText();
+
+    for (const forbidden of [
+      "diagnóstico interno",
+      "ponto fraco",
+      "quiz",
+      "sinais pendentes",
+      "oportunidades bloqueadas",
+      "qr code",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not render forbidden terms", () => {
+    render(<MobileStrategicProfileMediaKitModal profile={mediaKitProfile()} open onClose={jest.fn()} />);
+    const text = dialogText();
+
+    for (const forbidden of [
+      "api_key",
+      "apikey",
+      "base64",
+      "signedurl",
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "novo mídia kit",
+      "mídia kit mobile",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import forbidden integrations or real Media Kit surfaces", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of ["MediaKitView", "fetch", "Prisma", "banco", "Gemini", "OpenAI", "Stripe", "SDK"]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.tsx
@@ -1,0 +1,138 @@
+import type { MobileStrategicProfile } from "../../../videoUpload/mobileStrategicProfileMapping";
+
+type MobileStrategicProfileMediaKitModalProps = {
+  profile: MobileStrategicProfile;
+  open: boolean;
+  onClose: () => void;
+};
+
+function safeMediaKitHref(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 120) return null;
+  if (/(api[_-]?key|signature|signed|token=|x-amz|base64|data:)/i.test(trimmed)) return null;
+  if (/[a-z0-9+/=]{80,}/i.test(trimmed)) return null;
+  return trimmed;
+}
+
+export function MobileStrategicProfileMediaKitModal({
+  profile,
+  open,
+  onClose,
+}: MobileStrategicProfileMediaKitModalProps) {
+  if (!open) return null;
+
+  const bridge = profile.mediaKitBridge;
+  const identity = profile.header.identity;
+  const mediaKitHref = safeMediaKitHref(bridge.href);
+  const isAvailable = bridge.state === "available";
+  const title = isAvailable ? "Compartilhar Mídia Kit" : "Ativar Mídia Kit";
+  const description = isAvailable
+    ? "Use o Mídia Kit existente para apresentar seu perfil para marcas."
+    : "Conectar Instagram é o próximo passo para ativar o Mídia Kit existente.";
+  const linkActionsDisabled = !isAvailable || !mediaKitHref;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-end bg-zinc-950/55 px-4 py-5 sm:place-items-center"
+      role="presentation"
+      onClick={onClose}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-strategic-profile-media-kit-modal-title"
+        className="w-full max-w-sm rounded-[1.75rem] bg-white p-5 text-zinc-950 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase text-zinc-500">Mídia Kit existente</p>
+            <h2 id="mobile-strategic-profile-media-kit-modal-title" className="mt-1 text-xl font-semibold">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Fechar modal de Mídia Kit"
+            className="grid h-9 w-9 place-items-center rounded-full bg-zinc-100 text-lg font-semibold text-zinc-700"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="mt-3 text-sm leading-6 text-zinc-600">{description}</p>
+
+        <div className="mt-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h3 className="truncate text-base font-semibold text-zinc-950">{identity.displayName}</h3>
+              {identity.displayHandle ? (
+                <p className="mt-0.5 text-sm text-zinc-500">{identity.displayHandle}</p>
+              ) : null}
+            </div>
+            <span className="shrink-0 rounded-full bg-white px-3 py-1 text-xs font-semibold text-zinc-700">
+              {isAvailable ? "Mídia Kit ativo" : "Instagram"}
+            </span>
+          </div>
+
+          {isAvailable ? (
+            mediaKitHref ? (
+              <p className="mt-4 break-all rounded-xl bg-white px-3 py-2 text-xs font-semibold text-zinc-600">
+                {mediaKitHref}
+              </p>
+            ) : (
+              <p className="mt-4 rounded-xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600">
+                O link do Mídia Kit existente ainda não está disponível nesta preview.
+              </p>
+            )
+          ) : (
+            <p className="mt-4 rounded-xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600">
+              Esta preview não conecta Instagram de verdade; ela só mostra a ponte visual para o recurso existente.
+            </p>
+          )}
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            disabled={linkActionsDisabled}
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+          >
+            Copiar link
+          </button>
+          <button
+            type="button"
+            disabled={linkActionsDisabled}
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+          >
+            Compartilhar
+          </button>
+          <button
+            type="button"
+            disabled={linkActionsDisabled}
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+          >
+            Ver como marca
+          </button>
+          <button
+            type="button"
+            disabled={linkActionsDisabled}
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+          >
+            Abrir Mídia Kit
+          </button>
+        </div>
+
+        <button
+          type="button"
+          className="mt-5 w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white"
+          onClick={onClose}
+        >
+          Fechar
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
 import {
   buildMobileStrategicProfilePreviewFixture,
@@ -90,6 +90,39 @@ describe("MobileStrategicProfilePreview", () => {
     expect(text).not.toContain("mediakitview");
     expect(text).not.toContain("qr code");
     expect(text).not.toContain("diagnóstico interno");
+  });
+
+  it("Media Kit modal does not appear by default", () => {
+    renderState("media_kit_available");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens Media Kit modal from share_media_kit action", () => {
+    renderState("media_kit_available");
+
+    fireEvent.click(screen.getByRole("button", { name: "Compartilhar Mídia Kit" }));
+
+    expect(screen.getByRole("dialog", { name: "Compartilhar Mídia Kit" })).toBeInTheDocument();
+    expect(screen.getByText("Use o Mídia Kit existente para apresentar seu perfil para marcas.")).toBeInTheDocument();
+  });
+
+  it("opens Media Kit modal from bridge action", () => {
+    renderState("media_kit_available");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copiar link" }));
+
+    expect(screen.getByRole("dialog", { name: "Compartilhar Mídia Kit" })).toBeInTheDocument();
+    expect(screen.getByText("/mediakit/ana-preview")).toBeInTheDocument();
+  });
+
+  it("closes Media Kit modal from close button", () => {
+    renderState("media_kit_available");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copiar link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fechar" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("Community appears only as destination/nav, without social surfaces", () => {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import type {
   MobileStrategicProfile,
   MobileStrategicProfileAction,
@@ -8,6 +11,7 @@ import {
   MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
   type MobileStrategicProfilePreviewFixtureState,
 } from "./buildMobileStrategicProfilePreviewFixture";
+import { MobileStrategicProfileMediaKitModal } from "./MobileStrategicProfileMediaKitModal";
 
 type MobileStrategicProfilePreviewProps = {
   profile: MobileStrategicProfile;
@@ -21,6 +25,17 @@ const CARD_TONE: Record<MobileStrategicProfileSectionCard["tone"], string> = {
   action: "border-zinc-200 bg-zinc-50",
   locked: "border-amber-100 bg-amber-50/70",
 };
+
+const MEDIA_KIT_ACTION_INTENTS = new Set<MobileStrategicProfileAction["intent"]>([
+  "share_media_kit",
+  "copy_link",
+  "view_as_brand",
+  "edit_or_open_media_kit",
+]);
+
+function isMediaKitAction(action: MobileStrategicProfileAction): boolean {
+  return MEDIA_KIT_ACTION_INTENTS.has(action.intent);
+}
 
 function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePreviewFixtureState }) {
   return (
@@ -42,11 +57,18 @@ function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePr
   );
 }
 
-function ActionButton({ action }: { action: MobileStrategicProfileAction }) {
+function ActionButton({
+  action,
+  onAction,
+}: {
+  action: MobileStrategicProfileAction;
+  onAction?: (action: MobileStrategicProfileAction) => void;
+}) {
   return (
     <button
       type="button"
       disabled={action.disabled}
+      onClick={() => onAction?.(action)}
       className={
         action.priority === "primary"
           ? "rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-zinc-300"
@@ -97,7 +119,13 @@ function AuthGate({ profile }: { profile: MobileStrategicProfile }) {
   );
 }
 
-function ProfileHeader({ profile }: { profile: MobileStrategicProfile }) {
+function ProfileHeader({
+  profile,
+  onAction,
+}: {
+  profile: MobileStrategicProfile;
+  onAction: (action: MobileStrategicProfileAction) => void;
+}) {
   const identity = profile.header.identity;
   const initials = identity.displayName
     .split(/\s+/)
@@ -140,7 +168,7 @@ function ProfileHeader({ profile }: { profile: MobileStrategicProfile }) {
 
       <div className="mt-4 flex flex-wrap gap-2">
         {profile.primaryActions.slice(0, 2).map((action) => (
-          <ActionButton key={action.id} action={action} />
+          <ActionButton key={action.id} action={action} onAction={onAction} />
         ))}
       </div>
     </header>
@@ -202,7 +230,13 @@ function ProfileSection({ section }: { section: MobileStrategicProfileSection })
   );
 }
 
-function MediaKitBridge({ profile }: { profile: MobileStrategicProfile }) {
+function MediaKitBridge({
+  profile,
+  onOpen,
+}: {
+  profile: MobileStrategicProfile;
+  onOpen: () => void;
+}) {
   const bridge = profile.mediaKitBridge;
   if (bridge.state === "hidden" || bridge.state === "unavailable" || !bridge.title || !bridge.description) return null;
 
@@ -220,9 +254,17 @@ function MediaKitBridge({ profile }: { profile: MobileStrategicProfile }) {
       {bridge.actions.length > 0 ? (
         <div className="mt-4 flex flex-wrap gap-2">
           {bridge.actions.map((action) => (
-            <ActionButton key={action.id} action={action} />
+            <ActionButton key={action.id} action={action} onAction={onOpen} />
           ))}
         </div>
+      ) : bridge.state === "connect_instagram_required" ? (
+        <button
+          type="button"
+          className="mt-4 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-800"
+          onClick={onOpen}
+        >
+          Ativar Mídia Kit
+        </button>
       ) : null}
     </section>
   );
@@ -254,7 +296,15 @@ export function MobileStrategicProfilePreview({
   profile,
   activeState,
 }: MobileStrategicProfilePreviewProps) {
+  const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
+
   if (profile.authGate.visible) return <AuthGate profile={profile} />;
+
+  const handleAction = (action: MobileStrategicProfileAction) => {
+    if (isMediaKitAction(action)) {
+      setMediaKitModalOpen(true);
+    }
+  };
 
   return (
     <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
@@ -272,7 +322,7 @@ export function MobileStrategicProfilePreview({
 
         <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
           <div className="min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
-            <ProfileHeader profile={profile} />
+            <ProfileHeader profile={profile} onAction={handleAction} />
             <Tabs profile={profile} />
 
             <div className="mt-5 grid gap-5 pb-2">
@@ -292,7 +342,7 @@ export function MobileStrategicProfilePreview({
                 <ProfileSection key={section.id} section={section} />
               ))}
 
-              <MediaKitBridge profile={profile} />
+              <MediaKitBridge profile={profile} onOpen={() => setMediaKitModalOpen(true)} />
 
               {profile.communityBridge.visible ? (
                 <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
@@ -306,6 +356,11 @@ export function MobileStrategicProfilePreview({
           </div>
         </div>
       </div>
+      <MobileStrategicProfileMediaKitModal
+        profile={profile}
+        open={mediaKitModalOpen}
+        onClose={() => setMediaKitModalOpen(false)}
+      />
     </main>
   );
 }

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -116,6 +116,8 @@ Já existe:
 - MM45 materializa visualmente o Perfil Estratégico mobile em preview interna, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit ou Comunidade reais;
 - strategic profile login intent copy foi criado em MM46 como camada segura de auth copy/reuso;
 - MM46 reaproveita `LoginClient` para copy contextual de Perfil Estratégico e análise narrativa, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera NextAuth;
+- media kit modal bridge foi criado em MM47 como camada segura de UI interna/preview;
+- MM47 adiciona um modal visual/local para apontar ao Mídia Kit existente, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit real ou `MediaKitView`;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1089,6 +1089,32 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, Mídia Kit real, `MediaKitView`, Comunidade real, billing ou Stripe.
 
+### MM47 — Media Kit Modal Bridge
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx`
+
+O que faz:
+
+- cria modal visual/local para acessar o Mídia Kit existente a partir do Perfil Estratégico mobile;
+- mantém Mídia Kit como recurso existente, sem recriar ou alterar `MediaKitView`;
+- abre o modal a partir da ação `share_media_kit` e dos botões do `mediaKitBridge`;
+- adiciona ações visuais para copiar link, compartilhar, ver como marca e abrir Mídia Kit;
+- cobre estado informativo de ativação quando conectar Instagram é o próximo passo.
+
+O que não faz:
+
+- não executa clipboard real, Web Share API, abertura de aba ou navegação real;
+- não cria novo Mídia Kit, QR Code, seção pública nova ou alteração em `/mediakit/[token]`;
+- não altera endpoint, `LoginClient`, NextAuth, navegação/sidebar, `ActivationPendingWidget`, Mídia Kit real, `MediaKitView` ou Comunidade real;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing ou Stripe.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -253,8 +253,9 @@ Exemplos:
 43. MM44 — Strategic Profile Mapping Layer. Monta o modelo consumível do Perfil Estratégico mobile a partir do estado e do diagnóstico.
 44. MM45 — Strategic Profile Preview UI. Materializa a primeira preview interna visual do Perfil Estratégico mobile.
 45. MM46 — Strategic Profile Login Intent Copy. Reaproveita o login existente para copy contextual de Perfil e análise narrativa.
-46. Teste real manual quando houver quota/billing disponível.
-47. Integração experimental futura no Board de Criação.
+46. MM47 — Media Kit Modal Bridge. Cria a ponte visual em modal entre Perfil Estratégico e Mídia Kit existente.
+47. Teste real manual quando houver quota/billing disponível.
+48. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -339,6 +340,8 @@ MM44 adiciona `MobileStrategicProfile` como mapping puro acima de MM43. MM43 res
 MM45 é a primeira materialização visual do Perfil Estratégico. A UI interna consome `MobileStrategicProfile` e não reconstrói lógica de estado, tier, Mídia Kit ou Comunidade. O Perfil substitui a ideia de uma página isolada de diagnóstico: a análise de vídeo segue como ação temporária para atualizar o Perfil. A preview usa formato mobile-first com header de perfil, tabs internas, ações, Mídia Kit Bridge e navegação mockada Perfil / + / Comunidade, sem alterar navegação real.
 
 MM46 conecta a intenção anônima ao login existente. Usuário anônimo deve passar pelo `LoginClient` já existente, com copy contextual para criar Perfil Estratégico ou analisar o primeiro vídeo. O Perfil Estratégico só existe como experiência interna depois da autenticação, e a intenção original deve ser preservada por `callbackUrl`. Não há nova tela de login, novo provider, alteração de NextAuth ou mudança de navegação real.
+
+MM47 materializa o Mídia Kit como bridge visual do Perfil, não como nova seção, aba ou produto. O Perfil traduz estratégia internamente, enquanto o Mídia Kit existente continua sendo a saída pública/comercial. O modal apenas aponta para copiar, compartilhar, ver como marca ou abrir o recurso existente em modo preview/local, sem clipboard real, Web Share API, navegação real, QR Code, alteração de `MediaKitView` ou mudança em `/mediakit/[token]`.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
## Summary

Stacked over #843.

MM47 adds a local visual Media Kit modal bridge inside the mobile Strategic Profile preview.

Changes:
- Adds `MobileStrategicProfileMediaKitModal.tsx`.
- Connects the modal to `MobileStrategicProfilePreview.tsx`.
- Opens the modal from `share_media_kit`, `copy_link`, `view_as_brand`, and `edit_or_open_media_kit` preview actions.
- Covers the `connect_instagram_required` informational state.
- Renders creator name, handle, safe Media Kit link when available, `Mídia Kit ativo`, and visual-only actions: Copiar link, Compartilhar, Ver como marca, and Abrir Mídia Kit.
- Keeps Media Kit as an existing resource bridge only.
- Updates docs for MM47.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, schema, or Prisma changes.
- No endpoint changes.
- No `LoginClient` changes.
- No NextAuth changes.
- No `MediaKitView` changes.
- No real `/mediakit/[token]` changes.
- No clipboard, Web Share API, `window.open`, or automatic navigation side effects.
- No real Community changes.
- No real navigation/sidebar changes.
- No real Instagram integration.
- No real billing or Stripe integration.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings outside this scope in `brand-report/[slug]/page.tsx` and `BrandNarrativeMatchesPanel.tsx`.