### PR TITLE
feat: integrate mobile strategic profile analyze flow in mock mode

### DIFF
--- a/src/app/api/dashboard/mobile-strategic-profile/analyze/route.test.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/analyze/route.test.ts
@@ -1,0 +1,140 @@
+/** @jest-environment node */
+import "next/dist/server/node-polyfill-fetch";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { isMobileStrategicProfileEnabled } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileFeatureFlag";
+import { upsertStrategicProfileSnapshot } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService";
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("@/app/api/auth/resolveAuthOptions", () => ({
+  resolveAuthOptions: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileStrategicProfileFeatureFlag", () => ({
+  isMobileStrategicProfileEnabled: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService", () => ({
+  upsertStrategicProfileSnapshot: jest.fn(),
+}));
+
+const getServerSession = require("next-auth/next").getServerSession as jest.Mock;
+
+function createRequest(body: any) {
+  return new NextRequest("http://localhost/api/dashboard/mobile-strategic-profile/analyze", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /api/dashboard/mobile-strategic-profile/analyze", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE = "mock";
+    (isMobileStrategicProfileEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it("bloqueia acesso se a feature flag estiver desativada", async () => {
+    (isMobileStrategicProfileEnabled as jest.Mock).mockReturnValue(false);
+
+    const res = await POST(createRequest({ creatorGoal: "sponsored_content" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toContain("Perfil Estratégico mobile está desativado");
+  });
+
+  it("bloqueia acesso se usuário estiver deslogado/anônimo", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const res = await POST(createRequest({ creatorGoal: "sponsored" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("bloqueia se o provider mode não for mock", async () => {
+    process.env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE = "real";
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_12" } });
+
+    const res = await POST(createRequest({ creatorGoal: "sponsored" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("Apenas modo de simulação (mock) é suportado");
+  });
+
+  it("bloqueia payload contendo chave restrita file", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_12" } });
+
+    const res = await POST(createRequest({ creatorGoal: "sponsored", file: "video.mp4" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("não é permitido nesta rota");
+  });
+
+  it("bloqueia payload contendo chave restrita videoUrl", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_12" } });
+
+    const res = await POST(createRequest({ creatorGoal: "sponsored", videoUrl: "https://youtube.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("bloqueia payload contendo string em Base64", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_12" } });
+
+    const res = await POST(createRequest({ creatorGoal: "data:image/png;base64,iVBORw0KGgoAAA" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("bloqueia payload com assinaturas de signed URLs ou chaves de mídia", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_12" } });
+
+    const res = await POST(createRequest({ creatorGoal: "url?signature=123" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("processa com sucesso e salva snapshot com fonte mock_analysis", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { id: "usr_12", planStatus: "active" },
+    });
+
+    const mockSnapshot = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "active",
+      unlockedSignals: [],
+      pendingSignals: [],
+      recurringPatterns: [],
+      opportunities: [],
+      diagnosisSummary: "Resumo do diagnóstico",
+      commercialSummary: "Resumo comercial",
+      lastAnalysisSummary: "Último vídeo analisado",
+    };
+
+    (upsertStrategicProfileSnapshot as jest.Mock).mockResolvedValue({
+      userId: "usr_12",
+      snapshot: mockSnapshot,
+      source: "mock_analysis",
+    });
+
+    const res = await POST(
+      createRequest({
+        creatorGoal: "Quero crescer em publis orgânicas",
+        selectedGoalOption: "sponsored_content",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.snapshotUpdated).toBe(true);
+    expect(body.snapshot.schemaVersion).toBe("mobile_strategic_profile_snapshot_v1");
+
+    expect(upsertStrategicProfileSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "usr_12",
+        source: "mock_analysis",
+      })
+    );
+  });
+});

--- a/src/app/api/dashboard/mobile-strategic-profile/analyze/route.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/analyze/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { resolveAuthOptions } from "@/app/api/auth/resolveAuthOptions";
+import { isMobileStrategicProfileEnabled } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileFeatureFlag";
+import { runVideoNarrativeMockProvider } from "@/app/dashboard/boards/videoUpload/videoNarrativeMockProvider";
+import { upsertStrategicProfileSnapshot } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotService";
+import { mapAnalysisToSnapshotPayload } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileAnalyzeSnapshotMapper";
+
+const SIGNED_URL_KEYWORDS = ["signature=", "expires=", "token=", "policy="];
+const BASE64_INDICATOR = "base64";
+
+export async function GET() {
+  return NextResponse.json({ message: "Método não permitido." }, { status: 405 });
+}
+
+export async function POST(request: Request) {
+  try {
+    // 1. Feature Flag Check
+    if (!isMobileStrategicProfileEnabled()) {
+      return NextResponse.json(
+        { message: "Acesso proibido: Perfil Estratégico mobile está desativado." },
+        { status: 403 }
+      );
+    }
+
+    // 2. Auth Session Check
+    const session = await getServerSession(await resolveAuthOptions());
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "Acesso não autorizado: sessão não identificada." },
+        { status: 401 }
+      );
+    }
+
+    // 3. Provider Mode Check
+    const providerMode = process.env.VIDEO_NARRATIVE_INTERNAL_PROVIDER_MODE || "mock";
+    if (providerMode !== "mock") {
+      return NextResponse.json(
+        { message: "Apenas modo de simulação (mock) é suportado nesta rota." },
+        { status: 400 }
+      );
+    }
+
+    // 4. Content Type Check
+    const contentType = request.headers.get("content-type") || "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      return NextResponse.json(
+        { message: "Content-type inválido: deve ser application/json." },
+        { status: 400 }
+      );
+    }
+
+    // 5. Payload extraction & parsing
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { message: "Payload inválido: formato JSON corrompido." },
+        { status: 400 }
+      );
+    }
+
+    if (!body || typeof body !== "object") {
+      return NextResponse.json(
+        { message: "Payload inválido: deve ser um objeto." },
+        { status: 400 }
+      );
+    }
+
+    // 6. Rígidas regras de segurança contra vazamento de vídeo, URLs e base64
+    const forbiddenKeys = ["file", "videoUrl", "thumbnailUrl", "base64", "url", "video"];
+    for (const key of forbiddenKeys) {
+      if (key in body || body[key]) {
+        return NextResponse.json(
+          { message: `Regra de segurança: o campo '${key}' não é permitido nesta rota.` },
+          { status: 400 }
+        );
+      }
+    }
+
+    const serializedBody = JSON.stringify(body);
+    if (serializedBody.length > 5000) {
+      return NextResponse.json(
+        { message: "Regra de segurança: tamanho do payload excedeu o limite máximo seguro." },
+        { status: 400 }
+      );
+    }
+
+    if (serializedBody.includes(BASE64_INDICATOR) || /data:[a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+;base64,/i.test(serializedBody)) {
+      return NextResponse.json(
+        { message: "Regra de segurança: strings em Base64 não são permitidas." },
+        { status: 400 }
+      );
+    }
+
+    for (const keyword of SIGNED_URL_KEYWORDS) {
+      if (serializedBody.toLowerCase().includes(keyword)) {
+        return NextResponse.json(
+          { message: "Regra de segurança: links assinados ou de mídias não são permitidos." },
+          { status: 400 }
+        );
+      }
+    }
+
+    // 7. Validação do formulário leve do creator
+    const creatorGoal = typeof body.creatorGoal === "string" ? body.creatorGoal : "";
+    const selectedGoalOption = typeof body.selectedGoalOption === "string" ? body.selectedGoalOption : "";
+
+    if (creatorGoal.length > 500 || selectedGoalOption.length > 100) {
+      return NextResponse.json(
+        { message: "Dados do formulário muito longos." },
+        { status: 400 }
+      );
+    }
+
+    // 8. Resolução do cenário mock baseado no objetivo do criador
+    let mockScenario: any = "skincare_routine";
+    if (selectedGoalOption === "sponsored_content") {
+      mockScenario = "brand_potential";
+    } else if (selectedGoalOption === "authority") {
+      mockScenario = "backstage_process";
+    } else if (selectedGoalOption === "retention") {
+      mockScenario = "weak_hook";
+    } else if (selectedGoalOption === "format_test") {
+      mockScenario = "collab_potential";
+    }
+
+    // Se houver um mockScenario explícito enviado para QA (e for um cenário válido), podemos usar opcionalmente
+    const allowedScenarios = [
+      "skincare_routine",
+      "backstage_process",
+      "brand_potential",
+      "weak_hook",
+      "collab_potential",
+      "unclear_content",
+      "ad_adaptation"
+    ];
+    if (typeof body.mockScenario === "string" && allowedScenarios.includes(body.mockScenario)) {
+      mockScenario = body.mockScenario;
+    }
+
+    // 9. Executar a simulação narrativa pura
+    const analysis = runVideoNarrativeMockProvider({
+      input: {
+        id: `mock-flow-${Date.now()}`,
+        creatorQuestion: creatorGoal || "Como posso melhorar meu posicionamento?",
+        createdAt: new Date().toISOString(),
+      },
+      options: {
+        scenario: mockScenario,
+      },
+    });
+
+    // 10. Mapear para Snapshot
+    const snapshotPayload = mapAnalysisToSnapshotPayload(analysis);
+
+    // 11. Salvar no banco Mongoose com a fonte mock_analysis
+    const upserted = await upsertStrategicProfileSnapshot({
+      userId: session.user.id,
+      status: "active",
+      accessLevel: session.user.planStatus === "active" ? "premium" : "free",
+      snapshot: snapshotPayload,
+      source: "mock_analysis",
+      lastAnalyzedAt: new Date(),
+    });
+
+    return NextResponse.json({
+      ok: true,
+      snapshotUpdated: true,
+      snapshot: upserted.snapshot,
+    });
+
+  } catch (err: any) {
+    console.error("Erro no processamento da análise mock:", err);
+    return NextResponse.json(
+      { message: "Ocorreu um erro ao processar a simulação do seu diagnóstico estratégico." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
@@ -1,14 +1,21 @@
 import fs from "fs";
 import path from "path";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MobileStrategicProfileAnalyzeFlow } from "./MobileStrategicProfileAnalyzeFlow";
 
 const SOURCE_PATH = path.join(__dirname, "MobileStrategicProfileAnalyzeFlow.tsx");
 
-function renderFlow() {
+function renderFlow(onSubmitAnalysis?: any) {
   const onClose = jest.fn();
   const onComplete = jest.fn();
-  render(<MobileStrategicProfileAnalyzeFlow open onClose={onClose} onComplete={onComplete} />);
+  render(
+    <MobileStrategicProfileAnalyzeFlow
+      open
+      onClose={onClose}
+      onComplete={onComplete}
+      onSubmitAnalysis={onSubmitAnalysis}
+    />
+  );
   return { onClose, onComplete };
 }
 
@@ -38,14 +45,18 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     expect(screen.getByText("Preview local. Nenhum arquivo será enviado neste protótipo.")).toBeInTheDocument();
   });
 
-  it("advances to creator goal", () => {
+  it("advances to creator goal and allows selection", () => {
     renderFlow();
     continueFlow();
     continueFlow();
 
     expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ganhar autoridade" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Preparar publi" })).toBeInTheDocument();
+    
+    // Click "Preparar publi" to select
+    const sponsoredBtn = screen.getByRole("button", { name: "Preparar publi" });
+    fireEvent.click(sponsoredBtn);
+    expect(sponsoredBtn).toHaveClass("bg-zinc-950 text-white");
   });
 
   it("advances to quick questions", () => {
@@ -59,30 +70,57 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     expect(screen.getByText("Esse conteúdo representa sua fase atual?")).toBeInTheDocument();
   });
 
-  it("advances to updating profile", () => {
-    renderFlow();
-    continueFlow();
-    continueFlow();
-    continueFlow();
-    continueFlow();
+  it("chama onSubmitAnalysis ao entrar em updating_profile e avança para sucesso", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    renderFlow(onSubmit);
+
+    continueFlow(); // intro -> mock_upload
+    continueFlow(); // mock_upload -> creator_goal
+    continueFlow(); // creator_goal -> quick_questions
+    continueFlow(); // quick_questions -> updating_profile
 
     expect(screen.getByText("Atualizando seu Perfil Estratégico")).toBeInTheDocument();
-    expect(screen.getByText("Estamos conectando essa leitura ao seu diagnóstico vivo.")).toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedGoalOption: "authority",
+      })
+    );
+
+    // Wait until it advances to success step
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+    });
   });
 
-  it("advances to updated confirmation and completes", () => {
-    const { onComplete } = renderFlow();
-    continueFlow();
-    continueFlow();
-    continueFlow();
-    continueFlow();
-    continueFlow();
+  it("mostra erro amigável se onSubmitAnalysis falhar e permite tentar novamente", async () => {
+    const onSubmit = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("Erro de conexão simulado."))
+      .mockResolvedValueOnce(undefined);
 
-    expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
-    expect(screen.getByText("Identificamos novos aprendizados sobre sua narrativa.")).toBeInTheDocument();
+    const { onComplete } = renderFlow(onSubmit);
 
-    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+    continueFlow(); // intro -> mock_upload
+    continueFlow(); // mock_upload -> creator_goal
+    continueFlow(); // creator_goal -> quick_questions
+    continueFlow(); // quick_questions -> updating_profile
 
+    await waitFor(() => {
+      expect(screen.getByText("Erro na atualização")).toBeInTheDocument();
+      expect(screen.getByText("Erro de conexão simulado.")).toBeInTheDocument();
+    });
+
+    // Clique em tentar novamente
+    const retryBtn = screen.getByRole("button", { name: "Tentar novamente" });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+    });
+
+    // Clique em concluir
+    const completeBtn = screen.getByRole("button", { name: "Voltar para meu Perfil" });
+    fireEvent.click(completeBtn);
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const STEPS = [
   "intro",
@@ -15,6 +15,12 @@ type MobileStrategicProfileAnalyzeFlowProps = {
   open: boolean;
   onClose: () => void;
   onComplete: () => void;
+  onSubmitAnalysis?: (payload: {
+    creatorGoal: string;
+    selectedGoalOption: "authority" | "retention" | "format_test" | "sponsored_content";
+    quickAnswers?: Array<{ id: string; value: string }>;
+    mockScenario?: string;
+  }) => Promise<void>;
 };
 
 function nextStep(current: AnalyzeFlowStep): AnalyzeFlowStep {
@@ -30,28 +36,102 @@ export function MobileStrategicProfileAnalyzeFlow({
   open,
   onClose,
   onComplete,
+  onSubmitAnalysis,
 }: MobileStrategicProfileAnalyzeFlowProps) {
   const [step, setStep] = useState<AnalyzeFlowStep>("intro");
+  const [selectedOption, setSelectedOption] = useState<"authority" | "retention" | "format_test" | "sponsored_content">("authority");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [submitAttempt, setSubmitAttempt] = useState(0);
+
+  useEffect(() => {
+    if (!open) {
+      setStep("intro");
+      setErrorMsg(null);
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  // Executa o envio da análise ao entrar na etapa 'updating_profile'
+  useEffect(() => {
+    if (step !== "updating_profile") return;
+
+    let active = true;
+
+    async function triggerSubmit() {
+      if (onSubmitAnalysis) {
+        setIsSubmitting(true);
+        setErrorMsg(null);
+        try {
+          await onSubmitAnalysis({
+            creatorGoal: "Como posso otimizar meu posicionamento de conteúdo?",
+            selectedGoalOption: selectedOption,
+            quickAnswers: [
+              { id: "represents_current_phase", value: "sim" },
+              { id: "wants_to_repeat_direction", value: "sim" }
+            ],
+          });
+          if (active) {
+            setIsSubmitting(false);
+            setStep("updated_confirmation");
+          }
+        } catch (err: any) {
+          if (active) {
+            setIsSubmitting(false);
+            setErrorMsg(err.message || "Ocorreu um erro no processamento do diagnóstico.");
+          }
+        }
+      } else {
+        // Fallback local do preview de simulação offline (1000ms)
+        const timer = setTimeout(() => {
+          if (active) {
+            setStep("updated_confirmation");
+          }
+        }, 1000);
+        return () => clearTimeout(timer);
+      }
+    }
+
+    triggerSubmit();
+
+    return () => {
+      active = false;
+    };
+  }, [step, selectedOption, onSubmitAnalysis, submitAttempt]);
 
   if (!open) return null;
 
-  const goNext = () => setStep((current) => nextStep(current));
+  const goNext = () => {
+    setStep((current) => nextStep(current));
+  };
+
   const close = () => {
     setStep("intro");
+    setErrorMsg(null);
     onClose();
   };
+
   const complete = () => {
     setStep("intro");
+    setErrorMsg(null);
     onComplete();
   };
+
   const currentStepIndex = stepIndex(step);
+
+  const goalOptions = [
+    { label: "Ganhar autoridade", value: "authority" as const },
+    { label: "Melhorar retenção", value: "retention" as const },
+    { label: "Testar formato", value: "format_test" as const },
+    { label: "Preparar publi", value: "sponsored_content" as const },
+  ];
 
   return (
     <section
       role="dialog"
       aria-modal="true"
       aria-labelledby="mobile-strategic-profile-analyze-flow-title"
-      className="absolute inset-x-0 bottom-0 z-40 rounded-t-[2rem] border-t border-zinc-200 bg-white p-5 shadow-2xl"
+      className="absolute inset-x-0 bottom-0 z-40 rounded-t-[2rem] border-t border-zinc-200 bg-white p-5 shadow-2xl animate-in slide-in-from-bottom duration-300"
     >
       <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-zinc-200" aria-hidden="true" />
       <div className="flex items-start justify-between gap-4">
@@ -66,8 +146,9 @@ export function MobileStrategicProfileAnalyzeFlow({
         <button
           type="button"
           aria-label="Fechar fluxo de análise"
-          className="grid h-9 w-9 place-items-center rounded-full bg-zinc-100 text-lg font-semibold text-zinc-700"
+          className="grid h-9 w-9 place-items-center rounded-full bg-zinc-100 text-lg font-semibold text-zinc-700 hover:bg-zinc-200 transition-colors"
           onClick={close}
+          disabled={isSubmitting}
         >
           ×
         </button>
@@ -110,15 +191,23 @@ export function MobileStrategicProfileAnalyzeFlow({
           <div>
             <p className="text-sm font-semibold text-zinc-950">Qual era o objetivo do conteúdo?</p>
             <div className="mt-3 grid grid-cols-2 gap-2">
-              {["Ganhar autoridade", "Melhorar retenção", "Testar formato", "Preparar publi"].map((label) => (
-                <button
-                  key={label}
-                  type="button"
-                  className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] px-3 py-3 text-left text-sm font-semibold text-zinc-800"
-                >
-                  {label}
-                </button>
-              ))}
+              {goalOptions.map((opt) => {
+                const isSelected = selectedOption === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`rounded-2xl border px-3 py-3 text-left text-sm font-semibold transition-all duration-200 ${
+                      isSelected
+                        ? "border-zinc-950 bg-zinc-950 text-white shadow-sm"
+                        : "border-zinc-200 bg-[#f7f7f4] text-zinc-800 hover:border-zinc-300"
+                    }`}
+                    onClick={() => setSelectedOption(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
             </div>
           </div>
         ) : null}
@@ -143,11 +232,26 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         {step === "updating_profile" ? (
-          <div className="rounded-[1.5rem] border border-sky-100 bg-sky-50 p-4">
-            <p className="text-sm font-semibold text-zinc-950">Atualizando seu Perfil Estratégico</p>
-            <p className="mt-2 text-sm leading-6 text-zinc-600">
-              Estamos conectando essa leitura ao seu diagnóstico vivo.
-            </p>
+          <div className="rounded-[1.5rem] border border-sky-100 bg-sky-50 p-4 transition-all">
+            {errorMsg ? (
+              <div>
+                <p className="text-sm font-semibold text-red-600">Erro na atualização</p>
+                <p className="mt-2 text-sm leading-6 text-red-500">{errorMsg}</p>
+              </div>
+            ) : (
+              <div>
+                <div className="flex items-center gap-2">
+                  <svg className="animate-spin h-5 w-5 text-sky-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  <p className="text-sm font-semibold text-zinc-950">Atualizando seu Perfil Estratégico</p>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-zinc-600">
+                  Estamos conectando essa leitura ao seu diagnóstico vivo.
+                </p>
+              </div>
+            )}
           </div>
         ) : null}
 
@@ -165,16 +269,38 @@ export function MobileStrategicProfileAnalyzeFlow({
         {step === "updated_confirmation" ? (
           <button
             type="button"
-            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white"
+            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zinc-800 transition-colors"
             onClick={complete}
           >
             Voltar para meu Perfil
           </button>
+        ) : step === "updating_profile" && errorMsg ? (
+          <div className="flex w-full gap-2">
+            <button
+              type="button"
+              className="w-1/2 rounded-full border border-zinc-300 bg-white px-4 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-50 transition-colors"
+              onClick={close}
+            >
+              Fechar
+            </button>
+            <button
+              type="button"
+              className="w-1/2 rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zinc-800 transition-colors"
+              onClick={() => {
+                setErrorMsg(null);
+                setSubmitAttempt((prev) => prev + 1);
+                setStep("updating_profile");
+              }}
+            >
+              Tentar novamente
+            </button>
+          </div>
         ) : (
           <button
             type="button"
-            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white"
+            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zinc-800 transition-colors disabled:opacity-50 disabled:pointer-events-none"
             onClick={goNext}
+            disabled={isSubmitting}
           >
             Continuar
           </button>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -18,6 +18,12 @@ type MobileStrategicProfilePreviewProps = {
   profile: MobileStrategicProfile;
   activeState?: MobileStrategicProfilePreviewFixtureState;
   isRealShell?: boolean;
+  onSubmitAnalysis?: (payload: {
+    creatorGoal: string;
+    selectedGoalOption: "authority" | "retention" | "format_test" | "sponsored_content";
+    quickAnswers?: Array<{ id: string; value: string }>;
+    mockScenario?: string;
+  }) => Promise<void>;
 };
 
 const CARD_TONE: Record<MobileStrategicProfileSectionCard["tone"], string> = {
@@ -346,6 +352,7 @@ export function MobileStrategicProfilePreview({
   profile,
   activeState,
   isRealShell,
+  onSubmitAnalysis,
 }: MobileStrategicProfilePreviewProps) {
   const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
   const [analyzeFlowOpen, setAnalyzeFlowOpen] = useState(false);
@@ -435,6 +442,7 @@ export function MobileStrategicProfilePreview({
               open={analyzeFlowOpen}
               onClose={() => setAnalyzeFlowOpen(false)}
               onComplete={handleAnalyzeComplete}
+              onSubmitAnalysis={onSubmitAnalysis}
             />
           </div>
         </div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
@@ -10,7 +10,7 @@ jest.mock("../../../../home/homeSummaryClient", () => ({
 
 jest.mock("./MobileStrategicProfilePreview", () => {
   return {
-    MobileStrategicProfilePreview: ({ profile }: any) => (
+    MobileStrategicProfilePreview: ({ profile, onSubmitAnalysis }: any) => (
       <div data-testid="profile-preview-mock">
         <h1 data-testid="profile-display-name">{profile.header.identity.displayName}</h1>
         <p data-testid="profile-bio">{profile.header.identity.bio}</p>
@@ -19,6 +19,9 @@ jest.mock("./MobileStrategicProfilePreview", () => {
         <span data-testid="profile-mediakit-state">{profile.mediaKitBridge.state}</span>
         <span data-testid="profile-mediakit-href">{profile.mediaKitBridge.href || ""}</span>
         <span data-testid="profile-community-href">{profile.communityBridge.href || ""}</span>
+        <button data-testid="trigger-analysis-submit" onClick={() => onSubmitAnalysis?.({ creatorGoal: "test", selectedGoalOption: "authority" })}>
+          Submit
+        </button>
       </div>
     ),
   };
@@ -242,5 +245,54 @@ describe("MobileStrategicProfileRealShellClient", () => {
     await act(async () => {
       await Promise.resolve();
     });
+  });
+
+  it("chama o endpoint de análise no submit e atualiza o estado com o snapshot recebido", async () => {
+    (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
+
+    const mockNewSnapshot = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "active",
+      unlockedSignals: ["Novo Sinal"],
+      pendingSignals: [],
+      recurringPatterns: ["Novo Padrão"],
+      opportunities: [],
+      diagnosisSummary: "Novo Diagnóstico",
+      commercialSummary: "Novo Comercial",
+      lastAnalysisSummary: "Novo Vídeo",
+    };
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        ok: true,
+        snapshotUpdated: true,
+        snapshot: mockNewSnapshot,
+      }),
+    };
+
+    const globalFetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(mockResponse as any);
+
+    render(
+      <MobileStrategicProfileRealShellClient
+        session={mockSession}
+        stateQuery={null}
+      />
+    );
+
+    // Dispara a submissão via botão mockado
+    await act(async () => {
+      screen.getByTestId("trigger-analysis-submit").click();
+    });
+
+    expect(globalFetchSpy).toHaveBeenCalledWith(
+      "/api/dashboard/mobile-strategic-profile/analyze",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ creatorGoal: "test", selectedGoalOption: "authority" }),
+      })
+    );
+
+    globalFetchSpy.mockRestore();
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -125,6 +125,44 @@ export function MobileStrategicProfileRealShellClient({
     };
   }, [session, stateQuery, initialSnapshotPayload]);
 
+  const handleAnalysisSubmit = async (payload: {
+    creatorGoal: string;
+    selectedGoalOption: "authority" | "retention" | "format_test" | "sponsored_content";
+    quickAnswers?: Array<{ id: string; value: string }>;
+    mockScenario?: string;
+  }) => {
+    const response = await fetch("/api/dashboard/mobile-strategic-profile/analyze", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errData = await response.json().catch(() => ({}));
+      throw new Error(errData.message || "Erro ao conectar com o serviço de análise mockada.");
+    }
+
+    const data = await response.json();
+    if (data.snapshot) {
+      const { buildMobileStrategicProfileFromSnapshot } = await import("../../../videoUpload/mobileStrategicProfileSnapshotMapping");
+      const input = buildMobileStrategicProfileFromSnapshot({
+        sessionUser: session?.user ? {
+          name: session.user.name,
+          email: session.user.email,
+          image: session.user.image,
+          instagramConnected: Boolean(session.user.instagramConnected || session.user.isInstagramConnected),
+          instagramUsername: session.user.instagramUsername,
+          planStatus: session.user.planStatus,
+        } : null,
+        snapshotPayload: data.snapshot,
+        accessLevel: session?.user?.planStatus === "active" ? "premium" : "free",
+      });
+      setProfile(buildMobileStrategicProfile(input));
+    }
+  };
+
   return (
     <div className="relative">
       {isHydrating && (
@@ -142,6 +180,7 @@ export function MobileStrategicProfileRealShellClient({
       <MobileStrategicProfilePreview
         profile={profile}
         isRealShell={true}
+        onSubmitAnalysis={handleAnalysisSubmit}
       />
     </div>
   );

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileAnalyzeSnapshotMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileAnalyzeSnapshotMapper.test.ts
@@ -1,0 +1,56 @@
+import { mapAnalysisToSnapshotPayload, cleanForbiddenText } from "./mobileStrategicProfileAnalyzeSnapshotMapper";
+import { createEmptyVideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+
+describe("mobileStrategicProfileAnalyzeSnapshotMapper", () => {
+  it("sanitiza termos proibidos com regex insensível a maiúsculas/minúsculas", () => {
+    expect(cleanForbiddenText("Meu score é bom")).toBe("Meu é bom");
+    expect(cleanForbiddenText("Sem nota ou pontos de ranking")).toBe("Sem ou de");
+    expect(cleanForbiddenText("Viralizar garantido e certeza absoluta")).toBe("Viralizar e absoluta");
+    expect(cleanForbiddenText("Tem histórico de vídeos salvos")).toBe("Tem histórico de");
+    expect(cleanForbiddenText("Novo Mídia Kit mobile")).toBe("mobile");
+  });
+
+  it("converte uma análise útil em snapshot versionado com limites de tamanho seguros", () => {
+    const analysis = {
+      ...createEmptyVideoNarrativeAnalysis({ id: "test-id" }),
+      summary: "Rotina de bastidores da pauta de autocuidado.",
+      spokenTopics: ["autocuidado", "bastidores"],
+      diagnosis: {
+        strengths: ["Conexão direta com a audiência."],
+        weaknesses: [],
+        recommendedAdjustments: ["Deixar o gancho mais evidente."],
+      },
+      brandMatch: {
+        enabled: true,
+        territories: ["beleza"],
+        whyBrandsWouldFit: "Boa narrativa para marcas de cuidados corporais.",
+      },
+      profileSignals: [
+        { type: "recurring_theme", value: "Autenticidade", confidence: "high", shouldPersistLater: true },
+      ] as any[],
+    };
+
+    const snapshot = mapAnalysisToSnapshotPayload(analysis);
+
+    expect(snapshot.schemaVersion).toBe("mobile_strategic_profile_snapshot_v1");
+    expect(snapshot.profileState).toBe("active");
+    expect(snapshot.diagnosisSummary).toBe("Rotina de bastidores da pauta de autocuidado.");
+    expect(snapshot.recurringPatterns).toContain("Conexão direta com a audiência.");
+    expect(snapshot.recurringPatterns).toContain("Autenticidade");
+    expect(snapshot.opportunities).toContain("beleza");
+    expect(snapshot.unlockedSignals).toContain("autocuidado");
+    expect(snapshot.pendingSignals).toContain("Deixar o gancho mais evidente.");
+    expect(snapshot.commercialSummary).toBe("Boa narrativa para marcas de cuidados corporais.");
+  });
+
+  it("resguarda queda para textos vazios ou ausentes de forma elegante", () => {
+    const analysis = createEmptyVideoNarrativeAnalysis({ id: "empty" });
+    const snapshot = mapAnalysisToSnapshotPayload(analysis);
+
+    expect(snapshot.schemaVersion).toBe("mobile_strategic_profile_snapshot_v1");
+    expect(snapshot.profileState).toBe("active");
+    expect(snapshot.diagnosisSummary).toBe("Diagnóstico estratégico ativo baseado no seu último vídeo.");
+    expect(snapshot.recurringPatterns).toEqual([]);
+    expect(snapshot.opportunities).toEqual([]);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileAnalyzeSnapshotMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileAnalyzeSnapshotMapper.ts
@@ -1,0 +1,100 @@
+import type { VideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+
+const forbiddenTerms = [
+  /score/gi,
+  /nota/gi,
+  /pontos/gi,
+  /ranking/gi,
+  /gabarito/gi,
+  /garantido/gi,
+  /certeza/gi,
+  /comprovado/gi,
+  /viralizar garantido/gi,
+  /match real/gi,
+  /marca garantida/gi,
+  /patrocínio garantido/gi,
+  /vídeos salvos/gi,
+  /histórico de vídeos/gi,
+  /novo Mídia Kit/gi,
+  /Mídia Kit mobile/gi,
+  /18 sinais/gi,
+  /3 narrativas/gi,
+  /percentual de perfil/gi,
+];
+
+/**
+ * Remove qualquer termo proibido nos textos gerados para visualização do Perfil.
+ */
+export function cleanForbiddenText(text: string): string {
+  if (!text) return "";
+  let cleaned = text;
+  for (const regex of forbiddenTerms) {
+    cleaned = cleaned.replace(regex, "");
+  }
+  // Remove múltiplos espaços e limpa pontas
+  return cleaned.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Mapeia uma análise de vídeo em um snapshot persistível.
+ */
+export function mapAnalysisToSnapshotPayload(
+  analysis: VideoNarrativeAnalysis
+): MobileStrategicProfileSnapshotPayload {
+  const recurringPatterns = [
+    ...(analysis.diagnosis?.strengths || []),
+    ...analysis.profileSignals
+      .filter((s) => s.type === "recurring_theme" || s.type === "content_strength")
+      .map((s) => s.value),
+  ].map(cleanForbiddenText).filter(Boolean);
+
+  const opportunities = [
+    ...(analysis.brandMatch?.territories || []),
+    ...analysis.profileSignals
+      .filter((s) => s.type === "brand_territory")
+      .map((s) => s.value),
+  ].map(cleanForbiddenText).filter(Boolean);
+
+  const unlockedSignals = [
+    ...(analysis.spokenTopics || []),
+    ...analysis.profileSignals
+      .filter((s) => s.type === "positioning_signal")
+      .map((s) => s.value),
+  ].map(cleanForbiddenText).filter(Boolean);
+
+  const pendingSignals = [
+    ...(analysis.diagnosis?.recommendedAdjustments || []),
+    ...analysis.profileSignals
+      .filter((s) => s.type === "creative_gap")
+      .map((s) => s.value),
+  ].map(cleanForbiddenText).filter(Boolean);
+
+  const diagnosisSummary = cleanForbiddenText(
+    analysis.summary || 
+    analysis.blueprintSuggestion?.whyThisPath || 
+    "Diagnóstico estratégico ativo baseado no seu último vídeo."
+  );
+
+  const commercialSummary = cleanForbiddenText(
+    analysis.brandMatch?.whyBrandsWouldFit || 
+    "Oportunidades e marcas recomendadas para sua narrativa."
+  );
+
+  const lastAnalysisSummary = cleanForbiddenText(
+    analysis.hook?.detected || 
+    "Análise de gancho e retenção narrativa processada."
+  );
+
+  return {
+    schemaVersion: "mobile_strategic_profile_snapshot_v1",
+    profileState: "active",
+    unlockedSignals: unlockedSignals.slice(0, 5),
+    pendingSignals: pendingSignals.slice(0, 5),
+    recurringPatterns: recurringPatterns.slice(0, 5),
+    opportunities: opportunities.slice(0, 5),
+    diagnosisSummary: diagnosisSummary.substring(0, 2000),
+    commercialSummary: commercialSummary.substring(0, 2000),
+    lastAnalysisSummary: lastAnalysisSummary.substring(0, 2000),
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #855.

MM58 connects the mobile Strategic Profile analyze flow to a safe mock-mode integration path and persists the resulting private Strategic Profile snapshot.

Changes:
- Adds a dedicated mapper from mock narrative analysis into a versioned Strategic Profile snapshot.
- Adds a safe mock analyze endpoint for the mobile Strategic Profile flow.
- Rejects unsafe payloads such as file, videoUrl, thumbnailUrl, base64, oversized strings, and signed-link-like content.
- Saves successful mock analysis results as `mock_analysis` snapshots.
- Updates the analyze flow with interactive goal selection, submitting, success, error, and retry states.
- Updates the real shell client to call the mock analyze endpoint and update the profile after success.
- Preserves preview behavior without requiring the endpoint.

## Validation

Reported passing:
- Analyze snapshot mapper tests.
- Mock analyze endpoint tests.
- Analyze flow tests.
- RealShellClient tests.
- Typecheck/build reported passing in the walkthrough.

## Guardrails

No real Gemini/OpenAI, upload/storage, saved video, saved thumbnail, visual video history, real provider, unsafe raw response persistence, MediaKitView changes, Community changes, real navigation changes, shell/sidebar changes, ActivationPendingWidget changes, LoginClient changes, NextAuth changes, or new billing integration.