### PR TITLE
docs: add mobile strategic profile UX QA checklist

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -124,6 +124,8 @@ Já existe:
 - MM49 consolida `Perfil / + / Comunidade` para navegação mobile futura, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera navegação real;
 - activation widget conflict strategy foi criado em MM50 como camada segura de estratégia/contrato;
 - MM50 modela conflitos do `ActivationPendingWidget` com bottom nav, ação central, Mídia Kit modal e fluxo de análise, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera `ActivationPendingWidget` real;
+- strategic profile mobile UX QA checklist foi criado em MM51 como camada segura de QA;
+- MM51 valida a experiência do Perfil Estratégico como produto antes de integração real, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera UI real de produção;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
@@ -1,0 +1,284 @@
+# Mobile Strategic Profile UX QA
+
+## Visão geral
+
+Esta checklist valida a experiência mobile do Perfil Estratégico antes de qualquer integração real.
+
+Frase-guia:
+
+> O Perfil da D2C é o diagnóstico vivo do creator. Cada vídeo analisado atualiza esse perfil.
+
+Objetivo do QA:
+
+- confirmar que o Perfil parece a casa mobile do app;
+- confirmar que o usuário entende a relação entre Perfil, diagnóstico vivo e análise de vídeo;
+- validar que `+` é ação central, não aba;
+- validar que Mídia Kit e Comunidade seguem como recursos existentes;
+- impedir dependência visual de histórico de vídeos ou dashboard espremido;
+- registrar achados antes de polish/copy ou integração real.
+
+Documentos relacionados:
+
+- `MOBILE_STRATEGIC_PROFILE_NAVIGATION_STRATEGY.md`
+- `MOBILE_STRATEGIC_PROFILE_ACTIVATION_WIDGET_STRATEGY.md`
+
+## Setup da preview
+
+URL base:
+
+- `/dashboard/boards/mobile-strategic-profile-preview`
+
+Feature flag:
+
+- `NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1`
+
+Requisito de acesso:
+
+- usuário `admin/dev`;
+- preview interna apenas;
+- nenhuma navegação real deve ser alterada durante este QA.
+
+## Estados obrigatórios da preview
+
+- Anonymous profile: `/dashboard/boards/mobile-strategic-profile-preview?state=anonymous_view_profile`
+- Anonymous analyze: `/dashboard/boards/mobile-strategic-profile-preview?state=anonymous_analyze_video`
+- Account only: `/dashboard/boards/mobile-strategic-profile-preview?state=account_only`
+- First reading free: `/dashboard/boards/mobile-strategic-profile-preview?state=first_reading_free`
+- Premium without Instagram: `/dashboard/boards/mobile-strategic-profile-preview?state=premium_without_instagram`
+- Instagram optimized: `/dashboard/boards/mobile-strategic-profile-preview?state=instagram_optimized`
+- Media Kit available: `/dashboard/boards/mobile-strategic-profile-preview?state=media_kit_available`
+
+## Critérios do topo do Perfil
+
+- [ ] O topo parece um perfil social, não um dashboard.
+- [ ] Nome, handle e bio aparecem com clareza.
+- [ ] Status pills explicam estado, não métrica técnica.
+- [ ] Não aparecem “18 sinais”, “3 narrativas” ou percentual de perfil.
+- [ ] CTA principal está claro.
+- [ ] Botão `+` é entendido como ação de análise.
+
+## Critérios do Auth Gate
+
+- [ ] Usuário anônimo não vê Perfil fake.
+- [ ] Copy de Perfil orienta criar Perfil Estratégico.
+- [ ] Copy de `+` orienta analisar primeiro vídeo.
+- [ ] Preview não chama login real.
+- [ ] Preview não importa `LoginClient`.
+- [ ] Intenção futura de callback fica clara.
+
+## Critérios do Perfil em construção
+
+- [ ] Estado não parece vazio.
+- [ ] Usuário entende que já tem uma casa no app.
+- [ ] CTA “Analisar primeiro vídeo” aparece cedo.
+- [ ] Comercial aparece como limitado/construção.
+- [ ] Mídia Kit não aparece como disponível sem condição.
+- [ ] Não há sensação de erro ou bloqueio agressivo.
+
+## Critérios da primeira leitura gratuita
+
+- [ ] Entrega valor real.
+- [ ] Mostra diagnóstico inicial.
+- [ ] Mostra próximo passo.
+- [ ] Sugere Instagram sem parecer obrigatório.
+- [ ] Não parece relatório longo.
+- [ ] Não tenta parecer perfil completo.
+
+## Critérios do premium
+
+- [ ] Parece mais completo que free.
+- [ ] Diagnóstico tem profundidade.
+- [ ] Comercial aparece como tradução estratégica.
+- [ ] Não promete marca, publi ou match.
+- [ ] Instagram é apresentado como precisão futura, não obrigação.
+
+## Critérios do Instagram optimized
+
+- [ ] Mostra leitura mais precisa.
+- [ ] Mostra Instagram conectado.
+- [ ] Não promete performance.
+- [ ] Não afirma uso de dados reais se for mock/preview.
+- [ ] Mídia Kit disponível aparece como bridge quando aplicável.
+
+## Critérios do Mídia Kit modal
+
+- [ ] Mídia Kit não é aba principal.
+- [ ] Modal abre a partir da ação de Mídia Kit.
+- [ ] Modal parece ponte para recurso existente.
+- [ ] Não cria Mídia Kit mobile novo.
+- [ ] Não altera `MediaKitView`.
+- [ ] Não mostra diagnóstico interno.
+- [ ] Não mostra ponto fraco, quiz, sinais pendentes ou recomendações internas.
+- [ ] Botões são visuais/local preview only.
+- [ ] Sem clipboard real.
+- [ ] Sem Web Share API.
+- [ ] Sem `window.open`.
+- [ ] Sem navegação automática.
+
+## Critérios do fluxo +
+
+- [ ] `+` do header abre fluxo.
+- [ ] `+` da bottom nav abre o mesmo fluxo.
+- [ ] Botão “Analisar vídeo” abre o mesmo fluxo.
+- [ ] Botão “Analisar primeiro vídeo” abre o mesmo fluxo.
+- [ ] Fluxo é curto.
+- [ ] Fluxo parece temporário.
+- [ ] Confirmação diz “Diagnóstico atualizado.”
+- [ ] Volta para o Perfil.
+- [ ] Não cria recibo longo.
+- [ ] Não cria página final.
+- [ ] Não cria histórico de vídeos.
+- [ ] Não mostra upload real.
+- [ ] Não usa `FileReader`.
+- [ ] Não usa `fetch`.
+- [ ] Não usa storage.
+
+## Critérios de navegação
+
+- [ ] Bottom nav mockada tem apenas Perfil / + / Comunidade.
+- [ ] Perfil é destino principal.
+- [ ] `+` é ação central, não aba.
+- [ ] Comunidade é destino existente.
+- [ ] Mídia Kit não aparece na bottom nav.
+- [ ] Diagnóstico não aparece na bottom nav.
+- [ ] Comercial não aparece na bottom nav.
+- [ ] Campanhas, CRM e calculadora não aparecem no mobile enxuto.
+
+## Critérios de Comunidade
+
+- [ ] Comunidade aparece apenas como destino.
+- [ ] Não existe feed novo.
+- [ ] Não existe chat.
+- [ ] Não existem comentários.
+- [ ] Não existem creators públicos novos.
+- [ ] Não duplica página existente.
+
+## Critérios do ActivationPendingWidget
+
+- [ ] Widget não aparece dentro da preview do Perfil.
+- [ ] Estratégia documenta conflito com bottom nav.
+- [ ] Estratégia documenta conflito com `+`.
+- [ ] Estratégia documenta conflito com Mídia Kit modal.
+- [ ] Estratégia documenta conflito com fluxo de análise.
+- [ ] Nenhuma alteração real foi feita no widget.
+
+## Critérios de linguagem
+
+A experiência deve soar:
+
+- simples;
+- estratégica;
+- humana;
+- app-first;
+- prática;
+- orientada a próximo passo.
+
+Não deve soar:
+
+- dashboard técnico;
+- relatório longo;
+- curso;
+- rede social nova;
+- jogo;
+- paywall agressivo;
+- laudo médico;
+- CRM.
+
+Termos proibidos:
+
+- score;
+- nota;
+- pontos;
+- ranking;
+- gabarito;
+- garantido;
+- certeza;
+- comprovado;
+- viralizar garantido;
+- match real;
+- marca garantida;
+- patrocínio garantido;
+- vídeos salvos;
+- histórico de vídeos;
+- novo Mídia Kit;
+- Mídia Kit mobile;
+- 18 sinais;
+- 3 narrativas;
+- percentual de perfil.
+
+## Critérios de segurança
+
+Validar que a experiência não renderiza:
+
+- API key;
+- base64 longo;
+- URL assinada com token;
+- texto bruto sensível;
+- arquivo real de vídeo;
+- thumbnail real;
+- diagnóstico interno no Mídia Kit;
+- dados privados de Instagram real.
+
+## Critérios de aprovação geral
+
+A experiência só passa se:
+
+- usuário anônimo entende por que precisa entrar;
+- usuário só com Gmail entende como começar;
+- usuário free entende valor da primeira leitura;
+- usuário premium entende o valor do diagnóstico vivo;
+- usuário com Instagram entende a precisão adicional;
+- Perfil parece a casa do app;
+- `+` parece ação, não aba;
+- Mídia Kit parece recurso existente;
+- Comunidade parece destino existente;
+- não há histórico de vídeos;
+- não há duplicação de produto pronto;
+- a tela não parece dashboard espremido;
+- a experiência é compreensível em até 30 segundos.
+
+## Tabela de achados
+
+| Cenário | Largura | Achado | Severidade | Ação sugerida | Status |
+|---|---:|---|---|---|---|
+| anonymous_view_profile | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| anonymous_analyze_video | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| account_only | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| first_reading_free | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| premium_without_instagram | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| instagram_optimized | 390 |  | blocker/high/medium/low/polish |  | aberto |
+| media_kit_available | 390 |  | blocker/high/medium/low/polish |  | aberto |
+
+Severidades permitidas:
+
+- blocker;
+- high;
+- medium;
+- low;
+- polish.
+
+## Próximas decisões sugeridas
+
+Após QA, os próximos PRs prováveis são:
+
+- MM52 — Strategic Profile Mobile Visual Polish;
+- MM53 — Strategic Profile Preview Copy Refinement;
+- MM54 — Mobile Navigation Integration Plan;
+- MM55 — Strategic Profile Data Integration Readiness.
+
+Não recomendar integração real antes do QA/polish visual.
+
+## Guardrails do MM51
+
+- Sem Gemini real.
+- Sem upload/storage real.
+- Sem persistência.
+- Sem endpoint alterado.
+- Sem `LoginClient` alterado.
+- Sem NextAuth alterado.
+- Sem `MediaKitView` alterado.
+- Sem Comunidade real alterada.
+- Sem navegação real alterada.
+- Sem `ActivationPendingWidget` alterado.
+- Sem Instagram real.
+- Sem billing real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1195,6 +1195,30 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing ou Stripe.
 
+### MM51 — Strategic Profile Mobile UX QA Checklist
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MOBILE_STRATEGIC_PROFILE_UX_QA.md`
+- `mobileStrategicProfileUxQa.test.ts`
+
+O que faz:
+
+- cria checklist manual/testável para validar a experiência mobile do Perfil Estratégico;
+- cobre auth gate, Perfil em construção, primeira leitura, premium, Instagram optimized, Mídia Kit modal, fluxo `+`, navegação, Comunidade e `ActivationPendingWidget`;
+- define critérios de aprovação antes de integração real;
+- define tabela de achados e próximas decisões sugeridas;
+- recomenda QA/polish visual antes de qualquer integração real.
+
+O que não faz:
+
+- não altera UI, preview, navegação real, `ActivationPendingWidget`, `LoginClient`, NextAuth, endpoint, `MediaKitView` ou Comunidade real;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing ou Stripe.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -257,8 +257,9 @@ Exemplos:
 47. MM48 — Analyze Entry and Return Flow. Modela o fluxo local do `+ / Analisar vídeo` que retorna ao Perfil.
 48. MM49 — Mobile Navigation Preview Strategy. Consolida a estratégia futura de navegação app-first mobile.
 49. MM50 — Activation Widget Conflict Strategy. Modela o conflito do widget de ativação com a experiência mobile app-first futura.
-50. Teste real manual quando houver quota/billing disponível.
-51. Integração experimental futura no Board de Criação.
+50. MM51 — Strategic Profile Mobile UX QA Checklist. Define QA visual/funcional antes de integração real.
+51. Teste real manual quando houver quota/billing disponível.
+52. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -351,6 +352,8 @@ MM48 materializa o `+` como ação central, não como aba. A análise de vídeo 
 MM49 consolida a navegação app-first futura como `Perfil / + / Comunidade`. O Perfil é a home mobile, o `+` é mecanismo de atualização do Perfil e Comunidade é destino existente. Mídia Kit segue como bridge/modal, enquanto Diagnóstico e Comercial ficam dentro do Perfil. A integração real da navegação, sidebar mobile e `ActivationPendingWidget` fica para etapa posterior; este PR não altera produção.
 
 MM50 fecha a análise dos conflitos de camada mobile. O `ActivationPendingWidget` fica fora da preview do Perfil, e qualquer integração real depende de feature flag e decisão futura. A estratégia recomenda manter produção atual, preferir card interno do Perfil ou ocultação no futuro app mobile, sem alterar widget real, `useActivationChecklist`, sidebar ou navegação real.
+
+MM51 é uma pausa de QA antes de qualquer integração real. A experiência do Perfil Estratégico precisa ser validada como produto: clareza do Perfil como diagnóstico vivo, entendimento do `+` como ação, Mídia Kit como recurso existente, Comunidade como destino existente e ausência de histórico de vídeos. Os próximos passos devem priorizar polish visual e refinamento de copy antes de dados reais, navegação real, upload/storage ou provider real.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileUxQa.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileUxQa.test.ts
@@ -1,0 +1,282 @@
+import fs from "fs";
+import path from "path";
+
+const VIDEO_UPLOAD_DIR = __dirname;
+const CHECKLIST_PATH = path.join(VIDEO_UPLOAD_DIR, "MOBILE_STRATEGIC_PROFILE_UX_QA.md");
+const TEST_SOURCE_PATH = path.join(VIDEO_UPLOAD_DIR, "mobileStrategicProfileUxQa.test.ts");
+
+function readChecklist(): string {
+  return fs.readFileSync(CHECKLIST_PATH, "utf8");
+}
+
+describe("mobileStrategicProfileUxQa", () => {
+  it("creates the mobile strategic profile UX QA document", () => {
+    expect(fs.existsSync(CHECKLIST_PATH)).toBe(true);
+  });
+
+  it("contains setup, feature flag and admin/dev access requirement", () => {
+    const content = readChecklist();
+
+    expect(content).toContain("/dashboard/boards/mobile-strategic-profile-preview");
+    expect(content).toContain("NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1");
+    expect(content).toContain("admin/dev");
+  });
+
+  it("contains all required preview state URLs", () => {
+    const content = readChecklist();
+
+    [
+      "state=anonymous_view_profile",
+      "state=anonymous_analyze_video",
+      "state=account_only",
+      "state=first_reading_free",
+      "state=premium_without_instagram",
+      "state=instagram_optimized",
+      "state=media_kit_available",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contains all required QA criteria sections", () => {
+    const content = readChecklist();
+
+    [
+      "## Critérios do topo do Perfil",
+      "## Critérios do Auth Gate",
+      "## Critérios do Perfil em construção",
+      "## Critérios da primeira leitura gratuita",
+      "## Critérios do premium",
+      "## Critérios do Instagram optimized",
+      "## Critérios do Mídia Kit modal",
+      "## Critérios do fluxo +",
+      "## Critérios de navegação",
+      "## Critérios de Comunidade",
+      "## Critérios do ActivationPendingWidget",
+      "## Critérios de linguagem",
+      "## Critérios de segurança",
+      "## Critérios de aprovação geral",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("covers the profile top and auth gate expectations", () => {
+    const content = readChecklist();
+
+    [
+      "perfil social, não um dashboard",
+      "Nome, handle e bio",
+      "Status pills",
+      "Botão `+`",
+      "Usuário anônimo não vê Perfil fake",
+      "criar Perfil Estratégico",
+      "analisar primeiro vídeo",
+      "Preview não chama login real",
+      "Preview não importa `LoginClient`",
+      "callback",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("covers construction, free, premium and Instagram optimized expectations", () => {
+    const content = readChecklist();
+
+    [
+      "CTA “Analisar primeiro vídeo”",
+      "Comercial aparece como limitado/construção",
+      "Mídia Kit não aparece como disponível sem condição",
+      "Entrega valor real",
+      "Mostra diagnóstico inicial",
+      "Sugere Instagram sem parecer obrigatório",
+      "Parece mais completo que free",
+      "Comercial aparece como tradução estratégica",
+      "Não promete marca, publi ou match",
+      "Mostra leitura mais precisa",
+      "Mostra Instagram conectado",
+      "Não afirma uso de dados reais se for mock/preview",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("covers Media Kit modal criteria", () => {
+    const content = readChecklist();
+
+    [
+      "Mídia Kit não é aba principal",
+      "ponte para recurso existente",
+      "Não cria Mídia Kit mobile novo",
+      "Não altera `MediaKitView`",
+      "Não mostra diagnóstico interno",
+      "Sem clipboard real",
+      "Sem Web Share API",
+      "Sem `window.open`",
+      "Sem navegação automática",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("covers plus flow and navigation criteria", () => {
+    const content = readChecklist();
+
+    [
+      "`+` do header abre fluxo",
+      "`+` da bottom nav abre o mesmo fluxo",
+      "Botão “Analisar vídeo” abre o mesmo fluxo",
+      "Confirmação diz “Diagnóstico atualizado.”",
+      "Volta para o Perfil",
+      "Não cria histórico de vídeos",
+      "Não mostra upload real",
+      "Não usa `FileReader`",
+      "Não usa `fetch`",
+      "Bottom nav mockada tem apenas Perfil / + / Comunidade",
+      "`+` é ação central, não aba",
+      "Mídia Kit não aparece na bottom nav",
+      "Diagnóstico não aparece na bottom nav",
+      "Comercial não aparece na bottom nav",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("covers Community and ActivationPendingWidget criteria", () => {
+    const content = readChecklist();
+
+    [
+      "Comunidade aparece apenas como destino",
+      "Não existe feed novo",
+      "Não existe chat",
+      "Não existem comentários",
+      "Não existem creators públicos novos",
+      "Widget não aparece dentro da preview do Perfil",
+      "Estratégia documenta conflito com bottom nav",
+      "Estratégia documenta conflito com `+`",
+      "Estratégia documenta conflito com Mídia Kit modal",
+      "Estratégia documenta conflito com fluxo de análise",
+      "Nenhuma alteração real foi feita no widget",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contains forbidden language and security criteria", () => {
+    const content = readChecklist();
+
+    [
+      "Termos proibidos:",
+      "score",
+      "nota",
+      "pontos",
+      "ranking",
+      "gabarito",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "viralizar garantido",
+      "match real",
+      "marca garantida",
+      "patrocínio garantido",
+      "vídeos salvos",
+      "histórico de vídeos",
+      "novo Mídia Kit",
+      "Mídia Kit mobile",
+      "18 sinais",
+      "3 narrativas",
+      "percentual de perfil",
+      "API key",
+      "base64 longo",
+      "URL assinada com token",
+      "texto bruto sensível",
+      "arquivo real de vídeo",
+      "thumbnail real",
+      "dados privados de Instagram real",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contains general approval criteria", () => {
+    const content = readChecklist();
+
+    [
+      "usuário anônimo entende por que precisa entrar",
+      "usuário só com Gmail entende como começar",
+      "usuário free entende valor da primeira leitura",
+      "usuário premium entende o valor do diagnóstico vivo",
+      "usuário com Instagram entende a precisão adicional",
+      "Perfil parece a casa do app",
+      "`+` parece ação, não aba",
+      "Mídia Kit parece recurso existente",
+      "Comunidade parece destino existente",
+      "não há histórico de vídeos",
+      "a tela não parece dashboard espremido",
+      "compreensível em até 30 segundos",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contains findings table, severities and next decisions", () => {
+    const content = readChecklist();
+
+    expect(content).toContain("| Cenário | Largura | Achado | Severidade | Ação sugerida | Status |");
+    ["blocker", "high", "medium", "low", "polish"].forEach((term) => {
+      expect(content).toContain(term);
+    });
+    [
+      "MM52 — Strategic Profile Mobile Visual Polish",
+      "MM53 — Strategic Profile Preview Copy Refinement",
+      "MM54 — Mobile Navigation Integration Plan",
+      "MM55 — Strategic Profile Data Integration Readiness",
+      "Não recomendar integração real antes do QA/polish visual.",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("contains explicit MM51 guardrails", () => {
+    const content = readChecklist();
+
+    [
+      "Sem Gemini real.",
+      "Sem upload/storage real.",
+      "Sem persistência.",
+      "Sem endpoint alterado.",
+      "Sem `LoginClient` alterado.",
+      "Sem NextAuth alterado.",
+      "Sem `MediaKitView` alterado.",
+      "Sem Comunidade real alterada.",
+      "Sem navegação real alterada.",
+      "Sem `ActivationPendingWidget` alterado.",
+      "Sem Instagram real.",
+      "Sem billing real.",
+    ].forEach((term) => {
+      expect(content).toContain(term);
+    });
+  });
+
+  it("keeps the static QA test free from app/runtime imports", () => {
+    const source = fs.readFileSync(TEST_SOURCE_PATH, "utf8");
+
+    [
+      "React",
+      "LoginClient",
+      "NextAuth",
+      "MediaKitView",
+      "ActivationPendingWidget",
+      "fetch",
+      "Prisma",
+      "Gemini",
+      "OpenAI",
+      "Stripe",
+      "@google/genai",
+      "next/navigation",
+    ].forEach((term) => {
+      expect(source).not.toContain(`from "${term}`);
+      expect(source).not.toContain(`from '${term}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stacked over #847.

MM51 adds a manual and testable UX QA checklist for the mobile Strategic Profile experience before any real integration.

Changes:
- Adds `MOBILE_STRATEGIC_PROFILE_UX_QA.md`.
- Adds `mobileStrategicProfileUxQa.test.ts`.
- Covers preview setup, required states, Profile header, auth gate, construction state, first free reading, premium, Instagram optimized, Media Kit modal, + flow, navigation, Community, ActivationPendingWidget, language, safety, and approval criteria.
- Defines required scenarios: anonymous_view_profile, anonymous_analyze_video, account_only, first_reading_free, premium_without_instagram, instagram_optimized, and media_kit_available.
- Sets the next suggested decisions as visual polish, copy refinement, mobile navigation integration plan, and data integration readiness.
- Updates docs for MM51.

## Validation

- UX QA checklist tests passed.
- Activation widget strategy tests passed.
- Navigation strategy tests passed.
- MobileStrategicProfilePreview tests passed.
- Analyze flow tests passed.
- Media Kit modal tests passed.
- Typecheck passed.
- Build passed with existing warnings outside this scope.

## Guardrails

No real Gemini, upload/storage, persistence, endpoint, login/auth, MediaKitView, Community, real navigation, ActivationPendingWidget, Instagram, or billing changes.