### PR TITLE
feat: add mobile strategic profile analyze return flow

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
@@ -1,0 +1,149 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MobileStrategicProfileAnalyzeFlow } from "./MobileStrategicProfileAnalyzeFlow";
+
+const SOURCE_PATH = path.join(__dirname, "MobileStrategicProfileAnalyzeFlow.tsx");
+
+function renderFlow() {
+  const onClose = jest.fn();
+  const onComplete = jest.fn();
+  render(<MobileStrategicProfileAnalyzeFlow open onClose={onClose} onComplete={onComplete} />);
+  return { onClose, onComplete };
+}
+
+function continueFlow() {
+  fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+}
+
+describe("MobileStrategicProfileAnalyzeFlow", () => {
+  it("does not appear by default", () => {
+    render(<MobileStrategicProfileAnalyzeFlow open={false} onClose={jest.fn()} onComplete={jest.fn()} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders intro step", () => {
+    renderFlow();
+
+    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).toBeInTheDocument();
+    expect(screen.getByText("Envie um vídeo para a D2C entender novos sinais da sua narrativa.")).toBeInTheDocument();
+  });
+
+  it("advances to mock upload", () => {
+    renderFlow();
+    continueFlow();
+
+    expect(screen.getByText("Vídeo selecionado para análise")).toBeInTheDocument();
+    expect(screen.getByText("Preview local. Nenhum arquivo será enviado neste protótipo.")).toBeInTheDocument();
+  });
+
+  it("advances to creator goal", () => {
+    renderFlow();
+    continueFlow();
+    continueFlow();
+
+    expect(screen.getByText("Qual era o objetivo desse conteúdo?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ganhar autoridade" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preparar publi" })).toBeInTheDocument();
+  });
+
+  it("advances to quick questions", () => {
+    renderFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+
+    expect(screen.getByText("Duas perguntas rápidas para entender contexto")).toBeInTheDocument();
+    expect(screen.getByText("Esse conteúdo representa sua fase atual?")).toBeInTheDocument();
+  });
+
+  it("advances to updating profile", () => {
+    renderFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+
+    expect(screen.getByText("Atualizando seu diagnóstico vivo...")).toBeInTheDocument();
+    expect(screen.getByText("Estamos conectando esta leitura ao seu Perfil Estratégico.")).toBeInTheDocument();
+  });
+
+  it("advances to updated confirmation and completes", () => {
+    const { onComplete } = renderFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+    continueFlow();
+
+    expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+    expect(screen.getByText("Identificamos novos sinais sobre sua narrativa.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes without completing", () => {
+    const { onClose, onComplete } = renderFlow();
+
+    fireEvent.click(screen.getByLabelText("Fechar fluxo de análise"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("does not render forbidden terms or a real file input", () => {
+    const { container } = render(<MobileStrategicProfileAnalyzeFlow open onClose={jest.fn()} onComplete={jest.fn()} />);
+    const text = container.textContent?.toLowerCase() ?? "";
+
+    expect(container.querySelector('input[type="file"]')).not.toBeInTheDocument();
+    for (const forbidden of [
+      "api_key",
+      "apikey",
+      "base64",
+      "signedurl",
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "histórico de vídeos",
+      "vídeos salvos",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import or call forbidden browser and integration APIs", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of ["Gemini", "OpenAI", "Prisma", "banco", "Stripe", "SDK", "next/navigation"]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+
+    for (const forbiddenCall of [
+      "fetch(",
+      "FileReader",
+      "navigator.storage",
+      "localStorage",
+      "sessionStorage",
+      "router.push",
+      "input type=\"file\"",
+    ]) {
+      expect(source).not.toContain(forbiddenCall);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+
+const STEPS = [
+  "intro",
+  "mock_upload",
+  "creator_goal",
+  "quick_questions",
+  "updating_profile",
+  "updated_confirmation",
+] as const;
+
+type AnalyzeFlowStep = (typeof STEPS)[number];
+
+type MobileStrategicProfileAnalyzeFlowProps = {
+  open: boolean;
+  onClose: () => void;
+  onComplete: () => void;
+};
+
+function nextStep(current: AnalyzeFlowStep): AnalyzeFlowStep {
+  const index = STEPS.indexOf(current);
+  return STEPS[Math.min(index + 1, STEPS.length - 1)] ?? "updated_confirmation";
+}
+
+export function MobileStrategicProfileAnalyzeFlow({
+  open,
+  onClose,
+  onComplete,
+}: MobileStrategicProfileAnalyzeFlowProps) {
+  const [step, setStep] = useState<AnalyzeFlowStep>("intro");
+
+  if (!open) return null;
+
+  const goNext = () => setStep((current) => nextStep(current));
+  const close = () => {
+    setStep("intro");
+    onClose();
+  };
+  const complete = () => {
+    setStep("intro");
+    onComplete();
+  };
+
+  return (
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mobile-strategic-profile-analyze-flow-title"
+      className="absolute inset-x-0 bottom-0 z-40 rounded-t-[1.75rem] border-t border-zinc-200 bg-white p-5 shadow-2xl"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase text-zinc-500">Analisar vídeo</p>
+          <h2 id="mobile-strategic-profile-analyze-flow-title" className="mt-1 text-xl font-semibold text-zinc-950">
+            {step === "updated_confirmation" ? "Diagnóstico atualizado." : "Vamos atualizar seu Perfil Estratégico"}
+          </h2>
+        </div>
+        <button
+          type="button"
+          aria-label="Fechar fluxo de análise"
+          className="grid h-9 w-9 place-items-center rounded-full bg-zinc-100 text-lg font-semibold text-zinc-700"
+          onClick={close}
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="mt-4">
+        {step === "intro" ? (
+          <div>
+            <p className="text-sm leading-6 text-zinc-600">
+              Envie um vídeo para a D2C entender novos sinais da sua narrativa.
+            </p>
+            <div className="mt-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+              <p className="text-sm font-semibold text-zinc-950">Atualizar Perfil</p>
+              <p className="mt-1 text-sm leading-6 text-zinc-600">
+                A análise é temporária e retorna para o Diagnóstico vivo.
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {step === "mock_upload" ? (
+          <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 p-4">
+            <p className="text-sm font-semibold text-zinc-950">Vídeo selecionado para análise</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">
+              Preview local. Nenhum arquivo será enviado neste protótipo.
+            </p>
+          </div>
+        ) : null}
+
+        {step === "creator_goal" ? (
+          <div>
+            <p className="text-sm font-semibold text-zinc-950">Qual era o objetivo desse conteúdo?</p>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              {["Ganhar autoridade", "Melhorar retenção", "Testar formato", "Preparar publi"].map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  className="rounded-2xl border border-zinc-200 bg-zinc-50 px-3 py-3 text-left text-sm font-semibold text-zinc-800"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {step === "quick_questions" ? (
+          <div>
+            <p className="text-sm font-semibold text-zinc-950">Duas perguntas rápidas para entender contexto</p>
+            <div className="mt-3 grid gap-3">
+              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+                <p className="text-sm font-semibold text-zinc-800">Esse conteúdo representa sua fase atual?</p>
+                <p className="mt-1 text-xs leading-5 text-zinc-500">Resposta visual nesta preview, sem salvar nada.</p>
+              </div>
+              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+                <p className="text-sm font-semibold text-zinc-800">Você quer repetir essa direção no próximo post?</p>
+                <p className="mt-1 text-xs leading-5 text-zinc-500">A leitura volta para o Perfil Estratégico.</p>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {step === "updating_profile" ? (
+          <div className="rounded-2xl border border-sky-100 bg-sky-50 p-4">
+            <p className="text-sm font-semibold text-zinc-950">Atualizando seu diagnóstico vivo...</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">
+              Estamos conectando esta leitura ao seu Perfil Estratégico.
+            </p>
+          </div>
+        ) : null}
+
+        {step === "updated_confirmation" ? (
+          <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
+            <p className="text-sm font-semibold text-zinc-950">Identificamos novos sinais sobre sua narrativa.</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">
+              A confirmação é curta porque o destino final é o seu Perfil.
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-5 flex gap-2">
+        {step === "updated_confirmation" ? (
+          <button
+            type="button"
+            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white"
+            onClick={complete}
+          >
+            Voltar para meu Perfil
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white"
+            onClick={goNext}
+          >
+            Continuar
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -18,6 +18,20 @@ function renderedText(container: HTMLElement): string {
   return container.textContent?.toLowerCase() ?? "";
 }
 
+function clickAnalyzeAction(label: string) {
+  const button = screen
+    .getAllByRole("button", { name: label })
+    .find((candidate) => candidate.textContent === label);
+  if (!button) throw new Error(`Action button not found: ${label}`);
+  fireEvent.click(button);
+}
+
+function advanceAnalyzeFlowToConfirmation() {
+  for (let index = 0; index < 5; index += 1) {
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+  }
+}
+
 describe("MobileStrategicProfilePreview", () => {
   it("auth gate renders Perfil Estratégico copy", () => {
     renderState("anonymous_view_profile");
@@ -90,6 +104,81 @@ describe("MobileStrategicProfilePreview", () => {
     expect(text).not.toContain("mediakitview");
     expect(text).not.toContain("qr code");
     expect(text).not.toContain("diagnóstico interno");
+  });
+
+  it("Analyze flow does not appear by default", () => {
+    renderState("first_reading_free");
+
+    expect(screen.queryByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).not.toBeInTheDocument();
+  });
+
+  it("opens Analyze flow from header plus button", () => {
+    renderState("first_reading_free");
+
+    fireEvent.click(screen.getByLabelText("Analisar vídeo"));
+
+    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).toBeInTheDocument();
+  });
+
+  it("opens Analyze flow from bottom nav central plus", () => {
+    renderState("first_reading_free");
+    const nav = screen.getByLabelText("Navegação mobile futura");
+
+    fireEvent.click(within(nav).getByRole("button", { name: "Analisar vídeo pela ação central" }));
+
+    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).toBeInTheDocument();
+  });
+
+  it("opens Analyze flow from Analisar vídeo action", () => {
+    renderState("first_reading_free");
+
+    clickAnalyzeAction("Analisar vídeo");
+
+    expect(screen.getByText("Envie um vídeo para a D2C entender novos sinais da sua narrativa.")).toBeInTheDocument();
+  });
+
+  it("opens Analyze flow from Analisar primeiro vídeo action in account_only", () => {
+    renderState("account_only");
+
+    clickAnalyzeAction("Analisar primeiro vídeo");
+
+    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).toBeInTheDocument();
+  });
+
+  it("anonymous auth gate does not open real Analyze flow", () => {
+    renderState("anonymous_analyze_video");
+
+    fireEvent.click(screen.getByRole("button", { name: "Entrar para analisar vídeo" }));
+
+    expect(screen.queryByRole("dialog", { name: "Vamos atualizar seu Perfil Estratégico" })).not.toBeInTheDocument();
+  });
+
+  it("Analyze flow returns to Profile after short confirmation", () => {
+    renderState("first_reading_free");
+
+    clickAnalyzeAction("Analisar vídeo");
+    advanceAnalyzeFlowToConfirmation();
+
+    expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
+    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getByText("Perfil atualizado nesta simulação.")).toBeInTheDocument();
+  });
+
+  it("Analyze flow does not create analyzed videos history or active file input", () => {
+    const { container } = renderState("first_reading_free");
+
+    clickAnalyzeAction("Analisar vídeo");
+    advanceAnalyzeFlowToConfirmation();
+    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+
+    const text = renderedText(container);
+    expect(text).not.toContain("histórico de vídeos");
+    expect(text).not.toContain("vídeos salvos");
+    expect(container.querySelector('input[type="file"]')).not.toBeInTheDocument();
   });
 
   it("Media Kit modal does not appear by default", () => {
@@ -196,6 +285,10 @@ describe("MobileStrategicProfilePreview", () => {
       "NextAuth",
       "MediaKitView",
       "fetch",
+      "FileReader",
+      "localStorage",
+      "sessionStorage",
+      "router.push",
       "Prisma",
       "banco",
       "Gemini",

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -11,6 +11,7 @@ import {
   MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
   type MobileStrategicProfilePreviewFixtureState,
 } from "./buildMobileStrategicProfilePreviewFixture";
+import { MobileStrategicProfileAnalyzeFlow } from "./MobileStrategicProfileAnalyzeFlow";
 import { MobileStrategicProfileMediaKitModal } from "./MobileStrategicProfileMediaKitModal";
 
 type MobileStrategicProfilePreviewProps = {
@@ -35,6 +36,10 @@ const MEDIA_KIT_ACTION_INTENTS = new Set<MobileStrategicProfileAction["intent"]>
 
 function isMediaKitAction(action: MobileStrategicProfileAction): boolean {
   return MEDIA_KIT_ACTION_INTENTS.has(action.intent);
+}
+
+function isAnalyzeAction(action: MobileStrategicProfileAction): boolean {
+  return action.intent === "analyze_video";
 }
 
 function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePreviewFixtureState }) {
@@ -122,9 +127,11 @@ function AuthGate({ profile }: { profile: MobileStrategicProfile }) {
 function ProfileHeader({
   profile,
   onAction,
+  onAnalyze,
 }: {
   profile: MobileStrategicProfile;
   onAction: (action: MobileStrategicProfileAction) => void;
+  onAnalyze: () => void;
 }) {
   const identity = profile.header.identity;
   const initials = identity.displayName
@@ -142,7 +149,12 @@ function ProfileHeader({
           <p className="text-sm font-semibold text-zinc-950">{identity.displayHandle ?? "Perfil Estratégico"}</p>
           <p className="text-xs text-zinc-500">Diagnóstico vivo</p>
         </div>
-        <button type="button" className="grid h-9 w-9 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white">
+        <button
+          type="button"
+          aria-label="Analisar vídeo"
+          className="grid h-9 w-9 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white"
+          onClick={onAnalyze}
+        >
           +
         </button>
       </div>
@@ -270,24 +282,36 @@ function MediaKitBridge({
   );
 }
 
-function BottomNav({ profile }: { profile: MobileStrategicProfile }) {
+function BottomNav({
+  profile,
+  onAnalyze,
+}: {
+  profile: MobileStrategicProfile;
+  onAnalyze: () => void;
+}) {
   return (
     <nav className="sticky bottom-0 mt-6 grid grid-cols-3 border-t border-zinc-200 bg-white px-4 py-3" aria-label="Navegação mobile futura">
-      {profile.navigation.items.map((item) => (
-        <a
-          key={item.id}
-          href={item.href ?? "#"}
-          className={
-            item.role === "central_action"
-              ? "mx-auto grid h-12 w-12 place-items-center rounded-full bg-zinc-950 text-lg font-semibold text-white"
-              : item.active
-                ? "text-center text-xs font-semibold text-zinc-950"
-                : "text-center text-xs font-semibold text-zinc-500"
-          }
-        >
-          {item.label}
-        </a>
-      ))}
+      {profile.navigation.items.map((item) =>
+        item.role === "central_action" ? (
+          <button
+            key={item.id}
+            type="button"
+            aria-label="Analisar vídeo pela ação central"
+            className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-zinc-950 text-lg font-semibold text-white"
+            onClick={onAnalyze}
+          >
+            {item.label}
+          </button>
+        ) : (
+          <a
+            key={item.id}
+            href={item.href ?? "#"}
+            className={item.active ? "text-center text-xs font-semibold text-zinc-950" : "text-center text-xs font-semibold text-zinc-500"}
+          >
+            {item.label}
+          </a>
+        ),
+      )}
     </nav>
   );
 }
@@ -297,13 +321,25 @@ export function MobileStrategicProfilePreview({
   activeState,
 }: MobileStrategicProfilePreviewProps) {
   const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
+  const [analyzeFlowOpen, setAnalyzeFlowOpen] = useState(false);
+  const [profileUpdated, setProfileUpdated] = useState(false);
 
   if (profile.authGate.visible) return <AuthGate profile={profile} />;
 
   const handleAction = (action: MobileStrategicProfileAction) => {
     if (isMediaKitAction(action)) {
       setMediaKitModalOpen(true);
+      return;
     }
+
+    if (isAnalyzeAction(action)) {
+      setAnalyzeFlowOpen(true);
+    }
+  };
+
+  const handleAnalyzeComplete = () => {
+    setAnalyzeFlowOpen(false);
+    setProfileUpdated(true);
   };
 
   return (
@@ -321,19 +357,30 @@ export function MobileStrategicProfilePreview({
         </header>
 
         <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
-          <div className="min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
-            <ProfileHeader profile={profile} onAction={handleAction} />
+          <div className="relative min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
+            <ProfileHeader profile={profile} onAction={handleAction} onAnalyze={() => setAnalyzeFlowOpen(true)} />
             <Tabs profile={profile} />
 
             <div className="mt-5 grid gap-5 pb-2">
+              {profileUpdated ? (
+                <section className="mx-5 rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
+                  <p className="text-sm font-semibold text-zinc-950">Diagnóstico atualizado</p>
+                  <p className="mt-1 text-sm leading-6 text-zinc-600">Perfil atualizado nesta simulação.</p>
+                </section>
+              ) : null}
+
               {profile.constructionState.visible ? (
                 <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
                   <h3 className="text-base font-semibold text-zinc-950">{profile.constructionState.title}</h3>
                   <p className="mt-2 text-sm leading-6 text-zinc-600">{profile.constructionState.description}</p>
                   {profile.constructionState.recommendedActionLabel ? (
-                    <span className="mt-3 inline-flex rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white">
+                    <button
+                      type="button"
+                      className="mt-3 inline-flex rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
+                      onClick={() => setAnalyzeFlowOpen(true)}
+                    >
                       {profile.constructionState.recommendedActionLabel}
-                    </span>
+                    </button>
                   ) : null}
                 </section>
               ) : null}
@@ -352,7 +399,12 @@ export function MobileStrategicProfilePreview({
               ) : null}
             </div>
 
-            <BottomNav profile={profile} />
+            <BottomNav profile={profile} onAnalyze={() => setAnalyzeFlowOpen(true)} />
+            <MobileStrategicProfileAnalyzeFlow
+              open={analyzeFlowOpen}
+              onClose={() => setAnalyzeFlowOpen(false)}
+              onComplete={handleAnalyzeComplete}
+            />
           </div>
         </div>
       </div>

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -118,6 +118,8 @@ Já existe:
 - MM46 reaproveita `LoginClient` para copy contextual de Perfil Estratégico e análise narrativa, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera NextAuth;
 - media kit modal bridge foi criado em MM47 como camada segura de UI interna/preview;
 - MM47 adiciona um modal visual/local para apontar ao Mídia Kit existente, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit real ou `MediaKitView`;
+- analyze entry and return flow foi criado em MM48 como camada segura de UI interna/mock;
+- MM48 modela a ação `+ / Analisar vídeo` como fluxo local que retorna ao Perfil, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit, Comunidade ou login reais;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1115,6 +1115,32 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing ou Stripe.
 
+### MM48 — Analyze Entry and Return Flow
+
+Status: concluído.
+
+Arquivos principais:
+
+- `../components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx`
+
+O que faz:
+
+- cria fluxo local/mockado para a ação `+ / Analisar vídeo`;
+- trata análise como ação temporária que atualiza o Perfil Estratégico;
+- usa o mesmo fluxo para o `+` do header, o `+` central da bottom nav, `Analisar vídeo` e `Analisar primeiro vídeo`;
+- mostra etapas curtas de intro, upload mockado, objetivo, perguntas rápidas, atualização e confirmação;
+- mostra confirmação curta e retorna para o Perfil na seção Diagnóstico;
+- adiciona indicação temporária local de diagnóstico atualizado na simulação.
+
+O que não faz:
+
+- não cria upload real, input de arquivo ativo, storage, endpoint, persistência, histórico de vídeos ou página final separada;
+- não usa fetch, FileReader, storage do navegador, router push ou navegação real;
+- não altera Mídia Kit, Comunidade, `LoginClient`, NextAuth, navegação/sidebar, `ActivationPendingWidget` ou `MediaKitView`;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing, Stripe ou match real de marcas/creators.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -254,8 +254,9 @@ Exemplos:
 44. MM45 — Strategic Profile Preview UI. Materializa a primeira preview interna visual do Perfil Estratégico mobile.
 45. MM46 — Strategic Profile Login Intent Copy. Reaproveita o login existente para copy contextual de Perfil e análise narrativa.
 46. MM47 — Media Kit Modal Bridge. Cria a ponte visual em modal entre Perfil Estratégico e Mídia Kit existente.
-47. Teste real manual quando houver quota/billing disponível.
-48. Integração experimental futura no Board de Criação.
+47. MM48 — Analyze Entry and Return Flow. Modela o fluxo local do `+ / Analisar vídeo` que retorna ao Perfil.
+48. Teste real manual quando houver quota/billing disponível.
+49. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -342,6 +343,8 @@ MM45 é a primeira materialização visual do Perfil Estratégico. A UI interna 
 MM46 conecta a intenção anônima ao login existente. Usuário anônimo deve passar pelo `LoginClient` já existente, com copy contextual para criar Perfil Estratégico ou analisar o primeiro vídeo. O Perfil Estratégico só existe como experiência interna depois da autenticação, e a intenção original deve ser preservada por `callbackUrl`. Não há nova tela de login, novo provider, alteração de NextAuth ou mudança de navegação real.
 
 MM47 materializa o Mídia Kit como bridge visual do Perfil, não como nova seção, aba ou produto. O Perfil traduz estratégia internamente, enquanto o Mídia Kit existente continua sendo a saída pública/comercial. O modal apenas aponta para copiar, compartilhar, ver como marca ou abrir o recurso existente em modo preview/local, sem clipboard real, Web Share API, navegação real, QR Code, alteração de `MediaKitView` ou mudança em `/mediakit/[token]`.
+
+MM48 materializa o `+` como ação central, não como aba. A análise de vídeo alimenta o Perfil Estratégico e retorna para a seção Diagnóstico, em vez de criar página isolada, recibo longo ou histórico visual. O produto preserva o aprendizado no diagnóstico vivo; o arquivo de vídeo pode ser descartado futuramente. A preview usa apenas estado local/mockado, sem upload real, storage, endpoint, persistência, fetch, FileReader ou navegação real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
## Summary

Stacked over #844.

MM48 adds a local/mock analyze entry and return flow inside the mobile Strategic Profile preview.

Changes:
- Adds `MobileStrategicProfileAnalyzeFlow.tsx`.
- Connects the flow to `MobileStrategicProfilePreview.tsx`.
- Opens the same flow from the header `+`, bottom nav central `+`, `Analisar vídeo`, and `Analisar primeiro vídeo` actions.
- Adds short local flow steps: intro, mock upload, creator goal, quick questions, profile updating, and updated confirmation.
- Confirmation shows `Diagnóstico atualizado.` and returns to the Profile with a local `Perfil atualizado nesta simulação.` indication.
- Keeps the Profile as the destination after analysis.
- Avoids final receipt pages, video history, upload/storage, endpoint calls, and persistence.
- Updates docs for MM48.

## Guardrails

- No real Gemini or OpenAI calls.
- No real upload or storage.
- No persistence, database, schema, or Prisma changes.
- No endpoint changes.
- No `LoginClient` changes.
- No NextAuth changes.
- No `MediaKitView` changes.
- No real Community changes.
- No real navigation/sidebar changes.
- No real Instagram integration.
- No real billing or Stripe integration.
- No video history section.

## Validation

- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.test.tsx`
- `npm test -- --runInBand src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run build`

Build completed with existing warnings outside this scope in `brand-report/[slug]/page.tsx` and `BrandNarrativeMatchesPanel.tsx`.