### PR TITLE
feat: add mobile strategic profile activation widget strategy

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -122,6 +122,8 @@ Já existe:
 - MM48 modela a ação `+ / Analisar vídeo` como fluxo local que retorna ao Perfil, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera Mídia Kit, Comunidade ou login reais;
 - mobile navigation preview strategy foi criado em MM49 como camada segura de estratégia/contrato;
 - MM49 consolida `Perfil / + / Comunidade` para navegação mobile futura, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera navegação real;
+- activation widget conflict strategy foi criado em MM50 como camada segura de estratégia/contrato;
+- MM50 modela conflitos do `ActivationPendingWidget` com bottom nav, ação central, Mídia Kit modal e fluxo de análise, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera `ActivationPendingWidget` real;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_ACTIVATION_WIDGET_STRATEGY.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_ACTIVATION_WIDGET_STRATEGY.md
@@ -1,0 +1,68 @@
+# Mobile Strategic Profile Activation Widget Strategy
+
+## Visão geral
+
+O ActivationPendingWidget é útil na experiência atual, mas pode competir com a nova navegação mobile app-first do Perfil Estratégico.
+
+Este documento define a estratégia futura sem alterar o widget real.
+
+## Estado atual
+
+Sem alterar produção, o comportamento atual deve ser tratado como:
+
+- widget fixo no mobile;
+- aparece próximo ao rodapé;
+- pode expandir ou minimizar;
+- pode executar ações reais em produção;
+- usa camada visual alta.
+
+Arquivos relacionados, apenas para contexto:
+
+- `src/app/dashboard/components/activation/ActivationPendingWidget.tsx`;
+- `src/app/dashboard/components/activation/useActivationChecklist.ts`;
+- `src/app/dashboard/components/sidebar/config.tsx`.
+
+## Conflitos com o Perfil Estratégico
+
+O widget pode competir com:
+
+- bottom nav;
+- botão `+`;
+- CTAs do Perfil;
+- modal de Mídia Kit;
+- fluxo de análise;
+- safe area.
+
+## Políticas possíveis
+
+- manter em produção por enquanto;
+- ocultar na experiência mobile app-first futura;
+- transformar em card interno;
+- manter só desktop;
+- reposicionar com safe area;
+- controlar por feature flag.
+
+## Recomendação atual
+
+- não alterar produção agora;
+- não renderizar o widget dentro da preview do Perfil;
+- em futura integração mobile, preferir ocultar o widget flutuante e transformar ativação em card interno do Perfil.
+
+## Integração futura
+
+- só mexer depois de a navegação real do Perfil ser implementada;
+- usar feature flag;
+- testar com bottom nav e modal de Mídia Kit;
+- preservar desktop se necessário;
+- validar o fluxo de análise com o widget ausente, oculto ou transformado em card.
+
+## Fora de escopo
+
+- alteração do widget real;
+- alteração de `useActivationChecklist`;
+- alteração de navegação real;
+- alteração de billing;
+- alteração de Instagram;
+- alteração de Mídia Kit;
+- endpoint, upload, storage ou persistência;
+- Gemini real.

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md
@@ -88,6 +88,14 @@ Não recriar Comunidade, página social, chat, comentários, creators públicos,
 - migrar a home mobile para Perfil sem quebrar o dashboard atual;
 - revisar `src/app/dashboard/components/sidebar/config.tsx` com cuidado antes de qualquer alteração real.
 
+### ActivationPendingWidget conflict
+
+Risco identificado: o widget de ativação atual pode competir com bottom nav, botão `+`, CTAs do Perfil, modal de Mídia Kit, fluxo de análise e safe area.
+
+Estratégia temporária: não renderizar esse widget dentro da preview do Perfil e não alterar produção nesta fase.
+
+Recomendação futura: quando a navegação mobile real for integrada por feature flag, preferir ocultar o widget flutuante no app mobile e transformar ativação em card interno do Perfil, preservando comportamento desktop se necessário.
+
 ## Fora de escopo
 
 - produção;

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1169,6 +1169,32 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing ou Stripe.
 
+### MM50 — Activation Widget Conflict Strategy
+
+Status: concluído.
+
+Arquivos principais:
+
+- `mobileStrategicProfileActivationWidgetStrategy.ts`
+- `mobileStrategicProfileActivationWidgetStrategy.test.ts`
+- `MOBILE_STRATEGIC_PROFILE_ACTIVATION_WIDGET_STRATEGY.md`
+
+O que faz:
+
+- cria estratégia pura/documental para o conflito entre `ActivationPendingWidget` e futura experiência mobile app-first;
+- modela riscos com bottom nav, botão `+`, Mídia Kit modal e fluxo de análise;
+- recomenda não alterar produção agora;
+- prepara decisão futura por feature flag;
+- recomenda card interno do Perfil como opção futura.
+
+O que não faz:
+
+- não altera widget real, `useActivationChecklist`, navegação real, sidebar/config, `DashboardShell` ou `BoardShell`;
+- não altera endpoint, `LoginClient`, NextAuth, `MediaKitView`, Mídia Kit real ou Comunidade real;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing ou Stripe.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -256,8 +256,9 @@ Exemplos:
 46. MM47 — Media Kit Modal Bridge. Cria a ponte visual em modal entre Perfil Estratégico e Mídia Kit existente.
 47. MM48 — Analyze Entry and Return Flow. Modela o fluxo local do `+ / Analisar vídeo` que retorna ao Perfil.
 48. MM49 — Mobile Navigation Preview Strategy. Consolida a estratégia futura de navegação app-first mobile.
-49. Teste real manual quando houver quota/billing disponível.
-50. Integração experimental futura no Board de Criação.
+49. MM50 — Activation Widget Conflict Strategy. Modela o conflito do widget de ativação com a experiência mobile app-first futura.
+50. Teste real manual quando houver quota/billing disponível.
+51. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -348,6 +349,8 @@ MM47 materializa o Mídia Kit como bridge visual do Perfil, não como nova seç�
 MM48 materializa o `+` como ação central, não como aba. A análise de vídeo alimenta o Perfil Estratégico e retorna para a seção Diagnóstico, em vez de criar página isolada, recibo longo ou histórico visual. O produto preserva o aprendizado no diagnóstico vivo; o arquivo de vídeo pode ser descartado futuramente. A preview usa apenas estado local/mockado, sem upload real, storage, endpoint, persistência, fetch, FileReader ou navegação real.
 
 MM49 consolida a navegação app-first futura como `Perfil / + / Comunidade`. O Perfil é a home mobile, o `+` é mecanismo de atualização do Perfil e Comunidade é destino existente. Mídia Kit segue como bridge/modal, enquanto Diagnóstico e Comercial ficam dentro do Perfil. A integração real da navegação, sidebar mobile e `ActivationPendingWidget` fica para etapa posterior; este PR não altera produção.
+
+MM50 fecha a análise dos conflitos de camada mobile. O `ActivationPendingWidget` fica fora da preview do Perfil, e qualquer integração real depende de feature flag e decisão futura. A estratégia recomenda manter produção atual, preferir card interno do Perfil ou ocultação no futuro app mobile, sem alterar widget real, `useActivationChecklist`, sidebar ou navegação real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileActivationWidgetStrategy.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileActivationWidgetStrategy.test.ts
@@ -1,0 +1,182 @@
+import fs from "fs";
+import path from "path";
+import { buildMobileStrategicProfileActivationWidgetStrategy } from "./mobileStrategicProfileActivationWidgetStrategy";
+
+const SOURCE_PATH = path.join(__dirname, "mobileStrategicProfileActivationWidgetStrategy.ts");
+
+function build(
+  params: Partial<Parameters<typeof buildMobileStrategicProfileActivationWidgetStrategy>[0]> = {},
+) {
+  return buildMobileStrategicProfileActivationWidgetStrategy({
+    currentSurface: "production_dashboard",
+    viewport: "mobile",
+    createdAt: "2026-05-19T00:00:00.000Z",
+    ...params,
+  });
+}
+
+function textOf(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("mobileStrategicProfileActivationWidgetStrategy", () => {
+  it("current production does not recommend immediate change", () => {
+    const result = build({ currentSurface: "production_dashboard", viewport: "mobile" });
+
+    expect(["keep_current_for_production", "defer_until_navigation_integration"]).toContain(result.recommendedPolicy);
+    expect(result.shouldChangeProductionNow).toBe(false);
+  });
+
+  it("strategic profile preview does not recommend rendering the widget inside preview", () => {
+    const result = build({
+      currentSurface: "strategic_profile_preview",
+      viewport: "mobile",
+      hasBottomNav: true,
+      hasCentralAnalyzeAction: true,
+    });
+
+    expect(result.recommendedPolicy).toBe("defer_until_navigation_integration");
+    expect(result.shouldChangeProductionNow).toBe(false);
+    expect(result.guardrails.map((item) => item.id)).toContain("do_not_change_activation_widget_now");
+  });
+
+  it("future mobile app with bottom nav recommends hiding or converting to profile card", () => {
+    const result = build({
+      currentSurface: "future_mobile_app",
+      viewport: "mobile",
+      hasBottomNav: true,
+    });
+
+    expect(["hide_on_future_mobile_app", "convert_to_profile_card"]).toContain(result.recommendedPolicy);
+    expect(result.shouldHideInFutureMobileApp).toBe(true);
+  });
+
+  it("future mobile app with central analyze action registers central action competition", () => {
+    const result = build({
+      currentSurface: "future_mobile_app",
+      viewport: "mobile",
+      hasCentralAnalyzeAction: true,
+    });
+
+    expect(result.conflicts.map((item) => item.id)).toContain("central_action_competition");
+    expect(result.risks.find((item) => item.id === "central_action_competition")?.severity).toBe("high");
+  });
+
+  it("bottom nav, Media Kit modal and analyze flow register specific conflicts", () => {
+    const result = build({
+      currentSurface: "future_mobile_app",
+      viewport: "mobile",
+      hasBottomNav: true,
+      hasMediaKitModal: true,
+      hasAnalyzeFlow: true,
+    });
+
+    expect(result.conflicts.map((item) => item.id)).toEqual(expect.arrayContaining([
+      "bottom_nav_overlap",
+      "media_kit_modal_overlap",
+      "analyze_flow_distraction",
+    ]));
+    expect(result.risks.find((item) => item.id === "bottom_nav_overlap")?.severity).toBe("high");
+    expect(result.risks.find((item) => item.id === "media_kit_modal_overlap")?.severity).toBe("medium");
+    expect(result.risks.find((item) => item.id === "analyze_flow_distraction")?.severity).toBe("medium");
+  });
+
+  it("desktop can keep desktop-only behavior", () => {
+    const result = build({
+      currentSurface: "future_mobile_app",
+      viewport: "desktop",
+    });
+
+    expect(result.recommendedPolicy).toBe("desktop_only");
+    expect(result.shouldKeepDesktopOnly).toBe(true);
+  });
+
+  it("construction profile recommends profile card as future option", () => {
+    const result = build({
+      currentSurface: "future_mobile_app",
+      viewport: "mobile",
+      profileAvailability: "construction",
+    });
+
+    expect(result.recommendedPolicy).toBe("convert_to_profile_card");
+    expect(result.shouldConvertToProfileCard).toBe(true);
+    expect(result.futureDecisions.map((item) => item.id)).toContain("convert_to_profile_card");
+  });
+
+  it("includes required guardrails", () => {
+    const result = build();
+    const guardrailIds = result.guardrails.map((item) => item.id);
+
+    expect(guardrailIds).toEqual(expect.arrayContaining([
+      "do_not_change_activation_widget_now",
+      "do_not_overlap_bottom_nav",
+      "do_not_compete_with_central_plus",
+      "do_not_block_media_kit_modal",
+      "do_not_interrupt_analyze_flow",
+      "prefer_profile_card_for_mobile_onboarding",
+      "keep_desktop_behavior_until_integration",
+      "require_feature_flag_before_real_change",
+    ]));
+  });
+
+  it("reserves safe area when mobile widget or bottom nav are present", () => {
+    expect(build({ viewport: "mobile", activationWidgetVisible: true }).shouldReserveSafeArea).toBe(true);
+    expect(build({ viewport: "mobile", hasBottomNav: true }).shouldReserveSafeArea).toBe(true);
+  });
+
+  it("does not use forbidden terms", () => {
+    const text = textOf(build({
+      currentSurface: "future_mobile_app",
+      viewport: "mobile",
+      hasBottomNav: true,
+      hasCentralAnalyzeAction: true,
+      hasMediaKitModal: true,
+      hasAnalyzeFlow: true,
+      activationWidgetVisible: true,
+      profileAvailability: "construction",
+    }));
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("does not import React components or forbidden integrations", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    for (const forbidden of [
+      "React",
+      "ActivationPendingWidget",
+      "useActivationChecklist",
+      "sidebar/config",
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "fetch",
+      "Prisma",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "SDK",
+    ]) {
+      expect(importLines).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileActivationWidgetStrategy.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileActivationWidgetStrategy.ts
@@ -1,0 +1,252 @@
+import { sanitizeMobileStrategicProfileText } from "./mobileStrategicProfileStateContract";
+
+export type MobileStrategicProfileActivationWidgetSurface =
+  | "production_dashboard"
+  | "strategic_profile_preview"
+  | "future_mobile_app";
+
+export type MobileStrategicProfileActivationWidgetViewport = "mobile" | "desktop";
+
+export type MobileStrategicProfileActivationWidgetPolicy =
+  | "keep_current_for_production"
+  | "hide_on_future_mobile_app"
+  | "convert_to_profile_card"
+  | "desktop_only"
+  | "reserve_safe_area_above_bottom_nav"
+  | "defer_until_navigation_integration";
+
+export type MobileStrategicProfileActivationWidgetRiskSeverity = "high" | "medium" | "low";
+
+export interface MobileStrategicProfileActivationWidgetStrategyInput {
+  currentSurface: MobileStrategicProfileActivationWidgetSurface;
+  viewport: MobileStrategicProfileActivationWidgetViewport;
+  hasBottomNav?: boolean;
+  hasCentralAnalyzeAction?: boolean;
+  hasMediaKitModal?: boolean;
+  hasAnalyzeFlow?: boolean;
+  activationWidgetVisible?: boolean;
+  activationWidgetCompletionVisible?: boolean;
+  profileAvailability?: "auth_gate" | "construction" | "active" | null;
+  createdAt?: string | null;
+}
+
+export interface MobileStrategicProfileActivationWidgetConflict {
+  id:
+    | "bottom_nav_overlap"
+    | "central_action_competition"
+    | "media_kit_modal_overlap"
+    | "analyze_flow_distraction"
+    | "profile_cta_duplication"
+    | "safe_area_collision";
+  surface: MobileStrategicProfileActivationWidgetSurface;
+  description: string;
+}
+
+export interface MobileStrategicProfileActivationWidgetRisk {
+  id:
+    | "bottom_nav_overlap"
+    | "central_action_competition"
+    | "media_kit_modal_overlap"
+    | "analyze_flow_distraction"
+    | "onboarding_cta_duplication"
+    | "z_index_conflict"
+    | "safe_area_collision"
+    | "production_regression";
+  severity: MobileStrategicProfileActivationWidgetRiskSeverity;
+  description: string;
+}
+
+export interface MobileStrategicProfileActivationWidgetFutureDecision {
+  id:
+    | "hide_with_feature_flag"
+    | "convert_to_profile_card"
+    | "desktop_only"
+    | "safe_area_reposition"
+    | "construction_state_only"
+    | "profile_checklist";
+  title: string;
+  description: string;
+}
+
+export interface MobileStrategicProfileActivationWidgetGuardrail {
+  id:
+    | "do_not_change_activation_widget_now"
+    | "do_not_overlap_bottom_nav"
+    | "do_not_compete_with_central_plus"
+    | "do_not_block_media_kit_modal"
+    | "do_not_interrupt_analyze_flow"
+    | "prefer_profile_card_for_mobile_onboarding"
+    | "keep_desktop_behavior_until_integration"
+    | "require_feature_flag_before_real_change";
+  description: string;
+}
+
+export interface MobileStrategicProfileActivationWidgetStrategy {
+  currentSurface: MobileStrategicProfileActivationWidgetSurface;
+  viewport: MobileStrategicProfileActivationWidgetViewport;
+  recommendedPolicy: MobileStrategicProfileActivationWidgetPolicy;
+  conflicts: MobileStrategicProfileActivationWidgetConflict[];
+  risks: MobileStrategicProfileActivationWidgetRisk[];
+  guardrails: MobileStrategicProfileActivationWidgetGuardrail[];
+  futureDecisions: MobileStrategicProfileActivationWidgetFutureDecision[];
+  shouldChangeProductionNow: boolean;
+  shouldHideInFutureMobileApp: boolean;
+  shouldConvertToProfileCard: boolean;
+  shouldKeepDesktopOnly: boolean;
+  shouldReserveSafeArea: boolean;
+  createdAt: string | null;
+}
+
+function clean(value: string | null | undefined): string | null {
+  const sanitized = sanitizeMobileStrategicProfileText(value ?? "").trim();
+  return sanitized || null;
+}
+
+function conflict(
+  id: MobileStrategicProfileActivationWidgetConflict["id"],
+  surface: MobileStrategicProfileActivationWidgetSurface,
+  description: string,
+): MobileStrategicProfileActivationWidgetConflict {
+  return { id, surface, description };
+}
+
+function risk(
+  id: MobileStrategicProfileActivationWidgetRisk["id"],
+  severity: MobileStrategicProfileActivationWidgetRiskSeverity,
+  description: string,
+): MobileStrategicProfileActivationWidgetRisk {
+  return { id, severity, description };
+}
+
+function guardrail(
+  id: MobileStrategicProfileActivationWidgetGuardrail["id"],
+  description: string,
+): MobileStrategicProfileActivationWidgetGuardrail {
+  return { id, description };
+}
+
+function decidePolicy(
+  input: MobileStrategicProfileActivationWidgetStrategyInput,
+): MobileStrategicProfileActivationWidgetPolicy {
+  if (input.currentSurface === "production_dashboard") {
+    return input.viewport === "desktop" ? "keep_current_for_production" : "defer_until_navigation_integration";
+  }
+
+  if (input.currentSurface === "strategic_profile_preview") {
+    return "defer_until_navigation_integration";
+  }
+
+  if (input.viewport === "desktop") {
+    return "desktop_only";
+  }
+
+  if (input.profileAvailability === "construction") {
+    return "convert_to_profile_card";
+  }
+
+  if (input.hasBottomNav || input.hasCentralAnalyzeAction) {
+    return "hide_on_future_mobile_app";
+  }
+
+  return "reserve_safe_area_above_bottom_nav";
+}
+
+export function buildMobileStrategicProfileActivationWidgetStrategy(
+  input: MobileStrategicProfileActivationWidgetStrategyInput,
+): MobileStrategicProfileActivationWidgetStrategy {
+  const recommendedPolicy = decidePolicy(input);
+  const mobile = input.viewport === "mobile";
+  const futureMobile = input.currentSurface === "future_mobile_app";
+  const preview = input.currentSurface === "strategic_profile_preview";
+  const production = input.currentSurface === "production_dashboard";
+
+  const conflicts: MobileStrategicProfileActivationWidgetConflict[] = [];
+  if (input.hasBottomNav) {
+    conflicts.push(conflict("bottom_nav_overlap", input.currentSurface, "Widget de ativação pode ocupar a mesma área da bottom nav."));
+  }
+  if (input.hasCentralAnalyzeAction) {
+    conflicts.push(conflict("central_action_competition", input.currentSurface, "Widget de ativação pode competir com a ação central +."));
+  }
+  if (input.hasMediaKitModal) {
+    conflicts.push(conflict("media_kit_modal_overlap", input.currentSurface, "Widget de ativação pode competir em camada visual com o modal de Mídia Kit."));
+  }
+  if (input.hasAnalyzeFlow) {
+    conflicts.push(conflict("analyze_flow_distraction", input.currentSurface, "Widget de ativação pode tirar foco do fluxo de análise."));
+  }
+  if (input.activationWidgetCompletionVisible || input.profileAvailability === "construction") {
+    conflicts.push(conflict("profile_cta_duplication", input.currentSurface, "Widget de ativação pode duplicar CTAs do Perfil em construção."));
+  }
+  if (mobile && input.activationWidgetVisible) {
+    conflicts.push(conflict("safe_area_collision", input.currentSurface, "Widget de ativação pode colidir com safe area no mobile."));
+  }
+
+  const shouldHideInFutureMobileApp = futureMobile && mobile && Boolean(input.hasBottomNav || input.hasCentralAnalyzeAction);
+  const shouldConvertToProfileCard = futureMobile && mobile && input.profileAvailability === "construction";
+  const shouldKeepDesktopOnly = input.viewport === "desktop" && (production || futureMobile);
+  const shouldReserveSafeArea = mobile && Boolean(input.activationWidgetVisible || input.hasBottomNav);
+
+  return {
+    currentSurface: input.currentSurface,
+    viewport: input.viewport,
+    recommendedPolicy,
+    conflicts,
+    risks: [
+      risk("bottom_nav_overlap", "high", "Bottom nav e widget de ativação podem disputar a área inferior mobile."),
+      risk("central_action_competition", "high", "Ação central + pode perder prioridade visual se o widget flutuante continuar no mesmo espaço."),
+      risk("media_kit_modal_overlap", "medium", "Modal de Mídia Kit pode competir com camada visual do widget."),
+      risk("analyze_flow_distraction", "medium", "Fluxo de análise pode perder foco se houver chamada de ativação simultânea."),
+      risk("onboarding_cta_duplication", "medium", "CTAs de onboarding podem duplicar CTAs do Perfil Estratégico."),
+      risk("z_index_conflict", "medium", "Camadas flutuantes podem gerar conflito visual em mobile."),
+      risk("safe_area_collision", "high", "Área segura inferior do celular pode ser ocupada por nav e widget ao mesmo tempo."),
+      risk("production_regression", "high", "Alterar o widget real antes da integração pode quebrar a experiência atual."),
+    ],
+    guardrails: [
+      guardrail("do_not_change_activation_widget_now", "Não alterar o widget de ativação real neste PR."),
+      guardrail("do_not_overlap_bottom_nav", "Não deixar widget flutuante competir com bottom nav futura."),
+      guardrail("do_not_compete_with_central_plus", "Não competir com a ação central +."),
+      guardrail("do_not_block_media_kit_modal", "Não bloquear ou sobrepor o modal de Mídia Kit."),
+      guardrail("do_not_interrupt_analyze_flow", "Não interromper o fluxo de análise."),
+      guardrail("prefer_profile_card_for_mobile_onboarding", "Preferir card interno do Perfil para onboarding mobile."),
+      guardrail("keep_desktop_behavior_until_integration", "Preservar desktop até integração real com feature flag."),
+      guardrail("require_feature_flag_before_real_change", "Toda alteração real deve passar por feature flag."),
+    ],
+    futureDecisions: [
+      {
+        id: "hide_with_feature_flag",
+        title: "Ocultar no app mobile futuro",
+        description: "Ocultar o widget flutuante por feature flag quando a navegação app-first estiver ativa.",
+      },
+      {
+        id: "convert_to_profile_card",
+        title: "Transformar em card interno",
+        description: "Mover ativação para card interno do Perfil em estados de construção.",
+      },
+      {
+        id: "desktop_only",
+        title: "Manter apenas desktop",
+        description: "Preservar comportamento desktop se a experiência mobile exigir bottom nav limpa.",
+      },
+      {
+        id: "safe_area_reposition",
+        title: "Reposicionar com safe area",
+        description: "Reposicionar acima da bottom nav se o widget seguir visível no mobile.",
+      },
+      {
+        id: "construction_state_only",
+        title: "Mostrar só em construção",
+        description: "Exibir ativação apenas em account_only/construction se continuar útil.",
+      },
+      {
+        id: "profile_checklist",
+        title: "Checklist dentro do Perfil",
+        description: "Substituir widget flutuante por checklist contextual dentro do Perfil.",
+      },
+    ],
+    shouldChangeProductionNow: false,
+    shouldHideInFutureMobileApp,
+    shouldConvertToProfileCard,
+    shouldKeepDesktopOnly,
+    shouldReserveSafeArea,
+    createdAt: clean(input.createdAt),
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #846.

MM50 adds a pure strategy layer for how the existing ActivationPendingWidget should coexist with the future mobile Strategic Profile experience.

Changes:
- Adds `mobileStrategicProfileActivationWidgetStrategy.ts` and tests.
- Adds `MOBILE_STRATEGIC_PROFILE_ACTIVATION_WIDGET_STRATEGY.md`.
- Models policies, conflicts, risks, guardrails, and future decisions.
- Keeps current production behavior unchanged.
- Recommends deferring real changes until mobile navigation integration.
- For the future mobile app, favors hiding the floating widget or converting it into an internal Profile card when bottom nav, central +, Media Kit modal, or analyze flow are present.
- Updates docs for MM50.

## Validation

- Activation widget strategy tests passed.
- Navigation strategy tests passed.
- MobileStrategicProfilePreview tests passed.
- Typecheck passed.
- Build passed with existing warnings outside this scope.

## Guardrails

No real Gemini, upload/storage, persistence, endpoint, login/auth, MediaKitView, Community, real navigation, ActivationPendingWidget, Instagram, or billing changes.