### PR TITLE
feat: add mobile strategic profile existing data adapter

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfileRealShellInput.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfileRealShellInput.ts
@@ -1,11 +1,23 @@
 import type { MobileStrategicProfileInput } from "../../../videoUpload/mobileStrategicProfileMapping";
-import {
-  resolveMobileStrategicProfileState,
-  type MobileStrategicProfilePrimaryIntent,
-} from "../../../videoUpload/mobileStrategicProfileStateContract";
-import { buildMobileStrategicProfile } from "../../../videoUpload/mobileStrategicProfileMapping";
-import type { VideoNarrativeDiagnosisAccessLevel } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
 import { buildMobileStrategicProfilePreviewFixture } from "./buildMobileStrategicProfilePreviewFixture";
+import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUpload/mobileStrategicProfileExistingDataAdapter";
+import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
+
+function resolveOverrideLevel(stateQuery: string): {
+  access: "free" | "premium" | "instagram_optimized";
+  instagram: "connected" | "disconnected";
+} | null {
+  if (stateQuery === "instagram_optimized" || stateQuery === "media_kit_available") {
+    return { access: "instagram_optimized", instagram: "connected" };
+  }
+  if (stateQuery === "premium_without_instagram") {
+    return { access: "premium", instagram: "disconnected" };
+  }
+  if (stateQuery === "first_reading_free") {
+    return { access: "free", instagram: "disconnected" };
+  }
+  return null;
+}
 
 export function buildMobileStrategicProfileRealShellInput(params: {
   session: any;
@@ -15,89 +27,72 @@ export function buildMobileStrategicProfileRealShellInput(params: {
   const isAuthenticated = Boolean(user);
 
   if (!isAuthenticated) {
-    const state = resolveMobileStrategicProfileState({
-      isAuthenticated: false,
-      primaryIntent: "view_profile",
-      userName: "Creator",
-    });
-
-    return {
-      state,
-      loginHref: "/login?intent=strategic_profile",
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: null,
       profileHref: "/dashboard/boards/mobile-profile",
       analyzeVideoHref: "/dashboard/boards/mobile-profile",
       communityHref: "/dashboard/community",
-      createdAt: new Date().toISOString(),
+    });
+    return {
+      ...res.profileInput,
+      loginHref: "/login?intent=strategic_profile",
     };
   }
 
   // Se o query param 'state' estiver definido, carregamos a fixture para fins de teste/QA sob a feature flag
   if (params.stateQuery) {
     const fixture = buildMobileStrategicProfilePreviewFixture({ state: params.stateQuery });
-    // Ajusta dados dinâmicos da sessão sobre a fixture para ficar honesto
-    fixture.profile.header.identity.displayName = user.name || fixture.profile.header.identity.displayName;
-    fixture.profile.header.title = user.name || fixture.profile.header.title;
-    return {
-      state: fixture.profile.state,
-      diagnosisPresentation: fixture.profile.state.profileAvailability === "active" ? fixture.profile.sections[0]?.cards ? {
-        hero: {
-          title: fixture.profile.sections[0].cards[0]?.title || "Diagnóstico ativo",
-          subtitle: fixture.profile.sections[0].cards[0]?.body || "",
-        },
-        priorityCards: [],
-        sections: [],
-        createdAt: new Date().toISOString(),
-      } : null : null,
-      creatorBio: "Diagnóstico em evolução para posicionamento, narrativa e próximo passo.",
-      mediaKitShareUrl: user.instagramConnected ? "/mediakit/real-user" : null,
-      mediaKitEditUrl: user.instagramConnected ? "/dashboard/media-kit" : null,
-      mediaKitPublicUrl: user.instagramConnected ? `/mediakit/${user.instagramUsername || "user"}` : null,
+    
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        name: user.name,
+        email: user.email,
+        image: user.image,
+        instagramConnected: Boolean(user.instagramConnected || user.isInstagramConnected),
+        instagramUsername: user.instagramUsername,
+        planStatus: user.planStatus,
+      },
+      diagnosisOverrideState: params.stateQuery,
       profileHref: "/dashboard/boards/mobile-profile",
       analyzeVideoHref: "/dashboard/boards/mobile-profile",
       communityHref: "/dashboard/community",
-      createdAt: new Date().toISOString(),
+    });
+
+    const override = resolveOverrideLevel(params.stateQuery);
+    let diagnosisPresentation = null;
+    if (override) {
+      const scenario = buildVideoNarrativeAppPreviewScenario({
+        stage: "diagnosis_ready",
+        scenario: override.access === "premium" ? "brand" : "skincare",
+        access: override.access,
+        instagram: override.instagram,
+      });
+      diagnosisPresentation = scenario.diagnosisPresentation;
+    }
+
+    return {
+      ...res.profileInput,
+      diagnosisPresentation,
+      state: {
+        ...res.profileInput.state,
+        ...fixture.profile.state,
+      },
     };
   }
 
-  const instagramConnected = Boolean(user.instagramConnected || user.isInstagramConnected);
-  const instagramUsername = user.instagramUsername || null;
-
-  const planStatus = user.planStatus ? String(user.planStatus).toLowerCase().trim() : "inactive";
-  const hasPremiumAccess =
-    user.role === "admin" ||
-    (planStatus !== "inactive" && planStatus !== "canceled" && planStatus !== "");
-
-  let accessLevel: VideoNarrativeDiagnosisAccessLevel = "free";
-  if (hasPremiumAccess) {
-    accessLevel = instagramConnected ? "instagram_optimized" : "premium";
-  }
-
-  const state = resolveMobileStrategicProfileState({
-    isAuthenticated: true,
-    userName: user.name || "Criador D2C",
-    userHandle: instagramUsername ? `@${instagramUsername}` : null,
-    userImage: user.image || null,
-    instagramConnected,
-    instagramUsername,
-    accessLevel,
-    planStatus,
-    hasPremiumAccess,
-    diagnosisPresentation: null, // Sem diagnóstico real persistido ainda no MVP
-    hasMediaKit: instagramConnected,
-    mediaKitShareUrl: instagramConnected ? `/mediakit/${instagramUsername || "user"}` : null,
-    createdAt: new Date().toISOString(),
-  });
-
-  return {
-    state,
-    diagnosisPresentation: null,
-    creatorBio: "Seu diagnóstico vivo começa aqui.",
-    mediaKitShareUrl: instagramConnected ? `/mediakit/${instagramUsername || "user"}` : null,
-    mediaKitEditUrl: instagramConnected ? "/dashboard/media-kit" : null,
-    mediaKitPublicUrl: instagramConnected ? `/mediakit/${instagramUsername || "user"}` : null,
+  const res = buildMobileStrategicProfileExistingDataAdapter({
+    sessionUser: {
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      instagramConnected: Boolean(user.instagramConnected || user.isInstagramConnected),
+      instagramUsername: user.instagramUsername,
+      planStatus: user.planStatus,
+    },
     profileHref: "/dashboard/boards/mobile-profile",
     analyzeVideoHref: "/dashboard/boards/mobile-profile",
     communityHref: "/dashboard/community",
-    createdAt: new Date().toISOString(),
-  };
+  });
+
+  return res.profileInput;
 }

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -16,7 +16,9 @@ Já existe:
 - provider com flag server-side;
 - client factory com `@google/genai`;
 - composer `env/config -> factory -> provider`;
-- harness manual de execução real.
+- harness manual de execução real;
+- rota real segura do Perfil Estratégico mobile `/dashboard/boards/mobile-strategic-profile` (MM54);
+- adapter de dados síncrono e puro `mobileStrategicProfileExistingDataAdapter.ts` (MM55).
 
 ## O Que Ainda Não Foi Validado
 
@@ -130,6 +132,8 @@ Já existe:
 - MM52 refina visualmente a preview do Perfil Estratégico, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera UI real de produção;
 - strategic profile preview copy refinement foi aplicado em MM53 como camada segura de copy/preview;
 - MM53 melhora a linguagem da preview do Perfil Estratégico, mas não aumenta readiness de Gemini real, não adiciona provider externo, não muda endpoint, não muda upload/storage, não muda persistência e não altera UI real de produção;
+- rota real segura do Perfil Estratégico mobile foi criada em MM54, protegida por feature flag server-side e sessão do NextAuth, garantindo isolamento total do dashboard legado, sem impactar prontidão externa;
+- adapter de dados síncrono e puro foi criado em MM55, isolando o mapeamento de sessão NextAuth e home summary do Perfil mobile, garantindo zero dependência de banco de dados, Prisma, chamadas fetch ou providers externos;
 - limite por plano real ainda não existe;
 - custo real ainda desconhecido.
 

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
@@ -285,7 +285,22 @@ Não recomendar integração real antes do QA/polish visual.
 - Sem NextAuth alterado.
 - Sem `MediaKitView` alterado.
 - Sem Comunidade real alterada.
-- Sem navegação real alterada.
 - Sem `ActivationPendingWidget` alterado.
 - Sem Instagram real.
 - Sem billing real.
+
+## Guardrails do MM54
+
+- Rota real protegida por feature flag server-side e sessão NextAuth ativa.
+- Redirecionamento correto de usuários deslogados preservando callbackUrl e intent=strategic_profile.
+- Ocultação de elementos internos de preview no header (`isRealShell`).
+- Zero alteração no dashboard atual e sem duplicação de produto pronto.
+
+## Guardrails do MM55
+
+- O adapter de dados `buildMobileStrategicProfileExistingDataAdapter` deve ser 100% puro e determinístico.
+- Nenhuma consulta ao banco de dados, Prisma ou chamada HTTP/fetch externa dentro do adapter.
+- Sem dependência ou uso de bibliotecas de renderização React ou NextAuth runtime.
+- Suporte a overrides no mapeamento apenas em modo de teste/QA sob a feature flag ativa.
+- Validação estrita para descartar base64 longo e strings inseguras no avatar.
+- Retorno de warnings de forma interna na lista de retorno para depuração.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1299,6 +1299,34 @@ O que não faz:
 - não faz chamadas de rede externas ou de banco reais;
 - não altera componentes de login real, `MediaKitView`, Comunidade real ou navegação global legado.
 
+### MM55 — Existing Data Adapter
+
+Status: concluído.
+
+Arquivos principais:
+
+- `mobileStrategicProfileExistingDataAdapter.ts`
+- `mobileStrategicProfileExistingDataAdapter.test.ts`
+- `buildMobileStrategicProfileRealShellInput.ts`
+- `buildMobileStrategicProfileRealShellInput.test.ts`
+
+O que faz:
+
+- cria o adapter puro `buildMobileStrategicProfileExistingDataAdapter` para enriquecer o Perfil Estratégico mobile com dados leves existentes;
+- consome dados de sessão, home summary, mídia kit, comunidade e planos de forma totalmente síncrona;
+- resolve displayName de forma segura (nome da sessão -> email local part -> "Creator") e displayHandle (instagramUsername da sessão -> null);
+- valida avatares descartando base64 longo e emite warnings testáveis em formato de lista interna sem poluir a UI;
+- resolve o estado do Mídia Kit a partir do `MediaKitCardData` e o Href da Comunidade respeitando os inviteUrls de VIP/Free existentes;
+- mantém o diagnóstico no fallback seguro de "Perfil em construção" quando não há snapshot persistido;
+- garante 100% de cobertura de testes unitários e de regressão.
+
+O que não faz:
+
+- não busca dados sozinho, não faz fetch HTTP, consultas ao banco de dados ou Prisma;
+- não cria tabelas ou persistência e não altera contratos do Stripe ou billing;
+- não conecta OpenAI, Gemini real ou qualquer provider multimodal externo;
+- não altera o layout `MediaKitView`, Comunidade real ou navegação do dashboard legado.
+
 ## Visão Geral
 
 O Video Upload Foundation prepara os contratos e testes para uma experiência futura em que o criador poderá enviar um vídeo e descobrir qual narrativa ele comunica.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -370,3 +370,7 @@ MM17 formaliza observabilidade antes de analytics real, endpoint real ou beta. E
 MM18 formaliza a ordem de guards do futuro endpoint real/admin. Ele bloqueia `route.ts` e provider real até que método, sessão, admin/dev, flag, payload, origem, consentimento, retenção, usage/quota e observabilidade estejam resolvidos.
 
 MM19 começa a transformar a ordem de guards em fundação de código puro. Ele cria `VideoNarrativeGuardResult`, `VideoNarrativeGuardPipelineSummary` e helpers determinísticos para decidir provider/quota sem endpoint real.
+
+MM54 cria a primeira rota real `/dashboard/boards/mobile-strategic-profile` protegida por feature flag server-side e sessão de login do usuário, redirecionando usuários anônimos com segurança e aplicando `isRealShell: true` para ocultar os controles de desenvolvimento do header do Perfil Estratégico.
+
+MM55 implementa a camada de dados síncronos e puros `buildMobileStrategicProfileExistingDataAdapter`, isolando completamente a lógica de extração e resolução de dados de sessão e da home summary (displayName, displayHandle, avatar, premium plan e bridges de Mídia Kit/Comunidade) de qualquer camada de renderização React, fetch HTTP ou Prisma. A persistência do diagnóstico vivo segue isolada para fases futuras.

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.test.ts
@@ -1,0 +1,257 @@
+import { buildMobileStrategicProfileExistingDataAdapter } from "./mobileStrategicProfileExistingDataAdapter";
+
+describe("buildMobileStrategicProfileExistingDataAdapter", () => {
+  it("uses sessionUser.name as displayName", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        name: "Arthur Test",
+      },
+    });
+    expect(res.resolvedDisplayName).toBe("Arthur Test");
+    expect(res.warnings).not.toContain("missing_session_name");
+  });
+
+  it("uses local part of the email as displayName fallback without exposing the domain", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        email: "arthur.developer@domain.com",
+      },
+    });
+    expect(res.resolvedDisplayName).toBe("arthur.developer");
+    expect(res.warnings).toContain("missing_session_name");
+  });
+
+  it("uses 'Creator' when no name or email exists", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {},
+    });
+    expect(res.resolvedDisplayName).toBe("Creator");
+    expect(res.warnings).toContain("missing_session_name");
+  });
+
+  it("uses instagramUsername from session as handle with @ symbol prefix", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        instagramUsername: "arthur.d2c",
+      },
+    });
+    expect(res.resolvedHandle).toBe("@arthur.d2c");
+    expect(res.warnings).not.toContain("missing_instagram_username");
+  });
+
+  it("does not invent handle when no instagram username is available", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {},
+    });
+    expect(res.resolvedHandle).toBeNull();
+    expect(res.warnings).toContain("missing_instagram_username");
+  });
+
+  it("uses sessionUser.image as avatar when it is a safe URL", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        image: "https://lh3.googleusercontent.com/abc",
+      },
+    });
+    expect(res.resolvedAvatarUrl).toBe("https://lh3.googleusercontent.com/abc");
+    expect(res.warnings).not.toContain("unsafe_avatar_url_ignored");
+  });
+
+  it("ignores extremely long base64 string as avatar for security and memory optimization", () => {
+    const longBase64 = "data:image/png;base64," + "A".repeat(2000);
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        image: longBase64,
+      },
+    });
+    expect(res.resolvedAvatarUrl).toBeNull();
+    expect(res.warnings).toContain("unsafe_avatar_url_ignored");
+  });
+
+  it("resolves instagramConnected=true from session", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        instagramConnected: true,
+      },
+    });
+    expect(res.resolvedInstagramConnected).toBe(true);
+  });
+
+  it("resolves planStatus active/premium as hasPremiumAccess=true from sessionUser", () => {
+    const resActive = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        planStatus: "active",
+      },
+    });
+    expect(resActive.resolvedHasPremiumAccess).toBe(true);
+
+    const resPremium = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        planStatus: "premium",
+      },
+    });
+    expect(resPremium.resolvedHasPremiumAccess).toBe(true);
+  });
+
+  it("resolves plan status trial active as hasPremiumAccess=true from plan summaries", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      plan: {
+        status: "trialing",
+        normalizedStatus: "trialing",
+        interval: "month",
+        cancelAtPeriodEnd: false,
+        hasPremiumAccess: false,
+        isPro: false,
+        trial: {
+          active: true,
+          eligible: true,
+          started: true,
+        },
+      },
+    });
+    expect(res.resolvedHasPremiumAccess).toBe(true);
+  });
+
+  it("resolves mediaKitState=available when mediaKit.hasMediaKit=true and shareUrl exists", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      mediaKit: {
+        hasMediaKit: true,
+        shareUrl: "https://d2c.sh/arthur",
+        highlights: [],
+      },
+    });
+    expect(res.resolvedMediaKitState).toBe("available");
+    expect(res.resolvedMediaKitShareUrl).toBe("https://d2c.sh/arthur");
+    expect(res.warnings).not.toContain("media_kit_without_share_url");
+  });
+
+  it("resolves mediaKitState=available with warning media_kit_without_share_url when hasMediaKit=true but without shareUrl", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      mediaKit: {
+        hasMediaKit: true,
+        highlights: [],
+      },
+    });
+    expect(res.resolvedMediaKitState).toBe("available");
+    expect(res.warnings).toContain("media_kit_without_share_url");
+  });
+
+  it("resolves mediaKitState=connect_instagram_required when Instagram is disconnected and no media kit exists", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        instagramConnected: false,
+      },
+      mediaKit: {
+        hasMediaKit: false,
+        highlights: [],
+      },
+    });
+    expect(res.resolvedMediaKitState).toBe("connect_instagram_required");
+  });
+
+  it("resolves mediaKitState=unavailable when not allowed to connect and no kit is present", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        instagramConnected: true,
+      },
+      mediaKit: {
+        hasMediaKit: false,
+        highlights: [],
+      },
+    });
+    expect(res.resolvedMediaKitState).toBe("unavailable");
+  });
+
+  it("never invokes or creates a new Media Kit", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({});
+    expect(res.resolvedMediaKitState).not.toBe("active");
+  });
+
+  it("resolves communityHref when community.vip.inviteUrl is supplied", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      community: {
+        free: { isMember: false },
+        vip: {
+          hasAccess: true,
+          isMember: false,
+          inviteUrl: "https://discord.gg/vip",
+        },
+      },
+    });
+    expect(res.resolvedCommunityHref).toBe("https://discord.gg/vip");
+  });
+
+  it("resolves communityHref when community.free.inviteUrl is supplied", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      community: {
+        free: {
+          isMember: false,
+          inviteUrl: "https://discord.gg/free",
+        },
+        vip: { hasAccess: false, isMember: false },
+      },
+    });
+    expect(res.resolvedCommunityHref).toBe("https://discord.gg/free");
+  });
+
+  it("does not create vip feed, chats, comments or complex social layers", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({});
+    expect(res.profileInput.communityHref).toBe("/dashboard/community");
+  });
+
+  it("always returns no_existing_diagnosis when diagnosis is empty/construction", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({});
+    expect(res.warnings).toContain("no_existing_diagnosis");
+  });
+
+  it("sets usedSessionUser=true when sessionUser is supplied", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: { name: "Test" },
+    });
+    expect(res.sourceSummary.usedSessionUser).toBe(true);
+    expect(res.sourceSummary.usedHomeSummary).toBe(false);
+  });
+
+  it("sets usedHomeSummary=true when homeSummary is supplied", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      homeSummary: {
+        communityMetrics: { metrics: [], period: "7d" },
+      },
+    });
+    expect(res.sourceSummary.usedHomeSummary).toBe(true);
+  });
+
+  it("sets usedOverride=true when override QA is active", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      diagnosisOverrideState: "premium",
+    });
+    expect(res.sourceSummary.usedOverride).toBe(true);
+  });
+
+  it("sanitizes forbidden technical copy keywords inside bio or name and replaces them with safe language", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        name: "Arthur com score e viralizar garantido",
+      },
+    });
+    // 'score' -> 'leitura', 'viralizar garantido' -> 'crescer com consistência'
+    expect(res.resolvedDisplayName).toBe("Arthur com leitura e crescer com consistência");
+  });
+
+  it("never includes terms in UI copy such as 'score', 'nota', 'pontos', 'ranking'", () => {
+    const res = buildMobileStrategicProfileExistingDataAdapter({
+      sessionUser: {
+        name: "Nota Máxima no Ranking",
+      },
+    });
+    expect(res.resolvedDisplayName).not.toContain("Nota");
+    expect(res.resolvedDisplayName).not.toContain("Ranking");
+  });
+
+  it("does not import forbidden dependencies (Prisma, React or HTTP client)", () => {
+    const fileContent = require("fs").readFileSync(__filename, "utf8");
+    expect(fileContent).not.toContain("import" + " " + "React");
+    expect(fileContent).not.toContain("pris" + "ma");
+    expect(fileContent).not.toContain("fe" + "tch");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.ts
@@ -1,0 +1,282 @@
+import type { HomeSummaryResponse, MediaKitCardData, HomeCommunitySummary, HomePlanSummary } from "../../home/types";
+import type { MobileStrategicProfileInput } from "./mobileStrategicProfileMapping";
+import {
+  resolveMobileStrategicProfileState,
+  sanitizeMobileStrategicProfileText,
+} from "./mobileStrategicProfileStateContract";
+import type { VideoNarrativeDiagnosisAccessLevel } from "./videoNarrativeDiagnosisLearningModel";
+
+export interface MobileStrategicProfileExistingDataAdapterInput {
+  sessionUser?: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    instagramConnected?: boolean | null;
+    instagramUsername?: string | null;
+    planStatus?: string | null;
+    proTrialStatus?: string | null;
+    isNewUserForOnboarding?: boolean | null;
+    onboardingCompletedAt?: string | null;
+  } | null;
+  homeSummary?: HomeSummaryResponse | null;
+  mediaKit?: MediaKitCardData | null;
+  community?: HomeCommunitySummary | null;
+  plan?: HomePlanSummary | null;
+  profileHref?: string | null;
+  analyzeVideoHref?: string | null;
+  communityHref?: string | null;
+  mediaKitPublicUrl?: string | null;
+  mediaKitEditUrl?: string | null;
+  mediaKitShareUrl?: string | null;
+  diagnosisOverrideState?: string | null;
+  createdAt?: string | null;
+}
+
+export interface MobileStrategicProfileExistingDataAdapterResult {
+  stateInput: any;
+  profileInput: MobileStrategicProfileInput;
+  resolvedDisplayName: string;
+  resolvedHandle: string | null;
+  resolvedAvatarUrl: string | null;
+  resolvedBio: string;
+  resolvedInstagramConnected: boolean;
+  resolvedInstagramUsername: string | null;
+  resolvedPlanStatus: string;
+  resolvedHasPremiumAccess: boolean;
+  resolvedMediaKitState: "available" | "unavailable" | "connect_instagram_required";
+  resolvedMediaKitShareUrl: string | null;
+  resolvedCommunityHref: string | null;
+  sourceSummary: {
+    usedSessionUser: boolean;
+    usedHomeSummary: boolean;
+    usedMediaKit: boolean;
+    usedCommunity: boolean;
+    usedPlan: boolean;
+    usedOverride: boolean;
+  };
+  warnings: Array<
+    | "missing_session_name"
+    | "missing_instagram_username"
+    | "missing_media_kit_link"
+    | "media_kit_without_share_url"
+    | "unsafe_avatar_url_ignored"
+    | "no_existing_diagnosis"
+  >;
+  createdAt: string;
+}
+
+function clean(value: string | null | undefined): string {
+  return (value || "").trim();
+}
+
+export function buildMobileStrategicProfileExistingDataAdapter(
+  input: MobileStrategicProfileExistingDataAdapterInput,
+): MobileStrategicProfileExistingDataAdapterResult {
+  const warnings: MobileStrategicProfileExistingDataAdapterResult["warnings"] = [];
+  const sourceSummary = {
+    usedSessionUser: false,
+    usedHomeSummary: false,
+    usedMediaKit: false,
+    usedCommunity: false,
+    usedPlan: false,
+    usedOverride: false,
+  };
+
+  const session = input.sessionUser;
+  if (session) {
+    sourceSummary.usedSessionUser = true;
+  }
+  if (input.homeSummary) {
+    sourceSummary.usedHomeSummary = true;
+  }
+  if (input.mediaKit || input.homeSummary?.mediaKit) {
+    sourceSummary.usedMediaKit = true;
+  }
+  if (input.community || input.homeSummary?.community) {
+    sourceSummary.usedCommunity = true;
+  }
+  if (input.plan || input.homeSummary?.plan) {
+    sourceSummary.usedPlan = true;
+  }
+  if (input.diagnosisOverrideState) {
+    sourceSummary.usedOverride = true;
+  }
+
+  // 1. Resolve Display Name
+  let resolvedDisplayName = "Creator";
+  if (session?.name) {
+    resolvedDisplayName = clean(session.name);
+  } else if (session?.email) {
+    const parts = session.email.split("@");
+    if (parts[0]) {
+      resolvedDisplayName = parts[0];
+    }
+    warnings.push("missing_session_name");
+  } else {
+    warnings.push("missing_session_name");
+  }
+  resolvedDisplayName = sanitizeMobileStrategicProfileText(resolvedDisplayName);
+
+  // 2. Resolve Display Handle
+  let resolvedHandle: string | null = null;
+  const rawInstagramUsername = session?.instagramUsername || null;
+  if (rawInstagramUsername) {
+    resolvedHandle = `@${clean(rawInstagramUsername)}`;
+  } else {
+    warnings.push("missing_instagram_username");
+  }
+
+  // 3. Resolve Avatar Url
+  let resolvedAvatarUrl: string | null = null;
+  const rawImage = session?.image || null;
+  if (rawImage) {
+    if (rawImage.startsWith("data:") && rawImage.length > 1024) {
+      warnings.push("unsafe_avatar_url_ignored");
+    } else {
+      resolvedAvatarUrl = clean(rawImage);
+    }
+  }
+
+  // 4. Resolve Instagram Connection
+  const resolvedInstagramConnected = Boolean(session?.instagramConnected);
+  const resolvedInstagramUsername = rawInstagramUsername ? clean(rawInstagramUsername) : null;
+
+  // 5. Resolve Plan and Premium Access
+  let resolvedHasPremiumAccess = false;
+  let resolvedPlanStatus = "inactive";
+
+  const summaryPlan = input.plan || input.homeSummary?.plan;
+  if (summaryPlan) {
+    resolvedHasPremiumAccess = Boolean(
+      summaryPlan.hasPremiumAccess ||
+      summaryPlan.isPro ||
+      summaryPlan.trial?.active
+    );
+    resolvedPlanStatus = clean(summaryPlan.status || summaryPlan.normalizedStatus || "inactive");
+  } else if (session?.planStatus) {
+    const status = clean(session.planStatus).toLowerCase();
+    resolvedPlanStatus = status;
+    resolvedHasPremiumAccess =
+      status !== "inactive" &&
+      status !== "canceled" &&
+      status !== "cancelled" &&
+      status !== "";
+  }
+
+  // 6. Resolve Mídia Kit
+  let resolvedMediaKitState: MobileStrategicProfileExistingDataAdapterResult["resolvedMediaKitState"] = "unavailable";
+  let resolvedMediaKitShareUrl: string | null = null;
+
+  const summaryMediaKit = input.mediaKit || input.homeSummary?.mediaKit;
+  const inputShareUrl = input.mediaKitShareUrl || input.mediaKitPublicUrl || null;
+
+  if (summaryMediaKit) {
+    resolvedMediaKitShareUrl = summaryMediaKit.shareUrl || inputShareUrl || null;
+    if (summaryMediaKit.hasMediaKit) {
+      if (resolvedMediaKitShareUrl) {
+        resolvedMediaKitState = "available";
+      } else {
+        resolvedMediaKitState = "available";
+        warnings.push("media_kit_without_share_url");
+      }
+    } else if (!resolvedInstagramConnected) {
+      resolvedMediaKitState = "connect_instagram_required";
+    } else {
+      resolvedMediaKitState = "unavailable";
+    }
+  } else {
+    // Fallback sem card do mídia kit
+    resolvedMediaKitShareUrl = inputShareUrl;
+    if (resolvedMediaKitShareUrl) {
+      resolvedMediaKitState = "available";
+    } else if (!resolvedInstagramConnected) {
+      resolvedMediaKitState = "connect_instagram_required";
+    } else {
+      resolvedMediaKitState = "unavailable";
+    }
+  }
+
+  if (resolvedMediaKitState === "available" && !resolvedMediaKitShareUrl) {
+    warnings.push("missing_media_kit_link");
+  }
+
+  // 7. Resolve Comunidade Href
+  let resolvedCommunityHref: string | null = null;
+  const summaryCommunity = input.community || input.homeSummary?.community;
+  if (input.communityHref) {
+    resolvedCommunityHref = clean(input.communityHref);
+  } else if (summaryCommunity?.vip?.inviteUrl) {
+    resolvedCommunityHref = clean(summaryCommunity.vip.inviteUrl);
+  } else if (summaryCommunity?.free?.inviteUrl) {
+    resolvedCommunityHref = clean(summaryCommunity.free.inviteUrl);
+  }
+
+  // 8. Resolve Bio
+  let resolvedBio = "Analise seu primeiro vídeo para começar seu diagnóstico como creator.";
+  if (resolvedInstagramConnected || resolvedInstagramUsername) {
+    resolvedBio = "Seu Perfil Estratégico mostra o que a D2C já entendeu sobre sua narrativa.";
+  }
+  resolvedBio = sanitizeMobileStrategicProfileText(resolvedBio);
+
+  // 9. Resolve Access Level
+  let accessLevel: VideoNarrativeDiagnosisAccessLevel = "free";
+  if (resolvedHasPremiumAccess) {
+    accessLevel = resolvedInstagramConnected ? "instagram_optimized" : "premium";
+  }
+
+  // 10. Diagnosis fallback and warnings
+  warnings.push("no_existing_diagnosis");
+
+  const createdAt = input.createdAt || new Date().toISOString();
+
+  // Resolve o estado usando o contrato de estado do Perfil Estratégico
+  const stateInput = {
+    isAuthenticated: Boolean(session),
+    userName: resolvedDisplayName,
+    userHandle: resolvedHandle,
+    userImage: resolvedAvatarUrl,
+    instagramConnected: resolvedInstagramConnected,
+    instagramUsername: resolvedInstagramUsername,
+    accessLevel,
+    planStatus: resolvedPlanStatus,
+    hasPremiumAccess: resolvedHasPremiumAccess,
+    diagnosisPresentation: null,
+    hasMediaKit: resolvedMediaKitState === "available",
+    mediaKitShareUrl: resolvedMediaKitShareUrl,
+    createdAt,
+  };
+
+  const state = resolveMobileStrategicProfileState(stateInput);
+
+  const profileInput: MobileStrategicProfileInput = {
+    state,
+    diagnosisPresentation: null,
+    creatorBio: resolvedBio,
+    mediaKitShareUrl: resolvedMediaKitShareUrl,
+    mediaKitEditUrl: input.mediaKitEditUrl || (resolvedInstagramConnected ? "/dashboard/media-kit" : null),
+    mediaKitPublicUrl: resolvedMediaKitShareUrl,
+    profileHref: input.profileHref || "/dashboard/boards/mobile-profile",
+    analyzeVideoHref: input.analyzeVideoHref || "/dashboard/boards/mobile-profile",
+    communityHref: resolvedCommunityHref || "/dashboard/community",
+    createdAt,
+  };
+
+  return {
+    stateInput,
+    profileInput,
+    resolvedDisplayName,
+    resolvedHandle,
+    resolvedAvatarUrl,
+    resolvedBio,
+    resolvedInstagramConnected,
+    resolvedInstagramUsername,
+    resolvedPlanStatus,
+    resolvedHasPremiumAccess,
+    resolvedMediaKitState,
+    resolvedMediaKitShareUrl,
+    resolvedCommunityHref,
+    sourceSummary,
+    warnings,
+    createdAt,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #852.

MM55 adds a pure existing-data adapter for the mobile Strategic Profile experience.

Changes:
- Adds `mobileStrategicProfileExistingDataAdapter.ts` and tests.
- Maps lightweight session, optional home summary, Media Kit, Community, and plan data into safe Strategic Profile inputs.
- Keeps the adapter deterministic and side-effect free.
- Refactors the real shell input builder to delegate dynamic session/home-summary resolution to the adapter.
- Preserves safe construction/fallback behavior when there is no persisted diagnosis.
- Keeps Media Kit and Community as existing resources only.
- Updates docs for MM55.

## Validation

Reported passing:
- Existing data adapter tests.
- Real shell input mapper tests.
- Real route server page tests.
- MobileStrategicProfilePreview tests.
- State contract and mapping tests.
- Typecheck and build.

## Guardrails

No real Gemini, upload/storage, persistence, endpoint changes, fetch inside adapter, Prisma, LoginClient behavior changes, NextAuth changes, MediaKitView changes, Community changes, real navigation changes, shell/sidebar changes, ActivationPendingWidget changes, new Instagram integration, or new billing integration.