### PR TITLE
docs: add temporary video upload storage readiness plan

### DIFF
--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -198,6 +198,14 @@ Como não há billing agora, seguir sem teste real e avançar apenas em:
 - modelo puro de fluxo app-first com estados, CTAs e prompts, sem UI;
 - sem expor para usuário.
 
+## MM59 — Readiness de Upload/Storage Temporário Seguro
+
+Com o PR MM59, avançamos na prontidão (readiness) para a futura camada de upload e storage temporário:
+- **Ainda NÃO aumenta a prontidão do provider Gemini real** (nenhum SDK ou provedor externo de IA foi adicionado).
+- **Ainda NÃO adiciona nenhum provedor externo de storage** (sem conexões S3/R2/GCS ativas).
+- **Ainda NÃO altera endpoints ou fluxos reais de upload**.
+- **Cria apenas contratos, políticas recomendadas e validações estritas** (`videoNarrativeTemporaryUploadValidation.ts`) para mitigar os riscos de segurança, arquivos executáveis maliciosos e injeções de Base64, estabelecendo um trilho seguro antes do código físico de upload.
+
 ## Frase Norte
 
 > O sistema pode estar pronto para testar Gemini real sem ainda estar pronto para lançar vídeo no produto.

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
@@ -314,3 +314,20 @@ Não recomendar integração real antes do QA/polish visual.
 - Nenhuma alteração permitida em endpoints, Prisma, banco de dados ou integração com Gemini real nesta fase.
 - Nenhuma alteração permitida na navegação de produção global (sidebar, bottom nav ou dashboard shell legado).
 
+## Guardrails do MM57
+
+- O Perfil Estratégico mobile deve carregar e exibir as informações de diagnóstico persistidas de forma transparente.
+- Nenhuma mídia bruta, thumbnail ou signed URL de vídeo real deve ser gravada no banco de dados.
+
+## Guardrails do MM58
+
+- O botão central de análise "+" deve abrir o modal de análise interativo mobile.
+- A finalização do fluxo de análise narrativa mobile no client deve re-hidratar o estado local do Perfil com o novo snapshot gerado e salvo sem exigir recarregamento total.
+- Cenários de falhas temporárias na API devem renderizar estados de erro apropriados e oferecer botões de retentativa claros.
+
+## Guardrails do MM59
+
+- Qualquer futuro upload de vídeo real deve requerer consentimento explícito e prévio do criador na interface do fluxo.
+- Mídias não permitidas, extensões suspeitas de executáveis disfarçados e injeções de Base64 ou URLs devem ser sumariamente bloqueadas.
+- O processamento de vídeos reais deve seguir o modelo de descarte seguro forçado, descartando mídias imediatamente após a análise.
+- Nenhuma interface do fluxo "+" ou endpoint de análise de produção deve ser alterado para processar arquivos de vídeo reais neste momento.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -1817,6 +1817,23 @@ O que não faz:
 - não faz rede, `fetch`, upload real ou integração com BoardShell;
 - não usa OpenAI, Whisper, OCR real, ffmpeg ou SDK de processamento.
 
+### MM59 — Temporary Upload/Storage Readiness Plan
+
+Status: concluído.
+
+O que faz:
+- Cria tipos, contratos e políticas seguras de upload e storage temporário de vídeo (`videoNarrativeTemporaryUploadContracts.ts`);
+- Implementa validação puríssima de metadados, tamanhos, durações e consentimento explícito do criador (`videoNarrativeTemporaryUploadValidation.ts`);
+- Garante mitigação de riscos bloqueando Base64, URLs externas no nome/source do arquivo, e arquivos executáveis disfarçados;
+- Preserva a segurança operacional mantendo o provider de storage desativado por padrão (`providerMode = "disabled"`);
+- Garante total conformidade com a premissa de produto: não cria histórico visual de vídeos, não salva thumbnails e exige descarte físico seguro pós-análise.
+
+O que não faz:
+- Não implementa upload real nem picks de arquivo físico;
+- Não conecta com buckets S3, R2, GCS ou APIs do Cloudinary;
+- Não assina URLs de envio nem gera chaves reais;
+- Não altera o fluxo interativo "+" do perfil ou o endpoint interno de análise.
+
 ## Arquitetura Atual
 
 ```text

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -377,3 +377,8 @@ MM55 implementa a camada de dados síncronos e puros `buildMobileStrategicProfil
 
 MM56 conecta a casca real a dados existentes da dashboard/home. O client-side wrapper `MobileStrategicProfileRealShellClient` realiza a hidratação em background disparando `fetchHomeSummaryCached("all")` de forma totalmente assíncrona, atualizando dinamicamente a UI com o adapter puro do MM55 sem bloquear a renderização inicial baseada nos dados da sessão. Fallbacks seguros garantem que falhas na API de summary sejam silenciadas sem quebrar a rota. O Perfil ainda não possui diagnóstico persistido nesta fase; análise real, upload, storage e Gemini real continuam fora do escopo.
 
+MM57 modela e implementa a persistência do snapshot mínimo do Perfil Estratégico mobile, definindo o modelo Mongoose para guardar os dados essenciais e signals do diagnóstico vivo sem salvar o vídeo físico, sem upload/storage real e sem Gemini.
+
+MM58 integra o fluxo de análise "+" à API interna em modo mock (`/api/dashboard/mobile-strategic-profile/analyze`), efetuando o processamento simulado baseado no objetivo do criador, gravando o novo snapshot no banco de dados, e re-renderizando a interface cliente reativamente com o perfil vivo atualizado de forma instantânea.
+
+MM59 prepara a futura camada de upload temporário e storage seguro de mídias. Cria tipos de políticas, contratos e validações rígidas de metadados, tamanhos e extensões (`videoNarrativeTemporaryUploadValidation.ts`) para evitar abusos e executáveis. O vídeo segue descartável e efêmero; o snapshot estratégico permanece como a única memória viva persistente. Os provedores reais de storage e Gemini continuam desativados por padrão.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_TEMPORARY_UPLOAD_STORAGE_STRATEGY.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_TEMPORARY_UPLOAD_STORAGE_STRATEGY.md
@@ -1,0 +1,110 @@
+# Estratégia de Upload e Armazenamento Temporário de Vídeo
+
+## 📋 Introdução & Objetivo
+O Perfil Estratégico da Data2Content (D2C) atua como o **diagnóstico vivo do creator**. Cada vídeo analisado enriquece e atualiza esse perfil com novos aprendizados, signals e padrões narrativos.
+
+Para habilitar a análise de vídeos reais no futuro mantendo **privacidade máxima, segurança e economia de custos**, estabelecemos uma arquitetura baseada em **Upload Temporário com Descarte Seguro**. Sob esta abordagem, o vídeo bruto funciona apenas como uma pauta efêmera de processamento: **o vídeo é carregado temporariamente, analisado pelo modelo multimodal, e deletado imediatamente após a conclusão da análise estratégica.**
+
+---
+
+## 🔒 Princípios de Segurança (O que nunca salvar)
+Para evitar riscos jurídicos, de privacidade e custos astronômicos de armazenamento, as seguintes restrições são absolutas:
+1. **Sem Histórico Visual de Vídeos**: A D2C **nunca** exibirá uma galeria de vídeos enviados, lista de vídeos analisados ou player para assistir vídeos antigos. O único artefato permanente é o diagnóstico atualizado no Perfil.
+2. **Descarte Imediato**: Todo arquivo físico enviado deve ser excluído assim que o processamento do pipeline da IA for concluído (seja em caso de sucesso ou de falha irrecuperável).
+3. **Persistência Proibida**:
+   - Nunca salvar o vídeo bruto ou compactado de forma permanente.
+   - Nunca persistir assinaturas de URLs (signed URLs) ou tokens temporários no banco de dados.
+   - Nunca expor URLs de buckets públicos.
+   - Nunca salvar ou reter imagens de thumbnails do vídeo.
+
+---
+
+## 📊 Limites de Arquivo & Quotas (Políticas de Quota)
+
+A política de limites visa assegurar excelente desempenho na rede e evitar abusos maliciosos:
+
+| Métrica | Limite Padrão | Justificativa de Produto / Técnica |
+| :--- | :--- | :--- |
+| **maxFileSizeBytes** | 100 MB | Suficiente para vídeos comprimidos de celular. Evita consumo excessivo de banda de upload no servidor. |
+| **maxDurationSeconds** | 300s (5 min) | Cobre com folga o limite padrão de vídeos verticais (Reels/Shorts/TikTok), mantendo foco em micro-narrativas. |
+| **retentionTtlMinutes** | 60 minutos | Tempo ótimo para processamento assíncrono e resiliência na fila sem manter mídias em repouso por mais tempo que o necessário. |
+
+---
+
+## 🛡️ Validação Rigorosa de Metadados & Arquivos
+Antes que qualquer requisição de upload seja autorizada ou processada pelo storage provider:
+- **MimeType & Extensões Coerentes**: Permitidos apenas `video/mp4`, `video/quicktime` (MOV) e `video/webm`.
+- **Prevenção contra Executáveis**: Bloqueio ativo contra dupla extensão (ex: `video.mp4.exe`) e assinaturas restritas de extensões como `.exe`, `.sh`, `.bat`, `.js`, etc.
+- **Sanitização estrita de Nomes**: Eliminação de caracteres de escape de diretórios (ex: `../`), substituição de espaços por sublinhados (`_`) e restrição a caracteres seguros (`a-zA-Z0-9.\-_`).
+- **Bloqueio de Injeções**: Rejeição imediata de strings em Base64 ou URLs externas passadas como nome do arquivo.
+
+---
+
+## ⚙️ Feature Flags Propostas
+
+Para garantir a ativação gradual, o controle do sistema de upload e storage temporário será regido pelas seguintes flags:
+
+```bash
+# Habilita o upload real e bypassa o mock local
+VIDEO_NARRATIVE_REAL_UPLOAD_ENABLED=false
+
+# Define o provedor ativo ('disabled', 'local_mock', 's3', 'r2', 'gcs', 'cloudinary')
+VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER=disabled
+
+# Define o tamanho máximo de upload permitido por payload (em MB)
+VIDEO_NARRATIVE_TEMP_UPLOAD_MAX_MB=100
+
+# Tempo limite para descarte forçado do arquivo temporário
+VIDEO_NARRATIVE_TEMP_UPLOAD_TTL_MINUTES=60
+```
+
+---
+
+## 🌩️ Provedores de Storage Avaliados (Abstração)
+
+Embora a implementação atual mantenha o provider como `disabled`, projetamos a interface para ser compatível com os principais players do mercado:
+
+1. **Cloudflare R2**:
+   - *Prós*: Sem tarifas de egress (saída de dados), o que zera o custo de leitura de grandes volumes de vídeo pelas APIs de IA. Suporta API S3 perfeitamente.
+   - *Recomendação*: **Candidato preferencial** devido ao custo-benefício de transferência e compatibilidade nativa com Next.js.
+2. **AWS S3**:
+   - *Prós*: Robustez, SLA extremamente alto e ecossistema maduro.
+   - *Contras*: Custos de transferência e egress significativamente elevados para arquivos de vídeo.
+3. **Google Cloud Storage (GCS)**:
+   - *Prós*: Excelente latência em infraestruturas hospedadas no Google Cloud e integração de alta performance com a suíte Gemini API (Vertex AI).
+4. **Cloudinary**:
+   - *Prós*: Ferramentas automáticas de compressão e conversão de vídeo na borda.
+   - *Contras*: Limites de créditos e custo por transformação muito altos para pipelines puramente estratégicos/estatísticos.
+
+---
+
+## 🔄 Fluxo de Processamento Futuro (Ciclo de Vida)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Creator as Aplicativo (Cliente)
+  participant Servidor as Next.js API
+  participant Storage as Storage Temporário (R2)
+  participant IA as Pipeline Gemini Multimodal
+  participant DB as Banco Mongoose
+
+  Creator->>Servidor: 1. Solicita sessão de upload (fileName, sizeBytes, consentAccepted)
+  Note over Servidor: Valida sessão, quota, consentimento e metadados
+  Servidor-->>Creator: 2. Retorna Signed Upload URL curta (válida por 5 minutos)
+  Creator->>Storage: 3. Faz upload direto do vídeo bruto via PUT
+  Creator->>Servidor: 4. Notifica upload concluído
+  Note over Servidor: Registra status 'uploaded' e trava lock de processamento
+  Servidor->>IA: 5. Dispara análise narrativa da IA passando o vídeo temporário
+  IA-->>Servidor: 6. Retorna diagnóstico estratégico estruturado
+  Servidor->>Storage: 7. Solicita deleção imediata do arquivo físico do vídeo
+  Servidor->>DB: 8. Salva o Snapshot Estratégico (Sem armazenar o vídeo)
+  Servidor-->>Creator: 9. Diagnóstico atualizado renderizado no Perfil
+```
+
+---
+
+## ⚖️ Consentimento Ativo do Creator
+O envio só é habilitado após o consentimento explícito em uma caixa de diálogo antes de selecionar a mídia. O consentimento contém:
+- **Finalidade**: `"video_narrative_analysis"` para diagnóstico no perfil estratégico.
+- **Transparência**: Alerta claro de que o vídeo físico **não é mantido** e será permanentemente descartado em até 1 hora ou imediatamente após o processamento.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadContracts.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadContracts.test.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_TEMPORARY_UPLOAD_POLICY } from "./videoNarrativeTemporaryUploadContracts";
+
+describe("VideoNarrativeTemporaryUploadPolicy Contracts", () => {
+  it("default policy vem com provider disabled e storage none", () => {
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.providerMode).toBe("disabled");
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.storageProvider).toBe("none");
+  });
+
+  it("default policy não permite persistir vídeo nem thumbnail", () => {
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.allowRawVideoPersistence).toBe(false);
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.allowThumbnailPersistence).toBe(false);
+  });
+
+  it("default policy exige consentimento explícito do usuário", () => {
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.requireExplicitConsent).toBe(true);
+  });
+
+  it("default policy tem TTL curto (máximo de 1 hora / 60 minutos)", () => {
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.retentionTtlMinutes).toBeLessThanOrEqual(60);
+  });
+
+  it("default policy não permite persistência de URL assinada nem acesso público", () => {
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.allowSignedUrlPersistence).toBe(false);
+    expect(DEFAULT_TEMPORARY_UPLOAD_POLICY.allowPublicAccess).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadContracts.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadContracts.ts
@@ -1,0 +1,93 @@
+export type VideoNarrativeTemporaryUploadProviderMode =
+  | "disabled"
+  | "mock"
+  | "planned"
+  | "real";
+
+export type VideoNarrativeTemporaryUploadStorageProvider =
+  | "none"
+  | "local_mock"
+  | "s3"
+  | "r2"
+  | "gcs"
+  | "cloudinary"
+  | "unknown";
+
+export type VideoNarrativeTemporaryUploadPolicy = {
+  maxFileSizeBytes: number;
+  maxDurationSeconds: number;
+  acceptedMimeTypes: string[];
+  acceptedExtensions: string[];
+  retentionTtlMinutes: number;
+  requireExplicitConsent: boolean;
+  allowThumbnailPersistence: boolean;
+  allowRawVideoPersistence: boolean;
+  allowTranscriptPersistence: boolean;
+  allowSignedUrlPersistence: boolean;
+  allowPublicAccess: boolean;
+  providerMode: VideoNarrativeTemporaryUploadProviderMode;
+  storageProvider: VideoNarrativeTemporaryUploadStorageProvider;
+};
+
+export type VideoNarrativeTemporaryUploadValidationInput = {
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  durationSeconds?: number;
+  userConsentAccepted: boolean;
+  source: string;
+  createdAt: string;
+};
+
+export type VideoNarrativeTemporaryUploadIssue = {
+  code: string;
+  message: string;
+  severity: "blocker" | "warning" | "info";
+};
+
+export type VideoNarrativeTemporaryUploadValidationResult = {
+  ok: boolean;
+  issues: VideoNarrativeTemporaryUploadIssue[];
+  normalizedMetadata?: {
+    fileName: string;
+    mimeType: string;
+    sizeBytes: number;
+    durationSeconds?: number;
+    sanitizedAt: string;
+  };
+  safeForTemporaryUpload: boolean;
+  shouldPersistVideo: boolean;
+  shouldPersistThumbnail: boolean;
+  shouldDeleteAfterAnalysis: boolean;
+};
+
+/**
+ * Política padrão inicial e segura (Default Policy).
+ * Justificativas de Produto:
+ * - maxFileSizeBytes (100MB): Suficiente para a esmagadora maioria de vídeos curtos
+ *   comprimidos gravados em celulares (Reels/Shorts/TikToks), evitando o upload de
+ *   arquivos brutos gigantescos de câmera que geram sobrecarga de rede e custos elevados.
+ * - maxDurationSeconds (300 segundos / 5 minutos): Cobre o limite máximo do Shorts/Reels,
+ *   garantindo o escopo no formato de microconteúdo.
+ * - acceptedMimeTypes: Cobre os codecs e empacotamentos mais comuns no ecossistema web/mobile.
+ * - retentionTtlMinutes (60 minutos): Tempo curto que permite o processamento
+ *   completo da IA mesmo em cenários de fila sem deixar arquivos acumulados permanentemente.
+ * - allow*Persistence (false): O perfil é o único diagnóstico persistido; a mídia física é descartável.
+ * - providerMode ("disabled") / storageProvider ("none"): Mantém o fluxo real desativado
+ *   por default até a ativação explícita de feature flags.
+ */
+export const DEFAULT_TEMPORARY_UPLOAD_POLICY: VideoNarrativeTemporaryUploadPolicy = {
+  maxFileSizeBytes: 100 * 1024 * 1024, // 100MB
+  maxDurationSeconds: 300,             // 5 minutos
+  acceptedMimeTypes: ["video/mp4", "video/quicktime", "video/webm"],
+  acceptedExtensions: [".mp4", ".mov", ".webm"],
+  retentionTtlMinutes: 60,             // 1 hora
+  requireExplicitConsent: true,
+  allowThumbnailPersistence: false,
+  allowRawVideoPersistence: false,
+  allowTranscriptPersistence: false,
+  allowSignedUrlPersistence: false,
+  allowPublicAccess: false,
+  providerMode: "disabled",
+  storageProvider: "none",
+};

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadValidation.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadValidation.test.ts
@@ -1,0 +1,170 @@
+import fs from "fs";
+import path from "path";
+import { validateTemporaryUploadInput, sanitizeFileName } from "./videoNarrativeTemporaryUploadValidation";
+import { DEFAULT_TEMPORARY_UPLOAD_POLICY } from "./videoNarrativeTemporaryUploadContracts";
+
+const SOURCE_PATH = path.join(__dirname, "videoNarrativeTemporaryUploadValidation.ts");
+
+describe("VideoNarrativeTemporaryUploadValidation Tests", () => {
+  const validBaseInput = {
+    fileName: "vlog_final.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 10 * 1024 * 1024, // 10MB
+    durationSeconds: 60,
+    userConsentAccepted: true,
+    source: "creator_mobile_upload",
+    createdAt: new Date().toISOString(),
+  };
+
+  it("aceita mp4 válido dentro do limite com consentimento", () => {
+    const res = validateTemporaryUploadInput(validBaseInput);
+    expect(res.ok).toBe(true);
+    expect(res.safeForTemporaryUpload).toBe(true);
+    expect(res.issues).toHaveLength(0);
+  });
+
+  it("aceita quicktime válido dentro do limite com consentimento", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      fileName: "vlog_ios.mov",
+      mimeType: "video/quicktime",
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejeita mimeType não permitido", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      mimeType: "application/pdf",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "invalid_mime_type")).toBe(true);
+  });
+
+  it("rejeita extensão incoerente", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      fileName: "vlog_final.pdf",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "invalid_extension")).toBe(true);
+  });
+
+  it("rejeita sizeBytes zero ou negativo", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      sizeBytes: 0,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "empty_file")).toBe(true);
+  });
+
+  it("rejeita arquivo acima do limite", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      sizeBytes: 200 * 1024 * 1024, // 200MB, excede 100MB
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "file_too_large")).toBe(true);
+  });
+
+  it("rejeita duração acima do limite", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      durationSeconds: 600, // 10 minutos, excede 5
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "duration_too_long")).toBe(true);
+  });
+
+  it("rejeita sem consentimento", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      userConsentAccepted: false,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "consent_required")).toBe(true);
+  });
+
+  it("rejeita filename com base64 longo", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      fileName: "data:video/mp4;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=.mp4",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "base64_filename_blocked")).toBe(true);
+  });
+
+  it("rejeita filename/source com URL externa", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      fileName: "https://my-bucket.s3.amazonaws.com/dangerous.mp4",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "url_source_blocked")).toBe(true);
+  });
+
+  it("rejeita executable/disfarce", () => {
+    const res = validateTemporaryUploadInput({
+      ...validBaseInput,
+      fileName: "cute_cat.mp4.exe",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.code === "executable_disguise_blocked")).toBe(true);
+  });
+
+  it("sanitiza filename adequadamente removendo caminhos e mantendo caracteres seguros", () => {
+    expect(sanitizeFileName("../../malicious.mp4")).toBe("._._malicious.mp4");
+    expect(sanitizeFileName("meu video legal.mp4")).toBe("meu_video_legal.mp4");
+    expect(sanitizeFileName("video*com$caracteres#.mov")).toBe("video_comcaracteres.mov");
+  });
+
+  it("retorna shouldDeleteAfterAnalysis=true para upload válido", () => {
+    const res = validateTemporaryUploadInput(validBaseInput);
+    expect(res.shouldDeleteAfterAnalysis).toBe(true);
+  });
+
+  it("retorna shouldPersistVideo=false sempre", () => {
+    const res = validateTemporaryUploadInput(validBaseInput);
+    expect(res.shouldPersistVideo).toBe(false);
+  });
+
+  it("retorna shouldPersistThumbnail=false sempre", () => {
+    const res = validateTemporaryUploadInput(validBaseInput);
+    expect(res.shouldPersistThumbnail).toBe(false);
+  });
+
+  it("não usa fetch ou APIs do browser", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    expect(source).not.toContain("fetch(");
+  });
+
+  it("não importa SDK de storage", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    const importLines = source
+      .split("\n")
+      .filter((line) => line.trim().startsWith("import"))
+      .join("\n");
+
+    expect(importLines).not.toContain("@aws-sdk");
+    expect(importLines).not.toContain("@google-cloud");
+    expect(importLines).not.toContain("cloudinary");
+  });
+
+  it("não importa Gemini nem OpenAI", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    expect(source).not.toContain("Gemini");
+    expect(source).not.toContain("OpenAI");
+  });
+
+  it("não importa Prisma nem Mongoose", () => {
+    const source = fs.readFileSync(SOURCE_PATH, "utf8");
+    expect(source).not.toContain("prisma");
+    expect(source).not.toContain("mongoose");
+  });
+
+  it("não altera endpoint de análise nem fluxo +", () => {
+    // Apenas assertividade documental e de isolamento de código
+    expect(true).toBe(true);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadValidation.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadValidation.ts
@@ -1,0 +1,156 @@
+import {
+  VideoNarrativeTemporaryUploadPolicy,
+  VideoNarrativeTemporaryUploadValidationInput,
+  VideoNarrativeTemporaryUploadValidationResult,
+  DEFAULT_TEMPORARY_UPLOAD_POLICY,
+} from "./videoNarrativeTemporaryUploadContracts";
+
+const RESTRICTED_EXTENSIONS = [
+  ".exe", ".bat", ".sh", ".bin", ".cmd", ".msi", ".js", ".ts", ".vbs", ".scr", ".pif"
+];
+
+/**
+ * Sanitiza o nome do arquivo para garantir compatibilidade com sistemas de arquivos comuns,
+ * prevenindo injeções de caminhos ou caracteres maliciosos.
+ */
+export function sanitizeFileName(fileName: string): string {
+  if (!fileName) return "unnamed_video.mp4";
+  
+  // Remove caracteres perigosos ou invasores
+  let name = fileName.replace(/[\\/:*?"<>|]/g, "_");
+  
+  // Agrupa múltiplos pontos seguidos
+  name = name.replace(/\.+/g, ".");
+  
+  // Converte múltiplos espaços em underscore
+  name = name.replace(/\s+/g, "_");
+  
+  // Mantém apenas caracteres seguros de forma restrita
+  name = name.replace(/[^a-zA-Z0-9.\-_]/g, "");
+  
+  return name || "video.mp4";
+}
+
+/**
+ * Validador puro e seguro para entrada de mídias temporárias.
+ */
+export function validateTemporaryUploadInput(
+  input: VideoNarrativeTemporaryUploadValidationInput,
+  policy: VideoNarrativeTemporaryUploadPolicy = DEFAULT_TEMPORARY_UPLOAD_POLICY
+): VideoNarrativeTemporaryUploadValidationResult {
+  const issues: Array<{ code: string; message: string; severity: "blocker" | "warning" | "info" }> = [];
+
+  // 1. Consentimento explícito do usuário
+  if (policy.requireExplicitConsent && !input.userConsentAccepted) {
+    issues.push({
+      code: "consent_required",
+      message: "O consentimento explícito para processamento temporário do vídeo é obrigatório.",
+      severity: "blocker",
+    });
+  }
+
+  // 2. Mime Type permitido
+  if (!policy.acceptedMimeTypes.includes(input.mimeType)) {
+    issues.push({
+      code: "invalid_mime_type",
+      message: `Mime type '${input.mimeType}' não é suportado pela política.`,
+      severity: "blocker",
+    });
+  }
+
+  // 3. Extensão do arquivo e disfarces
+  const lowerFileName = input.fileName.toLowerCase();
+  const extMatch = lowerFileName.match(/\.[a-z0-9]+$/);
+  const extension = extMatch ? extMatch[0] : "";
+
+  if (!policy.acceptedExtensions.includes(extension)) {
+    issues.push({
+      code: "invalid_extension",
+      message: `Extensão de arquivo '${extension}' não é permitida.`,
+      severity: "blocker",
+    });
+  }
+
+  // Bloqueio de disfarces de executáveis ou arquivos nocivos
+  for (const restricted of RESTRICTED_EXTENSIONS) {
+    if (lowerFileName.includes(restricted)) {
+      issues.push({
+        code: "executable_disguise_blocked",
+        message: "Assinatura ou extensão de arquivo executável bloqueada por motivos de segurança.",
+        severity: "blocker",
+      });
+      break;
+    }
+  }
+
+  // 4. Validação de tamanho (sizeBytes)
+  if (input.sizeBytes <= 0) {
+    issues.push({
+      code: "empty_file",
+      message: "O tamanho do arquivo deve ser maior que zero.",
+      severity: "blocker",
+    });
+  } else if (input.sizeBytes > policy.maxFileSizeBytes) {
+    issues.push({
+      code: "file_too_large",
+      message: `O arquivo excede o limite máximo permitido de ${policy.maxFileSizeBytes / (1024 * 1024)}MB.`,
+      severity: "blocker",
+    });
+  }
+
+  // 5. Validação de duração em segundos
+  if (input.durationSeconds !== undefined) {
+    if (input.durationSeconds <= 0) {
+      issues.push({
+        code: "invalid_duration",
+        message: "A duração do vídeo deve ser maior que zero.",
+        severity: "blocker",
+      });
+    } else if (input.durationSeconds > policy.maxDurationSeconds) {
+      issues.push({
+        code: "duration_too_long",
+        message: `A duração do vídeo excede o limite de ${policy.maxDurationSeconds} segundos.`,
+        severity: "blocker",
+      });
+    }
+  }
+
+  // 6. Bloqueios estritos contra Base64 e URLs externas nos metadados
+  const base64Regex = /data:[a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+;base64,/i;
+  if (base64Regex.test(input.fileName) || input.fileName.toLowerCase().includes("base64")) {
+    issues.push({
+      code: "base64_filename_blocked",
+      message: "Nome de arquivo em formato Base64 bloqueado por segurança.",
+      severity: "blocker",
+    });
+  }
+
+  const urlRegex = /^(https?:\/\/|ftp:\/\/|www\.)/i;
+  if (urlRegex.test(input.fileName) || urlRegex.test(input.source)) {
+    issues.push({
+      code: "url_source_blocked",
+      message: "URLs externas não são permitidas como nome de arquivo ou fonte primária.",
+      severity: "blocker",
+    });
+  }
+
+  const ok = issues.filter((i) => i.severity === "blocker").length === 0;
+
+  return {
+    ok,
+    issues,
+    safeForTemporaryUpload: ok,
+    shouldPersistVideo: policy.allowRawVideoPersistence,
+    shouldPersistThumbnail: policy.allowThumbnailPersistence,
+    shouldDeleteAfterAnalysis: true, // Sempre deletar após análise para segurança absoluta
+    normalizedMetadata: ok
+      ? {
+          fileName: sanitizeFileName(input.fileName),
+          mimeType: input.mimeType,
+          sizeBytes: input.sizeBytes,
+          durationSeconds: input.durationSeconds,
+          sanitizedAt: new Date().toISOString(),
+        }
+      : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Stacked over #856.

MM59 adds contracts, validations, and documentation for future temporary video upload/storage readiness without implementing real upload or storage.

Changes:
- Adds temporary upload/storage contracts and tests.
- Adds pure validation for file metadata, consent, MIME types, extensions, size, duration, unsafe filenames/sources, and executable disguises.
- Adds `VIDEO_NARRATIVE_TEMPORARY_UPLOAD_STORAGE_STRATEGY.md`.
- Defines safe default policy with provider disabled, no video persistence, no thumbnail persistence, no signed URL persistence, consent required, and short retention.
- Documents storage provider options such as R2, S3, GCS, Cloudinary, and local mock without implementing any provider.
- Updates docs and QA notes for MM59.

## Validation

Reported passing:
- Temporary upload contracts tests.
- Temporary upload validation tests.
- MM58 regression tests.
- Typecheck.
- `git diff --check`.

## Guardrails

No real Gemini/OpenAI, real upload, real storage, real provider, saved video, saved thumbnail, persisted signed URL, visual video history, analysis endpoint changes, real file input flow changes, storage SDKs, MediaKitView changes, Community changes, real navigation changes, shell/sidebar changes, ActivationPendingWidget changes, LoginClient changes, NextAuth changes, or new billing integration.