### PR TITLE
feat: polish mobile strategic profile preview UI

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -22,6 +22,10 @@ function nextStep(current: AnalyzeFlowStep): AnalyzeFlowStep {
   return STEPS[Math.min(index + 1, STEPS.length - 1)] ?? "updated_confirmation";
 }
 
+function stepIndex(step: AnalyzeFlowStep): number {
+  return STEPS.indexOf(step);
+}
+
 export function MobileStrategicProfileAnalyzeFlow({
   open,
   onClose,
@@ -40,17 +44,21 @@ export function MobileStrategicProfileAnalyzeFlow({
     setStep("intro");
     onComplete();
   };
+  const currentStepIndex = stepIndex(step);
 
   return (
     <section
       role="dialog"
       aria-modal="true"
       aria-labelledby="mobile-strategic-profile-analyze-flow-title"
-      className="absolute inset-x-0 bottom-0 z-40 rounded-t-[1.75rem] border-t border-zinc-200 bg-white p-5 shadow-2xl"
+      className="absolute inset-x-0 bottom-0 z-40 rounded-t-[2rem] border-t border-zinc-200 bg-white p-5 shadow-2xl"
     >
+      <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-zinc-200" aria-hidden="true" />
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase text-zinc-500">Analisar vídeo</p>
+          <p className="text-xs font-semibold uppercase text-zinc-500">
+            Etapa {currentStepIndex + 1} de {STEPS.length} · Analisar vídeo
+          </p>
           <h2 id="mobile-strategic-profile-analyze-flow-title" className="mt-1 text-xl font-semibold text-zinc-950">
             {step === "updated_confirmation" ? "Diagnóstico atualizado." : "Vamos atualizar seu Perfil Estratégico"}
           </h2>
@@ -65,13 +73,22 @@ export function MobileStrategicProfileAnalyzeFlow({
         </button>
       </div>
 
+      <div className="mt-4 grid grid-cols-6 gap-1" aria-hidden="true">
+        {STEPS.map((item, index) => (
+          <span
+            key={item}
+            className={index <= currentStepIndex ? "h-1.5 rounded-full bg-zinc-950" : "h-1.5 rounded-full bg-zinc-200"}
+          />
+        ))}
+      </div>
+
       <div className="mt-4">
         {step === "intro" ? (
           <div>
             <p className="text-sm leading-6 text-zinc-600">
               Envie um vídeo para a D2C entender novos sinais da sua narrativa.
             </p>
-            <div className="mt-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+            <div className="mt-5 rounded-[1.5rem] border border-zinc-200 bg-[#f7f7f4] p-4">
               <p className="text-sm font-semibold text-zinc-950">Atualizar Perfil</p>
               <p className="mt-1 text-sm leading-6 text-zinc-600">
                 A análise é temporária e retorna para o Diagnóstico vivo.
@@ -81,7 +98,7 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         {step === "mock_upload" ? (
-          <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 p-4">
+          <div className="rounded-[1.5rem] border border-dashed border-zinc-300 bg-[#f7f7f4] p-4">
             <p className="text-sm font-semibold text-zinc-950">Vídeo selecionado para análise</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">
               Preview local. Nenhum arquivo será enviado neste protótipo.
@@ -97,7 +114,7 @@ export function MobileStrategicProfileAnalyzeFlow({
                 <button
                   key={label}
                   type="button"
-                  className="rounded-2xl border border-zinc-200 bg-zinc-50 px-3 py-3 text-left text-sm font-semibold text-zinc-800"
+                  className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] px-3 py-3 text-left text-sm font-semibold text-zinc-800"
                 >
                   {label}
                 </button>
@@ -110,11 +127,11 @@ export function MobileStrategicProfileAnalyzeFlow({
           <div>
             <p className="text-sm font-semibold text-zinc-950">Duas perguntas rápidas para entender contexto</p>
             <div className="mt-3 grid gap-3">
-              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+              <div className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4">
                 <p className="text-sm font-semibold text-zinc-800">Esse conteúdo representa sua fase atual?</p>
                 <p className="mt-1 text-xs leading-5 text-zinc-500">Resposta visual nesta preview, sem salvar nada.</p>
               </div>
-              <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+              <div className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4">
                 <p className="text-sm font-semibold text-zinc-800">Você quer repetir essa direção no próximo post?</p>
                 <p className="mt-1 text-xs leading-5 text-zinc-500">A leitura volta para o Perfil Estratégico.</p>
               </div>
@@ -123,7 +140,7 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         {step === "updating_profile" ? (
-          <div className="rounded-2xl border border-sky-100 bg-sky-50 p-4">
+          <div className="rounded-[1.5rem] border border-sky-100 bg-sky-50 p-4">
             <p className="text-sm font-semibold text-zinc-950">Atualizando seu diagnóstico vivo...</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">
               Estamos conectando esta leitura ao seu Perfil Estratégico.
@@ -132,7 +149,7 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         {step === "updated_confirmation" ? (
-          <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
+          <div className="rounded-[1.5rem] border border-emerald-100 bg-emerald-50 p-4">
             <p className="text-sm font-semibold text-zinc-950">Identificamos novos sinais sobre sua narrativa.</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">
               A confirmação é curta porque o destino final é o seu Perfil.

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileMediaKitModal.tsx
@@ -34,7 +34,7 @@ export function MobileStrategicProfileMediaKitModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 grid place-items-end bg-zinc-950/55 px-4 py-5 sm:place-items-center"
+      className="fixed inset-0 z-50 grid place-items-end bg-zinc-950/60 px-4 py-5 backdrop-blur-sm sm:place-items-center"
       role="presentation"
       onClick={onClose}
     >
@@ -42,12 +42,13 @@ export function MobileStrategicProfileMediaKitModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="mobile-strategic-profile-media-kit-modal-title"
-        className="w-full max-w-sm rounded-[1.75rem] bg-white p-5 text-zinc-950 shadow-2xl"
+        className="w-full max-w-sm rounded-[2rem] bg-white p-5 text-zinc-950 shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
+        <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-zinc-200" aria-hidden="true" />
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-xs font-semibold uppercase text-zinc-500">Mídia Kit existente</p>
+            <p className="text-xs font-semibold uppercase text-zinc-500">Ponte para recurso existente</p>
             <h2 id="mobile-strategic-profile-media-kit-modal-title" className="mt-1 text-xl font-semibold">
               {title}
             </h2>
@@ -64,7 +65,7 @@ export function MobileStrategicProfileMediaKitModal({
 
         <p className="mt-3 text-sm leading-6 text-zinc-600">{description}</p>
 
-        <div className="mt-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+        <div className="mt-5 rounded-[1.5rem] border border-zinc-200 bg-[#f7f7f4] p-4">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
               <h3 className="truncate text-base font-semibold text-zinc-950">{identity.displayName}</h3>
@@ -72,23 +73,23 @@ export function MobileStrategicProfileMediaKitModal({
                 <p className="mt-0.5 text-sm text-zinc-500">{identity.displayHandle}</p>
               ) : null}
             </div>
-            <span className="shrink-0 rounded-full bg-white px-3 py-1 text-xs font-semibold text-zinc-700">
+            <span className="shrink-0 rounded-full bg-white px-3 py-1 text-xs font-semibold text-emerald-700 shadow-sm">
               {isAvailable ? "Mídia Kit ativo" : "Instagram"}
             </span>
           </div>
 
           {isAvailable ? (
             mediaKitHref ? (
-              <p className="mt-4 break-all rounded-xl bg-white px-3 py-2 text-xs font-semibold text-zinc-600">
+              <p className="mt-4 break-all rounded-2xl bg-white px-3 py-2 text-xs font-semibold text-zinc-600 shadow-sm">
                 {mediaKitHref}
               </p>
             ) : (
-              <p className="mt-4 rounded-xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600">
+              <p className="mt-4 rounded-2xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600 shadow-sm">
                 O link do Mídia Kit existente ainda não está disponível nesta preview.
               </p>
             )
           ) : (
-            <p className="mt-4 rounded-xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600">
+            <p className="mt-4 rounded-2xl bg-white px-3 py-2 text-sm leading-6 text-zinc-600 shadow-sm">
               Esta preview não conecta Instagram de verdade; ela só mostra a ponte visual para o recurso existente.
             </p>
           )}
@@ -98,28 +99,28 @@ export function MobileStrategicProfileMediaKitModal({
           <button
             type="button"
             disabled={linkActionsDisabled}
-            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2.5 text-sm font-semibold text-zinc-800 shadow-sm disabled:text-zinc-400 disabled:shadow-none"
           >
             Copiar link
           </button>
           <button
             type="button"
             disabled={linkActionsDisabled}
-            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2.5 text-sm font-semibold text-zinc-800 shadow-sm disabled:text-zinc-400 disabled:shadow-none"
           >
             Compartilhar
           </button>
           <button
             type="button"
             disabled={linkActionsDisabled}
-            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2.5 text-sm font-semibold text-zinc-800 shadow-sm disabled:text-zinc-400 disabled:shadow-none"
           >
             Ver como marca
           </button>
           <button
             type="button"
             disabled={linkActionsDisabled}
-            className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+            className="rounded-full border border-zinc-200 bg-white px-3 py-2.5 text-sm font-semibold text-zinc-800 shadow-sm disabled:text-zinc-400 disabled:shadow-none"
           >
             Abrir Mídia Kit
           </button>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -33,6 +33,31 @@ function advanceAnalyzeFlowToConfirmation() {
 }
 
 describe("MobileStrategicProfilePreview", () => {
+  it("renders polished header with creator name, handle and bio", () => {
+    renderState("first_reading_free");
+
+    expect(screen.getByText("Ana Creator")).toBeInTheDocument();
+    expect(screen.getAllByText("@ana.creator").length).toBeGreaterThan(0);
+    expect(screen.getByText("Diagnóstico vivo do creator")).toBeInTheDocument();
+    expect(screen.getByText(/Use o botão \+ para trazer uma nova leitura/)).toBeInTheDocument();
+  });
+
+  it("renders header plus button as profile update action", () => {
+    renderState("first_reading_free");
+
+    expect(screen.getByLabelText("Analisar vídeo")).toBeInTheDocument();
+  });
+
+  it("renders status pills without forbidden technical language", () => {
+    const { container } = renderState("instagram_optimized");
+    const text = renderedText(container);
+
+    expect(screen.getByText("Instagram conectado")).toBeInTheDocument();
+    for (const forbidden of ["18 sinais", "3 narrativas", "percentual de perfil", "score", "ranking"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
   it("auth gate renders Perfil Estratégico copy", () => {
     renderState("anonymous_view_profile");
 
@@ -77,6 +102,7 @@ describe("MobileStrategicProfilePreview", () => {
 
   it("premium renders Commercial section without brand promise", () => {
     const { container } = renderState("premium_without_instagram");
+    fireEvent.click(screen.getByRole("tab", { name: "Comercial" }));
     const text = renderedText(container);
 
     expect(screen.getAllByText("Potencial comercial").length).toBeGreaterThan(0);
@@ -91,6 +117,30 @@ describe("MobileStrategicProfilePreview", () => {
 
     expect(screen.getAllByText("Leitura mais precisa").length).toBeGreaterThan(0);
     expect(screen.getByText("Instagram conectado")).toBeInTheDocument();
+  });
+
+  it("internal tabs switch between Diagnóstico and Comercial locally", () => {
+    renderState("premium_without_instagram");
+
+    expect(screen.getByRole("tab", { name: "Diagnóstico" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Diagnóstico vivo")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Comercial" }));
+
+    expect(screen.getByRole("tab", { name: "Comercial" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getAllByText("Potencial comercial").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Diagnóstico" }));
+
+    expect(screen.getByRole("tab", { name: "Diagnóstico" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Diagnóstico vivo")).toBeInTheDocument();
+  });
+
+  it("diagnosis tab keeps the first view compact", () => {
+    renderState("first_reading_free");
+    const diagnosisSection = screen.getByLabelText("Diagnóstico vivo");
+
+    expect(within(diagnosisSection).getAllByRole("article").length).toBeLessThanOrEqual(3);
   });
 
   it("Media Kit Bridge available renders visual buttons without changing MediaKitView", () => {
@@ -244,6 +294,23 @@ describe("MobileStrategicProfilePreview", () => {
     expect(within(nav).queryByText("Comercial")).not.toBeInTheDocument();
   });
 
+  it("all required preview states continue rendering", () => {
+    for (const state of [
+      "anonymous_view_profile",
+      "anonymous_analyze_video",
+      "account_only",
+      "first_reading_free",
+      "premium_without_instagram",
+      "instagram_optimized",
+      "media_kit_available",
+    ] satisfies MobileStrategicProfilePreviewFixtureState[]) {
+      const { unmount } = renderState(state);
+
+      expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
+      unmount();
+    }
+  });
+
   it("does not render forbidden terms", () => {
     const { container } = renderState("media_kit_available");
     const text = renderedText(container);
@@ -295,8 +362,13 @@ describe("MobileStrategicProfilePreview", () => {
       "OpenAI",
       "Stripe",
       "SDK",
+      "ActivationPendingWidget",
     ]) {
       expect(importLines).not.toContain(forbidden);
+    }
+
+    for (const forbiddenCall of ["fetch(", "router.push", "navigator.clipboard", "navigator.share", "window.open"]) {
+      expect(source).not.toContain(forbiddenCall);
     }
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -21,10 +21,10 @@ type MobileStrategicProfilePreviewProps = {
 
 const CARD_TONE: Record<MobileStrategicProfileSectionCard["tone"], string> = {
   neutral: "border-zinc-200 bg-white",
-  diagnosis: "border-sky-100 bg-sky-50/70",
-  commercial: "border-emerald-100 bg-emerald-50/70",
+  diagnosis: "border-sky-100 bg-sky-50/80",
+  commercial: "border-emerald-100 bg-emerald-50/80",
   action: "border-zinc-200 bg-zinc-50",
-  locked: "border-amber-100 bg-amber-50/70",
+  locked: "border-amber-100 bg-amber-50/80",
 };
 
 const MEDIA_KIT_ACTION_INTENTS = new Set<MobileStrategicProfileAction["intent"]>([
@@ -65,10 +65,14 @@ function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePr
 function ActionButton({
   action,
   onAction,
+  fullWidth = false,
 }: {
   action: MobileStrategicProfileAction;
   onAction?: (action: MobileStrategicProfileAction) => void;
+  fullWidth?: boolean;
 }) {
+  const baseClass = fullWidth ? "w-full justify-center" : "";
+
   return (
     <button
       type="button"
@@ -76,8 +80,8 @@ function ActionButton({
       onClick={() => onAction?.(action)}
       className={
         action.priority === "primary"
-          ? "rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-zinc-300"
-          : "rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-800 disabled:text-zinc-400"
+          ? `${baseClass} inline-flex min-h-[42px] items-center rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15 disabled:bg-zinc-300`
+          : `${baseClass} inline-flex min-h-[42px] items-center rounded-full border border-zinc-200 bg-white px-4 py-2.5 text-sm font-semibold text-zinc-800 disabled:text-zinc-400`
       }
     >
       {action.label}
@@ -100,13 +104,13 @@ function AuthGate({ profile }: { profile: MobileStrategicProfile }) {
         </header>
 
         <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
-          <div className="min-h-[680px] rounded-[1.5rem] bg-white px-5 py-5">
+          <div className="min-h-[680px] rounded-[1.5rem] bg-[#f7f7f4] px-5 py-5">
             <div className="flex items-center justify-between">
               <span className="text-sm font-semibold text-zinc-950">Perfil Estratégico</span>
-              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">D2C</span>
+              <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-zinc-600 shadow-sm">D2C</span>
             </div>
-            <div className="mt-24 grid place-items-center text-center">
-              <div className="grid h-20 w-20 place-items-center rounded-full bg-zinc-950 text-2xl font-semibold text-white">
+            <div className="mt-20 grid place-items-center rounded-[1.75rem] bg-white p-6 text-center shadow-sm">
+              <div className="grid h-20 w-20 place-items-center rounded-full bg-zinc-950 text-2xl font-semibold text-white shadow-lg shadow-zinc-950/20">
                 D2C
               </div>
               <h2 className="mt-6 text-2xl font-semibold text-zinc-950">{gate.title}</h2>
@@ -147,55 +151,72 @@ function ProfileHeader({
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm font-semibold text-zinc-950">{identity.displayHandle ?? "Perfil Estratégico"}</p>
-          <p className="text-xs text-zinc-500">Diagnóstico vivo</p>
+          <p className="text-xs font-medium text-zinc-500">Diagnóstico vivo do creator</p>
         </div>
         <button
           type="button"
           aria-label="Analisar vídeo"
-          className="grid h-9 w-9 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white"
+          className="grid h-10 w-10 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white shadow-lg shadow-zinc-950/20"
           onClick={onAnalyze}
         >
           +
         </button>
       </div>
 
-      <div className="mt-6 flex items-start gap-4">
-        <div className="grid h-20 w-20 shrink-0 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white">
-          {identity.userImage ? <span>{initials}</span> : initials}
+      <div className="mt-5 rounded-[1.75rem] bg-[#f7f7f4] p-4">
+        <div className="flex items-start gap-4">
+          <div className="grid h-20 w-20 shrink-0 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white shadow-lg shadow-zinc-950/15">
+            {identity.userImage ? <span>{initials}</span> : initials}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-xl font-semibold text-zinc-950">{identity.displayName}</h2>
+            {identity.displayHandle ? <p className="mt-0.5 text-sm text-zinc-500">{identity.displayHandle}</p> : null}
+            {identity.bio ? <p className="mt-2 text-sm leading-6 text-zinc-700">{identity.bio}</p> : null}
+          </div>
         </div>
-        <div className="min-w-0 flex-1">
-          <h2 className="text-xl font-semibold text-zinc-950">{identity.displayName}</h2>
-          {identity.displayHandle ? <p className="mt-0.5 text-sm text-zinc-500">{identity.displayHandle}</p> : null}
-          {identity.bio ? <p className="mt-2 text-sm leading-6 text-zinc-700">{identity.bio}</p> : null}
-        </div>
+
+        <p className="mt-4 rounded-2xl bg-white px-3 py-2 text-sm leading-6 text-zinc-700 shadow-sm">
+          Cada análise atualiza este Perfil Estratégico. Use o botão + para trazer uma nova leitura.
+        </p>
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">
-        {profile.header.statusPills.map((pill) => (
-          <span key={pill.id} className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-700">
+        {profile.header.statusPills.slice(0, 4).map((pill) => (
+          <span key={pill.id} className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 shadow-sm">
             {pill.label}
           </span>
         ))}
       </div>
 
-      <div className="mt-4 flex flex-wrap gap-2">
-        {profile.primaryActions.slice(0, 2).map((action) => (
-          <ActionButton key={action.id} action={action} onAction={onAction} />
+      <div className="mt-4 grid gap-2">
+        {profile.primaryActions.slice(0, 2).map((action, index) => (
+          <ActionButton key={action.id} action={action} onAction={onAction} fullWidth={index === 0} />
         ))}
       </div>
     </header>
   );
 }
 
-function Tabs({ profile }: { profile: MobileStrategicProfile }) {
+function Tabs({
+  profile,
+  activeTab,
+  onChange,
+}: {
+  profile: MobileStrategicProfile;
+  activeTab: "diagnosis" | "commercial";
+  onChange: (tab: "diagnosis" | "commercial") => void;
+}) {
   return (
-    <div className="mx-5 mt-5 grid grid-cols-2 rounded-full bg-zinc-100 p-1">
+    <div className="mx-5 mt-5 grid grid-cols-2 rounded-full bg-zinc-100 p-1" role="tablist" aria-label="Abas internas do Perfil">
       {profile.tabs.map((tab) => (
         <button
           key={tab.id}
           type="button"
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          onClick={() => onChange(tab.id)}
           className={
-            tab.active
+            activeTab === tab.id
               ? "rounded-full bg-white px-3 py-2 text-sm font-semibold text-zinc-950 shadow-sm"
               : "rounded-full px-3 py-2 text-sm font-semibold text-zinc-500"
           }
@@ -209,7 +230,7 @@ function Tabs({ profile }: { profile: MobileStrategicProfile }) {
 
 function SectionCard({ card }: { card: MobileStrategicProfileSectionCard }) {
   return (
-    <article className={`rounded-2xl border p-4 ${CARD_TONE[card.tone]}`}>
+    <article className={`rounded-[1.25rem] border p-4 ${CARD_TONE[card.tone]}`}>
       <div className="flex items-start justify-between gap-3">
         <h4 className="text-sm font-semibold text-zinc-950">{card.title}</h4>
         {card.locked ? <span className="rounded-full bg-white px-2 py-1 text-xs font-semibold text-zinc-500">Bloqueado</span> : null}
@@ -220,8 +241,10 @@ function SectionCard({ card }: { card: MobileStrategicProfileSectionCard }) {
 }
 
 function ProfileSection({ section }: { section: MobileStrategicProfileSection }) {
+  const visibleCards = section.cards.slice(0, section.id === "diagnosis" ? 3 : 4);
+
   return (
-    <section className="px-5">
+    <section className="px-5" aria-label={section.title}>
       <div className="flex items-end justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-zinc-950">{section.title}</h3>
@@ -234,7 +257,7 @@ function ProfileSection({ section }: { section: MobileStrategicProfileSection })
         ) : null}
       </div>
       <div className="mt-3 grid gap-3">
-        {section.cards.slice(0, 5).map((card) => (
+        {visibleCards.map((card) => (
           <SectionCard key={card.id} card={card} />
         ))}
       </div>
@@ -253,14 +276,14 @@ function MediaKitBridge({
   if (bridge.state === "hidden" || bridge.state === "unavailable" || !bridge.title || !bridge.description) return null;
 
   return (
-    <section className="mx-5 rounded-2xl border border-zinc-200 bg-white p-4">
+    <section className="mx-5 rounded-[1.5rem] border border-zinc-200 bg-white p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-zinc-950">{bridge.title}</h3>
           <p className="mt-1 text-sm leading-6 text-zinc-600">{bridge.description}</p>
         </div>
-        <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">
-          {bridge.state === "available" ? "Ativo" : "Instagram"}
+        <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
+          {bridge.state === "available" ? "Mídia Kit ativo" : "Instagram"}
         </span>
       </div>
       {bridge.actions.length > 0 ? (
@@ -272,7 +295,7 @@ function MediaKitBridge({
       ) : bridge.state === "connect_instagram_required" ? (
         <button
           type="button"
-          className="mt-4 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-800"
+          className="mt-4 rounded-full border border-zinc-200 bg-white px-4 py-2.5 text-sm font-semibold text-zinc-800"
           onClick={onOpen}
         >
           Ativar Mídia Kit
@@ -290,14 +313,14 @@ function BottomNav({
   onAnalyze: () => void;
 }) {
   return (
-    <nav className="sticky bottom-0 mt-6 grid grid-cols-3 border-t border-zinc-200 bg-white px-4 py-3" aria-label="Navegação mobile futura">
+    <nav className="sticky bottom-0 mt-6 grid grid-cols-3 items-center border-t border-zinc-200 bg-white/95 px-4 pb-4 pt-3 backdrop-blur" aria-label="Navegação mobile futura">
       {profile.navigation.items.map((item) =>
         item.role === "central_action" ? (
           <button
             key={item.id}
             type="button"
             aria-label="Analisar vídeo pela ação central"
-            className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-zinc-950 text-lg font-semibold text-white"
+            className="mx-auto -mt-7 grid h-14 w-14 place-items-center rounded-full border-4 border-white bg-zinc-950 text-xl font-semibold text-white shadow-xl shadow-zinc-950/25"
             onClick={onAnalyze}
           >
             {item.label}
@@ -323,6 +346,7 @@ export function MobileStrategicProfilePreview({
   const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
   const [analyzeFlowOpen, setAnalyzeFlowOpen] = useState(false);
   const [profileUpdated, setProfileUpdated] = useState(false);
+  const [activeTab, setActiveTab] = useState<"diagnosis" | "commercial">("diagnosis");
 
   if (profile.authGate.visible) return <AuthGate profile={profile} />;
 
@@ -340,7 +364,10 @@ export function MobileStrategicProfilePreview({
   const handleAnalyzeComplete = () => {
     setAnalyzeFlowOpen(false);
     setProfileUpdated(true);
+    setActiveTab("diagnosis");
   };
+
+  const activeSection = profile.sections.find((section) => section.id === activeTab);
 
   return (
     <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
@@ -359,7 +386,7 @@ export function MobileStrategicProfilePreview({
         <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
           <div className="relative min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
             <ProfileHeader profile={profile} onAction={handleAction} onAnalyze={() => setAnalyzeFlowOpen(true)} />
-            <Tabs profile={profile} />
+            <Tabs profile={profile} activeTab={activeTab} onChange={setActiveTab} />
 
             <div className="mt-5 grid gap-5 pb-2">
               {profileUpdated ? (
@@ -385,9 +412,7 @@ export function MobileStrategicProfilePreview({
                 </section>
               ) : null}
 
-              {profile.sections.map((section) => (
-                <ProfileSection key={section.id} section={section} />
-              ))}
+              {activeSection ? <ProfileSection section={activeSection} /> : null}
 
               <MediaKitBridge profile={profile} onOpen={() => setMediaKitModalOpen(true)} />
 

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -126,6 +126,8 @@ Já existe:
 - MM50 modela conflitos do `ActivationPendingWidget` com bottom nav, ação central, Mídia Kit modal e fluxo de análise, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera `ActivationPendingWidget` real;
 - strategic profile mobile UX QA checklist foi criado em MM51 como camada segura de QA;
 - MM51 valida a experiência do Perfil Estratégico como produto antes de integração real, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera UI real de produção;
+- strategic profile mobile visual polish foi aplicado em MM52 como camada segura de UI interna/preview;
+- MM52 refina visualmente a preview do Perfil Estratégico, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera UI real de produção;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
@@ -268,6 +268,11 @@ Após QA, os próximos PRs prováveis são:
 
 Não recomendar integração real antes do QA/polish visual.
 
+## Histórico
+
+- MM52 aplica polish visual inicial na preview mobile do Perfil Estratégico.
+- QA manual ainda deve ser executado antes de qualquer integração real.
+
 ## Guardrails do MM51
 
 - Sem Gemini real.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1219,6 +1219,32 @@ O que não faz:
 - não chama Gemini real, OpenAI, endpoint ou rede;
 - não conecta Instagram real, billing ou Stripe.
 
+### MM52 — Strategic Profile Mobile Visual Polish
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MobileStrategicProfilePreview.tsx`
+- `MobileStrategicProfilePreview.test.tsx`
+- `MobileStrategicProfileMediaKitModal.tsx`
+- `MobileStrategicProfileAnalyzeFlow.tsx`
+
+O que faz:
+
+- refina visualmente a preview mobile do Perfil Estratégico;
+- melhora header, status pills, CTAs, tabs internas, cards, bottom nav, modal de Mídia Kit e fluxo `+`;
+- torna Diagnóstico/Comercial tabs internas interativas localmente;
+- mantém Perfil como diagnóstico vivo;
+- mantém Mídia Kit e Comunidade como recursos existentes.
+
+O que não faz:
+
+- não altera contratos puros, mapping/state, endpoint, `LoginClient`, NextAuth, `MediaKitView`, Mídia Kit real, Comunidade real ou navegação real;
+- não cria upload real, storage real, persistência, banco/tabela, schema ou Prisma;
+- não chama Gemini real, OpenAI, endpoint ou rede;
+- não conecta Instagram real, billing ou Stripe.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -258,8 +258,9 @@ Exemplos:
 48. MM49 — Mobile Navigation Preview Strategy. Consolida a estratégia futura de navegação app-first mobile.
 49. MM50 — Activation Widget Conflict Strategy. Modela o conflito do widget de ativação com a experiência mobile app-first futura.
 50. MM51 — Strategic Profile Mobile UX QA Checklist. Define QA visual/funcional antes de integração real.
-51. Teste real manual quando houver quota/billing disponível.
-52. Integração experimental futura no Board de Criação.
+51. MM52 — Strategic Profile Mobile Visual Polish. Refina visualmente a preview interna do Perfil Estratégico.
+52. Teste real manual quando houver quota/billing disponível.
+53. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 
@@ -354,6 +355,8 @@ MM49 consolida a navegação app-first futura como `Perfil / + / Comunidade`. O 
 MM50 fecha a análise dos conflitos de camada mobile. O `ActivationPendingWidget` fica fora da preview do Perfil, e qualquer integração real depende de feature flag e decisão futura. A estratégia recomenda manter produção atual, preferir card interno do Perfil ou ocultação no futuro app mobile, sem alterar widget real, `useActivationChecklist`, sidebar ou navegação real.
 
 MM51 é uma pausa de QA antes de qualquer integração real. A experiência do Perfil Estratégico precisa ser validada como produto: clareza do Perfil como diagnóstico vivo, entendimento do `+` como ação, Mídia Kit como recurso existente, Comunidade como destino existente e ausência de histórico de vídeos. Os próximos passos devem priorizar polish visual e refinamento de copy antes de dados reais, navegação real, upload/storage ou provider real.
+
+MM52 é polish visual da experiência interna. Ele não muda arquitetura de dados, contratos puros, mapping/state ou endpoints. A UI continua consumindo `MobileStrategicProfile`, reforça que o Perfil substitui a ideia de diagnóstico isolado, mantém Diagnóstico/Comercial como abas internas e preserva Mídia Kit/Comunidade como recursos existentes.
 
 MM15 formaliza consentimento e retenção antes de upload real, endpoint real ou beta. O contrato trata vídeo como dado temporário de análise e bloqueia persistência automática de sinais narrativos no perfil.
 


### PR DESCRIPTION
## Summary

Stacked over #848.

MM52 applies visual polish to the mobile Strategic Profile preview so it feels more like a product experience than a functional prototype.

Changes:
- Refines the first fold with clearer handle, profile identity, status pills, CTAs, and + action.
- Improves mobile/app-first CTAs and lighter status pills.
- Makes Diagnóstico/Comercial tabs locally interactive without URL/router side effects.
- Compacts Diagnosis cards to reduce report-like feeling.
- Polishes the bottom nav mock for Perfil / + / Comunidade.
- Turns the Media Kit modal into a lighter sharing drawer.
- Improves the + analyze flow progression and keeps returning to the Profile.
- Updates docs and QA notes for MM52.

## Validation

- MobileStrategicProfilePreview tests passed.
- MediaKitModal tests passed.
- AnalyzeFlow tests passed.
- Preview route tests passed.
- UX QA checklist tests passed.
- Typecheck passed.
- Build passed with existing warnings outside this scope.

## Guardrails

No real Gemini, upload/storage, persistence, endpoint, login/auth, MediaKitView, Community, real navigation, ActivationPendingWidget, Instagram, or billing changes.