### PR TITLE
feat: add storage runtime adapter for Gemini input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "d2c-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1050.0",
         "@google/genai": "^2.3.0",
         "@headlessui/react": "^2.2.2",
         "@heroicons/react": "^2.2.0",
@@ -131,6 +132,503 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
+      "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.14",
+        "@aws-sdk/middleware-expect-continue": "^3.972.12",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.20",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.41",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.14.tgz",
+      "integrity": "sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.12.tgz",
+      "integrity": "sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.20.tgz",
+      "integrity": "sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.41.tgz",
+      "integrity": "sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2396,6 +2894,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4108,6 +4618,126 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@stripe/react-stripe-js": {
@@ -6571,6 +7201,12 @@
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -9008,6 +9644,43 @@
       ],
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -13981,6 +14654,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -16270,6 +16958,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -17953,6 +18653,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "compliance:whatsapp": "node scripts/compliance-whatsapp.mjs"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1050.0",
     "@google/genai": "^2.3.0",
     "@headlessui/react": "^2.2.2",
     "@heroicons/react": "^2.2.0",

--- a/src/app/api/dashboard/mobile-strategic-profile/upload-cleanup/route.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/upload-cleanup/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadFeatureFlag";
 import { evaluateVideoNarrativeSignedUploadAllowlist } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageAllowlist";
 import { validateVideoNarrativeTemporaryUploadCleanupPayload } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadCleanupTypes";
+import { deleteVideoNarrativeTemporaryStorageObject } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeAdapter";
 
 type MobileStrategicProfileCleanupSession = {
   user?: {
@@ -92,6 +93,20 @@ export async function POST(request: Request) {
           },
           { status: 403 },
         );
+      }
+    }
+
+    if (validation.payload.objectKey) {
+      const deleted = await deleteVideoNarrativeTemporaryStorageObject({
+        objectKey: validation.payload.objectKey,
+      });
+
+      if (deleted) {
+        return NextResponse.json({
+          ok: true,
+          status: "cleanup_accepted",
+          message: "Arquivo temporário excluído com sucesso do storage.",
+        });
       }
     }
 

--- a/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
+++ b/src/app/dashboard/boards/videoUpload/GEMINI_VIDEO_NARRATIVE_READINESS_AUDIT.md
@@ -271,6 +271,14 @@ MM67 solidifica a prontidão real (readiness) com ferramentas de validação iso
 - **Smoke Harness Isolado**: novo endpoint `/api/internal/video-narrative/gemini-smoke` protegido para devs, testando configuração da API real do Gemini de ponta a ponta sem salvar snapshot.
 - **Runtime Resolver**: garante que a análise real caia em bloqueio seguro (`missing_storage_adapter`) se o SDK de storage temporário não estiver implementado.
 
+## MM68 — Storage Runtime Adapter for Gemini Input
+
+MM68 implementa o acesso ao arquivo físico para consumo da IA:
+- **Provider Ready**: O bloqueio `storage_runtime_adapter_missing` agora avança para `ready` se provider (S3/R2) e chaves estiverem configurados.
+- **Buffer Flow**: Os bytes do vídeo são repassados ao Google GenAI em tempo de execução server-side. Nenhuma URL assinada é gerada, lida pelo client ou adicionada no payload de snapshot.
+- **Isolamento Constante**: Continua focado exclusivamente em allowlist, não afetando usuários comuns.
+- **Exclusão Transparente**: Uma vez processado, o vídeo efêmero é limpo do bucket via adapter da AWS SDK durante a request `upload-cleanup`.
+
 ## Frase Norte
 
 > O sistema pode estar pronto para testar Gemini real sem ainda estar pronto para lançar vídeo no produto.

--- a/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
+++ b/src/app/dashboard/boards/videoUpload/MOBILE_STRATEGIC_PROFILE_UX_QA.md
@@ -453,3 +453,10 @@ Não recomendar integração real antes do QA/polish visual.
 - A ausência do adapter real de storage no momento do teste deve bloquear o provider da IA de forma segura.
 - Erros de ausência de SDK, timeout ou permissões de adapter não vazam raw stack no console/client.
 - Não expor API Keys do Gemini durante a auditoria server-side, logs ou status codes da resposta da validação local.
+
+## Guardrails do MM68 (Runtime S3-compatible Adapter)
+
+- Adapter validará presencialmente as chaves (bucket/access/secret) antes de avançar;
+- Em caso de arquivo ausente/apagado ou credencial falha, a IA deve abortar com aviso seguro ao criador e NÃO vazar exceção da AWS;
+- `Cleanup_accepted`: O arquivo deve de fato ser deletado no bucket se provider disponível;
+- `Cleanup_not_configured`: Fallback seguro continua valendo e sem impactar persistência da snapshot se adapter de storage ou permissão faltarem.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -2068,3 +2068,14 @@ Descrever:
 - STOR4: contrato de auditoria de cleanup e eventos de retenção.
 - VU11: documentação de custos, limites e retenção.
 - VU12: upload real em PR separado ou fase isolada, somente depois das decisões de produto, segurança e custo.
+
+### MM68 — Storage Runtime Adapter for Gemini Input
+
+Status: concluído.
+
+- Conecta storage temporário server-side ao input seguro do Gemini.
+- Mantém acesso allowlist/admin-dev.
+- Não expõe signed URL ao client.
+- Não salva vídeo.
+- Não persiste objectKey/signed URL no snapshot.
+- Cleanup pode deletar objeto temporário quando provider suporta.

--- a/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_MULTIMODAL_NARRATIVE_ARCHITECTURE.md
@@ -274,8 +274,9 @@ Exemplos:
 64. MM65 — Gemini Provider Readiness + Response Adapter. Prompt real preparado, validation forte em runtime contra API key leakage.
 65. MM66 — Real Video Analysis Allowlist E2E. Rota `analyze-real` executa e-2-e da chamada multimodal isolada, sem afetar o mock.
 66. MM67 — Real Runtime Env + Gemini/Storage Smoke Harness. Validação env real local, resolver de falha segura p/ falta de SDK S3, smoke interno para devs.
-67. Teste real manual quando houver quota/billing disponível.
-68. Integração experimental futura no Board de Criação.
+67. MM68 — Storage Runtime Adapter for Gemini Input. Ponte segura entre o vídeo efêmero em S3 e a IA; mantém snapshot como única memória durável.
+68. Teste real manual quando houver quota/billing disponível.
+69. Integração experimental futura no Board de Criação.
 
 ## Critérios Antes De Provider Real
 

--- a/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_TEMPORARY_UPLOAD_STORAGE_STRATEGY.md
+++ b/src/app/dashboard/boards/videoUpload/VIDEO_NARRATIVE_TEMPORARY_UPLOAD_STORAGE_STRATEGY.md
@@ -223,3 +223,11 @@ MM67 adiciona o `videoNarrativeTemporaryStorageRuntimeResolver.ts` como validaç
 - o orquestrador bloqueia a análise real antes da execução com a IA, retornando a mensagem segura: "A análise real ainda precisa da conexão temporária de storage para ler o vídeo.";
 - garante que nenhum detalhe interno ou raw stack trace seja exposto ao criador no momento do bloqueio;
 - consolida a estratégia de que o Gemini provider não assume a responsabilidade do download e que o sistema está blindado contra falhas não tratadas na ausência de implementação do storage físico.
+
+## Fase MM68 — Storage Runtime Adapter
+
+MM68 implementa oficialmente o `videoNarrativeTemporaryStorageRuntimeAdapter.ts`, viabilizando o consumo e descarte real do arquivo armazenado:
+- **Resolução de Input**: Lê o `objectKey` e faz o download seguro como `Uint8Array` via @aws-sdk/client-s3 (server-side only);
+- **Consumo Seguro Multimodal**: Passa os bytes puros do buffer em tempo de memória para a API do Google, impedindo a geração ou o tráfego de signed URLs inseguras na interface.
+- **Deleção Programática**: O adapter conta com o método `deleteVideoNarrativeTemporaryStorageObject` que aciona a destruição do arquivo assim que a request de `upload-cleanup` é engatilhada, removendo da nuvem de imediato. O erro na deleção vira um log/warning não-impeditivo.
+- **Riscos de Custo/Timeout**: Ler arquivos pesados diretamente na Lambda/Runtime e transformá-los num Base64/buffer do Gemini requer atenção ao tamanho (MAX_MB suportado vs limites de Vercel e da IA), sendo vital os limites estritos definidos no contrato do Adapter.

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiProvider.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiProvider.ts
@@ -19,6 +19,12 @@ export type VideoNarrativeGeminiClientAdapter = {
     responseSchemaInstruction: string;
     model: string;
     maxOutputTokens: number;
+    videoInput?: {
+      mimeType: string;
+      bytes?: Uint8Array | Buffer;
+      uri?: string;
+      source: "temporary_storage";
+    };
   }): Promise<{ text: string | null }>;
 };
 
@@ -63,6 +69,12 @@ export async function runVideoNarrativeGeminiProvider(params: {
   env?: EnvLike;
   config?: VideoNarrativeGeminiProviderConfig;
   client?: VideoNarrativeGeminiClientAdapter | null;
+  videoInput?: {
+    mimeType: string;
+    bytes?: Uint8Array | Buffer;
+    uri?: string;
+    source: "temporary_storage";
+  };
 }): Promise<VideoNarrativeAiProviderResult> {
   const startedAt = Date.now();
   const resolved = params.config
@@ -118,6 +130,7 @@ export async function runVideoNarrativeGeminiProvider(params: {
         responseSchemaInstruction: prompt.responseSchemaInstruction,
         model: resolved.config.model!,
         maxOutputTokens: resolved.config.maxOutputTokens,
+        videoInput: params.videoInput,
       }),
       resolved.config.timeoutMs,
     );

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.test.ts
@@ -1,9 +1,14 @@
 import { runVideoNarrativeRealAnalysisOrchestrator } from "./videoNarrativeRealAnalysisOrchestrator";
 import { geminiVideoNarrativeResponseFixture } from "./__fixtures__/geminiVideoNarrativeResponse.fixture";
 import { resolveVideoNarrativeTemporaryStorageObject } from "./videoNarrativeTemporaryStorageRuntimeResolver";
+import { resolveVideoNarrativeTemporaryStorageInput } from "./videoNarrativeTemporaryStorageRuntimeAdapter";
 
 jest.mock("./videoNarrativeTemporaryStorageRuntimeResolver", () => ({
   resolveVideoNarrativeTemporaryStorageObject: jest.fn(),
+}));
+
+jest.mock("./videoNarrativeTemporaryStorageRuntimeAdapter", () => ({
+  resolveVideoNarrativeTemporaryStorageInput: jest.fn(),
 }));
 
 const env = {
@@ -42,6 +47,20 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
       status: "ready",
       safeMessage: "",
       issues: [],
+    });
+    (resolveVideoNarrativeTemporaryStorageInput as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: "ready",
+      geminiInput: {
+        mimeType: "video/mp4",
+        bytes: new Uint8Array([1, 2, 3]),
+        source: "temporary_storage",
+      },
+      safeDebugSummary: {
+        mimeType: "video/mp4",
+        sizeBytes: 1024,
+        provider: "cloudflare_r2",
+      },
     });
   });
 

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.ts
@@ -16,6 +16,7 @@ import { runVideoNarrativeGeminiProvider, type VideoNarrativeGeminiClientAdapter
 import { mapGeminiAnalysisToStrategicProfileSnapshot } from "./videoNarrativeGeminiSnapshotMapper";
 import type { VideoNarrativeRealAnalysisPayload } from "./videoNarrativeRealAnalysisTypes";
 import { resolveVideoNarrativeTemporaryStorageObject } from "./videoNarrativeTemporaryStorageRuntimeResolver";
+import { resolveVideoNarrativeTemporaryStorageInput } from "./videoNarrativeTemporaryStorageRuntimeAdapter";
 
 type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
@@ -138,6 +139,24 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
     });
   }
 
+  const storageInputResult = await resolveVideoNarrativeTemporaryStorageInput({
+    input: {
+      uploadSessionId: params.payload.uploadSessionId,
+      objectKey: params.payload.temporaryUpload?.objectKey ?? "",
+      mimeType: params.payload.temporaryUpload?.mimeType ?? "video/mp4",
+      sizeBytes: params.payload.temporaryUpload?.sizeBytes ?? 0,
+    },
+    env,
+  });
+
+  if (!storageInputResult.ok) {
+    return safeFailure({
+      status: "failed",
+      message: storageInputResult.safeMessage,
+      safeIssueCode: storageInputResult.status,
+    });
+  }
+
   const runProvider = deps.runProvider ?? runVideoNarrativeGeminiProvider;
   const providerResult = await runProvider({
     input: {
@@ -163,6 +182,7 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
     env,
     config: configResult.config,
     client: deps.geminiClient ?? null,
+    videoInput: storageInputResult.geminiInput,
   });
 
   if (!providerResult.ok || !providerResult.analysis) {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealRuntimeEnvAudit.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealRuntimeEnvAudit.test.ts
@@ -96,6 +96,26 @@ describe("videoNarrativeRealRuntimeEnvAudit", () => {
     );
   });
 
+  it("Retorna storage credentials missing", () => {
+    const env = {
+      GEMINI_API_KEY: "secret",
+      VIDEO_NARRATIVE_GEMINI_FLASH_ENABLED: "true",
+      VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED: "true",
+      VIDEO_NARRATIVE_REAL_UPLOAD_ENABLED: "true",
+      VIDEO_NARRATIVE_SIGNED_UPLOAD_ALLOWLIST_ENABLED: "true",
+      VIDEO_NARRATIVE_GEMINI_ALLOWLIST_ENABLED: "true",
+      VIDEO_NARRATIVE_GEMINI_ALLOWED_EMAILS: "test@example.com",
+      VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: "cloudflare_r2",
+      // Faltam as keys
+    };
+    const result = performVideoNarrativeRealRuntimeEnvAudit(env);
+    expect(result.ok).toBe(false);
+    expect(result.flags.storageCredentialsPresent).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ code: "storage_credentials_missing" })
+    );
+  });
+
   it("Retorna ready quando env fake está completa", () => {
     const env = {
       GEMINI_API_KEY: "fake-secret-key-123",
@@ -106,11 +126,15 @@ describe("videoNarrativeRealRuntimeEnvAudit", () => {
       VIDEO_NARRATIVE_GEMINI_ALLOWLIST_ENABLED: "true",
       VIDEO_NARRATIVE_GEMINI_ALLOWED_EMAILS: "test@example.com",
       VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: "cloudflare_r2",
+      VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET: "fake-bucket",
+      VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID: "fake-key",
+      VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY: "fake-secret",
     };
     const result = performVideoNarrativeRealRuntimeEnvAudit(env);
     expect(result.ok).toBe(true);
-    expect(result.issues).toHaveLength(1);
-    expect(result.issues[0].code).toBe("env_ready_for_smoke");
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues).toContainEqual(expect.objectContaining({ code: "env_ready_for_smoke" }));
+    expect(result.issues).toContainEqual(expect.objectContaining({ code: "storage_runtime_resolver_ready" }));
   });
 
   it("Não retorna nenhum secret", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealRuntimeEnvAudit.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealRuntimeEnvAudit.ts
@@ -5,6 +5,8 @@ export type VideoNarrativeEnvAuditIssueCode =
   | "real_upload_disabled"
   | "signed_upload_allowlist_disabled"
   | "storage_provider_missing"
+  | "storage_credentials_missing"
+  | "storage_runtime_resolver_ready"
   | "allowlist_missing"
   | "env_ready_for_smoke";
 
@@ -23,6 +25,7 @@ export type VideoNarrativeEnvAuditResult = {
     realUploadEnabled: boolean;
     signedUploadAllowlistEnabled: boolean;
     storageProvider: string;
+    storageCredentialsPresent: boolean;
     allowlistConfigured: boolean;
   };
 };
@@ -96,9 +99,25 @@ export function performVideoNarrativeRealRuntimeEnvAudit(
       code: "storage_provider_missing",
       message: "Nenhum provider de storage real configurado (VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER).",
     });
+  } else {
+    const bucket = !!env.VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET?.trim();
+    const accessKeyId = !!env.VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID?.trim();
+    const secretAccessKey = !!env.VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY?.trim();
+
+    if (!bucket || !accessKeyId || !secretAccessKey) {
+      issues.push({
+        code: "storage_credentials_missing",
+        message: "Credenciais de storage incompletas (falta bucket ou access keys).",
+      });
+    } else {
+      issues.push({
+        code: "storage_runtime_resolver_ready",
+        message: "Provider e credenciais de storage configurados e prontos.",
+      });
+    }
   }
 
-  const ok = issues.length === 0;
+  const ok = issues.filter(i => i.code !== "storage_runtime_resolver_ready").length === 0;
 
   if (ok) {
     issues.push({
@@ -117,6 +136,7 @@ export function performVideoNarrativeRealRuntimeEnvAudit(
       realUploadEnabled,
       signedUploadAllowlistEnabled,
       storageProvider,
+      storageCredentialsPresent: !!env.VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET?.trim() && !!env.VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID?.trim() && !!env.VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY?.trim(),
       allowlistConfigured,
     },
   };

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeAdapter.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeAdapter.test.ts
@@ -1,0 +1,170 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import {
+  resolveVideoNarrativeTemporaryStorageInput,
+  deleteVideoNarrativeTemporaryStorageObject,
+} from "./videoNarrativeTemporaryStorageRuntimeAdapter";
+
+describe("videoNarrativeTemporaryStorageRuntimeAdapter", () => {
+  const baseEnv = {
+    VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: "cloudflare_r2",
+    VIDEO_NARRATIVE_TEMP_STORAGE_ENDPOINT: "https://test.r2.cloudflarestorage.com",
+    VIDEO_NARRATIVE_TEMP_STORAGE_REGION: "auto",
+    VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET: "d2c-temp",
+    VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID: "key",
+    VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY: "secret",
+    VIDEO_NARRATIVE_TEMP_UPLOAD_MAX_MB: "100",
+  };
+
+  const baseInput = {
+    uploadSessionId: "session-123",
+    objectKey: "test-video.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 1024,
+  };
+
+  describe("resolveVideoNarrativeTemporaryStorageInput", () => {
+    it("retorna provider_not_configured quando provider falta", async () => {
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: baseInput,
+        env: { ...baseEnv, VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: undefined },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("provider_not_configured");
+        expect(res.issues[0].code).toBe("provider_disabled");
+      }
+    });
+
+    it("retorna missing_storage_adapter quando provider nao e suportado", async () => {
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: baseInput,
+        env: { ...baseEnv, VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: "google_cloud_storage" },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("missing_storage_adapter");
+        expect(res.issues[0].code).toBe("unsupported_provider");
+      }
+    });
+
+    it("rejeita objectKey vazio", async () => {
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: { ...baseInput, objectKey: "" },
+        env: baseEnv,
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("object_not_found");
+        expect(res.issues[0].code).toBe("empty_object_key");
+      }
+    });
+
+    it("rejeita mimeType nao suportado", async () => {
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: { ...baseInput, mimeType: "image/jpeg" },
+        env: baseEnv,
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("unsupported_mime_type");
+        expect(res.issues[0].code).toBe("invalid_mime_type");
+      }
+    });
+
+    it("rejeita sizeBytes acima do limite", async () => {
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: { ...baseInput, sizeBytes: 200 * 1024 * 1024 }, // 200MB
+        env: baseEnv,
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("object_too_large");
+        expect(res.issues[0].code).toBe("exceeds_max_size");
+      }
+    });
+
+    it("retorna bytes quando S3Client funciona corretamente", async () => {
+      const fakeBytes = new Uint8Array([1, 2, 3]);
+      const fakeS3Client = {
+        send: jest.fn().mockResolvedValue({
+          Body: {
+            transformToByteArray: jest.fn().mockResolvedValue(fakeBytes),
+          },
+        }),
+      } as unknown as S3Client;
+
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: baseInput,
+        env: baseEnv,
+        s3Client: fakeS3Client,
+      });
+
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.status).toBe("ready");
+        expect(res.geminiInput.bytes).toEqual(fakeBytes);
+        expect(res.geminiInput.mimeType).toBe("video/mp4");
+        expect(res.safeDebugSummary.provider).toBe("cloudflare_r2");
+      }
+    });
+
+    it("retorna download_failed quando S3Client lanca erro", async () => {
+      const fakeS3Client = {
+        send: jest.fn().mockRejectedValue(new Error("Network Error")),
+      } as unknown as S3Client;
+
+      const res = await resolveVideoNarrativeTemporaryStorageInput({
+        input: baseInput,
+        env: baseEnv,
+        s3Client: fakeS3Client,
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.status).toBe("download_failed");
+        expect(res.issues[0].code).toBe("s3_download_error");
+        expect(res.safeMessage).not.toContain("Network Error");
+      }
+    });
+  });
+
+  describe("deleteVideoNarrativeTemporaryStorageObject", () => {
+    it("deleta corretamente via S3Client", async () => {
+      const fakeS3Client = {
+        send: jest.fn().mockResolvedValue({}),
+      } as unknown as S3Client;
+
+      const res = await deleteVideoNarrativeTemporaryStorageObject({
+        objectKey: "test.mp4",
+        env: baseEnv,
+        s3Client: fakeS3Client,
+      });
+
+      expect(res).toBe(true);
+      expect(fakeS3Client.send).toHaveBeenCalled();
+    });
+
+    it("retorna false quando s3 lanca erro, silenciosamente", async () => {
+      const fakeS3Client = {
+        send: jest.fn().mockRejectedValue(new Error("Access Denied")),
+      } as unknown as S3Client;
+
+      const res = await deleteVideoNarrativeTemporaryStorageObject({
+        objectKey: "test.mp4",
+        env: baseEnv,
+        s3Client: fakeS3Client,
+      });
+
+      expect(res).toBe(false);
+    });
+
+    it("retorna false se provider invalido", async () => {
+      const res = await deleteVideoNarrativeTemporaryStorageObject({
+        objectKey: "test.mp4",
+        env: { ...baseEnv, VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER: "none" },
+      });
+
+      expect(res).toBe(false);
+    });
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeAdapter.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeAdapter.ts
@@ -1,0 +1,209 @@
+import { S3Client, GetObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+
+export type VideoNarrativeTemporaryStorageRuntimeAdapterInput = {
+  uploadSessionId: string;
+  objectKey: string;
+  mimeType: string;
+  sizeBytes: number;
+};
+
+export type VideoNarrativeTemporaryStorageRuntimeAdapterResult =
+  | {
+      ok: true;
+      status: "ready";
+      geminiInput: {
+        mimeType: string;
+        bytes?: Uint8Array | Buffer;
+        uri?: string;
+        source: "temporary_storage";
+      };
+      safeDebugSummary: {
+        mimeType: string;
+        sizeBytes: number;
+        provider: string;
+      };
+    }
+  | {
+      ok: false;
+      status:
+        | "missing_storage_adapter"
+        | "provider_not_configured"
+        | "object_not_found"
+        | "object_too_large"
+        | "unsupported_mime_type"
+        | "download_failed";
+      safeMessage: string;
+      issues: Array<{ code: string; message: string }>;
+    };
+
+type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+export async function resolveVideoNarrativeTemporaryStorageInput(params: {
+  input: VideoNarrativeTemporaryStorageRuntimeAdapterInput;
+  env?: EnvLike;
+  s3Client?: S3Client;
+}): Promise<VideoNarrativeTemporaryStorageRuntimeAdapterResult> {
+  const env = params.env ?? process.env;
+  const provider = env.VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER;
+
+  if (!provider || provider === "disabled" || provider === "none" || provider === "local_mock") {
+    return {
+      ok: false,
+      status: "provider_not_configured",
+      safeMessage: "O serviço de storage temporário não está configurado.",
+      issues: [{ code: "provider_disabled", message: `Storage provider ${provider || "none"} is not configured.` }],
+    };
+  }
+
+  if (!["cloudflare_r2", "r2", "aws_s3", "s3"].includes(provider)) {
+    return {
+      ok: false,
+      status: "missing_storage_adapter",
+      safeMessage: "A análise real ainda precisa da conexão temporária de storage para ler o vídeo.",
+      issues: [{ code: "unsupported_provider", message: `Provider ${provider} not fully implemented.` }],
+    };
+  }
+
+  const endpoint = env.VIDEO_NARRATIVE_TEMP_STORAGE_ENDPOINT;
+  const region = env.VIDEO_NARRATIVE_TEMP_STORAGE_REGION ?? "auto";
+  const bucket = env.VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET;
+  const accessKeyId = env.VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID;
+  const secretAccessKey = env.VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY;
+
+  if (!bucket || !accessKeyId || !secretAccessKey) {
+    return {
+      ok: false,
+      status: "provider_not_configured",
+      safeMessage: "O serviço de storage temporário não está configurado.",
+      issues: [{ code: "missing_credentials", message: "Storage credentials missing." }],
+    };
+  }
+
+  if (!params.input.objectKey) {
+    return {
+      ok: false,
+      status: "object_not_found",
+      safeMessage: "Referência de vídeo ausente.",
+      issues: [{ code: "empty_object_key", message: "Object key is empty." }],
+    };
+  }
+
+  const allowedTypes = ["video/mp4", "video/quicktime", "video/webm"];
+  if (!allowedTypes.includes(params.input.mimeType)) {
+    return {
+      ok: false,
+      status: "unsupported_mime_type",
+      safeMessage: "Formato de vídeo não suportado.",
+      issues: [{ code: "invalid_mime_type", message: "MimeType not allowed." }],
+    };
+  }
+
+  const maxMbStr = env.VIDEO_NARRATIVE_TEMP_UPLOAD_MAX_MB || "100";
+  const maxBytes = parseInt(maxMbStr, 10) * 1024 * 1024;
+  if (params.input.sizeBytes > maxBytes) {
+    return {
+      ok: false,
+      status: "object_too_large",
+      safeMessage: "Vídeo excede o tamanho permitido.",
+      issues: [{ code: "exceeds_max_size", message: "Size exceeds max MB." }],
+    };
+  }
+
+  try {
+    const s3 =
+      params.s3Client ??
+      new S3Client({
+        region,
+        endpoint: endpoint || undefined,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+      });
+
+    const getCommand = new GetObjectCommand({
+      Bucket: bucket,
+      Key: params.input.objectKey,
+    });
+
+    const getRes = await s3.send(getCommand);
+
+    if (!getRes.Body) {
+      throw new Error("Empty body returned from storage.");
+    }
+
+    const bytes = await getRes.Body.transformToByteArray();
+
+    return {
+      ok: true,
+      status: "ready",
+      geminiInput: {
+        mimeType: params.input.mimeType,
+        bytes,
+        source: "temporary_storage",
+      },
+      safeDebugSummary: {
+        mimeType: params.input.mimeType,
+        sizeBytes: params.input.sizeBytes,
+        provider,
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: "download_failed",
+      safeMessage: "Não foi possível recuperar o arquivo temporário de vídeo.",
+      issues: [{ code: "s3_download_error", message: "Failed to download object." }],
+    };
+  }
+}
+
+export async function deleteVideoNarrativeTemporaryStorageObject(params: {
+  objectKey: string;
+  env?: EnvLike;
+  s3Client?: S3Client;
+}): Promise<boolean> {
+  const env = params.env ?? process.env;
+  const provider = env.VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER;
+
+  if (!provider || provider === "disabled" || provider === "none" || provider === "local_mock") {
+    return false;
+  }
+
+  if (!["cloudflare_r2", "r2", "aws_s3", "s3"].includes(provider)) {
+    return false;
+  }
+
+  const endpoint = env.VIDEO_NARRATIVE_TEMP_STORAGE_ENDPOINT;
+  const region = env.VIDEO_NARRATIVE_TEMP_STORAGE_REGION ?? "auto";
+  const bucket = env.VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET;
+  const accessKeyId = env.VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID;
+  const secretAccessKey = env.VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY;
+
+  if (!bucket || !accessKeyId || !secretAccessKey || !params.objectKey) {
+    return false;
+  }
+
+  try {
+    const s3 =
+      params.s3Client ??
+      new S3Client({
+        region,
+        endpoint: endpoint || undefined,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+      });
+
+    const command = new DeleteObjectCommand({
+      Bucket: bucket,
+      Key: params.objectKey,
+    });
+
+    await s3.send(command);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeResolver.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageRuntimeResolver.ts
@@ -24,21 +24,75 @@ export type VideoNarrativeTemporaryStorageRuntimeResolverInput = {
 };
 
 export function resolveVideoNarrativeTemporaryStorageObject(
-  _input: VideoNarrativeTemporaryStorageRuntimeResolverInput
+  input: VideoNarrativeTemporaryStorageRuntimeResolverInput,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env
 ): VideoNarrativeTemporaryStorageRuntimeResolverResult {
-  // Atualmente o projeto não possui o SDK da AWS/Cloudflare configurado para gerar
-  // links assinados de leitura (signed downloads) ou para buscar o buffer do objeto.
-  // Portanto, a auditoria retorna corretamente que o adapter de storage está ausente.
-  
+  const provider = env.VIDEO_NARRATIVE_TEMP_STORAGE_PROVIDER;
+
+  if (!provider || provider === "disabled" || provider === "none" || provider === "local_mock") {
+    return {
+      ok: false,
+      status: "provider_not_configured",
+      safeMessage: "A análise real ainda precisa da conexão temporária de storage para ler o vídeo.",
+      issues: [
+        {
+          code: "provider_disabled",
+          message: "O serviço de storage temporário não está configurado."
+        }
+      ]
+    };
+  }
+
+  if (!["cloudflare_r2", "r2", "aws_s3", "s3"].includes(provider)) {
+    return {
+      ok: false,
+      status: "unsupported_provider",
+      safeMessage: "A análise real ainda precisa da conexão temporária de storage para ler o vídeo.",
+      issues: [
+        {
+          code: "unsupported_provider",
+          message: `Provider ${provider} not fully implemented.`
+        }
+      ]
+    };
+  }
+
+  const bucket = env.VIDEO_NARRATIVE_TEMP_STORAGE_BUCKET;
+  const accessKeyId = env.VIDEO_NARRATIVE_TEMP_STORAGE_ACCESS_KEY_ID;
+  const secretAccessKey = env.VIDEO_NARRATIVE_TEMP_STORAGE_SECRET_ACCESS_KEY;
+
+  if (!bucket || !accessKeyId || !secretAccessKey) {
+    return {
+      ok: false,
+      status: "provider_not_configured",
+      safeMessage: "O serviço de storage temporário não está configurado.",
+      issues: [
+        {
+          code: "missing_credentials",
+          message: "Storage credentials missing."
+        }
+      ]
+    };
+  }
+
+  if (!input.objectKey) {
+    return {
+      ok: false,
+      status: "missing_storage_adapter",
+      safeMessage: "Referência de vídeo ausente.",
+      issues: [
+        {
+          code: "empty_object_key",
+          message: "Object key is empty."
+        }
+      ]
+    };
+  }
+
   return {
-    ok: false,
-    status: "missing_storage_adapter",
-    safeMessage: "A análise real ainda precisa da conexão temporária de storage para ler o vídeo.",
-    issues: [
-      {
-        code: "storage_sdk_not_implemented",
-        message: "O SDK de storage necessário para resolver o objectKey não está configurado."
-      }
-    ]
+    ok: true,
+    status: "ready",
+    safeMessage: "Ready",
+    issues: []
   };
 }


### PR DESCRIPTION
## Summary

Stacked over #865.

MM68 adds the storage runtime adapter that bridges temporary video storage to safe Gemini multimodal input.

Changes:
- Adds server-side temporary storage runtime adapter.
- Uses `@aws-sdk/client-s3` server-side for S3/R2-compatible GetObject/DeleteObject operations.
- Converts temporary storage bytes into safe Gemini input without writing files locally.
- Updates the runtime resolver so storage readiness can become ready when provider/env are complete.
- Updates the real analysis orchestrator to use the storage runtime adapter before calling Gemini.
- Updates cleanup to delete temporary objects when provider config supports it.
- Extends env audit for storage credentials/readiness.
- Updates docs and QA notes for MM68.

## Validation

Reported passing:
- `videoNarrativeTemporaryStorageRuntimeAdapter.test.ts`.
- `videoNarrativeRealAnalysisOrchestrator.test.ts`.
- `videoNarrativeRealRuntimeEnvAudit.test.ts`.
- `upload-cleanup/route.test.ts`.
- Global typecheck.

## Guardrails

Allowlist/admin-dev only; common users blocked; no video saved in DB; no signed URL exposed to client; no signed URL persisted; no objectKey persisted in snapshot; no raw Gemini response saved; no committed secrets; no storage SDK in client components; mock endpoint preserved; Media Kit untouched; Community untouched; real navigation untouched; DashboardShell/BoardShell/sidebar untouched; ActivationPendingWidget untouched; LoginClient untouched; NextAuth untouched; and billing untouched.