### PR TITLE
feat: add mobile strategic profile navigation strategy

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -120,6 +120,8 @@ Já existe:
 - MM47 adiciona um modal visual/local para apontar ao Mídia Kit existente, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit real ou `MediaKitView`;
 - analyze entry and return flow foi criado em MM48 como camada segura de UI interna/mock;
 - MM48 modela a ação `+ / Analisar vídeo` como fluxo local que retorna ao Perfil, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit, Comunidade ou login reais;
+- mobile navigation preview strategy foi criado em MM49 como camada segura de estratégia/contrato;
+- MM49 consolida `Perfil / + / Comunidade` para navegação mobile futura, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera navegação real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md
@@ -1,0 +1,105 @@
+# Mobile Strategic Profile Navigation Strategy
+
+## Visão geral
+
+O mobile app-first da D2C deve começar pelo Perfil Estratégico, com `+` como ação central e Comunidade como destino existente.
+
+O Perfil é a home mobile porque concentra identidade, Diagnóstico vivo, leitura comercial interna e pontes para recursos existentes. A navegação real de produção não muda nesta fase.
+
+## Estrutura de navegação
+
+```text
+[Perfil]   [+]   [Comunidade]
+```
+
+## O que cada item faz
+
+### Perfil
+
+- home mobile futura;
+- lugar do Perfil Estratégico;
+- Diagnóstico vivo do creator;
+- Comercial como leitura interna;
+- Mídia Kit como bridge/modal.
+
+### +
+
+- ação central;
+- inicia análise temporária;
+- atualiza o Perfil;
+- volta para o Perfil;
+- não é aba;
+- não é destino permanente.
+
+### Comunidade
+
+- destino existente da Data2Content;
+- não recriada nesta linha;
+- sem nova superfície social neste PR.
+
+## O que fica fora da bottom nav
+
+- Mídia Kit;
+- Diagnóstico;
+- Comercial;
+- Vídeos analisados;
+- Campanhas/CRM;
+- Calculadora;
+- Configurações.
+
+Mídia Kit é bridge/modal. Diagnóstico e Comercial são abas internas do Perfil. Vídeos analisados não devem virar arquivo visual permanente no produto mobile.
+
+## Auth behavior futuro
+
+Usuário não logado:
+
+- Perfil -> `LoginClient` com `intent=strategic_profile`;
+- `+` -> `LoginClient` com `intent=analyze_video`;
+- Comunidade -> login/community existente.
+
+Este PR apenas modela a intenção. Não altera `LoginClient`, NextAuth ou callback real.
+
+## Mídia Kit
+
+Mídia Kit é recurso existente, acessado por modal/bridge a partir do Perfil.
+
+Não alterar `MediaKitView`, dashboard real de Mídia Kit ou rota pública de Mídia Kit nesta etapa.
+
+## Comunidade
+
+Comunidade é destino existente.
+
+Não recriar Comunidade, página social, chat, comentários, creators públicos, posts ou mídia kits públicos novos neste PR.
+
+## Riscos
+
+- `ActivationPendingWidget` pode competir visualmente com bottom nav, botão central `+`, CTAs do Perfil e modal de Mídia Kit;
+- a sidebar mobile atual já tem comportamento sensível e precisa de integração cuidadosa;
+- pode haver duplicidade com a home atual;
+- pode surgir pressão para transformar análises em arquivo visual permanente;
+- o botão `+` pode virar aba se a decisão de ação central não ficar explícita;
+- Mídia Kit e Comunidade podem aparecer duplicados se forem adicionados à bottom nav e mantidos em entradas existentes.
+
+## Decisões futuras
+
+- definir quando integrar a navegação real;
+- decidir como esconder, reposicionar ou transformar o `ActivationPendingWidget` no app mobile;
+- decidir se o widget fica apenas desktop, acima da bottom nav ou condicionado ao estado de onboarding;
+- migrar a home mobile para Perfil sem quebrar o dashboard atual;
+- revisar `src/app/dashboard/components/sidebar/config.tsx` com cuidado antes de qualquer alteração real.
+
+## Fora de escopo
+
+- produção;
+- sidebar real;
+- `DashboardShell` ou `BoardShell`;
+- Mídia Kit real;
+- `MediaKitView`;
+- Comunidade real;
+- `LoginClient`;
+- NextAuth;
+- upload/storage;
+- persistência;
+- Gemini real;
+- Instagram real;
+- billing real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1141,6 +1141,34 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing, Stripe ou match real de marcas/creators.
 
+### MM49 — Mobile Navigation Preview Strategy
+
+Status: concluído.
+
+Arquivos principais:
+
+- `mobileStrategicProfileNavigationStrategy.ts`
+- `mobileStrategicProfileNavigationStrategy.test.ts`
+- `MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md`
+
+O que faz:
+
+- cria estratégia pura/documental para futura navegação mobile;
+- define `Perfil / + / Comunidade`;
+- mantém `+` como ação central, não aba;
+- mantém Mídia Kit como bridge/modal;
+- mantém Diagnóstico e Comercial dentro do Perfil;
+- modela redirects futuros de auth por intenção para Perfil e análise;
+- documenta riscos com sidebar mobile e `ActivationPendingWidget`.
+
+O que não faz:
+
+- não altera navegação real, sidebar/config, `DashboardShell`, `BoardShell` ou rotas reais de produção;
+- não altera Mídia Kit real, `MediaKitView`, Comunidade real, `LoginClient`, NextAuth ou `ActivationPendingWidget`;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing ou Stripe.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -255,8 +255,9 @@ Exemplos:
 45. MM46 — Strategic Profile Login Intent Copy. Reaproveita o login existente para copy contextual de Perfil e análise narrativa.
 46. MM47 — Media Kit Modal Bridge. Cria a ponte visual em modal entre Perfil Estratégico e Mídia Kit existente.
 47. MM48 — Analyze Entry and Return Flow. Modela o fluxo local do `+ / Analisar vídeo` que retorna ao Perfil.
-48. Teste real manual quando houver quota/billing disponível.
-49. Integração experimental futura no Board de Criação.
+48. MM49 — Mobile Navigation Preview Strategy. Consolida a estratégia futura de navegação app-first mobile.
+49. Teste real manual quando houver quota/billing disponível.
+50. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -345,6 +346,8 @@ MM46 conecta a intenção anônima ao login existente. Usuário anônimo deve pa
 MM47 materializa o Mídia Kit como bridge visual do Perfil, não como nova seção, aba ou produto. O Perfil traduz estratégia internamente, enquanto o Mídia Kit existente continua sendo a saída pública/comercial. O modal apenas aponta para copiar, compartilhar, ver como marca ou abrir o recurso existente em modo preview/local, sem clipboard real, Web Share API, navegação real, QR Code, alteração de `MediaKitView` ou mudança em `/mediakit/[token]`.
 
 MM48 materializa o `+` como ação central, não como aba. A análise de vídeo alimenta o Perfil Estratégico e retorna para a seção Diagnóstico, em vez de criar página isolada, recibo longo ou histórico visual. O produto preserva o aprendizado no diagnóstico vivo; o arquivo de vídeo pode ser descartado futuramente. A preview usa apenas estado local/mockado, sem upload real, storage, endpoint, persistência, fetch, FileReader ou navegação real.
+
+MM49 consolida a navegação app-first futura como `Perfil / + / Comunidade`. O Perfil é a home mobile, o `+` é mecanismo de atualização do Perfil e Comunidade é destino existente. Mídia Kit segue como bridge/modal, enquanto Diagnóstico e Comercial ficam dentro do Perfil. A integração real da navegação, sidebar mobile e `ActivationPendingWidget` fica para etapa posterior; este PR não altera produção.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileNavigationStrategy.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileNavigationStrategy.test.ts
@@ -1,0 +1,225 @@
+import fs from "fs";
+import path from "path";
+import { buildMobileStrategicProfile } from "./mobileStrategicProfileMapping";
+import { buildMobileStrategicProfileNavigationStrategy } from "./mobileStrategicProfileNavigationStrategy";
+import { resolveMobileStrategicProfileState } from "./mobileStrategicProfileStateContract";
+
+const SOURCE_PATH = path.join(__dirname, "mobileStrategicProfileNavigationStrategy.ts");
+
+function makeProfile() {
+  const state = resolveMobileStrategicProfileState({
+    isAuthenticated: true,
+    userName: "Ana Creator",
+    userHandle: "@ana.creator",
+    instagramConnected: false,
+  });
+
+  return buildMobileStrategicProfile({
+    state,
+    profileHref: "/mobile-profile",
+    analyzeVideoHref: "/analyze-video",
+    communityHref: "/community",
+    loginHref: "/login",
+  });
+}
+
+function build(params: Partial<Parameters<typeof buildMobileStrategicProfileNavigationStrategy>[0]> = {}) {
+  return buildMobileStrategicProfileNavigationStrategy({
+    profile: makeProfile(),
+    isAuthenticated: true,
+    profileHref: "/mobile-profile",
+    analyzeVideoHref: "/analyze-video",
+    communityHref: "/community",
+    loginHref: "/login",
+    currentSurface: "preview",
+    createdAt: "2026-05-19T00:00:00.000Z",
+    ...params,
+  });
+}
+
+function textOf(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("mobileStrategicProfileNavigationStrategy", () => {
+  it("creates Perfil as primary destination", () => {
+    const result = build();
+
+    expect(result.primaryDestinations).toEqual([
+      expect.objectContaining({
+        id: "profile",
+        label: "Perfil",
+        role: "destination",
+        href: "/mobile-profile",
+        active: true,
+      }),
+    ]);
+  });
+
+  it("creates Comunidade as existing destination", () => {
+    const result = build();
+
+    expect(result.secondaryDestinations).toEqual([
+      expect.objectContaining({
+        id: "community",
+        label: "Comunidade",
+        role: "destination",
+        href: "/community",
+        existingResource: true,
+      }),
+    ]);
+    expect(textOf(result.secondaryDestinations)).toContain("destino existente");
+    expect(textOf(result.secondaryDestinations)).not.toContain("feed");
+    expect(textOf(result.secondaryDestinations)).not.toContain("chat");
+    expect(textOf(result.secondaryDestinations)).not.toContain("comments");
+  });
+
+  it("creates plus as central_action and not a primary destination tab", () => {
+    const result = build();
+
+    expect(result.centralAction).toEqual(expect.objectContaining({
+      id: "analyze_video",
+      label: "+",
+      helper: "Analisar vídeo",
+      role: "central_action",
+      destinationAfterCompletion: "profile",
+      temporary: true,
+    }));
+    expect(result.primaryDestinations.map((item) => item.id)).not.toContain("analyze_video");
+  });
+
+  it("keeps forbidden destinations out of bottom nav", () => {
+    const result = build();
+    const forbiddenIds = result.forbiddenDestinations.map((item) => item.id);
+
+    expect(forbiddenIds).toEqual(expect.arrayContaining([
+      "media_kit",
+      "diagnosis",
+      "commercial",
+      "videos",
+      "uploads",
+      "campaigns",
+      "calculator",
+      "crm",
+      "collabs",
+      "settings",
+    ]));
+  });
+
+  it("describes Media Kit as bridge/modal without MediaKitView", () => {
+    const result = build();
+    const mediaKit = result.forbiddenDestinations.find((item) => item.id === "media_kit");
+
+    expect(mediaKit?.reason).toContain("bridge/modal");
+    expect(textOf(mediaKit)).not.toContain("mediakitview");
+  });
+
+  it("creates auth redirects for anonymous profile and plus intents", () => {
+    const result = build({
+      isAuthenticated: false,
+      loginHref: "/login",
+    });
+
+    expect(result.authRedirects).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "profile_auth",
+        source: "profile",
+        intent: "strategic_profile",
+        href: "/login?intent=strategic_profile",
+      }),
+      expect.objectContaining({
+        id: "analyze_video_auth",
+        source: "analyze_video",
+        intent: "analyze_video",
+        href: "/login?intent=analyze_video",
+      }),
+    ]));
+  });
+
+  it("does not create profile auth redirect for authenticated users", () => {
+    const result = build({ isAuthenticated: true });
+
+    expect(result.authRedirects.find((item) => item.source === "profile")).toBeUndefined();
+  });
+
+  it("includes required risks and activation risk when widget is present", () => {
+    const result = build({ activationWidgetPresent: true });
+    const riskIds = result.risks.map((item) => item.id);
+
+    expect(riskIds).toEqual(expect.arrayContaining([
+      "activation_widget_overlap",
+      "sidebar_mobile_conflict",
+      "analyze_video_becoming_tab",
+      "duplicated_media_kit_entry",
+      "duplicated_community_entry",
+      "profile_becoming_dashboard",
+      "video_history_pressure",
+    ]));
+    expect(result.risks.find((item) => item.id === "activation_widget_overlap")?.severity).toBe("high");
+  });
+
+  it("includes required guardrails", () => {
+    const result = build();
+    const guardrailIds = result.guardrails.map((item) => item.id);
+
+    expect(guardrailIds).toEqual(expect.arrayContaining([
+      "do_not_recreate_media_kit",
+      "do_not_recreate_community",
+      "do_not_add_video_history",
+      "do_not_make_analyze_video_a_tab",
+      "do_not_change_real_navigation_yet",
+      "keep_profile_as_mobile_home",
+      "keep_diagnosis_inside_profile",
+      "keep_commercial_inside_profile",
+    ]));
+  });
+
+  it("does not use forbidden terms", () => {
+    const text = textOf(build({ activationWidgetPresent: true, isAuthenticated: false }));
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "vídeos salvos",
+      "histórico de vídeos",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import React components, real navigation or forbidden integrations", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "React",
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "sidebar/config",
+      "ActivationPendingWidget",
+      "fetch",
+      "Prisma",
+      "banco",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "SDK",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileNavigationStrategy.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileNavigationStrategy.ts
@@ -1,0 +1,310 @@
+import type {
+  MobileStrategicProfile,
+  MobileStrategicProfileNavigationModel,
+} from "./mobileStrategicProfileMapping";
+import { sanitizeMobileStrategicProfileText } from "./mobileStrategicProfileStateContract";
+
+export type MobileStrategicProfileNavigationSurface =
+  | "preview"
+  | "future_mobile_app"
+  | "production_dashboard";
+
+export type MobileStrategicProfileNavigationDestinationId =
+  | "profile"
+  | "community"
+  | "media_kit"
+  | "diagnosis"
+  | "commercial"
+  | "videos"
+  | "uploads"
+  | "campaigns"
+  | "calculator"
+  | "crm"
+  | "collabs"
+  | "settings";
+
+export type MobileStrategicProfileNavigationRiskSeverity = "high" | "medium" | "low";
+
+export interface MobileStrategicProfileNavigationStrategyInput {
+  profile: MobileStrategicProfile;
+  isAuthenticated: boolean;
+  profileHref?: string | null;
+  analyzeVideoHref?: string | null;
+  communityHref?: string | null;
+  loginHref?: string | null;
+  loginIntentProfileHref?: string | null;
+  loginIntentAnalyzeHref?: string | null;
+  activationWidgetPresent?: boolean;
+  currentSurface?: MobileStrategicProfileNavigationSurface;
+  createdAt?: string | null;
+}
+
+export interface MobileStrategicProfileNavigationDestination {
+  id: Extract<MobileStrategicProfileNavigationDestinationId, "profile" | "community">;
+  label: "Perfil" | "Comunidade";
+  role: "destination";
+  href: string | null;
+  active: boolean;
+  description: string;
+  existingResource: boolean;
+}
+
+export interface MobileStrategicProfileNavigationAction {
+  id: "analyze_video";
+  label: "+";
+  helper: "Analisar vídeo";
+  role: "central_action";
+  href: string | null;
+  destinationAfterCompletion: "profile";
+  temporary: true;
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationAuthRedirect {
+  id: "profile_auth" | "analyze_video_auth" | "community_auth";
+  source: "profile" | "analyze_video" | "community";
+  intent: "strategic_profile" | "analyze_video" | "community";
+  href: string | null;
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationForbiddenDestination {
+  id: Exclude<MobileStrategicProfileNavigationDestinationId, "profile" | "community">;
+  label: string;
+  reason: string;
+}
+
+export interface MobileStrategicProfileNavigationFutureDecision {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationRisk {
+  id:
+    | "activation_widget_overlap"
+    | "sidebar_mobile_conflict"
+    | "duplicated_media_kit_entry"
+    | "duplicated_community_entry"
+    | "analyze_video_becoming_tab"
+    | "profile_becoming_dashboard"
+    | "video_history_pressure";
+  severity: MobileStrategicProfileNavigationRiskSeverity;
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationGuardrail {
+  id:
+    | "do_not_recreate_media_kit"
+    | "do_not_recreate_community"
+    | "do_not_add_video_history"
+    | "do_not_make_analyze_video_a_tab"
+    | "do_not_change_real_navigation_yet"
+    | "keep_profile_as_mobile_home"
+    | "keep_diagnosis_inside_profile"
+    | "keep_commercial_inside_profile";
+  description: string;
+}
+
+export interface MobileStrategicProfileNavigationStrategy {
+  primaryDestinations: MobileStrategicProfileNavigationDestination[];
+  centralAction: MobileStrategicProfileNavigationAction;
+  secondaryDestinations: MobileStrategicProfileNavigationDestination[];
+  authRedirects: MobileStrategicProfileNavigationAuthRedirect[];
+  forbiddenDestinations: MobileStrategicProfileNavigationForbiddenDestination[];
+  futureDecisions: MobileStrategicProfileNavigationFutureDecision[];
+  risks: MobileStrategicProfileNavigationRisk[];
+  guardrails: MobileStrategicProfileNavigationGuardrail[];
+  sourceNavigation: MobileStrategicProfileNavigationModel;
+  currentSurface: MobileStrategicProfileNavigationSurface;
+  createdAt: string | null;
+}
+
+function clean(value: string | null | undefined): string | null {
+  const sanitized = sanitizeMobileStrategicProfileText(value ?? "").trim();
+  return sanitized || null;
+}
+
+function destinationHref(inputHref: string | null | undefined, fallbackHref: string | null | undefined): string | null {
+  return clean(inputHref) ?? clean(fallbackHref);
+}
+
+function loginIntentHref(params: {
+  explicitHref: string | null | undefined;
+  loginHref: string | null | undefined;
+  intent: "strategic_profile" | "analyze_video";
+}): string | null {
+  const explicitHref = clean(params.explicitHref);
+  if (explicitHref) return explicitHref;
+
+  const loginHref = clean(params.loginHref);
+  if (!loginHref) return null;
+  const separator = loginHref.includes("?") ? "&" : "?";
+  return `${loginHref}${separator}intent=${params.intent}`;
+}
+
+function forbiddenDestination(
+  id: MobileStrategicProfileNavigationForbiddenDestination["id"],
+  label: string,
+  reason: string,
+): MobileStrategicProfileNavigationForbiddenDestination {
+  return { id, label, reason };
+}
+
+function risk(
+  id: MobileStrategicProfileNavigationRisk["id"],
+  severity: MobileStrategicProfileNavigationRiskSeverity,
+  description: string,
+): MobileStrategicProfileNavigationRisk {
+  return { id, severity, description };
+}
+
+function guardrail(
+  id: MobileStrategicProfileNavigationGuardrail["id"],
+  description: string,
+): MobileStrategicProfileNavigationGuardrail {
+  return { id, description };
+}
+
+export function buildMobileStrategicProfileNavigationStrategy(
+  input: MobileStrategicProfileNavigationStrategyInput,
+): MobileStrategicProfileNavigationStrategy {
+  const profileHref = destinationHref(input.profileHref, input.profile.navigation.items.find((item) => item.id === "profile")?.href);
+  const communityHref = destinationHref(input.communityHref, input.profile.communityBridge.href);
+  const analyzeHref = destinationHref(input.analyzeVideoHref, input.profile.navigation.items.find((item) => item.id === "analyze_video")?.href);
+
+  const primaryDestinations: MobileStrategicProfileNavigationDestination[] = [
+    {
+      id: "profile",
+      label: "Perfil",
+      role: "destination",
+      href: profileHref,
+      active: true,
+      description: "Home mobile futura e lugar do Perfil Estratégico como Diagnóstico vivo.",
+      existingResource: false,
+    },
+  ];
+
+  const centralAction: MobileStrategicProfileNavigationAction = {
+    id: "analyze_video",
+    label: "+",
+    helper: "Analisar vídeo",
+    role: "central_action",
+    href: analyzeHref,
+    destinationAfterCompletion: "profile",
+    temporary: true,
+    description: "Ação central temporária para atualizar o Perfil; não é aba nem destino permanente.",
+  };
+
+  const secondaryDestinations: MobileStrategicProfileNavigationDestination[] = [
+    {
+      id: "community",
+      label: "Comunidade",
+      role: "destination",
+      href: communityHref,
+      active: false,
+      description: "Destino existente da Comunidade Data2Content, sem recriar superfícies sociais novas.",
+      existingResource: true,
+    },
+  ];
+
+  const authRedirects: MobileStrategicProfileNavigationAuthRedirect[] = input.isAuthenticated
+    ? []
+    : [
+        {
+          id: "profile_auth",
+          source: "profile",
+          intent: "strategic_profile",
+          href: loginIntentHref({
+            explicitHref: input.loginIntentProfileHref,
+            loginHref: input.loginHref,
+            intent: "strategic_profile",
+          }),
+          description: "Perfil deve usar LoginClient com intenção de Perfil Estratégico em etapa futura.",
+        },
+        {
+          id: "analyze_video_auth",
+          source: "analyze_video",
+          intent: "analyze_video",
+          href: loginIntentHref({
+            explicitHref: input.loginIntentAnalyzeHref,
+            loginHref: input.loginHref,
+            intent: "analyze_video",
+          }),
+          description: "Ação central deve usar LoginClient com intenção de análise narrativa em etapa futura.",
+        },
+        {
+          id: "community_auth",
+          source: "community",
+          intent: "community",
+          href: clean(input.loginHref),
+          description: "Comunidade pode usar login/community existente, sem criar fluxo novo.",
+        },
+      ];
+
+  return {
+    primaryDestinations,
+    centralAction,
+    secondaryDestinations,
+    authRedirects,
+    forbiddenDestinations: [
+      forbiddenDestination("media_kit", "Mídia Kit", "Mídia Kit existente deve ser bridge/modal dentro do Perfil, sem alterar a superfície real."),
+      forbiddenDestination("diagnosis", "Diagnóstico", "Diagnóstico é aba interna do Perfil Estratégico, não tab global."),
+      forbiddenDestination("commercial", "Comercial", "Comercial é aba interna do Perfil Estratégico, não tab global."),
+      forbiddenDestination("videos", "Vídeos analisados", "A análise é temporária e não deve criar arquivo visual permanente."),
+      forbiddenDestination("uploads", "Uploads", "Upload não é destino permanente da navegação mobile futura."),
+      forbiddenDestination("campaigns", "Campanhas", "Campanhas ficam fora da navegação mobile enxuta neste momento."),
+      forbiddenDestination("calculator", "Calculadora", "Calculadora fica fora da navegação mobile enxuta neste momento."),
+      forbiddenDestination("crm", "CRM", "CRM fica fora da navegação mobile enxuta neste momento."),
+      forbiddenDestination("collabs", "Collabs", "Collabs não entram como destino global nesta fase."),
+      forbiddenDestination("settings", "Configurações", "Configurações não entram na bottom nav app-first inicial."),
+    ],
+    futureDecisions: [
+      {
+        id: "real_navigation_integration",
+        title: "Integração com navegação real",
+        description: "Definir etapa futura para integrar a bottom nav sem alterar sidebar/config neste PR.",
+      },
+      {
+        id: "activation_widget_mobile_behavior",
+        title: "ActivationPendingWidget no mobile",
+        description: "Decidir entre ocultar por flag, transformar em card do Perfil, manter desktop, reposicionar ou condicionar ao onboarding.",
+      },
+      {
+        id: "mobile_home_migration",
+        title: "Migração da home mobile",
+        description: "Migrar Perfil como home mobile sem quebrar o dashboard atual.",
+      },
+    ],
+    risks: [
+      ...(input.activationWidgetPresent
+        ? [
+            risk(
+              "activation_widget_overlap",
+              "high",
+              "ActivationPendingWidget pode competir com bottom nav, ação central, CTAs do Perfil e modal de Mídia Kit.",
+            ),
+          ]
+        : []),
+      risk("sidebar_mobile_conflict", "high", "Sidebar/config atual tem comportamento mobile sensível e deve ser tratado em integração futura."),
+      risk("duplicated_media_kit_entry", "medium", "Mídia Kit pode aparecer duplicado se virar item de navegação além do bridge/modal."),
+      risk("duplicated_community_entry", "medium", "Comunidade pode aparecer duplicada entre navegação atual e bottom nav futura."),
+      risk("analyze_video_becoming_tab", "high", "A ação + pode virar aba por pressão de produto, quebrando a decisão de ação temporária."),
+      risk("profile_becoming_dashboard", "medium", "Perfil pode virar dashboard técnico se acumular métricas e módulos globais."),
+      risk("video_history_pressure", "medium", "Pode surgir pressão para criar arquivo visual de análises, contrariando o diagnóstico vivo."),
+    ],
+    guardrails: [
+      guardrail("do_not_recreate_media_kit", "Mídia Kit segue como recurso existente acessado por bridge/modal."),
+      guardrail("do_not_recreate_community", "Comunidade segue como destino existente, sem superfícies sociais novas."),
+      guardrail("do_not_add_video_history", "Não criar arquivo visual permanente de análises no Perfil mobile."),
+      guardrail("do_not_make_analyze_video_a_tab", "+ / Analisar vídeo é ação central, não aba."),
+      guardrail("do_not_change_real_navigation_yet", "Não alterar navegação real, sidebar/config, DashboardShell ou BoardShell neste PR."),
+      guardrail("keep_profile_as_mobile_home", "Perfil é a home mobile futura."),
+      guardrail("keep_diagnosis_inside_profile", "Diagnóstico fica dentro do Perfil."),
+      guardrail("keep_commercial_inside_profile", "Comercial fica dentro do Perfil."),
+    ],
+    sourceNavigation: input.profile.navigation,
+    currentSurface: input.currentSurface ?? "preview",
+    createdAt: clean(input.createdAt),
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #845.

MM49 adds a pure navigation strategy for the future mobile Strategic Profile experience.

Changes:
- Adds `mobileStrategicProfileNavigationStrategy.ts` and tests.
- Adds `MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md`.
- Models future navigation as Perfil / + / Comunidade.
- Keeps Perfil as the future mobile home.
- Keeps + as a central action, not a tab.
- Keeps Comunidade as an existing destination.
- Keeps Mídia Kit as a bridge/modal.
- Keeps Diagnóstico and Comercial as internal Perfil tabs.
- Documents risks around the current mobile sidebar, ActivationPendingWidget, duplicated entries, and video history pressure.
- Updates docs for MM49.

## Validation

- Navigation strategy tests passed.
- Mapping and state contract tests passed.
- MobileStrategicProfilePreview tests passed.
- Typecheck passed.
- Build passed with existing warnings outside this scope.

## Guardrails

No real Gemini, upload/storage, persistence, endpoint, login/auth, MediaKitView, Community, real navigation, Instagram, or billing changes.