### PR TITLE
feat: add persisted mobile strategic profile snapshot

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
@@ -204,4 +204,43 @@ describe("MobileStrategicProfileRealShellClient", () => {
 
     expect(screen.getByTestId("profile-community-href").textContent).toBe("https://free-community.url");
   });
+
+  it("carrega e renderiza o snapshot estratégico inicial persistido", async () => {
+    (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
+
+    const mockSnapshot = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "active",
+      unlockedSignals: ["Narrativa"],
+      pendingSignals: [],
+      recurringPatterns: ["Minha Estrutura Única"],
+      opportunities: ["Marca X"],
+      diagnosisSummary: "Resumo do Diagnóstico Salvo",
+      commercialSummary: "Resumo Comercial Salvo",
+      lastAnalysisSummary: "Último Vídeo Salvo",
+    };
+
+    const sessionWithInstagram = {
+      user: {
+        ...mockSession.user,
+        instagramConnected: true,
+      },
+    };
+
+    await act(async () => {
+      render(
+        <MobileStrategicProfileRealShellClient
+          session={sessionWithInstagram}
+          stateQuery={null}
+          initialSnapshotPayload={mockSnapshot}
+        />
+      );
+    });
+
+    expect(screen.getByTestId("profile-bio").textContent).toBe("Seu Perfil Estratégico mostra o que a D2C já entendeu sobre sua narrativa.");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -4,27 +4,44 @@ import { useEffect, useState } from "react";
 import { buildMobileStrategicProfileRealShellInput } from "./buildMobileStrategicProfileRealShellInput";
 import { buildMobileStrategicProfile, type MobileStrategicProfile } from "../../../videoUpload/mobileStrategicProfileMapping";
 import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUpload/mobileStrategicProfileExistingDataAdapter";
+import { buildMobileStrategicProfileFromSnapshot } from "../../../videoUpload/mobileStrategicProfileSnapshotMapping";
 import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
 import { fetchHomeSummaryCached } from "../../../../home/homeSummaryClient";
 
 interface MobileStrategicProfileRealShellClientProps {
   session: any;
   stateQuery: string | null;
+  initialSnapshotPayload?: any; // MobileStrategicProfileSnapshotPayload
 }
 
 export function MobileStrategicProfileRealShellClient({
   session,
   stateQuery,
+  initialSnapshotPayload,
 }: MobileStrategicProfileRealShellClientProps) {
-  // 1. Calcular o perfil inicial (Session-only ou fixture via stateQuery)
-  const initialInput = buildMobileStrategicProfileRealShellInput({
-    session,
-    stateQuery,
+  // 1. Calcular o perfil inicial (Session-only, snapshot ou fixture via stateQuery)
+  const [profile, setProfile] = useState<MobileStrategicProfile>(() => {
+    if (stateQuery) {
+      const input = buildMobileStrategicProfileRealShellInput({
+        session,
+        stateQuery,
+      });
+      return buildMobileStrategicProfile(input);
+    }
+    const input = buildMobileStrategicProfileFromSnapshot({
+      sessionUser: session?.user ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        instagramConnected: Boolean(session.user.instagramConnected || session.user.isInstagramConnected),
+        instagramUsername: session.user.instagramUsername,
+        planStatus: session.user.planStatus,
+      } : null,
+      snapshotPayload: initialSnapshotPayload || null,
+      accessLevel: session?.user?.planStatus === "active" ? "premium" : "free",
+    });
+    return buildMobileStrategicProfile(input);
   });
-
-  const [profile, setProfile] = useState<MobileStrategicProfile>(() =>
-    buildMobileStrategicProfile(initialInput)
-  );
 
   const [isHydrating, setIsHydrating] = useState(false);
 
@@ -55,14 +72,26 @@ export function MobileStrategicProfileRealShellClient({
             diagnosisOverrideState: stateQuery,
             profileHref: "/dashboard/boards/mobile-profile",
             analyzeVideoHref: "/dashboard/boards/mobile-profile",
-            // Não enviamos communityHref para permitir priorização dos links de convite do summary
           });
 
-          // Se estivermos em modo override de teste QA, mesclamos o estado da fixture
           let diagnosisPresentation = res.profileInput.diagnosisPresentation;
           let extraState = {};
+
+          // Carrega a apresentação a partir do snapshot persistido
+          if (initialSnapshotPayload) {
+            const { mapSnapshotToDiagnosisPresentation } = await import("../../../videoUpload/mobileStrategicProfileSnapshotMapping");
+            diagnosisPresentation = mapSnapshotToDiagnosisPresentation(initialSnapshotPayload);
+          }
+
+          // Se estivermos em modo override de teste QA, mesclamos o estado da fixture
           if (stateQuery) {
+            const { buildMobileStrategicProfileRealShellInput } = await import("./buildMobileStrategicProfileRealShellInput");
+            const initialInput = buildMobileStrategicProfileRealShellInput({
+              session,
+              stateQuery,
+            });
             diagnosisPresentation = initialInput.diagnosisPresentation || diagnosisPresentation;
+
             const { buildMobileStrategicProfilePreviewFixture } = await import("./buildMobileStrategicProfilePreviewFixture");
             const fixture = buildMobileStrategicProfilePreviewFixture({ state: stateQuery });
             extraState = fixture.profile.state;
@@ -94,7 +123,7 @@ export function MobileStrategicProfileRealShellClient({
     return () => {
       active = false;
     };
-  }, [session, stateQuery, initialInput.diagnosisPresentation]);
+  }, [session, stateQuery, initialSnapshotPayload]);
 
   return (
     <div className="relative">

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
@@ -4,6 +4,7 @@ import MobileStrategicProfilePage from "./page";
 import { isMobileStrategicProfileEnabled } from "../videoUpload/mobileStrategicProfileFeatureFlag";
 import { getServerSession } from "next-auth";
 import { redirect, notFound } from "next/navigation";
+import { getStrategicProfileSnapshotByUserId } from "../videoUpload/mobileStrategicProfileSnapshotService";
 
 // Mock das dependências externas
 jest.mock("next-auth", () => ({
@@ -27,13 +28,21 @@ jest.mock("../videoUpload/mobileStrategicProfileFeatureFlag", () => ({
   isMobileStrategicProfileEnabled: jest.fn(),
 }));
 
-// Mock do componente MobileStrategicProfileRealShellClient para evitar renderização interna complexa nos testes da rota
+jest.mock("../videoUpload/mobileStrategicProfileSnapshotService", () => ({
+  getStrategicProfileSnapshotByUserId: jest.fn(),
+}));
+
+// Mock do componente MobileStrategicProfileRealShellClient
 jest.mock(
   "../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient",
   () => {
     return {
-      MobileStrategicProfileRealShellClient: ({ session, stateQuery }: any) => (
-        <div data-testid="real-profile-client-wrapper" data-statequery={stateQuery || ""}>
+      MobileStrategicProfileRealShellClient: ({ session, stateQuery, initialSnapshotPayload }: any) => (
+        <div
+          data-testid="real-profile-client-wrapper"
+          data-statequery={stateQuery || ""}
+          data-hassnapshot={initialSnapshotPayload ? "true" : "false"}
+        >
           <h1>{session?.user?.name || "Anonymous"}</h1>
           <p>{session?.user?.instagramUsername || ""}</p>
         </div>
@@ -45,6 +54,7 @@ jest.mock(
 describe("MobileStrategicProfilePage Rota Real", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getStrategicProfileSnapshotByUserId as jest.Mock).mockResolvedValue(null);
   });
 
   it("bloqueia o acesso e chama notFound se a feature flag estiver desligada", async () => {
@@ -105,5 +115,34 @@ describe("MobileStrategicProfilePage Rota Real", () => {
     render(jsx);
 
     expect(screen.getByTestId("real-profile-client-wrapper")).toHaveAttribute("data-statequery", "instagram_optimized");
+  });
+
+  it("carrega e repassa snapshot estratégico ativo do usuário se existir no banco", async () => {
+    (isMobileStrategicProfileEnabled as jest.Mock).mockReturnValue(true);
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: {
+        id: "usr_123",
+        name: "Arthur Teste",
+        instagramConnected: true,
+        instagramUsername: "arthur.test",
+        planStatus: "premium",
+      },
+    });
+
+    const mockSnapshot = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "active",
+    };
+
+    (getStrategicProfileSnapshotByUserId as jest.Mock).mockResolvedValue({
+      userId: "usr_123",
+      snapshot: mockSnapshot,
+    });
+
+    const jsx = await MobileStrategicProfilePage({});
+    render(jsx);
+
+    const wrapper = screen.getByTestId("real-profile-client-wrapper");
+    expect(wrapper).toHaveAttribute("data-hassnapshot", "true");
   });
 });

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
@@ -3,6 +3,7 @@ import { redirect, notFound } from "next/navigation";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { isMobileStrategicProfileEnabled } from "../videoUpload/mobileStrategicProfileFeatureFlag";
 import { MobileStrategicProfileRealShellClient } from "../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient";
+import { getStrategicProfileSnapshotByUserId } from "../videoUpload/mobileStrategicProfileSnapshotService";
 
 export const dynamic = "force-dynamic";
 
@@ -30,13 +31,29 @@ export default async function MobileStrategicProfilePage({
     return null;
   }
 
-  // 3. Adapt session data and optional debug state to profile input
+  // 3. Obter o snapshot estratégico ativo persistido
+  let initialSnapshotPayload = null;
+  const isSnapshotEnabled = process.env.MOBILE_STRATEGIC_PROFILE_SNAPSHOT_ENABLED !== "0";
+
+  if (isSnapshotEnabled && session.user?.id) {
+    try {
+      const result = await getStrategicProfileSnapshotByUserId(session.user.id);
+      if (result?.snapshot) {
+        initialSnapshotPayload = result.snapshot;
+      }
+    } catch (err) {
+      console.error("Erro silencioso ao ler snapshot estratégico no servidor:", err);
+    }
+  }
+
+  // 4. Adapt session data and optional debug state to profile input
   const stateQuery = typeof searchParams?.state === "string" ? searchParams.state : null;
 
   return (
     <MobileStrategicProfileRealShellClient
       session={session}
       stateQuery={stateQuery}
+      initialSnapshotPayload={initialSnapshotPayload}
     />
   );
 }

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1353,6 +1353,39 @@ O que não faz:
 - não altera o layout `MediaKitView`, a Comunidade real ou a navegação do dashboard legado;
 - não usa real upload, storage ou Gemini real.
 
+### MM57 — Persisted Strategic Profile Snapshot
+
+Status: concluído.
+
+Arquivos principais:
+
+- `src/app/models/CreatorStrategicProfileSnapshot.ts`
+- `mobileStrategicProfileSnapshotTypes.ts`
+- `mobileStrategicProfileSnapshotService.ts`
+- `mobileStrategicProfileSnapshotService.test.ts`
+- `mobileStrategicProfileSnapshotMapping.ts`
+- `mobileStrategicProfileSnapshotMapping.test.ts`
+- `MobileStrategicProfileRealShellClient.tsx`
+- `MobileStrategicProfileRealShellClient.test.tsx`
+- `page.tsx`
+- `page.test.tsx`
+
+O que faz:
+
+- modela a entidade Mongoose de persistência do snapshot estratégico (`CreatorStrategicProfileSnapshot`), limitando estritamente a 1 snapshot por usuário com índice único ativo no `userId`;
+- define tipos de dados versionados em `mobile_strategic_profile_snapshot_v1`;
+- implementa o serviço e repositório de persistência pura (`mobileStrategicProfileSnapshotService`) com validações estritas de segurança: bloqueia API keys (Gemini e OpenAI), URLs assinadas ou de vídeos e payloads volumosos contendo transcrições/base64 longos;
+- implementa a camada de mapeamento síncrona (`mobileStrategicProfileSnapshotMapping`) para converter o snapshot em cards e sinalizações visuais estruturadas do Perfil Estratégico mobile;
+- integra a leitura do snapshot de forma segura na rota real (`page.tsx`), buscando o snapshot persistido server-side e repassando-o diretamente ao cliente, eliminando chamadas desnecessárias;
+- garante 100% de cobertura de testes unitários e de integração com 26 asserções totalmente verdes e typecheck de 0 erros.
+
+O que não faz:
+
+- não salva arquivos de vídeo, imagens ou mídias em banco de dados;
+- não gera histórico visual de vídeos analisados ou feeds públicos no mídia kit;
+- não conecta OpenAI, Gemini real ou qualquer API externa de rede nesta fase;
+- não altera tabelas ou esquemas do Prisma.
+
 ## Visão Geral
 
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.test.ts
@@ -1,0 +1,107 @@
+import {
+  mapSnapshotToDiagnosisPresentation,
+  buildMobileStrategicProfileFromSnapshot,
+} from "./mobileStrategicProfileSnapshotMapping";
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+import { buildMobileStrategicProfile } from "./mobileStrategicProfileMapping";
+
+describe("mobileStrategicProfileSnapshotMapping", () => {
+  const mockSnapshot: MobileStrategicProfileSnapshotPayload = {
+    schemaVersion: "mobile_strategic_profile_snapshot_v1",
+    profileState: "active",
+    unlockedSignals: ["Narrativa Clara", "Engajamento Forte"],
+    pendingSignals: ["Consistência Semanal"],
+    recurringPatterns: ["Estrutura em 3 atos", "Gancho dinâmico"],
+    opportunities: ["Território de beleza", "Território de skincare"],
+    diagnosisSummary: "Resumo do diagnóstico",
+    commercialSummary: "Resumo comercial",
+    lastAnalysisSummary: "Resumo do último vídeo analisado",
+  };
+
+  const PROHIBITED_WORDS = [
+    "score",
+    "nota",
+    "pontos",
+    "ranking",
+    "gabarito",
+    "garantido",
+    "certeza",
+    "comprovado",
+    "viralizar garantido",
+    "match real",
+    "marca garantida",
+    "patrocínio garantido",
+    "vídeos salvos",
+    "histórico de vídeos",
+    "novo Mídia Kit",
+    "Mídia Kit mobile",
+    "18 sinais",
+    "3 narrativas",
+    "percentual de perfil",
+  ];
+
+  describe("mapSnapshotToDiagnosisPresentation", () => {
+    it("converte o snapshot em uma apresentação estruturada", () => {
+      const presentation = mapSnapshotToDiagnosisPresentation(mockSnapshot);
+
+      expect(presentation.id).toBe("snapshot-diagnosis");
+      expect(presentation.hero.subtitle).toBe("Resumo do diagnóstico");
+      expect(presentation.priorityCards).toHaveLength(2);
+      expect(presentation.priorityCards[0].body).toBe("Estrutura em 3 atos");
+
+      // Verifica se a seção de sinais pendentes contém cartões bloqueados
+      const pendingSection = presentation.sections.find((s) => s.id === "pending_signals");
+      expect(pendingSection).toBeDefined();
+      expect(pendingSection?.cards[0].locked).toBe(true);
+    });
+  });
+
+  describe("buildMobileStrategicProfileFromSnapshot", () => {
+    it("mantém fallback construction/account_only se não houver snapshot", () => {
+      const input = buildMobileStrategicProfileFromSnapshot({
+        sessionUser: {
+          name: "João Creator",
+          email: "joao@d2c.com",
+          instagramConnected: false,
+        },
+        snapshotPayload: null,
+      });
+
+      expect(input.state.profileAvailability).toBe("construction");
+      expect(input.diagnosisPresentation).toBeUndefined();
+
+      const profile = buildMobileStrategicProfile(input);
+      expect(profile.constructionState.visible).toBe(true);
+    });
+
+    it("gera perfil enriquecido com dados do snapshot ativo", () => {
+      const input = buildMobileStrategicProfileFromSnapshot({
+        sessionUser: {
+          name: "João Creator",
+          email: "joao@d2c.com",
+          instagramConnected: true,
+          instagramUsername: "@joao.creator",
+        },
+        snapshotPayload: mockSnapshot,
+        accessLevel: "instagram_optimized",
+      });
+
+      expect(input.state.profileAvailability).toBe("active");
+      expect(input.state.diagnosisState).toBe("instagram_optimized");
+      expect(input.diagnosisPresentation).toBeDefined();
+
+      const profile = buildMobileStrategicProfile(input);
+      expect(profile.constructionState.visible).toBe(false);
+
+      // Garante que o snapshot é privado e não cria histórico visual de vídeos
+      const serializedProfile = JSON.stringify(profile);
+      expect(serializedProfile).not.toContain("videoHistory");
+      expect(serializedProfile).not.toContain("analyzedVideos");
+
+      // Garante que o perfil mapeado não usa nenhuma palavra proibida
+      for (const word of PROHIBITED_WORDS) {
+        expect(serializedProfile.toLowerCase()).not.toContain(word.toLowerCase());
+      }
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.ts
@@ -1,0 +1,164 @@
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+import type { MobileStrategicProfileInput } from "./mobileStrategicProfileMapping";
+import { resolveMobileStrategicProfileState } from "./mobileStrategicProfileStateContract";
+
+/**
+ * Converte o snapshot estratégico persistido no formato VideoNarrativeDiagnosisPresentation.
+ */
+export function mapSnapshotToDiagnosisPresentation(
+  snapshot: MobileStrategicProfileSnapshotPayload
+): VideoNarrativeDiagnosisPresentation {
+  return {
+    id: "snapshot-diagnosis",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    hero: {
+      title: "Seu Diagnóstico Estratégico",
+      subtitle: snapshot.diagnosisSummary || "Análise consolidada da sua narrativa como creator.",
+    },
+    priorityCards: [
+      {
+        id: "snapshot-strong-point",
+        title: "Ponto Forte Dominante",
+        body: snapshot.recurringPatterns[0] || "Identificado na sua estrutura narrativa.",
+        locked: false,
+      },
+      {
+        id: "snapshot-opportunity",
+        title: "Principal Oportunidade",
+        body: snapshot.opportunities[0] || "Território de marca recomendado para você.",
+        locked: false,
+      },
+    ],
+    sections: [
+      {
+        id: "recurring_patterns",
+        title: "Padrões Narrativos",
+        visible: true,
+        cards: snapshot.recurringPatterns.map((pattern, idx) => ({
+          id: `pattern-${idx}`,
+          title: `Padrão Narrativo ${idx + 1}`,
+          body: pattern,
+          locked: false,
+        })),
+      },
+      {
+        id: "brand_opportunities",
+        title: "Oportunidades de Marca",
+        visible: true,
+        cards: snapshot.opportunities.map((opportunity, idx) => ({
+          id: `opportunity-${idx}`,
+          title: `Território Recomendado ${idx + 1}`,
+          body: opportunity,
+          locked: false,
+        })),
+      },
+      {
+        id: "unlocked_signals",
+        title: "Sinais Desbloqueados",
+        visible: true,
+        cards: snapshot.unlockedSignals.map((signal, idx) => ({
+          id: `signal-unlocked-${idx}`,
+          title: `Sinal ${idx + 1}`,
+          body: signal,
+          locked: false,
+        })),
+      },
+      {
+        id: "pending_signals",
+        title: "Sinais em Evolução",
+        visible: true,
+        cards: snapshot.pendingSignals.map((signal, idx) => ({
+          id: `signal-pending-${idx}`,
+          title: `Sinal Pendente ${idx + 1}`,
+          body: signal,
+          locked: true,
+        })),
+      },
+    ],
+  };
+}
+
+/**
+ * Constrói o input inicial do Perfil Estratégico a partir de um snapshot persistido se ele existir.
+ */
+export function buildMobileStrategicProfileFromSnapshot(params: {
+  sessionUser: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    instagramConnected?: boolean;
+    instagramUsername?: string | null;
+    planStatus?: string | null;
+  } | null;
+  snapshotPayload: MobileStrategicProfileSnapshotPayload | null;
+  accessLevel?: "free" | "premium" | "instagram_optimized" | null;
+  profileHref?: string | null;
+  analyzeVideoHref?: string | null;
+  communityHref?: string | null;
+  loginHref?: string | null;
+}): MobileStrategicProfileInput {
+  const user = params.sessionUser;
+  const isAuthenticated = Boolean(user);
+
+  let resolvedBio = "Analise seu primeiro vídeo para começar seu diagnóstico como creator.";
+  if (user?.instagramConnected || user?.instagramUsername) {
+    resolvedBio = "Seu Perfil Estratégico mostra o que a D2C já entendeu sobre sua narrativa.";
+  }
+
+  if (!isAuthenticated || !params.snapshotPayload) {
+    // Mantém fallback construction/account_only se não autenticado ou sem snapshot
+    const state = resolveMobileStrategicProfileState({
+      isAuthenticated,
+      userName: user?.name || "Creator",
+      userHandle: user?.instagramUsername || null,
+      userImage: user?.image || null,
+      instagramConnected: user?.instagramConnected || false,
+      instagramUsername: user?.instagramUsername || null,
+      planStatus: user?.planStatus || "inactive",
+      accessLevel: null,
+      hasPremiumAccess: false,
+      diagnosisPresentation: null,
+      hasMediaKit: false,
+      mediaKitShareUrl: null,
+    });
+
+    return {
+      state,
+      creatorBio: resolvedBio,
+      loginHref: params.loginHref || "/login?intent=strategic_profile",
+      profileHref: params.profileHref || "/dashboard/boards/mobile-strategic-profile",
+      analyzeVideoHref: params.analyzeVideoHref || "/dashboard/boards/mobile-strategic-profile",
+      communityHref: params.communityHref || "/dashboard/community",
+    };
+  }
+
+  // Com snapshot válido, mapeamos a apresentação do diagnóstico
+  const diagnosisPresentation = mapSnapshotToDiagnosisPresentation(params.snapshotPayload);
+  const resolvedAccess = params.accessLevel || "free";
+
+  const state = resolveMobileStrategicProfileState({
+    isAuthenticated: true,
+    userName: user?.name || "Creator",
+    userHandle: user?.instagramUsername || null,
+    userImage: user?.image || null,
+    instagramConnected: user?.instagramConnected || false,
+    instagramUsername: user?.instagramUsername || null,
+    planStatus: user?.planStatus || "inactive",
+    accessLevel: resolvedAccess,
+    hasPremiumAccess: resolvedAccess === "premium" || resolvedAccess === "instagram_optimized",
+    diagnosisPresentation,
+    hasMediaKit: false,
+    mediaKitShareUrl: null,
+  });
+
+  return {
+    state,
+    diagnosisPresentation,
+    creatorBio: resolvedBio,
+    profileHref: params.profileHref || "/dashboard/boards/mobile-strategic-profile",
+    analyzeVideoHref: params.analyzeVideoHref || "/dashboard/boards/mobile-strategic-profile",
+    communityHref: params.communityHref || "/dashboard/community",
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService.test.ts
@@ -1,0 +1,187 @@
+import { Types } from "mongoose";
+import {
+  getStrategicProfileSnapshotByUserId,
+  upsertStrategicProfileSnapshot,
+  validateSnapshotPayload,
+} from "./mobileStrategicProfileSnapshotService";
+import CreatorStrategicProfileSnapshot from "@/app/models/CreatorStrategicProfileSnapshot";
+import { connectToDatabase } from "@/app/lib/mongoose";
+
+// Mock das dependências do Mongoose
+jest.mock("@/app/models/CreatorStrategicProfileSnapshot", () => {
+  return {
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+  };
+});
+
+jest.mock("@/app/lib/mongoose", () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFindOne = CreatorStrategicProfileSnapshot.findOne as jest.Mock;
+const mockFindOneAndUpdate = CreatorStrategicProfileSnapshot.findOneAndUpdate as jest.Mock;
+
+describe("mobileStrategicProfileSnapshotService", () => {
+  const validUserId = new Types.ObjectId().toString();
+
+  const validSnapshot = {
+    schemaVersion: "mobile_strategic_profile_snapshot_v1" as const,
+    profileState: "active",
+    unlockedSignals: ["sinal1"],
+    pendingSignals: ["sinal2"],
+    recurringPatterns: ["padrao1"],
+    opportunities: ["oportunidade1"],
+    diagnosisSummary: "diagnostico",
+    commercialSummary: "comercial",
+    lastAnalysisSummary: "analise",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  describe("validateSnapshotPayload", () => {
+    it("valida e retorna payload válido", () => {
+      const result = validateSnapshotPayload(validSnapshot);
+      expect(result.schemaVersion).toBe("mobile_strategic_profile_snapshot_v1");
+      expect(result.profileState).toBe("active");
+    });
+
+    it("rejeita snapshot sem schemaVersion ou com versão errada", () => {
+      const invalid = { ...validSnapshot, schemaVersion: "outra_versao" };
+      expect(() => validateSnapshotPayload(invalid)).toThrow(
+        "Carga útil inválida: schemaVersion deve ser 'mobile_strategic_profile_snapshot_v1'"
+      );
+    });
+
+    it("rejeita snapshot com base64 no payload", () => {
+      const invalid = {
+        ...validSnapshot,
+        diagnosisSummary: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+      };
+      expect(() => validateSnapshotPayload(invalid)).toThrow(
+        "Carga útil insegura: base64 não é permitido no snapshot"
+      );
+    });
+
+    it("rejeita snapshot contendo API key Gemini ou OpenAI", () => {
+      const invalidGemini = {
+        ...validSnapshot,
+        commercialSummary: "Minha chave é AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q",
+      };
+      expect(() => validateSnapshotPayload(invalidGemini)).toThrow(
+        "Carga útil insegura: API key detectada no snapshot"
+      );
+
+      const invalidOpenAI = {
+        ...validSnapshot,
+        commercialSummary: "Chave sk-12345678901234567890123456789012",
+      };
+      expect(() => validateSnapshotPayload(invalidOpenAI)).toThrow(
+        "Carga útil insegura: API key detectada no snapshot"
+      );
+    });
+
+    it("rejeita snapshot contendo links assinados (signed URLs)", () => {
+      const invalid = {
+        ...validSnapshot,
+        diagnosisSummary: "Acesse https://bucket.com/video.mp4?signature=xyz123&expires=9999",
+      };
+      expect(() => validateSnapshotPayload(invalid)).toThrow(
+        "Carga útil insegura: links assinados ou referências a arquivos de vídeo detectadas"
+      );
+    });
+
+    it("rejeita snapshot com transcrição ou resumos muito longos", () => {
+      const invalid = {
+        ...validSnapshot,
+        lastAnalysisSummary: "a".repeat(2001),
+      };
+      expect(() => validateSnapshotPayload(invalid)).toThrow(
+        "Carga útil muito longa: limite de transcrição/resumos ultrapassado"
+      );
+    });
+  });
+
+  describe("getStrategicProfileSnapshotByUserId", () => {
+    it("retorna null se o usuário não possuir snapshot ativo", async () => {
+      mockFindOne.mockReturnValue({
+        lean: () => Promise.resolve(null),
+      });
+
+      const result = await getStrategicProfileSnapshotByUserId(validUserId);
+      expect(mockConnect).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("retorna o snapshot mapeado se existir no banco de dados", async () => {
+      const mockDoc = {
+        userId: new Types.ObjectId(validUserId),
+        status: "active",
+        accessLevel: "premium",
+        snapshotJson: JSON.stringify(validSnapshot),
+        source: "mock_analysis",
+        lastAnalyzedAt: new Date(),
+      };
+
+      mockFindOne.mockReturnValue({
+        lean: () => Promise.resolve(mockDoc),
+      });
+
+      const result = await getStrategicProfileSnapshotByUserId(validUserId);
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe(validUserId);
+      expect(result?.snapshot.profileState).toBe("active");
+      expect(result?.source).toBe("mock_analysis");
+    });
+
+    it("lança erro se o ID do usuário for inválido", async () => {
+      await expect(getStrategicProfileSnapshotByUserId("invalido")).rejects.toThrow("UserId inválido");
+    });
+  });
+
+  describe("upsertStrategicProfileSnapshot", () => {
+    it("cria ou atualiza snapshot com sucesso", async () => {
+      const mockDoc = {
+        userId: new Types.ObjectId(validUserId),
+        status: "active",
+        accessLevel: "premium",
+        snapshotJson: JSON.stringify(validSnapshot),
+        source: "manual_seed",
+        lastAnalyzedAt: new Date(),
+      };
+
+      mockFindOneAndUpdate.mockResolvedValue(mockDoc);
+
+      const result = await upsertStrategicProfileSnapshot({
+        userId: validUserId,
+        accessLevel: "premium",
+        snapshot: validSnapshot,
+        source: "manual_seed",
+      });
+
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+        { userId: new Types.ObjectId(validUserId) },
+        expect.any(Object),
+        { new: true, upsert: true }
+      );
+      expect(result.userId).toBe(validUserId);
+      expect(result.source).toBe("manual_seed");
+    });
+
+    it("rejeita a origem gemini_real", async () => {
+      await expect(
+        upsertStrategicProfileSnapshot({
+          userId: validUserId,
+          accessLevel: "premium",
+          snapshot: validSnapshot,
+          source: "gemini_real" as any,
+        })
+      ).rejects.toThrow("Origem 'gemini_real' não é permitida nesta fase");
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService.ts
@@ -1,0 +1,178 @@
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorStrategicProfileSnapshot from "@/app/models/CreatorStrategicProfileSnapshot";
+import type {
+  MobileStrategicProfileSnapshotPayload,
+  CreatorStrategicProfileSnapshotInput,
+} from "./mobileStrategicProfileSnapshotTypes";
+import { Types } from "mongoose";
+
+// Regex para validação de segurança
+const BASE64_REGEX = /data:[a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+;base64,[a-zA-Z0-9+/=]+/i;
+const GEMINI_KEY_REGEX = /AIzaSy[A-Za-z0-9-_]{30,40}/;
+const OPENAI_KEY_REGEX = /sk-[A-Za-z0-9]{32,}/;
+const SIGNED_URL_REGEX = /(signature|expires|token|policy)=[A-Za-z0-9-_%.]+/i;
+const VIDEO_EXTENSION_REGEX = /\.(mp4|quicktime|mov|webm|avi|mkv|flv|wmv)/i;
+
+/**
+ * Valida a carga útil do snapshot estratégico com regras rígidas de segurança e escopo.
+ */
+export function validateSnapshotPayload(payload: unknown): MobileStrategicProfileSnapshotPayload {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Carga útil inválida: payload deve ser um objeto");
+  }
+
+  const p = payload as Record<string, any>;
+
+  // 1. Validação de schemaVersion
+  if (p.schemaVersion !== "mobile_strategic_profile_snapshot_v1") {
+    throw new Error("Carga útil inválida: schemaVersion deve ser 'mobile_strategic_profile_snapshot_v1'");
+  }
+
+  // 2. Validação básica de tipos
+  if (typeof p.profileState !== "string") {
+    throw new Error("profileState deve ser uma string");
+  }
+  if (!Array.isArray(p.unlockedSignals) || !p.unlockedSignals.every((s) => typeof s === "string")) {
+    throw new Error("unlockedSignals deve ser uma lista de strings");
+  }
+  if (!Array.isArray(p.pendingSignals) || !p.pendingSignals.every((s) => typeof s === "string")) {
+    throw new Error("pendingSignals deve ser uma lista de strings");
+  }
+  if (!Array.isArray(p.recurringPatterns) || !p.recurringPatterns.every((s) => typeof s === "string")) {
+    throw new Error("recurringPatterns deve ser uma lista de strings");
+  }
+  if (!Array.isArray(p.opportunities) || !p.opportunities.every((s) => typeof s === "string")) {
+    throw new Error("opportunities deve ser uma lista de strings");
+  }
+  if (typeof p.diagnosisSummary !== "string") {
+    throw new Error("diagnosisSummary deve ser uma string");
+  }
+  if (typeof p.commercialSummary !== "string") {
+    throw new Error("commercialSummary deve ser uma string");
+  }
+  if (typeof p.lastAnalysisSummary !== "string") {
+    throw new Error("lastAnalysisSummary deve ser uma string");
+  }
+
+  // 3. Bloqueio de transcrições longas
+  if (p.lastAnalysisSummary.length > 2000 || p.diagnosisSummary.length > 5000) {
+    throw new Error("Carga útil muito longa: limite de transcrição/resumos ultrapassado");
+  }
+
+  // 4. Bloqueio de base64 longo e strings excessivamente longas
+  const serialized = JSON.stringify(p);
+  if (serialized.length > 30000) {
+    throw new Error("Carga útil muito grande: excede o limite de tamanho seguro");
+  }
+
+  if (BASE64_REGEX.test(serialized) || serialized.includes("base64")) {
+    throw new Error("Carga útil insegura: base64 não é permitido no snapshot");
+  }
+
+  // 5. Bloqueio de API Keys/Tokens óbvios
+  if (GEMINI_KEY_REGEX.test(serialized) || OPENAI_KEY_REGEX.test(serialized)) {
+    throw new Error("Carga útil insegura: API key detectada no snapshot");
+  }
+
+  // 6. Bloqueio de vídeo/signed URLs
+  if (SIGNED_URL_REGEX.test(serialized) || VIDEO_EXTENSION_REGEX.test(serialized)) {
+    throw new Error("Carga útil insegura: links assinados ou referências a arquivos de vídeo detectadas");
+  }
+
+  return {
+    schemaVersion: "mobile_strategic_profile_snapshot_v1",
+    profileState: p.profileState,
+    unlockedSignals: p.unlockedSignals,
+    pendingSignals: p.pendingSignals,
+    recurringPatterns: p.recurringPatterns,
+    opportunities: p.opportunities,
+    diagnosisSummary: p.diagnosisSummary,
+    commercialSummary: p.commercialSummary,
+    lastAnalysisSummary: p.lastAnalysisSummary,
+    extraData: p.extraData,
+  };
+}
+
+/**
+ * Busca o snapshot estratégico ativo de um usuário.
+ */
+export async function getStrategicProfileSnapshotByUserId(
+  userId: string
+): Promise<CreatorStrategicProfileSnapshotInput | null> {
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    throw new Error("UserId inválido");
+  }
+
+  await connectToDatabase();
+
+  const doc = await CreatorStrategicProfileSnapshot.findOne({
+    userId: new Types.ObjectId(userId),
+    status: "active",
+  }).lean();
+
+  if (!doc) return null;
+
+  let parsedSnapshot: MobileStrategicProfileSnapshotPayload;
+  try {
+    parsedSnapshot = JSON.parse(doc.snapshotJson);
+  } catch (err) {
+    console.error("Erro ao decodificar snapshotJson:", err);
+    return null;
+  }
+
+  return {
+    userId: doc.userId.toString(),
+    status: doc.status,
+    accessLevel: doc.accessLevel,
+    snapshot: parsedSnapshot,
+    source: doc.source,
+    lastAnalyzedAt: doc.lastAnalyzedAt,
+  };
+}
+
+/**
+ * Salva ou atualiza (upsert) o snapshot estratégico do usuário.
+ */
+export async function upsertStrategicProfileSnapshot(
+  input: CreatorStrategicProfileSnapshotInput
+): Promise<CreatorStrategicProfileSnapshotInput> {
+  if (!input.userId || !Types.ObjectId.isValid(input.userId)) {
+    throw new Error("UserId inválido");
+  }
+
+  // Regra rígida: Rejeita fonte gemini_real neste PR
+  if ((input.source as string) === "gemini_real") {
+    throw new Error("Origem 'gemini_real' não é permitida nesta fase");
+  }
+
+  // Validar a carga útil do snapshot
+  const validatedSnapshot = validateSnapshotPayload(input.snapshot);
+
+  await connectToDatabase();
+
+  const updatedDoc = await CreatorStrategicProfileSnapshot.findOneAndUpdate(
+    { userId: new Types.ObjectId(input.userId) },
+    {
+      $set: {
+        status: input.status || "active",
+        accessLevel: input.accessLevel,
+        snapshotJson: JSON.stringify(validatedSnapshot),
+        source: input.source,
+        lastAnalyzedAt: input.lastAnalyzedAt || new Date(),
+      },
+    },
+    {
+      new: true,
+      upsert: true,
+    }
+  );
+
+  return {
+    userId: updatedDoc.userId.toString(),
+    status: updatedDoc.status,
+    accessLevel: updatedDoc.accessLevel,
+    snapshot: validatedSnapshot,
+    source: updatedDoc.source,
+    lastAnalyzedAt: updatedDoc.lastAnalyzedAt,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotTypes.ts
@@ -1,0 +1,21 @@
+export interface MobileStrategicProfileSnapshotPayload {
+  schemaVersion: "mobile_strategic_profile_snapshot_v1";
+  profileState: string;
+  unlockedSignals: string[];
+  pendingSignals: string[];
+  recurringPatterns: string[];
+  opportunities: string[];
+  diagnosisSummary: string;
+  commercialSummary: string;
+  lastAnalysisSummary: string;
+  extraData?: Record<string, any>;
+}
+
+export interface CreatorStrategicProfileSnapshotInput {
+  userId: string;
+  status?: "active" | "inactive" | "archived";
+  accessLevel: "free" | "premium" | "instagram_optimized";
+  snapshot: MobileStrategicProfileSnapshotPayload;
+  source: "manual_seed" | "mock_analysis" | "future_video_analysis" | "imported" | "unknown";
+  lastAnalyzedAt?: Date;
+}

--- a/src/app/models/CreatorStrategicProfileSnapshot.ts
+++ b/src/app/models/CreatorStrategicProfileSnapshot.ts
@@ -1,0 +1,74 @@
+import mongoose, { Schema, Types, Document, model } from "mongoose";
+
+export type CreatorStrategicProfileSnapshotStatus = "active" | "inactive" | "archived";
+
+export type CreatorStrategicProfileSnapshotSource =
+  | "manual_seed"
+  | "mock_analysis"
+  | "future_video_analysis"
+  | "imported"
+  | "unknown";
+
+export interface ICreatorStrategicProfileSnapshot extends Document {
+  userId: Types.ObjectId;
+  status: CreatorStrategicProfileSnapshotStatus;
+  accessLevel: "free" | "premium" | "instagram_optimized";
+  snapshotJson: string;
+  source: CreatorStrategicProfileSnapshotSource;
+  lastAnalyzedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const CreatorStrategicProfileSnapshotSchema = new Schema<ICreatorStrategicProfileSnapshot>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+      index: true,
+    },
+    status: {
+      type: String,
+      enum: ["active", "inactive", "archived"],
+      default: "active",
+      required: true,
+    },
+    accessLevel: {
+      type: String,
+      enum: ["free", "premium", "instagram_optimized"],
+      default: "free",
+      required: true,
+    },
+    snapshotJson: {
+      type: String,
+      required: true,
+    },
+    source: {
+      type: String,
+      enum: ["manual_seed", "mock_analysis", "future_video_analysis", "imported", "unknown"],
+      default: "manual_seed",
+      required: true,
+    },
+    lastAnalyzedAt: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+    collection: "creatorstrategicprofilesnapshots",
+  }
+);
+
+// Índices adicionais para consultas rápidas
+CreatorStrategicProfileSnapshotSchema.index({ status: 1 });
+CreatorStrategicProfileSnapshotSchema.index({ lastAnalyzedAt: -1 });
+
+const CreatorStrategicProfileSnapshot =
+  (mongoose.models.CreatorStrategicProfileSnapshot as mongoose.Model<ICreatorStrategicProfileSnapshot>) ||
+  model<ICreatorStrategicProfileSnapshot>("CreatorStrategicProfileSnapshot", CreatorStrategicProfileSnapshotSchema);
+
+export default CreatorStrategicProfileSnapshot;


### PR DESCRIPTION
## Summary

Stacked over #854.

MM57 adds the first persisted private Strategic Profile snapshot layer.

Changes:
- Adds a Mongoose model for `CreatorStrategicProfileSnapshot`.
- Adds versioned snapshot types.
- Adds snapshot service validation for schema version, unsafe strings, API keys, base64 payloads, video URLs, signed URLs, transcript size, total payload size, and source restrictions.
- Adds snapshot mapping into Strategic Profile UI sections/cards.
- Integrates server-side snapshot reading into the mobile Strategic Profile route.
- Preserves HomeSummary hydration while merging persisted narrative sections.
- Updates docs for MM57.

## Validation

Reported passing:
- MobileStrategicProfileRealShellClient tests.
- Snapshot service tests.
- Real route page tests.
- Snapshot mapping tests.
- Typecheck.

## Guardrails

No real Gemini/OpenAI, upload/storage, video persistence, visual video history, analysis endpoint changes, plus-flow endpoint integration, MediaKitView changes, Community changes, real navigation changes, shell/sidebar changes, ActivationPendingWidget changes, LoginClient changes, NextAuth changes, or new billing integration.