### PR TITLE
MM74-MM85 — Narrative Map Reading + Profile Synthesis Foundation

### DIFF
--- a/src/app/api/internal/video-narrative/analyze/route.test.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.test.ts
@@ -6,11 +6,25 @@ jest.mock("@/app/api/auth/[...nextauth]/route", () => ({
   authOptions: {},
 }));
 
+jest.mock("@/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMockSaveIntegration", () => ({
+  saveMockVideoNarrativeReading: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator", () => ({
+  runControlledVideoReadingSynthesisSnapshotWrite: jest.fn(),
+}));
+
 const {
   createBlockedVideoNarrativeGuardResult,
 } = require("@/app/dashboard/boards/videoUpload/videoNarrativeGuardContracts");
 const { GET, POST } = require("./route");
 const getServerSession = require("next-auth/next").getServerSession as jest.Mock;
+const saveMockVideoNarrativeReading =
+  require("@/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMockSaveIntegration")
+    .saveMockVideoNarrativeReading as jest.Mock;
+const runControlledVideoReadingSynthesisSnapshotWrite =
+  require("@/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator")
+    .runControlledVideoReadingSynthesisSnapshotWrite as jest.Mock;
 
 const FORBIDDEN_RESPONSE_FIELDS = [
   '"rawText"',
@@ -297,6 +311,186 @@ describe("POST /api/internal/video-narrative/analyze skeleton", () => {
     expect(JSON.stringify(body)).toContain("publi orgânica");
   });
 
+  it("fluxo mock salva leitura quando persistReading é permitido", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+    saveMockVideoNarrativeReading.mockResolvedValue({
+      ok: true,
+      diagnosisId: "manual-video-narrative-run",
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "low",
+        weight: "low",
+        profileImpactPreview: "Sinal em observação.",
+      },
+    });
+
+    const response = await POST(makeRequest({ ...validPayload(), persistReading: true }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(saveMockVideoNarrativeReading).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "665f0f2c8a0b7d1f2c3a4b5c",
+      diagnosisId: "manual-video-narrative-run",
+    }));
+    expect(body.readingSaveSummary).toEqual({
+      attempted: true,
+      ok: true,
+      diagnosisId: "manual-video-narrative-run",
+      errorCode: null,
+      message: null,
+    });
+    expect(body.synthesisSnapshotWrite).toBeNull();
+  });
+
+  it("com persistReading=true e persistSynthesisSnapshot=true salva leitura e tenta sintese", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+    saveMockVideoNarrativeReading.mockResolvedValue({
+      ok: true,
+      diagnosisId: "manual-video-narrative-run",
+      profileContribution: {
+        type: "confirms_existing_pattern",
+        confidence: "medium",
+        weight: "medium",
+        profileImpactPreview: "Sinal em formação.",
+      },
+    });
+    runControlledVideoReadingSynthesisSnapshotWrite.mockResolvedValue({
+      attempted: true,
+      written: true,
+      synthesisStatus: "signals_emerging",
+      analyzedReadingsCount: 2,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      persistReading: true,
+      persistSynthesisSnapshot: true,
+    }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(runControlledVideoReadingSynthesisSnapshotWrite).toHaveBeenCalledWith({
+      userId: "665f0f2c8a0b7d1f2c3a4b5c",
+      savedDiagnosisId: "manual-video-narrative-run",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+      requestId: expect.any(String),
+    });
+    expect(body.synthesisSnapshotWrite).toEqual({
+      attempted: true,
+      written: true,
+      synthesisStatus: "signals_emerging",
+      analyzedReadingsCount: 2,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+  });
+
+  it("se save reading falhar, sintese nao roda", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+    saveMockVideoNarrativeReading.mockResolvedValue({
+      ok: false,
+      errorCode: "diagnosis_persistence_failed",
+      message: "Não foi possível salvar a leitura documentada deste video agora.",
+    });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      persistReading: true,
+      persistSynthesisSnapshot: true,
+    }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(runControlledVideoReadingSynthesisSnapshotWrite).not.toHaveBeenCalled();
+    expect(body.synthesisSnapshotWrite).toEqual({
+      attempted: false,
+      written: false,
+      skippedReason: "saved_reading_not_found",
+    });
+  });
+
+  it("se sintese falhar, resposta mock continua segura", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+    saveMockVideoNarrativeReading.mockResolvedValue({
+      ok: true,
+      diagnosisId: "manual-video-narrative-run",
+    });
+    runControlledVideoReadingSynthesisSnapshotWrite.mockResolvedValue({
+      attempted: true,
+      written: false,
+      skippedReason: "synthesis_snapshot_write_failed",
+      synthesisStatus: "pattern_in_formation",
+      analyzedReadingsCount: 3,
+    });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      persistReading: true,
+      persistSynthesisSnapshot: true,
+    }));
+    const body = await readJson(response);
+    const serialized = JSON.stringify(body);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.synthesisSnapshotWrite.written).toBe(false);
+    expect(serialized).not.toContain("Error:");
+    expect(serialized).not.toContain("snapshotJson");
+  });
+
+  it("persistSynthesisSnapshot sem persistReading nao altera comportamento principal e nao roda sintese", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+
+    const response = await POST(makeRequest({
+      ...validPayload(),
+      persistSynthesisSnapshot: true,
+    }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(saveMockVideoNarrativeReading).not.toHaveBeenCalled();
+    expect(runControlledVideoReadingSynthesisSnapshotWrite).not.toHaveBeenCalled();
+    expect(body.synthesisSnapshotWrite).toEqual({
+      attempted: false,
+      written: false,
+      skippedReason: "saved_reading_not_found",
+    });
+  });
+
+  it("falha de persistência retorna erro seguro sem quebrar resposta mock", async () => {
+    enableEndpointFlag();
+    setProviderMode("mock");
+    getServerSession.mockResolvedValue({ user: { role: "admin", id: "665f0f2c8a0b7d1f2c3a4b5c" } });
+    saveMockVideoNarrativeReading.mockResolvedValue({
+      ok: false,
+      errorCode: "diagnosis_persistence_failed",
+      message: "Não foi possível salvar a leitura documentada deste video agora.",
+    });
+
+    const response = await POST(makeRequest({ ...validPayload(), persistReading: true }));
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.readingSaveSummary.ok).toBe(false);
+    expect(JSON.stringify(body)).not.toContain("Error:");
+  });
+
   it("POST mock mode weak hook returns hook diagnosis and primaryAction", async () => {
     enableEndpointFlag();
     setProviderMode("mock");
@@ -432,6 +626,7 @@ describe("POST /api/internal/video-narrative/analyze skeleton", () => {
       "BoardShell",
       "React",
       "from \"@/components",
+      "analyze-real",
     ];
 
     forbiddenFragments.forEach((fragment) => {

--- a/src/app/api/internal/video-narrative/analyze/route.ts
+++ b/src/app/api/internal/video-narrative/analyze/route.ts
@@ -17,7 +17,10 @@ import {
 import { isVideoNarrativeInternalEndpointEnabled } from "@/app/dashboard/boards/videoUpload/videoNarrativeInternalEndpointFeatureFlag";
 import { validateVideoNarrativeConsentRetentionForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeConsentRetentionGuards";
 import { validateVideoNarrativeInputSourceForPhase } from "@/app/dashboard/boards/videoUpload/videoNarrativeInputSourceGuards";
-import { hasUsefulVideoNarrativeAnalysis } from "@/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes";
+import {
+  hasUsefulVideoNarrativeAnalysis,
+  type VideoNarrativeAnalysis,
+} from "@/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes";
 import { runVideoNarrativeMockProvider } from "@/app/dashboard/boards/videoUpload/videoNarrativeMockProvider";
 import {
   buildVideoNarrativeObservabilityEvent,
@@ -30,6 +33,7 @@ import {
   buildPostCreationVideoSeedFromAnalysis,
   getPostCreationVideoSeedPrimaryAction,
   hasUsefulPostCreationVideoSeed,
+  type PostCreationVideoSeed,
 } from "@/app/dashboard/boards/videoUpload/videoNarrativePostCreationSeed";
 import {
   buildBlockedVideoNarrativeSafeResponse,
@@ -39,6 +43,8 @@ import {
   type VideoNarrativeSafeIssue,
   type VideoNarrativeSafeResponse,
   type VideoNarrativeSafeResponseStatus,
+  type VideoNarrativeReadingSaveSummary,
+  type VideoNarrativeSynthesisSnapshotWriteSummary,
 } from "@/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder";
 import * as usageQuotaGuards from "@/app/dashboard/boards/videoUpload/videoNarrativeUsageQuotaGuards";
 import { getServerSession } from "next-auth/next";
@@ -105,6 +111,119 @@ function compactEvents(
   events: Array<VideoNarrativeObservabilityEventPayload | null>,
 ): VideoNarrativeObservabilityEventPayload[] {
   return events.filter((event): event is VideoNarrativeObservabilityEventPayload => Boolean(event));
+}
+
+function shouldPersistReading(payload: unknown): boolean {
+  return isRecord(payload) && payload.persistReading === true;
+}
+
+function shouldPersistSynthesisSnapshot(payload: unknown): boolean {
+  return isRecord(payload) && payload.persistSynthesisSnapshot === true;
+}
+
+function userIdFromInternalUser(user: InternalPreviewUser): string | null {
+  const candidate = (user as InternalPreviewUser & { id?: unknown; _id?: unknown; userId?: unknown }).id ??
+    (user as InternalPreviewUser & { id?: unknown; _id?: unknown; userId?: unknown })._id ??
+    (user as InternalPreviewUser & { id?: unknown; _id?: unknown; userId?: unknown }).userId;
+  return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
+}
+
+async function buildReadingSaveSummary(params: {
+  payload: unknown;
+  user: InternalPreviewUser;
+  diagnosisId: string;
+  creatorGoal: string | null;
+  selectedGoalOption: string | null;
+  analysis: VideoNarrativeAnalysis;
+  seed: PostCreationVideoSeed;
+}): Promise<VideoNarrativeReadingSaveSummary | null> {
+  if (!shouldPersistReading(params.payload)) return null;
+
+  const userId = userIdFromInternalUser(params.user);
+  if (!userId) {
+    return {
+      attempted: true,
+      ok: false,
+      diagnosisId: null,
+      errorCode: "missing_user_id",
+      message: "Não foi possível salvar a leitura documentada agora.",
+    };
+  }
+
+  const { saveMockVideoNarrativeReading } = await import(
+    "@/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMockSaveIntegration"
+  );
+  const result = await saveMockVideoNarrativeReading({
+    userId,
+    diagnosisId: params.diagnosisId,
+    creatorGoal: params.creatorGoal,
+    selectedGoalOption: params.selectedGoalOption,
+    analysis: params.analysis,
+    seed: params.seed,
+    createdAt: CREATED_AT,
+  });
+
+  if (result.ok) {
+    return {
+      attempted: true,
+      ok: true,
+      diagnosisId: result.diagnosisId,
+      errorCode: null,
+      message: null,
+    };
+  }
+
+  return {
+    attempted: true,
+    ok: false,
+    diagnosisId: null,
+    errorCode: result.errorCode,
+    message: result.message,
+  };
+}
+
+async function buildSynthesisSnapshotWriteSummary(params: {
+  payload: unknown;
+  user: InternalPreviewUser;
+  readingSaveSummary: VideoNarrativeReadingSaveSummary | null;
+}): Promise<VideoNarrativeSynthesisSnapshotWriteSummary | null> {
+  if (!shouldPersistSynthesisSnapshot(params.payload)) return null;
+
+  if (!shouldPersistReading(params.payload) || !params.readingSaveSummary?.ok || !params.readingSaveSummary.diagnosisId) {
+    return {
+      attempted: false,
+      written: false,
+      skippedReason: "saved_reading_not_found",
+    };
+  }
+
+  const userId = userIdFromInternalUser(params.user);
+  if (!userId) {
+    return {
+      attempted: true,
+      written: false,
+      skippedReason: "saved_reading_not_found",
+    };
+  }
+
+  try {
+    const { runControlledVideoReadingSynthesisSnapshotWrite } = await import(
+      "@/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator"
+    );
+    return await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId,
+      savedDiagnosisId: params.readingSaveSummary.diagnosisId,
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+      requestId: REQUEST_ID,
+    });
+  } catch {
+    return {
+      attempted: true,
+      written: false,
+      skippedReason: "unknown_synthesis_write_error",
+    };
+  }
 }
 
 function buildGuardSummary(results: VideoNarrativeGuardResult[]): VideoNarrativeGuardPipelineSummary {
@@ -622,6 +741,22 @@ export async function POST(request: Request): Promise<NextResponse<VideoNarrativ
       issuesCount: usageDecision.issues.length,
     }),
   ]);
+  const readingSaveSummary = await buildReadingSaveSummary({
+    payload,
+    user,
+    diagnosisId: analysis.id,
+    creatorGoal: payloadValidation.normalized.creatorQuestion,
+    selectedGoalOption: isRecord(payload) && typeof payload.selectedGoalOption === "string"
+      ? payload.selectedGoalOption
+      : null,
+    analysis,
+    seed,
+  });
+  const synthesisSnapshotWrite = await buildSynthesisSnapshotWriteSummary({
+    payload,
+    user,
+    readingSaveSummary,
+  });
 
   return buildSafeJsonResponse(
     redactVideoNarrativeSafeResponse(
@@ -636,6 +771,8 @@ export async function POST(request: Request): Promise<NextResponse<VideoNarrativ
         usageDecision,
         quotaGuard: usageQuotaGuard,
         observabilityEvents: events,
+        readingSaveSummary,
+        synthesisSnapshotWrite,
       }),
     ),
     200,

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
@@ -4,6 +4,7 @@ import { MobileStrategicProfileRealShellClient } from "./MobileStrategicProfileR
 import { fetchHomeSummaryCached } from "../../../../home/homeSummaryClient";
 import { requestUploadSession } from "./mobileStrategicProfileUploadSessionClient";
 import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectUploadClient";
+import { buildNarrativeMapReadingPreviewFixture } from "./buildNarrativeMapReadingPreviewFixture";
 
 // Mock das dependências
 jest.mock("../../../../home/homeSummaryClient", () => ({
@@ -554,5 +555,62 @@ describe("MobileStrategicProfileRealShellClient", () => {
     expect(screen.getByTestId("profile-display-name").textContent).toBe("Arthur Teste");
 
     globalFetchSpy.mockRestore();
+  });
+
+  it("MM85 - renderiza shell real Perfil | Leituras | Oportunidades quando view model narrativo vem do servidor", async () => {
+    (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
+    const fixture = buildNarrativeMapReadingPreviewFixture({ state: "narrative_map_three_related_readings" });
+
+    render(
+      <MobileStrategicProfileRealShellClient
+        session={mockSession}
+        stateQuery={null}
+        initialNarrativeMapViewModel={fixture.viewModel}
+        initialNarrativeMapPresentation={fixture.presentation}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: "Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Leituras" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Oportunidades" })).toBeInTheDocument();
+    expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("MM85 - painel de snapshot review so aparece quando liberado como interno", async () => {
+    (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
+    const fixture = buildNarrativeMapReadingPreviewFixture({ state: "narrative_map_three_related_readings" });
+
+    const { rerender } = render(
+      <MobileStrategicProfileRealShellClient
+        session={mockSession}
+        stateQuery={null}
+        initialNarrativeMapViewModel={fixture.viewModel}
+        initialNarrativeMapPresentation={fixture.presentation}
+        initialSynthesisSnapshotWrite={fixture.synthesisSnapshotWrite}
+      />
+    );
+
+    expect(screen.queryByLabelText("Snapshot write review")).not.toBeInTheDocument();
+
+    rerender(
+      <MobileStrategicProfileRealShellClient
+        session={mockSession}
+        stateQuery={null}
+        initialNarrativeMapViewModel={fixture.viewModel}
+        initialNarrativeMapPresentation={fixture.presentation}
+        initialSynthesisSnapshotWrite={fixture.synthesisSnapshotWrite}
+        internalSnapshotReview
+      />
+    );
+
+    expect(screen.getByLabelText("Snapshot write review")).toBeInTheDocument();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
   });
 });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -6,20 +6,32 @@ import { buildMobileStrategicProfile, type MobileStrategicProfile } from "../../
 import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUpload/mobileStrategicProfileExistingDataAdapter";
 import { buildMobileStrategicProfileFromSnapshot } from "../../../videoUpload/mobileStrategicProfileSnapshotMapping";
 import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
+import { NarrativeMapMobileShell } from "./NarrativeMapMobileShell";
 import { fetchHomeSummaryCached } from "../../../../home/homeSummaryClient";
 import { requestUploadSession } from "./mobileStrategicProfileUploadSessionClient";
 import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectUploadClient";
+import type { CreatorNarrativeMapReadingPresentation } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+import type { NarrativeMapMobileViewModel } from "../../../videoUpload/narrativeMapMobileViewModel";
+import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
 
 interface MobileStrategicProfileRealShellClientProps {
   session: any;
   stateQuery: string | null;
   initialSnapshotPayload?: any; // MobileStrategicProfileSnapshotPayload
+  initialNarrativeMapViewModel?: NarrativeMapMobileViewModel | null;
+  initialNarrativeMapPresentation?: CreatorNarrativeMapReadingPresentation | null;
+  initialSynthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  internalSnapshotReview?: boolean;
 }
 
 export function MobileStrategicProfileRealShellClient({
   session,
   stateQuery,
   initialSnapshotPayload,
+  initialNarrativeMapViewModel,
+  initialNarrativeMapPresentation,
+  initialSynthesisSnapshotWrite,
+  internalSnapshotReview,
 }: MobileStrategicProfileRealShellClientProps) {
   const realAnalysisEnabled = process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED === "1";
 
@@ -238,15 +250,28 @@ export function MobileStrategicProfileRealShellClient({
           <span>Atualizando dados do Perfil...</span>
         </div>
       )}
-      <MobileStrategicProfilePreview
-        profile={profile}
-        isRealShell={true}
-        onSubmitAnalysis={handleAnalysisSubmit}
-        onCreateUploadSession={requestUploadSession}
-        onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
-        enableRealAnalysis={realAnalysisEnabled}
-        onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
-      />
+      {initialNarrativeMapViewModel && initialNarrativeMapPresentation ? (
+        <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
+          <div className="mx-auto grid max-w-5xl gap-5">
+            <NarrativeMapMobileShell
+              viewModel={initialNarrativeMapViewModel}
+              presentation={initialNarrativeMapPresentation}
+              snapshotReview={initialSynthesisSnapshotWrite}
+              internalReview={internalSnapshotReview}
+            />
+          </div>
+        </main>
+      ) : (
+        <MobileStrategicProfilePreview
+          profile={profile}
+          isRealShell={true}
+          onSubmitAnalysis={handleAnalysisSubmit}
+          onCreateUploadSession={requestUploadSession}
+          onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
+          enableRealAnalysis={realAnalysisEnabled}
+          onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
@@ -1,0 +1,155 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { NarrativeMapMobileShell } from "./NarrativeMapMobileShell";
+import { buildNarrativeMapReadingPreviewFixture } from "./buildNarrativeMapReadingPreviewFixture";
+
+function renderShell(state = "narrative_map_three_related_readings", internalReview = false) {
+  const fixture = buildNarrativeMapReadingPreviewFixture({ state });
+  return render(
+    <NarrativeMapMobileShell
+      viewModel={fixture.viewModel}
+      presentation={fixture.presentation}
+      snapshotReview={fixture.synthesisSnapshotWrite}
+      internalReview={internalReview}
+    />,
+  );
+}
+
+function renderedText(container: HTMLElement): string {
+  return container.textContent?.toLowerCase() ?? "";
+}
+
+describe("NarrativeMapMobileShell", () => {
+  it("renderiza tabs Perfil, Leituras e Oportunidades", () => {
+    renderShell();
+
+    expect(screen.getByRole("tab", { name: "Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Leituras" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Oportunidades" })).toBeInTheDocument();
+  });
+
+  it("Perfil mostra hero Seu mapa narrativo e capitulos do view model", () => {
+    renderShell();
+
+    expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Seu padrão")).toBeInTheDocument();
+    expect(screen.getByText("Sua tensão")).toBeInTheDocument();
+    expect(screen.getByText("Seu movimento")).toBeInTheDocument();
+    expect(screen.getByText("Seu território")).toBeInTheDocument();
+  });
+
+  it("Leituras mostra itens recentes e Ver leitura abre detalhe seguro", () => {
+    renderShell();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+    expect(screen.getByText("Leituras documentadas")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Ver leitura" }).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Ver leitura" })[0]);
+    const dialog = screen.getByRole("dialog", { name: "Vídeo sobre humor cotidiano com identificação rápida" });
+    expect(within(dialog).getByText("Contribuição")).toBeInTheDocument();
+    expect(within(dialog).queryByText(/objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath/)).not.toBeInTheDocument();
+  });
+
+  it("Leituras mostra empty state quando nao existirem", () => {
+    renderShell("narrative_map_no_readings");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+
+    expect(screen.getByText("Nenhuma leitura documentada ainda")).toBeInTheDocument();
+  });
+
+  it("Oportunidades mostra territorios e fit narrativo sem match real", () => {
+    const { container } = renderShell("narrative_map_commercial_signals");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
+
+    expect(screen.getAllByText("Territórios em formação").length).toBeGreaterThan(0);
+    expect(renderedText(container)).toContain("fit narrativo");
+    expect(renderedText(container)).not.toContain("match real");
+  });
+
+  it("CTA principal e secundaria seguem a hierarquia esperada", () => {
+    renderShell();
+
+    expect(screen.getByRole("button", { name: "Nova leitura" })).toHaveAttribute("data-priority", "primary");
+    expect(screen.getByRole("button", { name: "Ler diagnóstico completo" })).toHaveAttribute("data-priority", "secondary");
+  });
+
+  it("Ler diagnostico completo abre leitura completa sob demanda", () => {
+    renderShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ler diagnóstico completo" }));
+
+    expect(screen.getByRole("dialog", { name: "Diagnóstico completo" })).toBeInTheDocument();
+  });
+
+  it("cards principais nao renderizam fullReading diretamente", () => {
+    renderShell();
+
+    expect(screen.queryByText(/síntese dry-run|Capítulos em sequência/i)).not.toBeInTheDocument();
+  });
+
+  it("safety note aparece de forma discreta", () => {
+    renderShell();
+
+    expect(screen.getByText("A D2C guarda a leitura estratégica, não o vídeo.")).toBeInTheDocument();
+  });
+
+  it("Snapshot review panel renderiza auditoria segura apenas em contexto interno", () => {
+    const { rerender } = renderShell("narrative_map_three_related_readings", false);
+
+    expect(screen.queryByLabelText("Snapshot write review")).not.toBeInTheDocument();
+
+    const fixture = buildNarrativeMapReadingPreviewFixture({ state: "narrative_map_three_related_readings" });
+    rerender(
+      <NarrativeMapMobileShell
+        viewModel={fixture.viewModel}
+        presentation={fixture.presentation}
+        snapshotReview={fixture.synthesisSnapshotWrite}
+        internalReview
+      />,
+    );
+
+    const panel = screen.getByLabelText("Snapshot write review");
+    expect(within(panel).getByText("attempted")).toBeInTheDocument();
+    expect(within(panel).getByText("written")).toBeInTheDocument();
+    expect(within(panel).queryByText(/snapshotJson|payload|videoReading|stack trace/i)).not.toBeInTheDocument();
+  });
+
+  it("UI nao exibe termos proibidos", () => {
+    const { container } = renderShell("narrative_map_commercial_signals", true);
+    const text = renderedText(container);
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "viralizar",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "match real",
+      "publi garantida",
+      "gemini",
+      "raw response",
+      "objectkey",
+      "signedurl",
+      "uploadurl",
+      "thumbnailurl",
+      "localpath",
+      "storageproviderpath",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("shell nao chama endpoint real, SDK, storage ou modelo de snapshot", () => {
+    const source = [
+      "NarrativeMapMobileShell.tsx",
+      "NarrativeMapSnapshotReviewPanel.tsx",
+    ].map((file) => fs.readFileSync(path.join(__dirname, file), "utf8")).join("\n");
+
+    expect(source).not.toMatch(/fetch\(|analyze-real|@google\/genai|@aws-sdk|CreatorStrategicProfileSnapshot|from ["']mongoose["']/);
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import type { CreatorNarrativeMapReadingChapter, CreatorNarrativeMapReadingPresentation } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+import type { NarrativeMapMobileReadingItem, NarrativeMapMobileViewModel } from "../../../videoUpload/narrativeMapMobileViewModel";
+import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
+import { NarrativeMapReadingChapterCard } from "./NarrativeMapReadingChapterCard";
+import { NarrativeMapReadingChapterModal } from "./NarrativeMapReadingChapterModal";
+import { NarrativeMapReadingFullDiagnosisModal } from "./NarrativeMapReadingFullDiagnosisModal";
+import { NarrativeMapSnapshotReviewPanel } from "./NarrativeMapSnapshotReviewPanel";
+
+type NarrativeMapReadingPreviewTab = "profile" | "readings" | "opportunities";
+
+const TAB_LABELS: Record<NarrativeMapReadingPreviewTab, string> = {
+  profile: "Perfil",
+  readings: "Leituras",
+  opportunities: "Oportunidades",
+};
+
+function ReadingDetailModal({
+  reading,
+  onClose,
+}: {
+  reading: NarrativeMapMobileReadingItem | null;
+  onClose: () => void;
+}) {
+  if (!reading) return null;
+
+  return (
+    <div className="absolute inset-0 z-20 flex items-end bg-zinc-950/45 p-3" role="presentation">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label={reading.rememberedAs}
+        className="max-h-[82%] w-full overflow-y-auto rounded-[1.35rem] bg-white p-4 shadow-2xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold text-zinc-500">{reading.dateLabel}</p>
+            <h3 className="mt-1 text-lg font-semibold leading-6 text-zinc-950">{reading.rememberedAs}</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600"
+          >
+            Fechar
+          </button>
+        </div>
+        <div className="mt-4 grid gap-3">
+          <div className="rounded-2xl bg-zinc-50 p-3">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Contribuição</p>
+            <p className="mt-1 text-sm font-semibold text-zinc-950">{reading.contributionLabel}</p>
+          </div>
+          <div className="rounded-2xl bg-zinc-50 p-3">
+            <p className="text-xs font-semibold uppercase text-zinc-500">Como pesa no Perfil</p>
+            <p className="mt-1 text-sm leading-6 text-zinc-700">{reading.profileImpactPreview}</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export function NarrativeMapMobileShell({
+  viewModel,
+  presentation,
+  statusText,
+  stateNav,
+  snapshotReview,
+  internalReview,
+}: {
+  viewModel: NarrativeMapMobileViewModel;
+  presentation: CreatorNarrativeMapReadingPresentation;
+  statusText?: string | null;
+  stateNav?: ReactNode;
+  snapshotReview?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  internalReview?: boolean;
+}) {
+  const [activeTab, setActiveTab] = useState<NarrativeMapReadingPreviewTab>(
+    (viewModel.tabs.find((tab) => tab.active)?.id ?? "profile") as NarrativeMapReadingPreviewTab,
+  );
+  const [activeChapter, setActiveChapter] = useState<CreatorNarrativeMapReadingChapter | null>(null);
+  const [activeReading, setActiveReading] = useState<NarrativeMapMobileReadingItem | null>(null);
+  const [fullDiagnosisOpen, setFullDiagnosisOpen] = useState(false);
+  const profileChapters = useMemo(() => viewModel.profile.chapters, [viewModel.profile.chapters]);
+  const readingsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Leituras")?.value ?? "0";
+  const patternsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Padrões")?.value ?? "0";
+  const opportunitiesCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Oportunidades")?.value ?? "0";
+
+  return (
+    <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
+      <section className="relative min-h-[760px] overflow-hidden rounded-[1.5rem] bg-[#f7f7f4]">
+        <div className="px-5 pt-4" aria-label="Topo compacto do creator">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-base font-semibold text-zinc-950">{viewModel.profileHeader.displayName}</h2>
+              <p className="mt-0.5 text-xs font-medium text-zinc-500">
+                {viewModel.profileHeader.displayHandle} · {statusText ?? viewModel.profileHeader.statusLabel}
+              </p>
+            </div>
+            <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-zinc-600 shadow-sm">
+              D2C
+            </span>
+          </div>
+
+          <div className="mt-3 grid grid-cols-3 rounded-[1.1rem] bg-white p-2.5 text-center shadow-sm">
+            <div>
+              <p className="text-base font-semibold text-zinc-950">{readingsCount}</p>
+              <p className="text-[11px] font-medium text-zinc-500">Leituras</p>
+            </div>
+            <div>
+              <p className="text-base font-semibold text-zinc-950">{patternsCount}</p>
+              <p className="text-[11px] font-medium text-zinc-500">Padrões</p>
+            </div>
+            <div>
+              <p className="text-base font-semibold text-zinc-950">{opportunitiesCount}</p>
+              <p className="text-[11px] font-medium text-zinc-500">Oportunidades</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-5 pt-4">
+          <section className="rounded-[1.5rem] bg-white p-4 shadow-sm">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">{viewModel.hero.badgeLabel}</p>
+            <h2 className="mt-1.5 text-2xl font-semibold tracking-normal text-zinc-950">{viewModel.hero.title}</h2>
+            <p className="mt-2 text-base font-semibold leading-6 text-zinc-950">{viewModel.hero.headline}</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.hero.subheadline}</p>
+            <div className="mt-4 grid gap-2">
+              <button
+                type="button"
+                data-priority="primary"
+                className="min-h-[44px] rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15"
+              >
+                {viewModel.profile.primaryAction.label}
+              </button>
+              {viewModel.profile.secondaryAction ? (
+                <button
+                  type="button"
+                  data-priority="secondary"
+                  className="min-h-[38px] rounded-full border border-transparent bg-transparent px-4 py-2 text-sm font-semibold text-zinc-600 underline decoration-zinc-300 underline-offset-4"
+                  onClick={() => setFullDiagnosisOpen(true)}
+                >
+                  {viewModel.profile.secondaryAction.label}
+                </button>
+              ) : null}
+            </div>
+          </section>
+        </div>
+
+        <div className="mx-5 mt-4 grid grid-cols-3 rounded-full bg-white p-1 shadow-sm" role="tablist" aria-label="Abas do mapa narrativo">
+          {viewModel.tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={
+                activeTab === tab.id
+                  ? "rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+                  : "rounded-full px-3 py-2 text-xs font-semibold text-zinc-500"
+              }
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        <section className="grid gap-3 px-5 py-4" aria-label={`Capítulos — ${TAB_LABELS[activeTab]}`}>
+          {activeTab === "profile" ? profileChapters.map((chapter) => (
+            <NarrativeMapReadingChapterCard key={chapter.id} chapter={chapter} onOpen={setActiveChapter} />
+          )) : null}
+
+          {activeTab === "readings" ? (
+            <>
+              <div className="rounded-[1.35rem] bg-white p-4 shadow-sm">
+                <h3 className="text-base font-semibold text-zinc-950">{viewModel.readings.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.readings.description}</p>
+              </div>
+              {viewModel.readings.items.map((reading) => (
+                <article key={reading.id} className="rounded-[1.35rem] bg-white p-4 shadow-sm">
+                  <p className="text-xs font-semibold text-zinc-500">{reading.dateLabel}</p>
+                  <div className="mt-2 flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-zinc-950">{reading.contributionLabel}</p>
+                      <h3 className="mt-1 text-base font-semibold leading-6 text-zinc-950">{reading.rememberedAs}</h3>
+                    </div>
+                    <span className="shrink-0 rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-semibold text-zinc-600">
+                      {reading.statusLabel}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">{reading.profileImpactPreview}</p>
+                  <button
+                    type="button"
+                    className="mt-3 rounded-full border border-zinc-200 px-3 py-2 text-xs font-semibold text-zinc-700"
+                    onClick={() => setActiveReading(reading)}
+                  >
+                    {reading.action.label}
+                  </button>
+                </article>
+              ))}
+              {viewModel.readings.emptyState ? (
+                <div className="rounded-[1.35rem] bg-white p-4 text-center shadow-sm">
+                  <h3 className="text-base font-semibold text-zinc-950">{viewModel.readings.emptyState.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.readings.emptyState.description}</p>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+
+          {activeTab === "opportunities" ? (
+            <>
+              <div className="rounded-[1.35rem] bg-white p-4 shadow-sm">
+                <h3 className="text-base font-semibold text-zinc-950">{viewModel.opportunities.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.opportunities.description}</p>
+              </div>
+              {viewModel.opportunities.items.map((item) => (
+                <article key={item.id} className="rounded-[1.35rem] bg-white p-4 shadow-sm">
+                  <p className="text-xs font-semibold text-zinc-500">
+                    {item.type === "brand_territory"
+                      ? "Territórios em formação"
+                      : item.type === "media_kit_bridge"
+                        ? "Ponte para Mídia Kit"
+                        : "Tipo de collab possível"}
+                  </p>
+                  <h3 className="mt-2 text-base font-semibold leading-6 text-zinc-950">{item.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">{item.preview}</p>
+                </article>
+              ))}
+              {viewModel.opportunities.emptyState ? (
+                <div className="rounded-[1.35rem] bg-white p-4 text-center shadow-sm">
+                  <h3 className="text-base font-semibold text-zinc-950">{viewModel.opportunities.emptyState.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.opportunities.emptyState.description}</p>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </section>
+
+        {presentation.safetyNote ? (
+          <p className="mx-5 mb-5 rounded-2xl bg-white px-3 py-2 text-xs font-medium leading-5 text-zinc-500">
+            {presentation.safetyNote}
+          </p>
+        ) : null}
+
+        <NarrativeMapSnapshotReviewPanel review={snapshotReview} internal={internalReview} />
+        {stateNav}
+        <NarrativeMapReadingChapterModal chapter={activeChapter} onClose={() => setActiveChapter(null)} />
+        <ReadingDetailModal reading={activeReading} onClose={() => setActiveReading(null)} />
+        <NarrativeMapReadingFullDiagnosisModal
+          presentation={presentation}
+          open={fullDiagnosisOpen}
+          onClose={() => setFullDiagnosisOpen(false)}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingChapterCard.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingChapterCard.tsx
@@ -1,0 +1,51 @@
+import type { CreatorNarrativeMapReadingChapter } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+
+const TONE_CLASS: Record<CreatorNarrativeMapReadingChapter["tone"], string> = {
+  mirror: "border-zinc-200 bg-white",
+  attention: "border-amber-100 bg-white",
+  action: "border-zinc-200 bg-white",
+  opportunity: "border-emerald-100 bg-white",
+  neutral: "border-zinc-200 bg-white",
+};
+
+const ACTION_TONE_CLASS: Record<CreatorNarrativeMapReadingChapter["tone"], string> = {
+  mirror: "bg-zinc-50 text-zinc-700",
+  attention: "bg-amber-50 text-amber-900",
+  action: "bg-zinc-950 text-white",
+  opportunity: "bg-emerald-50 text-emerald-900",
+  neutral: "bg-zinc-50 text-zinc-700",
+};
+
+export function NarrativeMapReadingChapterCard({
+  chapter,
+  onOpen,
+}: {
+  chapter: CreatorNarrativeMapReadingChapter;
+  onOpen: (chapter: CreatorNarrativeMapReadingChapter) => void;
+}) {
+  return (
+    <article className={`rounded-[1.25rem] border p-4 shadow-sm ${TONE_CLASS[chapter.tone]}`}>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold text-zinc-950">{chapter.title}</h3>
+        {chapter.badgeLabel ? (
+          <span className="shrink-0 rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-semibold text-zinc-600">
+            {chapter.badgeLabel}
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-3 text-sm leading-6 text-zinc-700">{chapter.preview}</p>
+      {chapter.action ? (
+        <p className={`mt-3 rounded-2xl px-3 py-2 text-xs font-medium leading-5 ${ACTION_TONE_CLASS[chapter.tone]}`}>
+          {chapter.action}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        className="mt-4 text-sm font-semibold text-zinc-950 underline decoration-zinc-300 underline-offset-4"
+        onClick={() => onOpen(chapter)}
+      >
+        Ler capítulo
+      </button>
+    </article>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingChapterModal.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingChapterModal.tsx
@@ -1,0 +1,60 @@
+import type { CreatorNarrativeMapReadingChapter } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+
+export function NarrativeMapReadingChapterModal({
+  chapter,
+  onClose,
+}: {
+  chapter: CreatorNarrativeMapReadingChapter | null;
+  onClose: () => void;
+}) {
+  if (!chapter) return null;
+
+  return (
+    <div className="absolute inset-0 z-20 flex items-end bg-zinc-950/35 px-3 pb-3" role="dialog" aria-modal="true" aria-label={chapter.title}>
+      <section className="max-h-[88%] w-full overflow-y-auto rounded-[1.75rem] bg-white p-5 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            {chapter.badgeLabel ? (
+              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">
+                {chapter.badgeLabel}
+              </span>
+            ) : null}
+            <h2 className="mt-3 text-xl font-semibold text-zinc-950">{chapter.title}</h2>
+          </div>
+          <button
+            type="button"
+            className="grid h-9 w-9 shrink-0 place-items-center rounded-full border border-zinc-200 bg-white text-sm font-semibold text-zinc-700"
+            onClick={onClose}
+            aria-label="Fechar capítulo"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="mt-4 rounded-[1.25rem] bg-zinc-50 px-4 py-3">
+          <p className="text-sm leading-6 text-zinc-700">{chapter.fullReading}</p>
+        </div>
+
+        {chapter.evidence.length > 0 ? (
+          <div className="mt-5">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Onde isso aparece</h3>
+            <ul className="mt-2 grid gap-2">
+              {chapter.evidence.map((item) => (
+                <li key={item} className="rounded-2xl border border-zinc-100 bg-white px-3 py-2 text-sm leading-5 text-zinc-700">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {chapter.action ? (
+          <div className="mt-5 rounded-2xl bg-zinc-950 px-4 py-3 text-white">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Como usar agora</h3>
+            <p className="mt-1 text-sm leading-5">{chapter.action}</p>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx
@@ -1,0 +1,71 @@
+import type { CreatorNarrativeMapReadingPresentation } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+
+export function NarrativeMapReadingFullDiagnosisModal({
+  presentation,
+  open,
+  onClose,
+}: {
+  presentation: CreatorNarrativeMapReadingPresentation;
+  open: boolean;
+  onClose: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="absolute inset-0 z-20 bg-white" role="dialog" aria-modal="true" aria-label="Diagnóstico completo">
+      <section className="flex h-full flex-col">
+        <header className="border-b border-zinc-200 px-5 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase text-zinc-500">{presentation.statusLabel}</p>
+              <h2 className="mt-1 text-xl font-semibold text-zinc-950">Diagnóstico completo</h2>
+              <p className="mt-2 text-sm leading-5 text-zinc-600">
+                Capítulos em sequência para ler com calma, sem substituir a síntese futura do Perfil.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="grid h-9 w-9 shrink-0 place-items-center rounded-full border border-zinc-200 bg-white text-sm font-semibold text-zinc-700"
+              onClick={onClose}
+              aria-label="Fechar diagnóstico completo"
+            >
+              ×
+            </button>
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+          <div className="grid gap-5">
+            {presentation.chapters.map((chapter) => (
+              <article key={chapter.id} className="border-b border-zinc-200 pb-5 last:border-b-0">
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="text-base font-semibold text-zinc-950">{chapter.title}</h3>
+                  {chapter.badgeLabel ? (
+                    <span className="rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-semibold text-zinc-600">
+                      {chapter.badgeLabel}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-3 text-sm leading-6 text-zinc-700">{chapter.fullReading}</p>
+                {chapter.evidence.length > 0 ? (
+                  <ul className="mt-3 grid gap-1.5">
+                    {chapter.evidence.slice(0, 2).map((item) => (
+                      <li key={item} className="text-xs leading-5 text-zinc-500">
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+                {chapter.action ? (
+                  <p className="mt-3 rounded-2xl bg-zinc-50 px-3 py-2 text-xs font-medium leading-5 text-zinc-700">
+                    {chapter.action}
+                  </p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.test.tsx
@@ -1,0 +1,294 @@
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { NarrativeMapReadingPreview } from "./NarrativeMapReadingPreview";
+import {
+  buildNarrativeMapReadingPreviewFixture,
+  type NarrativeMapReadingPreviewState,
+} from "./buildNarrativeMapReadingPreviewFixture";
+
+const SOURCE_FILES = [
+  "NarrativeMapReadingPreview.tsx",
+  "NarrativeMapMobileShell.tsx",
+  "NarrativeMapSnapshotReviewPanel.tsx",
+  "NarrativeMapReadingChapterCard.tsx",
+  "NarrativeMapReadingChapterModal.tsx",
+  "NarrativeMapReadingFullDiagnosisModal.tsx",
+  "buildNarrativeMapReadingPreviewFixture.ts",
+];
+
+function renderState(state: NarrativeMapReadingPreviewState = "narrative_map_chapters") {
+  return render(<NarrativeMapReadingPreview fixture={buildNarrativeMapReadingPreviewFixture({ state })} />);
+}
+
+function renderedText(container: HTMLElement): string {
+  return container.textContent?.toLowerCase() ?? "";
+}
+
+function openFirstChapter() {
+  fireEvent.click(screen.getAllByRole("button", { name: "Ler capítulo" })[0]);
+}
+
+describe("NarrativeMapReadingPreview", () => {
+  it("renderiza topo compacto", () => {
+    renderState();
+
+    const header = screen.getByLabelText("Topo compacto do creator");
+
+    expect(within(header).getByText("Lívia Linhares")).toBeInTheDocument();
+    expect(within(header).getByText("@livialinharess · Perfil em formação")).toBeInTheDocument();
+    expect(within(header).getAllByText("3").length).toBeGreaterThan(0);
+    expect(within(header).getByText("Leituras")).toBeInTheDocument();
+    expect(within(header).getByText("1")).toBeInTheDocument();
+    expect(within(header).getByText("Padrões")).toBeInTheDocument();
+    expect(within(header).getByText("Oportunidades")).toBeInTheDocument();
+  });
+
+  it("renderiza hero com headline, subheadline/statusLabel e capitulos", () => {
+    renderState();
+
+    expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Um padrão começa a se repetir")).toBeInTheDocument();
+    expect(screen.getByText("Padrão em formação")).toBeInTheDocument();
+    expect(screen.getAllByText(/narrativa recorrente|começa a se repetir/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Seu padrão")).toBeInTheDocument();
+  });
+
+  it("CTA principal Nova leitura tem prioridade maior que Ler diagnostico completo", () => {
+    renderState();
+
+    expect(screen.getByRole("button", { name: "Nova leitura" })).toHaveAttribute("data-priority", "primary");
+    expect(screen.getByRole("button", { name: "Ler diagnóstico completo" })).toHaveAttribute(
+      "data-priority",
+      "secondary",
+    );
+  });
+
+  it("renderiza cards de capitulos com title e preview", () => {
+    renderState();
+
+    const profileSection = screen.getByLabelText("Capítulos — Perfil");
+    expect(within(profileSection).getByText("Seu padrão")).toBeInTheDocument();
+    expect(within(profileSection).getByText("Sua tensão")).toBeInTheDocument();
+    expect(within(profileSection).getByText("Seu movimento")).toBeInTheDocument();
+    expect(within(profileSection).getByText("Seu território")).toBeInTheDocument();
+    expect(within(profileSection).getAllByRole("button", { name: "Ler capítulo" })).toHaveLength(4);
+  });
+
+  it("cards nao exibem fullReading diretamente na tela principal", () => {
+    renderState();
+
+    expect(screen.queryByText(/Você parece ter mais força quando cuidado cotidiano/i)).not.toBeInTheDocument();
+  });
+
+  it("ao clicar em Ler capitulo abre modal com fullReading", () => {
+    renderState();
+    openFirstChapter();
+
+    const dialog = screen.getByRole("dialog", { name: "Seu padrão" });
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText(/síntese dry-run|leitura aparece/i)).toBeInTheDocument();
+  });
+
+  it("modal mostra evidence quando disponivel", () => {
+    renderState();
+    openFirstChapter();
+
+    const dialog = screen.getByRole("dialog", { name: "Seu padrão" });
+    expect(within(dialog).getByText("Onde isso aparece")).toBeInTheDocument();
+    expect(within(dialog).getAllByRole("listitem").length).toBeGreaterThan(0);
+  });
+
+  it("modal mostra action quando disponivel", () => {
+    renderState();
+    openFirstChapter();
+
+    const dialog = screen.getByRole("dialog", { name: "Seu padrão" });
+    expect(within(dialog).getByText("Como usar agora")).toBeInTheDocument();
+    expect(within(dialog).getAllByText(/3 vídeos|repetir/i).length).toBeGreaterThan(0);
+  });
+
+  it("modal fecha corretamente", () => {
+    renderState();
+    openFirstChapter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fechar capítulo" }));
+
+    expect(screen.queryByRole("dialog", { name: "Seu padrão" })).not.toBeInTheDocument();
+  });
+
+  it("botao Ler diagnostico completo abre leitura completa com multiplos capitulos", () => {
+    renderState();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ler diagnóstico completo" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Diagnóstico completo" });
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText("O que este vídeo revela")).toBeInTheDocument();
+    expect(within(dialog).getByText("Como pesa no Perfil")).toBeInTheDocument();
+    expect(within(dialog).getByText("Oportunidades em formação")).toBeInTheDocument();
+    expect(within(dialog).getByText(/Capítulos em sequência/)).toBeInTheDocument();
+  });
+
+  it("estado de primeira leitura nao crava padrao definitivo", () => {
+    const { container } = renderState("narrative_map_first_reading");
+    const text = renderedText(container);
+
+    expect(screen.getByText("Primeira leitura")).toBeInTheDocument();
+    expect(screen.getByText("Seu mapa começou")).toBeInTheDocument();
+    expect(text).toContain("ainda é cedo");
+    expect(text).not.toContain("padrão reforçado");
+    expect(text).not.toContain("padrão definitivo");
+  });
+
+  it("estado com Instagram conectado mostra copy de precisao sem prometer performance", () => {
+    const { container } = renderState("narrative_map_instagram");
+    const text = renderedText(container);
+
+    expect(screen.getByText("Cruzado com Instagram")).toBeInTheDocument();
+    expect(text).toContain("cruzado com instagram");
+    expect(screen.queryByRole("tab", { name: "Instagram" })).not.toBeInTheDocument();
+    expect(text).not.toContain("desempenho garantido");
+  });
+
+  it("estado de oportunidades nao promete match real, marca real ou creator real", () => {
+    const { container } = renderState("narrative_map_opportunities");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
+    const text = renderedText(container);
+
+    expect(text).toContain("território");
+    expect(text).toContain("fit narrativo");
+    expect(text).not.toContain("match real");
+    expect(text).not.toContain("marca real");
+    expect(text).not.toContain("creator real");
+    expect(text).not.toContain("publi garantida");
+  });
+
+  it("renderiza aba Leituras com leitura atual e recentes", () => {
+    renderState();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+
+    expect(screen.getByText("Leituras documentadas")).toBeInTheDocument();
+    expect(screen.getByText(/Cada vídeo enviado vira uma leitura/)).toBeInTheDocument();
+    expect(screen.getAllByText("Vídeo sobre humor cotidiano com identificação rápida").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Narrativa reforçada").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Ver leitura" }).length).toBeGreaterThan(0);
+  });
+
+  it("clicar em Ver leitura abre detalhe seguro", () => {
+    renderState();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Ver leitura" })[0]);
+
+    const dialog = screen.getByRole("dialog", { name: "Vídeo sobre humor cotidiano com identificação rápida" });
+    expect(within(dialog).getByText("Contribuição")).toBeInTheDocument();
+    expect(within(dialog).getByText("Como pesa no Perfil")).toBeInTheDocument();
+    expect(within(dialog).queryByText(/thumbnailUrl|objectKey|signedUrl|uploadUrl|localPath|storageProviderPath/)).not.toBeInTheDocument();
+  });
+
+  it("renderiza empty state quando não há leituras", () => {
+    renderState("narrative_map_empty_readings");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+
+    expect(screen.getByText("Nenhuma leitura documentada ainda")).toBeInTheDocument();
+  });
+
+  it("renderiza Oportunidades pelo view model sem match real", () => {
+    const { container } = renderState("narrative_map_opportunities");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
+
+    expect(screen.getAllByText("Territórios em formação").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Fit narrativo possível/)).toBeInTheDocument();
+    expect(renderedText(container)).not.toContain("match real");
+  });
+
+  it("preview renderiza síntese acumulada no hero e Perfil", () => {
+    renderState("narrative_map_three_related_readings");
+
+    expect(screen.getByText("Um padrão começa a se repetir")).toBeInTheDocument();
+    expect(screen.getByText("Seu padrão")).toBeInTheDocument();
+    expect(screen.getByText("Sua tensão")).toBeInTheDocument();
+    expect(screen.getByText("Seu movimento")).toBeInTheDocument();
+    expect(screen.getByText("Seu território")).toBeInTheDocument();
+  });
+
+  it("preview renderiza sinal emergente para duas leituras", () => {
+    renderState("narrative_map_two_related_readings");
+
+    expect(screen.getByText("Um sinal começa a aparecer")).toBeInTheDocument();
+    expect(screen.getByText("Sinais em formação")).toBeInTheDocument();
+  });
+
+  it("preview mostra Leituras recentes a partir da síntese", () => {
+    renderState("narrative_map_three_related_readings");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Leituras" }));
+
+    expect(screen.getAllByText("Vídeo sobre humor cotidiano com identificação rápida").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Ver leitura" })).toHaveLength(3);
+  });
+
+  it("preview mostra Oportunidades com territórios da síntese", () => {
+    renderState("narrative_map_commercial_signals");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
+
+    expect(screen.getAllByText(/rotina real/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Collab de problema/i)).toBeInTheDocument();
+  });
+
+  it("preview nao chama endpoint real ou mock", () => {
+    const source = SOURCE_FILES
+      .map((file) => fs.readFileSync(path.join(__dirname, file), "utf8"))
+      .join("\n");
+
+    expect(source).not.toMatch(/fetch\(|axios|analyze-real\/route|analyze\/route|api\/dashboard\/mobile-strategic-profile|videoNarrativeEndpointMockMode/);
+  });
+
+  it("preview nao importa SDKs, Mongoose, service de persistencia ou CreatorStrategicProfileSnapshot", () => {
+    const source = SOURCE_FILES
+      .map((file) => fs.readFileSync(path.join(__dirname, file), "utf8"))
+      .join("\n");
+
+    expect(source).not.toMatch(/@google\/genai|@aws-sdk|from ["']mongoose["']|CreatorVideoNarrativeDiagnosis\.|creatorVideoNarrativeDiagnosisService|createCreatorVideoNarrativeDiagnosis|CreatorStrategicProfileSnapshot/);
+  });
+
+  it("preview nao altera MobileStrategicProfile real fora do ambiente interno", () => {
+    const source = fs.readFileSync(path.join(__dirname, "MobileStrategicProfilePreview.tsx"), "utf8");
+
+    expect(source).not.toContain("NarrativeMapReadingPreview");
+    expect(source).not.toContain("narrative_map_chapters");
+  });
+
+  it("nao exibe termos proibidos na UI", () => {
+    const { container } = renderState("narrative_map_opportunities");
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
+    const text = renderedText(container);
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "viralizar",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "match real",
+      "publi garantida",
+      "gemini",
+      "raw response",
+      "objectkey",
+      "signedurl",
+      "uploadurl",
+      "thumbnailurl",
+      "localpath",
+      "storageproviderpath",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  NARRATIVE_MAP_READING_PREVIEW_STATES,
+  type NarrativeMapReadingPreviewFixture,
+} from "./buildNarrativeMapReadingPreviewFixture";
+import { NarrativeMapMobileShell } from "./NarrativeMapMobileShell";
+
+function StateChip({
+  state,
+  active,
+}: {
+  state: string;
+  active: boolean;
+}) {
+  return (
+    <a
+      href={`/dashboard/boards/mobile-strategic-profile-preview?state=${state}`}
+      className={
+        active
+          ? "shrink-0 rounded-full bg-zinc-950 px-3 py-1.5 text-xs font-semibold text-white"
+          : "shrink-0 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700"
+      }
+    >
+      {state.replace("narrative_map_", "").replaceAll("_", " ")}
+    </a>
+  );
+}
+
+export function NarrativeMapReadingPreview({ fixture }: { fixture: NarrativeMapReadingPreviewFixture }) {
+  return (
+    <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
+      <div className="mx-auto grid max-w-5xl gap-5">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Mapa narrativo</p>
+          <h1 className="mt-2 text-2xl font-semibold">Leituras em capítulos</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-700">
+            Harness mockado para validar cards curtos, leitura profunda sob demanda e variações de estado.
+          </p>
+          <nav className="mt-4 flex gap-2 overflow-x-auto pb-1" aria-label="Estados do mapa narrativo">
+            {NARRATIVE_MAP_READING_PREVIEW_STATES.map((state) => (
+              <StateChip key={state} state={state} active={state === fixture.id} />
+            ))}
+          </nav>
+        </header>
+
+        <NarrativeMapMobileShell
+          viewModel={fixture.viewModel}
+          presentation={fixture.presentation}
+          statusText={fixture.creator.status}
+          snapshotReview={fixture.synthesisSnapshotWrite}
+          internalReview
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapSnapshotReviewPanel.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapSnapshotReviewPanel.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
+
+export function NarrativeMapSnapshotReviewPanel({
+  review,
+  internal,
+}: {
+  review?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  internal?: boolean;
+}) {
+  if (!internal || !review) return null;
+
+  const rows = [
+    ["attempted", String(review.attempted)],
+    ["written", String(review.written)],
+    ["skippedReason", review.skippedReason ?? "none"],
+    ["synthesisStatus", review.synthesisStatus ?? "none"],
+    ["analyzedReadingsCount", String(review.analyzedReadingsCount ?? 0)],
+    ["updatedAt", review.updatedAt ?? "none"],
+    ["snapshotId", review.snapshotId ?? "none"],
+  ];
+
+  return (
+    <section className="mx-5 mb-4 rounded-[1.25rem] border border-zinc-200 bg-white p-4 shadow-sm" aria-label="Snapshot write review">
+      <p className="text-xs font-semibold uppercase text-zinc-500">Snapshot review interno</p>
+      <h3 className="mt-1 text-base font-semibold text-zinc-950">Escrita controlada do Perfil</h3>
+      <dl className="mt-3 grid gap-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-center justify-between gap-3 rounded-xl bg-zinc-50 px-3 py-2">
+            <dt className="text-xs font-semibold text-zinc-500">{label}</dt>
+            <dd className="max-w-[10rem] truncate text-right text-xs font-semibold text-zinc-800">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture.ts
@@ -1,0 +1,429 @@
+import {
+  buildCreatorNarrativeMapReadingPresentation,
+  type CreatorNarrativeMapReadingPresentation,
+} from "../../../videoUpload/creatorNarrativeMapReadingChapters";
+import { buildNarrativeMapReadingDiagnosisFixture } from "../../../videoUpload/creatorNarrativeMapReadingChaptersFixtures";
+import {
+  buildCreatorStrategicProfileSynthesis,
+  type CreatorStrategicProfileSynthesis,
+} from "../../../videoUpload/creatorStrategicProfileSynthesis";
+import {
+  buildCreatorStrategicProfileSynthesisReadingsFixture,
+  type CreatorStrategicProfileSynthesisFixtureState,
+} from "../../../videoUpload/creatorStrategicProfileSynthesisFixtures";
+import type { CreatorVideoNarrativeDiagnosisSafeReading } from "../../../videoUpload/creatorVideoNarrativeDiagnosisReadService";
+import {
+  buildNarrativeMapMobileViewModel,
+  type NarrativeMapMobileRecentReadingInput,
+  type NarrativeMapMobileViewModel,
+} from "../../../videoUpload/narrativeMapMobileViewModel";
+import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
+
+export type NarrativeMapReadingPreviewState =
+  | "narrative_map_chapters"
+  | "narrative_map_first_reading"
+  | "narrative_map_instagram"
+  | "narrative_map_opportunities"
+  | "narrative_map_empty_readings"
+  | "narrative_map_no_readings"
+  | "narrative_map_two_related_readings"
+  | "narrative_map_three_related_readings"
+  | "narrative_map_isolated_strong_video"
+  | "narrative_map_creative_deviation"
+  | "narrative_map_commercial_signals"
+  | "narrative_map_instagram_contextual";
+
+export const NARRATIVE_MAP_READING_PREVIEW_STATES: NarrativeMapReadingPreviewState[] = [
+  "narrative_map_chapters",
+  "narrative_map_first_reading",
+  "narrative_map_instagram",
+  "narrative_map_opportunities",
+  "narrative_map_empty_readings",
+  "narrative_map_no_readings",
+  "narrative_map_two_related_readings",
+  "narrative_map_three_related_readings",
+  "narrative_map_isolated_strong_video",
+  "narrative_map_creative_deviation",
+  "narrative_map_commercial_signals",
+  "narrative_map_instagram_contextual",
+];
+
+export interface NarrativeMapReadingPreviewFixture {
+  id: NarrativeMapReadingPreviewState;
+  label: string;
+  creator: {
+    name: string;
+    handle: string;
+    status: string;
+  };
+  metrics: {
+    readings: number;
+    patterns: number;
+    opportunities: number;
+  };
+  presentation: CreatorNarrativeMapReadingPresentation;
+  viewModel: NarrativeMapMobileViewModel;
+  synthesis: CreatorStrategicProfileSynthesis;
+  synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+}
+
+function first(value?: string | string[] | null): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export function isNarrativeMapReadingPreviewState(
+  value?: string | string[] | null,
+): value is NarrativeMapReadingPreviewState {
+  const id = first(value);
+  return NARRATIVE_MAP_READING_PREVIEW_STATES.some((state) => state === id);
+}
+
+function resolveState(value?: string | string[] | null): NarrativeMapReadingPreviewState {
+  const id = first(value);
+  return NARRATIVE_MAP_READING_PREVIEW_STATES.find((state) => state === id) ?? "narrative_map_chapters";
+}
+
+function recentReadingsFor(state: NarrativeMapReadingPreviewState): NarrativeMapMobileRecentReadingInput[] {
+  const readings = [
+    {
+      diagnosisId: "reading-1",
+      rememberedAs: "Vídeo sobre reunião que era para ser rápida",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      profileContribution: {
+        type: "confirms_existing_pattern",
+        confidence: "high",
+        weight: "high",
+        profileImpactPreview: "Reforça uma narrativa em formação.",
+      },
+    },
+    {
+      diagnosisId: "reading-2",
+      rememberedAs: "Vídeo sobre rotina adulta virando cena curta",
+      createdAt: "2026-05-18T10:00:00.000Z",
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "low",
+        weight: "low",
+        profileImpactPreview: "Abre uma hipótese para observar nas próximas leituras.",
+      },
+    },
+    {
+      diagnosisId: "reading-3",
+      rememberedAs: "Vídeo com bastidor e explicação prática",
+      createdAt: "2026-05-15T10:00:00.000Z",
+      profileContribution: {
+        type: "commercial_signal",
+        confidence: "medium",
+        weight: "medium",
+        profileImpactPreview: "Pode alimentar oportunidade futura se o território se repetir.",
+      },
+    },
+  ];
+
+  if (state === "narrative_map_empty_readings") return [];
+  if (state === "narrative_map_first_reading") return readings.slice(0, 1);
+  return readings;
+}
+
+function synthesisStateFor(state: NarrativeMapReadingPreviewState): CreatorStrategicProfileSynthesisFixtureState {
+  const map: Partial<Record<NarrativeMapReadingPreviewState, CreatorStrategicProfileSynthesisFixtureState>> = {
+    narrative_map_no_readings: "no_readings",
+    narrative_map_empty_readings: "no_readings",
+    narrative_map_first_reading: "first_reading",
+    narrative_map_two_related_readings: "two_related_readings",
+    narrative_map_chapters: "three_related_readings",
+    narrative_map_three_related_readings: "three_related_readings",
+    narrative_map_isolated_strong_video: "isolated_strong_video",
+    narrative_map_creative_deviation: "creative_deviation",
+    narrative_map_opportunities: "commercial_signals",
+    narrative_map_commercial_signals: "commercial_signals",
+    narrative_map_instagram: "instagram_contextual",
+    narrative_map_instagram_contextual: "instagram_contextual",
+  };
+  return map[state] ?? "three_related_readings";
+}
+
+function recentReadingsFromSafeReadings(
+  readings: CreatorVideoNarrativeDiagnosisSafeReading[],
+): NarrativeMapMobileRecentReadingInput[] {
+  return readings.map((reading) => ({
+    diagnosisId: reading.diagnosisId,
+    rememberedAs: reading.videoReading.rememberedAs,
+    createdAt: reading.analyzedAt ?? reading.createdAt ?? null,
+    profileContribution: {
+      type: reading.profileContribution.type,
+      confidence: reading.profileContribution.confidence,
+      weight: reading.profileContribution.weight,
+      profileImpactPreview: reading.profileContribution.profileImpactPreview,
+    },
+  }));
+}
+
+function buildFixture(params: {
+  state: NarrativeMapReadingPreviewState;
+  label: string;
+  creatorStatus: string;
+  metrics: NarrativeMapReadingPreviewFixture["metrics"];
+  presentation: CreatorNarrativeMapReadingPresentation;
+  readings?: CreatorVideoNarrativeDiagnosisSafeReading[];
+  synthesis?: CreatorStrategicProfileSynthesis;
+  instagramConnected?: boolean;
+  mediaKitAvailable?: boolean;
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+}): NarrativeMapReadingPreviewFixture {
+  const creator = {
+    name: "Lívia Linhares",
+    handle: "@livialinharess",
+    status: params.creatorStatus,
+  };
+  const recentReadings = params.readings
+    ? recentReadingsFromSafeReadings(params.readings)
+    : recentReadingsFor(params.state);
+  const synthesis = params.synthesis ?? buildCreatorStrategicProfileSynthesis({
+    readings: params.readings ?? [],
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+  });
+  return {
+    id: params.state,
+    label: params.label,
+    creator,
+    metrics: params.metrics,
+    presentation: params.presentation,
+    synthesis,
+    synthesisSnapshotWrite: params.synthesisSnapshotWrite ?? {
+      attempted: true,
+      written: params.state !== "narrative_map_no_readings" && params.state !== "narrative_map_empty_readings",
+      skippedReason: params.state === "narrative_map_no_readings" || params.state === "narrative_map_empty_readings"
+        ? "synthesis_empty"
+        : null,
+      synthesisStatus: synthesis.status,
+      analyzedReadingsCount: synthesis.analyzedReadingsCount,
+      updatedAt: synthesis.generatedAt,
+    },
+    viewModel: buildNarrativeMapMobileViewModel({
+      displayName: creator.name,
+      displayHandle: creator.handle,
+      currentPresentation: params.presentation,
+      recentReadings,
+      profileSynthesis: synthesis,
+      accessLevel: params.accessLevel,
+      instagramConnected: params.instagramConnected,
+      mediaKitAvailable: params.mediaKitAvailable,
+      activeTab: "profile",
+    }),
+  };
+}
+
+export function buildNarrativeMapReadingPreviewFixture(params: {
+  state?: string | string[] | null;
+} = {}): NarrativeMapReadingPreviewFixture {
+  const state = resolveState(params.state);
+  const baseDiagnosis = buildNarrativeMapReadingDiagnosisFixture();
+  const synthesisReadings = buildCreatorStrategicProfileSynthesisReadingsFixture(synthesisStateFor(state));
+  const synthesis = buildCreatorStrategicProfileSynthesis({
+    readings: synthesisReadings,
+    accessLevel: state === "narrative_map_instagram" || state === "narrative_map_instagram_contextual"
+      ? "instagram_optimized"
+      : "premium",
+    instagramConnected: state === "narrative_map_instagram" || state === "narrative_map_instagram_contextual",
+  });
+
+  if (
+    state === "narrative_map_no_readings" ||
+    state === "narrative_map_two_related_readings" ||
+    state === "narrative_map_three_related_readings" ||
+    state === "narrative_map_isolated_strong_video" ||
+    state === "narrative_map_creative_deviation" ||
+    state === "narrative_map_commercial_signals" ||
+    state === "narrative_map_instagram_contextual"
+  ) {
+    const currentReading = synthesisReadings[0];
+    return buildFixture({
+      state,
+      label: state.replace("narrative_map_", "").replaceAll("_", " "),
+      creatorStatus: synthesis.status === "empty" ? "Perfil aguardando leitura" : synthesisStatusToLabel(synthesis.status),
+      metrics: {
+        readings: synthesisReadings.length,
+        patterns: synthesis.recurringPatterns.length,
+        opportunities: synthesis.commercialTerritories.length + synthesis.collabTerritories.length,
+      },
+      presentation: buildCreatorNarrativeMapReadingPresentation({
+        diagnosis: currentReading
+          ? {
+              diagnosisId: currentReading.diagnosisId,
+              status: currentReading.status,
+              videoReading: currentReading.videoReading,
+              speechReading: currentReading.speechReading,
+              productionReading: currentReading.productionReading,
+              commercialReading: currentReading.commercialReading,
+              strategicRecommendation: currentReading.strategicRecommendation,
+              profileContribution: currentReading.profileContribution,
+              createdAt: currentReading.createdAt,
+            }
+          : {
+              ...baseDiagnosis,
+              diagnosisId: "empty-synthesis-reading",
+              profileContribution: {
+                type: "needs_more_samples",
+                confidence: "low",
+                weight: "low",
+                reason: "Ainda não há leitura salva.",
+                profileImpactPreview: "O Perfil aguarda a primeira leitura documentada.",
+              },
+            },
+        accessLevel: "premium",
+        instagramConnected: state === "narrative_map_instagram_contextual",
+        analyzedVideosCount: synthesisReadings.length,
+      }),
+      readings: synthesisReadings,
+      synthesis,
+      accessLevel: state === "narrative_map_instagram_contextual" ? "instagram_optimized" : "premium",
+      instagramConnected: state === "narrative_map_instagram_contextual",
+      mediaKitAvailable: state === "narrative_map_commercial_signals",
+    });
+  }
+
+  if (state === "narrative_map_first_reading") {
+    return buildFixture({
+      state,
+      label: "Primeira leitura",
+      creatorStatus: "Perfil em formação",
+      metrics: { readings: 1, patterns: 0, opportunities: 1 },
+      presentation: buildCreatorNarrativeMapReadingPresentation({
+        diagnosis: {
+          ...baseDiagnosis,
+          profileContribution: {
+            type: "opens_new_hypothesis",
+            confidence: "low",
+            weight: "low",
+            reason: "Como primeira leitura, este vídeo levanta uma hipótese sem definir o Perfil geral.",
+            profileImpactPreview: "Cria uma primeira pista para acompanhar nas próximas análises.",
+          },
+        },
+        accessLevel: "free",
+        analyzedVideosCount: 1,
+      }),
+      readings: synthesisReadings,
+      synthesis,
+      accessLevel: "free",
+    });
+  }
+
+  if (state === "narrative_map_instagram") {
+    return buildFixture({
+      state,
+      label: "Instagram conectado",
+      creatorStatus: "Cruzado com Instagram",
+      metrics: { readings: 7, patterns: 2, opportunities: 3 },
+      presentation: buildCreatorNarrativeMapReadingPresentation({
+        diagnosis: baseDiagnosis,
+        accessLevel: "instagram_optimized",
+        instagramConnected: true,
+        analyzedVideosCount: 7,
+      }),
+      readings: synthesisReadings,
+      synthesis,
+      accessLevel: "instagram_optimized",
+      instagramConnected: true,
+    });
+  }
+
+  if (state === "narrative_map_opportunities") {
+    return buildFixture({
+      state,
+      label: "Oportunidades",
+      creatorStatus: "Perfil em formação",
+      metrics: { readings: 7, patterns: 2, opportunities: 4 },
+      presentation: buildCreatorNarrativeMapReadingPresentation({
+        diagnosis: {
+          ...baseDiagnosis,
+          commercialReading: {
+            ...baseDiagnosis.commercialReading,
+            summary: "Há sinais de rotina real, vida adulta, apps e humor de identificação.",
+            brandTerritories: ["rotina real", "vida adulta", "apps", "humor de identificação"],
+            whyItCouldFitBrands: "A creator transforma situações comuns em cenas que ajudam a explicar um problema real.",
+            adAdaptationIdea: "Testar fit narrativo com uma cena de problema, escolha e consequência prática.",
+            limitations: "Ainda precisa repetir o mesmo território em novas leituras antes de virar frente principal.",
+          },
+          profileContribution: {
+            type: "commercial_signal",
+            confidence: "medium",
+            weight: "medium",
+            reason: "Este vídeo abre um território comercial possível, sem indicar parceria fechada.",
+            profileImpactPreview: "Pode alimentar oportunidades futuras se o mesmo território aparecer em mais leituras.",
+          },
+        },
+        accessLevel: "premium",
+        analyzedVideosCount: 7,
+      }),
+      readings: synthesisReadings,
+      synthesis,
+      accessLevel: "premium",
+    });
+  }
+
+  if (state === "narrative_map_empty_readings") {
+    return buildFixture({
+      state,
+      label: "Sem leituras",
+      creatorStatus: "Perfil aguardando leitura",
+      metrics: { readings: 0, patterns: 0, opportunities: 0 },
+      presentation: buildCreatorNarrativeMapReadingPresentation({
+        diagnosis: {
+          ...baseDiagnosis,
+          diagnosisId: "empty-reading-state",
+          commercialReading: {
+            ...baseDiagnosis.commercialReading,
+            brandTerritories: [],
+            summary: "Territórios em formação aparecem depois de leituras repetidas.",
+            whyItCouldFitBrands: "Ainda não há fit narrativo possível para organizar.",
+            adAdaptationIdea: "A ponte para Mídia Kit depende de leituras futuras.",
+            limitations: "Sem leitura salva, não há oportunidade a apresentar.",
+          },
+          profileContribution: {
+            type: "needs_more_samples",
+            confidence: "low",
+            weight: "low",
+            reason: "Ainda não há leitura salva.",
+            profileImpactPreview: "O Perfil aguarda a primeira leitura documentada.",
+          },
+        },
+        accessLevel: "free",
+        analyzedVideosCount: 0,
+      }),
+      readings: synthesisReadings,
+      synthesis,
+      accessLevel: "free",
+    });
+  }
+
+  return buildFixture({
+    state,
+    label: "Capítulos",
+    creatorStatus: "Perfil em formação",
+    metrics: { readings: 7, patterns: 2, opportunities: 3 },
+    presentation: buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: baseDiagnosis,
+      accessLevel: "premium",
+      analyzedVideosCount: 7,
+    }),
+    readings: synthesisReadings,
+    synthesis,
+    accessLevel: "premium",
+    mediaKitAvailable: true,
+  });
+}
+
+function synthesisStatusToLabel(status: CreatorStrategicProfileSynthesis["status"]): string {
+  const labels: Record<CreatorStrategicProfileSynthesis["status"], string> = {
+    empty: "Perfil aguardando leitura",
+    first_reading: "Primeira leitura",
+    signals_emerging: "Sinais em formação",
+    pattern_in_formation: "Padrão em formação",
+    profile_consistent: "Perfil consistente",
+  };
+  return labels[status];
+}

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
@@ -60,6 +60,21 @@ describe("MobileStrategicProfilePreviewPage", () => {
     expect(screen.getByRole("button", { name: "Copiar link" })).toBeInTheDocument();
   });
 
+  it("state query can render narrative map reading preview harness", async () => {
+    process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED = "1";
+
+    render(
+      await MobileStrategicProfilePreviewPage({
+        viewer: adminViewer,
+        searchParams: { state: "narrative_map_chapters" },
+      }),
+    );
+
+    expect(screen.getByText("Preview interno — Mapa narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();
+    expect(screen.getByText("Ler diagnóstico completo")).toBeInTheDocument();
+  });
+
   it("does not import forbidden integrations or real UI surfaces", () => {
     const source = fs.readFileSync(path.join(__dirname, "page.tsx"), "utf8");
     const importLines = source

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
@@ -1,5 +1,10 @@
 import { MobileStrategicProfilePreview } from "../components/videoUpload/appPreview/MobileStrategicProfilePreview";
 import { buildMobileStrategicProfilePreviewFixture } from "../components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture";
+import { NarrativeMapReadingPreview } from "../components/videoUpload/appPreview/NarrativeMapReadingPreview";
+import {
+  buildNarrativeMapReadingPreviewFixture,
+  isNarrativeMapReadingPreviewState,
+} from "../components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture";
 import {
   canAccessInternalPreview,
   getCurrentInternalPreviewUser,
@@ -43,7 +48,11 @@ export default async function MobileStrategicProfilePreviewPage({
     return <BlockedInternalPreview reason="permission" />;
   }
 
-  const fixture = buildMobileStrategicProfilePreviewFixture({ state: searchParams?.state });
+  if (isNarrativeMapReadingPreviewState(searchParams?.state)) {
+    const fixture = buildNarrativeMapReadingPreviewFixture({ state: searchParams?.state });
+    return <NarrativeMapReadingPreview fixture={fixture} />;
+  }
 
+  const fixture = buildMobileStrategicProfilePreviewFixture({ state: searchParams?.state });
   return <MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} />;
 }

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
@@ -5,6 +5,7 @@ import { isMobileStrategicProfileEnabled } from "../videoUpload/mobileStrategicP
 import { getServerSession } from "next-auth";
 import { redirect, notFound } from "next/navigation";
 import { getStrategicProfileSnapshotByUserId } from "../videoUpload/mobileStrategicProfileSnapshotService";
+import { buildNarrativeMapMobileViewModelFromReadings } from "../videoUpload/narrativeMapMobileViewModelServerSelector";
 
 // Mock das dependências externas
 jest.mock("next-auth", () => ({
@@ -32,16 +33,21 @@ jest.mock("../videoUpload/mobileStrategicProfileSnapshotService", () => ({
   getStrategicProfileSnapshotByUserId: jest.fn(),
 }));
 
+jest.mock("../videoUpload/narrativeMapMobileViewModelServerSelector", () => ({
+  buildNarrativeMapMobileViewModelFromReadings: jest.fn(),
+}));
+
 // Mock do componente MobileStrategicProfileRealShellClient
 jest.mock(
   "../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient",
   () => {
     return {
-      MobileStrategicProfileRealShellClient: ({ session, stateQuery, initialSnapshotPayload }: any) => (
+      MobileStrategicProfileRealShellClient: ({ session, stateQuery, initialSnapshotPayload, initialNarrativeMapViewModel }: any) => (
         <div
           data-testid="real-profile-client-wrapper"
           data-statequery={stateQuery || ""}
           data-hassnapshot={initialSnapshotPayload ? "true" : "false"}
+          data-hasnarrativemap={initialNarrativeMapViewModel ? "true" : "false"}
         >
           <h1>{session?.user?.name || "Anonymous"}</h1>
           <p>{session?.user?.instagramUsername || ""}</p>
@@ -55,6 +61,10 @@ describe("MobileStrategicProfilePage Rota Real", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getStrategicProfileSnapshotByUserId as jest.Mock).mockResolvedValue(null);
+    (buildNarrativeMapMobileViewModelFromReadings as jest.Mock).mockResolvedValue({
+      viewModel: { id: "narrative-map-test" },
+      currentPresentation: { id: "presentation-test" },
+    });
   });
 
   it("bloqueia o acesso e chama notFound se a feature flag estiver desligada", async () => {
@@ -144,5 +154,30 @@ describe("MobileStrategicProfilePage Rota Real", () => {
 
     const wrapper = screen.getByTestId("real-profile-client-wrapper");
     expect(wrapper).toHaveAttribute("data-hassnapshot", "true");
+  });
+
+  it("MM85 monta e repassa o NarrativeMapMobileViewModel seguro para o shell real", async () => {
+    (isMobileStrategicProfileEnabled as jest.Mock).mockReturnValue(true);
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: {
+        id: "665f0f2c8a0b7d1f2c3a4b5c",
+        name: "Arthur Teste",
+        instagramConnected: true,
+        instagramUsername: "arthur.test",
+        planStatus: "active",
+      },
+    });
+
+    const jsx = await MobileStrategicProfilePage({});
+    render(jsx);
+
+    expect(buildNarrativeMapMobileViewModelFromReadings).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "665f0f2c8a0b7d1f2c3a4b5c",
+      displayName: "Arthur Teste",
+      displayHandle: "@arthur.test",
+      accessLevel: "premium",
+      instagramConnected: true,
+    }));
+    expect(screen.getByTestId("real-profile-client-wrapper")).toHaveAttribute("data-hasnarrativemap", "true");
   });
 });

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
@@ -4,6 +4,7 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { isMobileStrategicProfileEnabled } from "../videoUpload/mobileStrategicProfileFeatureFlag";
 import { MobileStrategicProfileRealShellClient } from "../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient";
 import { getStrategicProfileSnapshotByUserId } from "../videoUpload/mobileStrategicProfileSnapshotService";
+import { buildNarrativeMapMobileViewModelFromReadings } from "../videoUpload/narrativeMapMobileViewModelServerSelector";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,8 @@ export default async function MobileStrategicProfilePage({
 
   // 3. Obter o snapshot estratégico ativo persistido
   let initialSnapshotPayload = null;
+  let initialNarrativeMapViewModel = null;
+  let initialNarrativeMapPresentation = null;
   const isSnapshotEnabled = process.env.MOBILE_STRATEGIC_PROFILE_SNAPSHOT_ENABLED !== "0";
 
   if (isSnapshotEnabled && session.user?.id) {
@@ -46,6 +49,23 @@ export default async function MobileStrategicProfilePage({
     }
   }
 
+  if (session.user?.id) {
+    try {
+      const result = await buildNarrativeMapMobileViewModelFromReadings({
+        userId: session.user.id,
+        displayName: session.user.name ?? "Creator",
+        displayHandle: session.user.instagramUsername ? `@${session.user.instagramUsername}` : null,
+        accessLevel: session.user.planStatus === "active" ? "premium" : "free",
+        instagramConnected: Boolean(session.user.instagramConnected),
+        mediaKitAvailable: Boolean(initialSnapshotPayload?.opportunities?.length),
+      });
+      initialNarrativeMapViewModel = result.viewModel;
+      initialNarrativeMapPresentation = result.currentPresentation;
+    } catch (err) {
+      console.error("Erro silencioso ao montar mapa narrativo mobile:", err);
+    }
+  }
+
   // 4. Adapt session data and optional debug state to profile input
   const stateQuery = typeof searchParams?.state === "string" ? searchParams.state : null;
 
@@ -54,6 +74,8 @@ export default async function MobileStrategicProfilePage({
       session={session}
       stateQuery={stateQuery}
       initialSnapshotPayload={initialSnapshotPayload}
+      initialNarrativeMapViewModel={initialNarrativeMapViewModel}
+      initialNarrativeMapPresentation={initialNarrativeMapPresentation}
     />
   );
 }

--- a/src/app/dashboard/boards/videoUpload/MM74_VIDEO_READING_DOCUMENT_FOUNDATION.md
+++ b/src/app/dashboard/boards/videoUpload/MM74_VIDEO_READING_DOCUMENT_FOUNDATION.md
@@ -1,0 +1,28 @@
+# MM74 — Video Reading Document Foundation
+
+Cada vídeo enviado pelo creator deve gerar uma leitura estratégica documentada. O Perfil Estratégico geral continua sendo uma síntese acumulada das leituras e não deve ser sobrescrito pelo diagnóstico direto de um único upload.
+
+Este PR cria apenas a fundação documental da leitura por vídeo por meio de `CreatorVideoNarrativeDiagnosis`. Um vídeo isolado não atualiza diretamente a narrativa principal do Perfil; ele registra uma contribuição documentada em `profileContribution`, que poderá alimentar um agregador em milestone posterior.
+
+Guardrails desta fundação:
+
+- o vídeo não é salvo;
+- thumbnail não é salva;
+- signed URL não é salva;
+- upload URL não é salva;
+- objectKey não é salvo;
+- raw Gemini response não é salva;
+- transcrição longa não é salva;
+- referências de storage, tokens, secrets e base64 grande são bloqueados ou redigidos antes da persistência.
+
+Fora de escopo neste PR:
+
+- agregador do Perfil;
+- split completo do prompt Gemini;
+- integração com Gemini schema;
+- mudança no endpoint real de análise;
+- mudança no endpoint mock;
+- UI final de Perfil, Leituras ou Oportunidades;
+- modais de capítulos;
+- matches reais;
+- integração com Media Kit real.

--- a/src/app/dashboard/boards/videoUpload/MM75_VIDEO_READING_DOCUMENT_MAPPER_FOUNDATION.md
+++ b/src/app/dashboard/boards/videoUpload/MM75_VIDEO_READING_DOCUMENT_MAPPER_FOUNDATION.md
@@ -1,0 +1,26 @@
+# MM75 — Video Reading Mapper Foundation
+
+Este milestone adiciona um mapper puro para transformar camadas narrativas ja estruturadas em `CreatorVideoNarrativeDiagnosisInput`.
+
+O mapper consome apenas contratos internos ja normalizados, como diagnostico estrategico, diagnostico evolutivo, presentation model, seed e metadados seguros. Ele nao recebe raw Gemini response como fonte de verdade, nao chama Gemini, nao usa SDK de storage, nao persiste nada sozinho e nao atualiza o Perfil Estrategico geral.
+
+O papel desta camada e preparar o caminho para um PR futuro em que a leitura por video possa ser salva depois da analise, mantendo a separacao de produto:
+
+- diagnostico do video vira leitura documentada do video;
+- Perfil Estrategico geral continua sendo sintese acumulada;
+- um video isolado gera `profileContribution`, mas nao sobrescreve a narrativa principal do Perfil.
+
+Guardrails preservados:
+
+- sem raw model output;
+- sem video salvo;
+- sem thumbnail persistida;
+- sem signed URL;
+- sem upload URL;
+- sem objectKey;
+- sem storage provider path;
+- sem localPath;
+- sem transcricao longa;
+- sem atualizacao de `CreatorStrategicProfileSnapshot`.
+
+O `profileContribution` e deterministico e conservador: primeira leitura vira hipotese ou necessidade de mais amostras, recorrencia compativel pode confirmar padrao existente, e oportunidades comerciais viram apenas `commercial_signal` sem promessa de match real ou publi garantida.

--- a/src/app/dashboard/boards/videoUpload/MM76_VIDEO_READING_SAVE_ORCHESTRATOR_FOUNDATION.md
+++ b/src/app/dashboard/boards/videoUpload/MM76_VIDEO_READING_SAVE_ORCHESTRATOR_FOUNDATION.md
@@ -1,0 +1,21 @@
+# MM76 — Video Reading Save Orchestrator Foundation
+
+Este milestone cria a camada server-side que salva uma leitura documentada por video a partir de uma analise narrativa ja estruturada.
+
+O orquestrador usa o mapper do MM75 para montar `CreatorVideoNarrativeDiagnosisInput`, passa novamente pelo sanitizer do MM74 e chama o service do MM74 para criar o documento persistente. A funcao e injetavel para testes e para uma integracao futura controlada.
+
+Fora de escopo neste PR:
+
+- nao chama Gemini;
+- nao chama storage;
+- nao cria upload session;
+- nao faz cleanup;
+- nao pluga endpoint real;
+- nao pluga endpoint mock;
+- nao altera UI;
+- nao atualiza `CreatorStrategicProfileSnapshot`;
+- nao altera o Perfil Estrategico geral.
+
+O retorno do orquestrador e minimo e seguro: `ok`, `diagnosisId`, `documentId` quando seguro e um resumo de `profileContribution`. Em falhas, retorna apenas codigo e mensagem segura, sem stack trace, env, secrets, raw provider payload, raw model output ou referencias de storage.
+
+O Perfil geral continua sendo responsabilidade de uma sintese/agregador futuro. Esta camada apenas prepara o caminho para salvar a leitura por video depois que uma analise ja estruturada existir.

--- a/src/app/dashboard/boards/videoUpload/MM77_NARRATIVE_MAP_READING_CHAPTERS_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/MM77_NARRATIVE_MAP_READING_CHAPTERS_CONTRACT.md
@@ -1,0 +1,71 @@
+# MM77 — Narrative Map Reading Chapters Contract
+
+Este milestone cria o contrato editorial que transforma uma `CreatorVideoNarrativeDiagnosis` ja documentada em capitulos humanos para a experiencia futura de mapa narrativo.
+
+## Decisao
+
+A tela principal deve mostrar cards curtos. Cada card representa um capitulo da leitura e pode abrir, em milestone futura, um modal ou bottom sheet com a leitura completa.
+
+A experiencia segue a formula:
+
+- card = espelho rapido;
+- modal = leitura profunda;
+- diagnostico completo = capitulos organizados.
+
+## O que foi criado
+
+- `CreatorNarrativeMapReadingChapter`
+- `CreatorNarrativeMapReadingPresentation`
+- `buildCreatorNarrativeMapReadingPresentation`
+
+O builder e puro, testavel e sem banco. Ele recebe uma leitura por video ja persistivel/documentada e devolve uma apresentacao editorial com:
+
+- headline;
+- subheadline;
+- statusLabel;
+- primaryAction;
+- safetyNote;
+- capitulos `pattern`, `tension`, `movement`, `territory`, `video_reveal`, `profile_impact` e `opportunities`.
+
+## Regras editoriais
+
+A camada traduz diagnostico documentado em leitura humana. A inspiracao e um espelho estrategico, nao um relatorio tecnico.
+
+Os capitulos usam:
+
+- espelho;
+- evidencia;
+- movimento.
+
+Quando ainda nao ha dados suficientes, o builder gera capitulos honestos:
+
+- ainda e cedo para cravar padrao;
+- este video abre uma hipotese inicial;
+- mais leituras ajudam a confirmar repeticao.
+
+## Guardrails
+
+Este PR nao cria endpoint, UI, agregador do Perfil ou matches reais.
+
+O builder nao:
+
+- chama Gemini;
+- chama storage;
+- persiste nada sozinho;
+- atualiza `CreatorStrategicProfileSnapshot`;
+- altera endpoint real ou endpoint mock;
+- altera upload, cleanup, billing, Stripe, NextAuth, shells, sidebar, MediaKitView ou Comunidade.
+
+Oportunidades seguem como territorios e fit narrativo em formacao, sem promessa de marca real ou parceria fechada.
+
+## Caminho futuro
+
+Em milestones posteriores, a UI mobile podera consumir este contrato para montar:
+
+- `Perfil`;
+- `Leituras`;
+- `Oportunidades`;
+- cards de leitura;
+- modais ou bottom sheets de capitulo.
+
+O Perfil geral continuara sendo atualizado apenas por sintese/agregador futuro, nunca diretamente por um unico video.

--- a/src/app/dashboard/boards/videoUpload/MM78_NARRATIVE_MAP_READING_CHAPTERS_PREVIEW_HARNESS.md
+++ b/src/app/dashboard/boards/videoUpload/MM78_NARRATIVE_MAP_READING_CHAPTERS_PREVIEW_HARNESS.md
@@ -1,0 +1,60 @@
+# MM78 — Narrative Map Reading Chapters Preview Harness
+
+Este milestone cria apenas um preview interno para validar a experiencia editorial criada no MM77.
+
+## Decisao
+
+A experiencia testada e:
+
+- card curto na tela principal;
+- leitura profunda sob demanda;
+- diagnostico completo em painel interno;
+- variacoes de primeira leitura, Instagram conectado e oportunidades em formacao.
+
+O preview usa fixtures e o builder puro do MM77. Ele nao chama endpoint, nao salva documentos e nao altera a UI real do Perfil Estrategico.
+
+## O que foi criado
+
+- `NarrativeMapReadingPreview`
+- `NarrativeMapReadingChapterCard`
+- `NarrativeMapReadingChapterModal`
+- `NarrativeMapReadingFullDiagnosisModal`
+- `buildNarrativeMapReadingPreviewFixture`
+
+O harness pode ser acessado pela rota interna ja protegida do preview mobile usando estados `narrative_map_*`.
+
+## O que a UX valida
+
+- A tela principal mostra o espelho.
+- O modal mostra a leitura.
+- Cards fechados entregam valor sozinhos.
+- Evidencias aparecem como lista curta.
+- A acao do capitulo fica clara.
+- O diagnostico completo existe, mas nao compete com a acao principal de nova leitura.
+
+## Guardrails
+
+Este PR nao:
+
+- pluga endpoint real;
+- pluga endpoint mock;
+- salva documento;
+- chama Gemini;
+- chama storage;
+- altera upload ou cleanup;
+- altera `CreatorStrategicProfileSnapshot`;
+- cria agregador do Perfil;
+- altera `MobileStrategicProfilePreview`;
+- altera `MediaKitView`, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegacao real.
+
+Instagram aparece apenas como camada de precisao. Oportunidades seguem como territorios e fit narrativo em formacao, sem match real ou promessa comercial.
+
+## Caminho futuro
+
+Um PR posterior pode transformar este harness em componentes de UI reais quando existir decisao de produto sobre a estrutura final:
+
+- Perfil;
+- Leituras;
+- Oportunidades;
+- bottom sheet de capitulo;
+- leitura completa.

--- a/src/app/dashboard/boards/videoUpload/MM79_NARRATIVE_MAP_READING_PREVIEW_QA_POLISH.md
+++ b/src/app/dashboard/boards/videoUpload/MM79_NARRATIVE_MAP_READING_PREVIEW_QA_POLISH.md
@@ -1,0 +1,74 @@
+# MM79 — Narrative Map Reading Preview QA Polish
+
+Este milestone revisa a experiencia visual e textual do preview interno criado no MM78.
+
+## O que foi revisado
+
+- Topo compacto do creator.
+- Hero do mapa narrativo.
+- Hierarquia dos CTAs.
+- Cards de capitulos.
+- Bottom sheet de capitulo.
+- Painel de diagnostico completo.
+- Estados de primeira leitura, Instagram conectado e oportunidades.
+- Testes de regressao textual e de guardrails.
+
+## Decisoes de UX
+
+- A tela principal mostra o espelho: nome, status, metricas curtas, hero e cards.
+- O card fechado precisa entregar valor sem exigir abertura.
+- O modal aprofunda a leitura com texto, evidencias e acao pratica.
+- O diagnostico completo fica secundario e organizado em sequencia.
+- Instagram aparece como camada de precisao, nao como aba.
+- Oportunidades continuam como territorio e fit narrativo em formacao.
+
+## Checklist de QA visual
+
+- Topo nao domina a tela.
+- Hero comunica a leitura em poucos segundos.
+- Card fechado ja entrega valor.
+- Modal aprofunda sem virar PDF.
+- Diagnostico completo e opcional.
+- Instagram aparece como camada de precisao.
+- Oportunidades nao prometem match real.
+- A linguagem soa humana, nao tecnica.
+- A experiencia segue espelho, evidencia e movimento.
+
+## Checklist de microcopy
+
+- Usar "Seu mapa narrativo".
+- Usar "Nova leitura" como CTA principal.
+- Usar "Ler diagnostico completo" como CTA secundario.
+- Usar "Onde isso aparece" para evidencias.
+- Usar "Como usar agora" para acao pratica.
+- Usar primeira leitura como hipotese, nao conclusao.
+- Evitar linguagem tecnica, mística ou de promessa comercial.
+
+## Guardrails mantidos
+
+Este PR nao:
+
+- altera endpoint real ou endpoint mock;
+- chama Gemini;
+- chama storage;
+- salva documento;
+- altera upload ou cleanup;
+- altera `CreatorStrategicProfileSnapshot`;
+- cria agregador do Perfil;
+- altera UI real do Perfil;
+- altera `MediaKitView`, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegacao real.
+
+Termos como object key, signed URL, storage, raw response e Gemini seguem fora da UI. Eles podem aparecer apenas em testes ou documentacao de guardrail.
+
+## Fora do escopo
+
+- Integrar endpoint real.
+- Integrar endpoint mock.
+- Salvar leitura por video.
+- Criar UI final de Perfil, Leituras e Oportunidades.
+- Criar agregador do Perfil.
+- Criar matches reais.
+
+## Proximo passo sugerido
+
+O proximo PR pode criar uma camada de adapter para escolher, em ambiente interno, qual leitura documentada alimenta o preview sem ainda plugar endpoint real ou persistencia nova.

--- a/src/app/dashboard/boards/videoUpload/MM80_NARRATIVE_MAP_READING_PREVIEW_ADAPTER_CONTRACT.md
+++ b/src/app/dashboard/boards/videoUpload/MM80_NARRATIVE_MAP_READING_PREVIEW_ADAPTER_CONTRACT.md
@@ -1,0 +1,52 @@
+# MM80 — Narrative Map Reading Preview Adapter Contract
+
+Este milestone cria um adapter puro para organizar leituras documentadas e capitulos editoriais em um view model da futura experiencia mobile.
+
+## Decisao
+
+O adapter transforma dados ja estruturados em `NarrativeMapMobileViewModel`.
+
+Ele nao busca dados, nao salva dados, nao chama endpoint e nao cria estrategia nova. A funcao apenas normaliza o que a UI precisa renderizar.
+
+## Experiencia futura
+
+A experiencia final sera organizada em:
+
+- Perfil;
+- Leituras;
+- Oportunidades.
+
+Perfil mostra o mapa narrativo atual. Leituras mostram evidencias documentadas por video. Oportunidades mostram territorios, fit narrativo e caminhos comerciais em formacao.
+
+## Regras de produto
+
+- Instagram e camada de precisao, nao aba.
+- Oportunidades sao territorios e fit narrativo enquanto nao houver match real.
+- Leituras usam `rememberedAs`, nao thumbnail persistida.
+- Um video isolado continua sendo leitura documentada, nao atualizacao direta do Perfil geral.
+- O CTA principal continua sendo "Nova leitura".
+- O diagnostico completo continua secundario.
+
+## Guardrails
+
+Este PR nao:
+
+- altera endpoint real ou endpoint mock;
+- chama Gemini;
+- chama storage;
+- busca banco;
+- salva documento;
+- altera `CreatorStrategicProfileSnapshot`;
+- cria agregador do Perfil;
+- altera UI real;
+- altera `MediaKitView`, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegacao real.
+
+O adapter nao importa service de persistencia, Mongoose/model direto, Gemini SDK, storage SDK ou endpoint real/mock.
+
+## Preview interno
+
+O harness interno passa a consumir o view model para header, hero, tabs e acoes, mas continua preview interno. Cards e modais seguem mockados e isolados.
+
+## Proximo passo sugerido
+
+Um proximo PR pode criar um adapter server-side controlado para montar este view model a partir de leituras ja consultadas por outro fluxo, ainda sem alterar endpoint real ou UI final.

--- a/src/app/dashboard/boards/videoUpload/MM81_MOCK_READING_LOOP_RETRIEVAL_PREVIEW_WIRING.md
+++ b/src/app/dashboard/boards/videoUpload/MM81_MOCK_READING_LOOP_RETRIEVAL_PREVIEW_WIRING.md
@@ -1,0 +1,71 @@
+# MM81 — Mock Reading Loop + Retrieval + Preview Wiring
+
+Status: concluído.
+
+Este PR fecha o primeiro ciclo mock seguro de leitura documentada por vídeo:
+
+análise mock estruturada → save orchestrator MM76 → `CreatorVideoNarrativeDiagnosis` salvo → retrieval seguro → selector server-side → adapter MM80 → preview interno em `Perfil | Leituras | Oportunidades`.
+
+## O que foi criado
+
+- `creatorVideoNarrativeDiagnosisReadService.ts`
+  - lista leituras por `userId`;
+  - busca leitura por `userId + diagnosisId`;
+  - limita leituras recentes;
+  - projeta apenas campos seguros para UI;
+  - não retorna metadados de arquivo, links, chaves, resposta bruta de modelo ou transcrição longa.
+
+- `narrativeMapMobileViewModelServerSelector.ts`
+  - recebe leituras já consultadas ou consulta pelo read service injetável;
+  - escolhe a leitura atual por `diagnosisId` ou usa a mais recente;
+  - monta `CreatorNarrativeMapReadingPresentation` via MM77;
+  - monta `NarrativeMapMobileViewModel` via MM80;
+  - retorna empty state quando não há leitura.
+
+- `creatorVideoNarrativeDiagnosisMockSaveIntegration.ts`
+  - conecta o fluxo mock interno ao save orchestrator MM76;
+  - roda apenas quando o endpoint interno recebe `persistReading: true`;
+  - devolve summary seguro quando o save falha.
+
+- Preview interno
+  - a rota interna continua sendo `/dashboard/boards/mobile-strategic-profile-preview`;
+  - o preview passa a renderizar `Perfil | Leituras | Oportunidades` a partir do view model;
+  - a aba `Leituras` mostra leitura atual, leituras recentes, `rememberedAs`, `contributionLabel`, `profileImpactPreview`, `dateLabel` e CTA `Ver leitura`;
+  - `Ver leitura` abre um detalhe seguro, sem mídia persistida.
+
+## Guardrails mantidos
+
+- Não pluga endpoint real.
+- Não chama Gemini real.
+- Não chama SDK de storage.
+- Não salva vídeo, thumbnail, signed URL, upload URL, object key ou path local.
+- Não atualiza `CreatorStrategicProfileSnapshot`.
+- Não cria agregador do Perfil.
+- Não altera UI real fora do preview interno.
+- Não altera MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell ou sidebar.
+- Não promete match real, marca real, creator real ou publi garantida.
+
+## UX validada
+
+A aba `Leituras` comunica:
+
+> Cada vídeo enviado vira uma leitura. O Perfil junta essas leituras para separar padrão, hipótese, desvio criativo e oportunidade.
+
+Os itens usam linguagem humana, por exemplo:
+
+- Hoje
+- Narrativa reforçada
+- Vídeo sobre reunião que era para ser rápida
+- Esse vídeo reforça um sinal de humor cotidiano com identificação rápida.
+- Ver leitura
+
+A aba `Oportunidades` continua limitada a:
+
+- Territórios em formação
+- Fit narrativo possível
+- Tipo de collab possível
+- Ponte para Mídia Kit
+
+## Próximo passo
+
+O próximo PR stacked sugerido é `Profile Synthesis V1 dry-run`: consumir leituras seguras já persistidas para gerar uma síntese seca do Perfil, sem atualizar `CreatorStrategicProfileSnapshot` e sem publicar efeito em UI real.

--- a/src/app/dashboard/boards/videoUpload/MM82_PROFILE_SYNTHESIS_DRY_RUN_PREVIEW.md
+++ b/src/app/dashboard/boards/videoUpload/MM82_PROFILE_SYNTHESIS_DRY_RUN_PREVIEW.md
@@ -1,0 +1,56 @@
+# MM82 — Profile Synthesis V1 Dry-Run + Preview
+
+Status: concluído.
+
+Este PR cria a primeira síntese acumulada do Perfil Estratégico a partir de leituras documentadas por vídeo.
+
+O fluxo validado é:
+
+`CreatorVideoNarrativeDiagnosis[]` → síntese dry-run do Perfil → `NarrativeMapMobileViewModel` enriquecido → preview interno.
+
+## O que foi criado
+
+- `creatorStrategicProfileSynthesis.ts`
+  - agregador puro e determinístico;
+  - consome leituras seguras já documentadas;
+  - gera status conservador: `empty`, `first_reading`, `signals_emerging`, `pattern_in_formation`, `profile_consistent`;
+  - organiza narrativa principal, narrativas em teste, padrões, tensões, forças, territórios comerciais e próximo movimento;
+  - protege contra uma leitura isolada virar narrativa principal de alta confiança.
+
+- `creatorStrategicProfileSynthesisFixtures.ts`
+  - fixtures para `no_readings`, `first_reading`, `two_related_readings`, `three_related_readings`, `isolated_strong_video`, `creative_deviation`, `commercial_signals` e `instagram_contextual`.
+
+- Integração com `narrativeMapMobileViewModelServerSelector.ts`
+  - o selector monta a síntese dry-run a partir das leituras recentes;
+  - o view model passa a receber a síntese como entrada opcional;
+  - a UI interna mostra o Perfil como síntese acumulada, não como a última leitura isolada.
+
+- Preview interno
+  - adiciona estados internos para validar empty, primeira leitura, sinais emergentes, padrão em formação, vídeo forte isolado, desvio criativo, sinais comerciais e Instagram contextual;
+  - a aba Perfil reflete `Seu padrão`, `Sua tensão`, `Seu movimento` e `Seu território` derivados da síntese;
+  - a aba Leituras continua listando leituras documentadas;
+  - a aba Oportunidades usa territórios comerciais/tipos de collab possíveis da síntese.
+
+## Guardrails mantidos
+
+- Não atualiza `CreatorStrategicProfileSnapshot`.
+- Não persiste snapshot geral.
+- Não pluga endpoint real.
+- Não chama Gemini real.
+- Não chama storage/R2.
+- Não altera UI real fora do preview interno.
+- Não altera MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell ou sidebar.
+- Não promete match real, marca real, creator real ou publi garantida.
+
+## Regra crítica
+
+Um vídeo isolado nunca vira narrativa principal definitiva.
+
+- 0 leituras: empty state.
+- 1 leitura: `first_reading`, linguagem de primeiro sinal.
+- 2 leituras parecidas: `signals_emerging`, sinal em formação.
+- 3+ leituras parecidas: `pattern_in_formation` ou `profile_consistent`, ainda com linguagem conservadora.
+
+## Próximo passo
+
+O próximo PR stacked poderá persistir a síntese no snapshot geral, com guardrails fortes para separar dry-run, revisão e atualização real de `CreatorStrategicProfileSnapshot`.

--- a/src/app/dashboard/boards/videoUpload/MM83_PROFILE_SYNTHESIS_SNAPSHOT_GUARDED_PERSISTENCE.md
+++ b/src/app/dashboard/boards/videoUpload/MM83_PROFILE_SYNTHESIS_SNAPSHOT_GUARDED_PERSISTENCE.md
@@ -1,0 +1,74 @@
+# MM83 — Profile Synthesis Snapshot Guarded Persistence
+
+Status: concluido.
+
+## Objetivo
+
+Este PR cria o write path explicito da sintese acumulada do Perfil para o snapshot geral `CreatorStrategicProfileSnapshot`.
+
+O Perfil geral passa a ter uma rota segura para ser atualizado por sintese acumulada de leituras documentadas, e nao pelo ultimo video isolado.
+
+Fluxo permitido:
+
+`CreatorVideoNarrativeDiagnosis[] -> CreatorStrategicProfileSynthesis V1 -> CreatorStrategicProfileSnapshot`
+
+Fluxo proibido:
+
+`ultimo video -> snapshot geral sobrescrito diretamente`
+
+## O que foi criado
+
+- `creatorStrategicProfileSynthesisSnapshotMapper.ts`
+  - transforma `CreatorStrategicProfileSynthesis` em `MobileStrategicProfileSnapshotPayload`;
+  - preserva o schema atual do snapshot;
+  - adiciona metadados seguros em `extraData`;
+  - usa linguagem conservadora quando ha pouca evidencia;
+  - preserva padroes existentes quando a sintese isolada ainda nao tem evidencia suficiente.
+
+- `creatorStrategicProfileSynthesisPersistenceService.ts`
+  - expoe `persistCreatorStrategicProfileSynthesis`;
+  - usa `dry_run` por padrao;
+  - escreve somente quando `mode: "write"` e a sintese e valida;
+  - bloqueia escrita com sintese `empty`;
+  - retorna resultado seguro, sem documento completo e sem stack trace.
+
+- `video_reading_synthesis_v1`
+  - nova origem auditavel para o snapshot;
+  - separa atualizacao por sintese acumulada de sementes manuais, mock analysis e analises futuras.
+
+## Metadados seguros
+
+O snapshot pode receber em `extraData`:
+
+- `synthesisVersion`;
+- `synthesisUpdatedAt`;
+- `synthesisSource`;
+- `analyzedReadingsCount`;
+- `synthesisStatus`;
+- `synthesisWarnings`.
+
+Esses metadados nao incluem payload bruto de leitura, midia, storage, resposta de modelo ou transcricao longa.
+
+## Guardrails
+
+- Este PR ainda nao pluga endpoint real.
+- Este PR ainda nao chama Gemini.
+- Este PR ainda nao chama storage/R2.
+- Este PR ainda nao altera upload ou cleanup.
+- Este PR ainda nao altera UI real.
+- Este PR ainda nao cria matches reais.
+- Este PR ainda nao salva video, thumbnail, signed URL, objectKey, raw response ou transcricao longa.
+- O selector e o preview continuam dry-run e nao escrevem snapshot.
+
+## Regra anti-overwrite
+
+- `empty`: nao escreve no snapshot em modo `write`.
+- `first_reading`: persiste como primeiro sinal/hipotese, sem criar padrao recorrente.
+- `signals_emerging`: persiste como sinal em formacao, sem tratar como narrativa definitiva.
+- `pattern_in_formation` e `profile_consistent`: podem preencher padroes recorrentes quando ha evidencia acumulada.
+
+Uma leitura isolada nao pode virar narrativa principal definitiva do Perfil.
+
+## Proximo passo
+
+O proximo PR pode integrar esse write path ao fluxo controlado, provavelmente primeiro no mock/allowlist, mantendo a separacao entre leitura documentada, sintese acumulada e persistencia do snapshot geral.

--- a/src/app/dashboard/boards/videoUpload/MM84_CONTROLLED_MOCK_SYNTHESIS_SNAPSHOT_WRITE.md
+++ b/src/app/dashboard/boards/videoUpload/MM84_CONTROLLED_MOCK_SYNTHESIS_SNAPSHOT_WRITE.md
@@ -1,0 +1,76 @@
+# MM84 — Controlled Mock/Allowlist Synthesis Snapshot Write
+
+Status: concluido.
+
+## Objetivo
+
+Este PR conecta o write path do MM83 a um fluxo mock/internal controlado.
+
+Fluxo permitido:
+
+`mock/internal analysis -> save CreatorVideoNarrativeDiagnosis -> list readings for user -> build CreatorStrategicProfileSynthesis -> persist synthesis snapshot with mode: "write" -> safe audit result`
+
+## O que foi criado
+
+- `creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts`
+  - orquestra leitura salva, retrieval seguro, sintese acumulada e escrita do snapshot;
+  - exige `enableSnapshotWrite: true`;
+  - exige `source: "mock_internal"`;
+  - valida que a leitura salva esta entre as leituras recentes do usuario;
+  - chama `persistCreatorStrategicProfileSynthesis` com `mode: "write"`;
+  - retorna somente auditoria segura.
+
+- Integracao na rota interna `/api/internal/video-narrative/analyze`
+  - `persistSynthesisSnapshot: true` so tem efeito quando `persistReading: true` tambem salva a leitura;
+  - o comportamento existente permanece igual quando o parametro nao e enviado;
+  - falha de sintese/escrita nao quebra a resposta principal mock.
+
+## Retorno seguro
+
+A rota pode retornar:
+
+```json
+{
+  "synthesisSnapshotWrite": {
+    "attempted": true,
+    "written": true,
+    "synthesisStatus": "signals_emerging",
+    "analyzedReadingsCount": 2,
+    "updatedAt": "2026-05-20T00:00:00.000Z"
+  }
+}
+```
+
+Nao retorna:
+
+- snapshot completo;
+- payload do mapper;
+- leituras completas;
+- metadados de video;
+- referencias de midia;
+- resposta bruta de modelo;
+- stack trace.
+
+## Guardrails
+
+- Este PR ainda nao pluga endpoint real publico.
+- Este PR ainda nao chama Gemini real.
+- Este PR ainda nao chama storage/R2.
+- Este PR ainda nao altera upload/cleanup.
+- Este PR ainda nao altera UI real.
+- Este PR ainda nao altera MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell ou sidebar.
+- Este PR ainda nao cria matches reais.
+- Usuarios comuns continuam bloqueados pela regra existente de acesso interno.
+
+## Regra anti-overwrite
+
+O snapshot e atualizado por sintese acumulada.
+
+Uma leitura isolada pode registrar estado inicial/hipotese, mas nao pode virar padrao definitivo. Sintese vazia nao escreve snapshot. Padroes em formacao exigem recorrencia nas leituras documentadas.
+
+## Proximo passo
+
+O proximo PR pode decidir entre:
+
+- expor uma UI interna para acionar o write controlado; ou
+- integrar o fluxo real gated/allowlist, mantendo Gemini/storage e endpoint publico fora ate a decisao de produto.

--- a/src/app/dashboard/boards/videoUpload/MM85_REAL_MOBILE_NARRATIVE_MAP_SHELL_SNAPSHOT_REVIEW.md
+++ b/src/app/dashboard/boards/videoUpload/MM85_REAL_MOBILE_NARRATIVE_MAP_SHELL_SNAPSHOT_REVIEW.md
@@ -1,0 +1,70 @@
+# MM85 — Real Mobile Narrative Map Shell + Snapshot Review Panel
+
+Status: concluido.
+
+## Objetivo
+
+Este PR leva a experiencia mobile real do Perfil Estrategico para a organizacao:
+
+- Perfil;
+- Leituras;
+- Oportunidades.
+
+A experiencia passa a usar `NarrativeMapMobileViewModel`, leituras recentes seguras e sintese acumulada do Perfil.
+
+## Produto
+
+O Perfil Estrategico nao e o ultimo video.
+
+O Perfil Estrategico e uma sintese viva das leituras documentadas.
+
+Fluxo visual:
+
+- Perfil: mapa narrativo acumulado;
+- Leituras: evidencias por video;
+- Oportunidades: territorios de marca, tipos de collab e ponte para Midia Kit.
+
+## O que foi criado
+
+- `NarrativeMapMobileShell.tsx`
+  - shell mobile compartilhado para a experiencia `Perfil | Leituras | Oportunidades`;
+  - renderiza hero, metricas, capitulos, leituras recentes, oportunidades e safety note;
+  - abre detalhe seguro de leitura e diagnostico completo sob demanda.
+
+- `NarrativeMapSnapshotReviewPanel.tsx`
+  - painel interno discreto para auditoria do write controlado do snapshot;
+  - renderiza apenas `attempted`, `written`, `skippedReason`, `synthesisStatus`, `analyzedReadingsCount`, `updatedAt` e `snapshotId`.
+
+- Pagina real `/dashboard/boards/mobile-strategic-profile`
+  - monta server-side o `NarrativeMapMobileViewModel` com `buildNarrativeMapMobileViewModelFromReadings`;
+  - passa o view model para o shell client;
+  - preserva fallback antigo quando o mapa narrativo nao pode ser montado.
+
+## Snapshot review
+
+O painel de review e opt-in via prop interna.
+
+Ele nao mostra:
+
+- snapshot completo;
+- payload do mapper;
+- leituras completas;
+- videoMetadata;
+- raw response;
+- storage metadata;
+- stack trace.
+
+## Guardrails
+
+- Endpoint real publico continua intocado.
+- Gemini/storage continuam intocados.
+- Upload/cleanup continuam intocados.
+- Nao ha matches reais.
+- Nao ha thumbnail persistida.
+- Nao ha galeria, player, filename bruto ou metadata de storage.
+- `CreatorStrategicProfileSnapshot` nao e importado em client component.
+- MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell e sidebar continuam fora do escopo.
+
+## Proximo passo
+
+O proximo PR pode integrar uma acao interna de review para comparar snapshot atual, sintese dry-run e write audit antes de qualquer rollout real/gated.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,355 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM74 — Video Reading Document Foundation
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM74_VIDEO_READING_DOCUMENT_FOUNDATION.md`
+- `creatorVideoNarrativeDiagnosisTypes.ts`
+- `creatorVideoNarrativeDiagnosisSanitizer.ts`
+- `creatorVideoNarrativeDiagnosisService.ts`
+- `creatorVideoNarrativeDiagnosisFixtures.ts`
+- `src/app/models/CreatorVideoNarrativeDiagnosis.ts`
+
+O que faz:
+
+- cria o contrato documental `CreatorVideoNarrativeDiagnosis` para persistir uma leitura estratégica por vídeo;
+- mantém `profileContribution` como ponte explícita entre leitura do vídeo e síntese futura do Perfil;
+- sanitiza/redige referências a signed URLs, storage URLs, object keys, tokens e base64 grande;
+- restringe `videoMetadata` a metadados seguros;
+- bloqueia raw model responses e transcrições longas antes da persistência.
+
+O que não faz:
+
+- não altera endpoint real ou endpoint mock;
+- não chama Gemini;
+- não salva vídeo, thumbnail, upload URL, signed URL, objectKey ou raw response;
+- não atualiza `CreatorStrategicProfileSnapshot`;
+- não cria agregador do Perfil nem UI final de Leituras/Oportunidades.
+
+### MM75 — Video Reading Mapper Foundation
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM75_VIDEO_READING_DOCUMENT_MAPPER_FOUNDATION.md`
+- `creatorVideoNarrativeDiagnosisMapper.ts`
+- `creatorVideoNarrativeDiagnosisMapperFixtures.ts`
+- `creatorVideoNarrativeDiagnosisMapper.test.ts`
+
+O que faz:
+
+- cria um mapper puro de camadas estruturadas para `CreatorVideoNarrativeDiagnosisInput`;
+- consome diagnóstico estratégico, diagnóstico evolutivo, presentation model, seed e metadados seguros;
+- passa o resultado pelo sanitizer do MM74 antes de devolver o contrato persistível;
+- classifica `profileContribution` de forma determinística e conservadora;
+- mantém oportunidades comerciais como territórios futuros, sem match real ou promessa de publi.
+
+O que não faz:
+
+- não lê raw Gemini response;
+- não chama Gemini;
+- não importa Mongoose, SDK de storage ou código client-side;
+- não persiste nada sozinho;
+- não altera endpoint real ou endpoint mock;
+- não atualiza `CreatorStrategicProfileSnapshot`;
+- não cria agregador do Perfil nem UI.
+
+### MM76 — Video Reading Save Orchestrator Foundation
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM76_VIDEO_READING_SAVE_ORCHESTRATOR_FOUNDATION.md`
+- `creatorVideoNarrativeDiagnosisSaveOrchestrator.ts`
+- `creatorVideoNarrativeDiagnosisSaveOrchestratorFixtures.ts`
+- `creatorVideoNarrativeDiagnosisSaveOrchestrator.test.ts`
+
+O que faz:
+
+- cria um orquestrador server-side e injetável para salvar leitura documentada por vídeo;
+- usa mapper MM75 + sanitizer/service MM74;
+- retorna apenas `diagnosisId`, `documentId` seguro e resumo de `profileContribution`;
+- converte falhas de mapper/service em mensagens seguras sem stack trace ou payload sensível.
+
+O que não faz:
+
+- não pluga endpoint real ou endpoint mock;
+- não chama Gemini ou storage;
+- não cria upload session nem cleanup;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral;
+- não altera UI, MediaKit, Comunidade, billing, Stripe, NextAuth, shells ou sidebar.
+
+### MM77 — Narrative Map Reading Chapters Contract
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM77_NARRATIVE_MAP_READING_CHAPTERS_CONTRACT.md`
+- `creatorNarrativeMapReadingChapters.ts`
+- `creatorNarrativeMapReadingChaptersFixtures.ts`
+- `creatorNarrativeMapReadingChapters.test.ts`
+
+O que faz:
+
+- cria um contrato editorial puro para transformar `CreatorVideoNarrativeDiagnosis` em capítulos de leitura;
+- prepara cards curtos e leituras completas para modais/bottom sheets futuros;
+- traduz `profileContribution` em impacto humano no Perfil;
+- limita previews, full readings, evidências e ações;
+- mantém oportunidades como territórios/fit narrativo em formação.
+
+O que não faz:
+
+- não cria UI;
+- não altera endpoint real ou endpoint mock;
+- não chama Gemini ou storage;
+- não persiste documentos novos;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral;
+- não cria agregador do Perfil nem matches reais.
+
+### MM78 — Narrative Map Reading Chapters Preview Harness
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM78_NARRATIVE_MAP_READING_CHAPTERS_PREVIEW_HARNESS.md`
+- `../components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapReadingChapterCard.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapReadingChapterModal.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx`
+- `../components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture.ts`
+- `../components/videoUpload/appPreview/NarrativeMapReadingPreview.test.tsx`
+
+O que faz:
+
+- cria um preview interno para validar capítulos do mapa narrativo;
+- renderiza cards curtos e modais/bottom sheet com leitura profunda;
+- adiciona estados mockados para capítulos, primeira leitura, Instagram conectado e oportunidades;
+- expõe o harness apenas dentro da rota interna de preview já protegida.
+
+O que não faz:
+
+- não cria UI real do Perfil Estratégico;
+- não altera endpoint real ou endpoint mock;
+- não chama Gemini ou storage;
+- não salva documento;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral;
+- não altera upload, cleanup, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real.
+
+### MM79 — Narrative Map Reading Preview QA Polish
+
+Status: concluído.
+
+Arquivo principal:
+
+- `MM79_NARRATIVE_MAP_READING_PREVIEW_QA_POLISH.md`
+
+O que faz:
+
+- melhora espaçamento, hierarquia e microcopy do preview interno MM78;
+- reforça a fórmula card curto, leitura profunda sob demanda e diagnóstico completo opcional;
+- adiciona regressões de UX para topo compacto, CTAs, cards, modal e termos proibidos.
+
+O que não faz:
+
+- não altera UI real do Perfil Estratégico;
+- não altera endpoint real ou endpoint mock;
+- não chama Gemini ou storage;
+- não salva documento;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral.
+
+### MM80 — Narrative Map Reading Preview Adapter Contract
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM80_NARRATIVE_MAP_READING_PREVIEW_ADAPTER_CONTRACT.md`
+- `narrativeMapMobileViewModel.ts`
+- `narrativeMapMobileViewModelFixtures.ts`
+- `narrativeMapMobileViewModel.test.ts`
+
+O que faz:
+
+- cria um view model puro para a futura experiência `Perfil | Leituras | Oportunidades`;
+- organiza capítulos, leituras recentes, métricas, CTAs e oportunidades;
+- mantém Instagram como camada de precisão, sem criar aba própria;
+- mantém oportunidades como territórios e fit narrativo em formação;
+- permite que o preview interno consuma o view model sem virar UI real.
+
+O que não faz:
+
+- não altera endpoint real ou endpoint mock;
+- não busca banco nem salva documento;
+- não chama Gemini ou storage;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral;
+- não altera UI real, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real.
+
+### MM81 — Mock Reading Loop + Retrieval + Preview Wiring
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM81_MOCK_READING_LOOP_RETRIEVAL_PREVIEW_WIRING.md`
+- `creatorVideoNarrativeDiagnosisReadService.ts`
+- `narrativeMapMobileViewModelServerSelector.ts`
+- `creatorVideoNarrativeDiagnosisMockSaveIntegration.ts`
+- `../components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx`
+- `../components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture.ts`
+
+O que faz:
+
+- fecha o primeiro ciclo mock seguro de leitura documentada por vídeo;
+- permite salvar leitura no fluxo mock interno quando `persistReading: true`;
+- cria retrieval server-side user-scoped com shape seguro para UI;
+- cria selector server-side para escolher leitura atual/recentes e montar o view model MM80;
+- atualiza o preview interno para renderizar `Perfil | Leituras | Oportunidades` com leituras recentes e oportunidades em formação.
+
+O que não faz:
+
+- não pluga endpoint real;
+- não chama Gemini ou storage;
+- não salva mídia persistida, thumbnail, objectKey, signed URL, upload URL ou path local;
+- não atualiza `CreatorStrategicProfileSnapshot` nem Perfil geral;
+- não cria agregador do Perfil;
+- não promete match real, marca real, creator real ou publi garantida;
+- não altera UI real, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real.
+
+### MM82 — Profile Synthesis V1 Dry-Run + Preview
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM82_PROFILE_SYNTHESIS_DRY_RUN_PREVIEW.md`
+- `creatorStrategicProfileSynthesis.ts`
+- `creatorStrategicProfileSynthesisFixtures.ts`
+- `creatorStrategicProfileSynthesis.test.ts`
+- `narrativeMapMobileViewModelServerSelector.ts`
+- `narrativeMapMobileViewModel.ts`
+- `../components/videoUpload/appPreview/buildNarrativeMapReadingPreviewFixture.ts`
+- `../components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx`
+
+O que faz:
+
+- cria a primeira síntese acumulada dry-run do Perfil Estratégico;
+- consome leituras documentadas seguras;
+- impede que uma única leitura sobrescreva a narrativa principal do Perfil;
+- enriquece o view model interno com síntese para `Perfil | Leituras | Oportunidades`;
+- atualiza o preview interno para mostrar Perfil como síntese acumulada, não como última leitura isolada.
+
+O que não faz:
+
+- não atualiza `CreatorStrategicProfileSnapshot`;
+- não persiste snapshot geral;
+- não pluga endpoint real;
+- não chama Gemini ou storage;
+- não altera UI real, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real;
+- não promete match real, marca real, creator real ou publi garantida.
+
+### MM83 — Profile Synthesis Snapshot Guarded Persistence
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM83_PROFILE_SYNTHESIS_SNAPSHOT_GUARDED_PERSISTENCE.md`
+- `creatorStrategicProfileSynthesisSnapshotMapper.ts`
+- `creatorStrategicProfileSynthesisSnapshotMapper.test.ts`
+- `creatorStrategicProfileSynthesisPersistenceService.ts`
+- `creatorStrategicProfileSynthesisPersistenceService.test.ts`
+- `creatorStrategicProfileSynthesis.ts`
+- `mobileStrategicProfileSnapshotTypes.ts`
+- `../../../models/CreatorStrategicProfileSnapshot.ts`
+
+O que faz:
+
+- cria o mapper seguro da síntese acumulada para o payload atual do snapshot;
+- cria o service explícito `persistCreatorStrategicProfileSynthesis`;
+- mantém `dry_run` como padrão e escreve somente com `mode: "write"`;
+- adiciona `video_reading_synthesis_v1` como origem auditável do snapshot;
+- bloqueia escrita com síntese vazia;
+- impede que primeira leitura ou vídeo isolado apaguem padrão existente sem evidência acumulada.
+
+O que não faz:
+
+- não pluga endpoint real;
+- não chama Gemini ou storage;
+- não altera upload/cleanup;
+- não altera UI real, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real;
+- não salva vídeo, thumbnail, signed URL, objectKey, raw response ou transcrição longa;
+- não integra automaticamente o selector ou preview ao write path.
+
+### MM84 — Controlled Mock/Allowlist Synthesis Snapshot Write
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM84_CONTROLLED_MOCK_SYNTHESIS_SNAPSHOT_WRITE.md`
+- `creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts`
+- `creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.test.ts`
+- `videoNarrativeSafeResponseBuilder.ts`
+- `../../../api/internal/video-narrative/analyze/route.ts`
+- `../../../api/internal/video-narrative/analyze/route.test.ts`
+
+O que faz:
+
+- conecta o write path do MM83 ao fluxo mock/internal;
+- exige `persistReading: true` e `persistSynthesisSnapshot: true`;
+- salva a leitura, consulta leituras recentes, gera síntese acumulada e escreve o snapshot com `mode: "write"`;
+- retorna apenas auditoria segura em `synthesisSnapshotWrite`;
+- preserva a resposta mock quando a síntese ou a escrita falham.
+
+O que não faz:
+
+- não pluga endpoint real público;
+- não chama Gemini ou storage;
+- não altera upload/cleanup;
+- não altera UI real, MediaKit, Comunidade, billing, Stripe, NextAuth, shells, sidebar ou navegação real;
+- não cria matches reais;
+- não ativa escrita por padrão para usuários comuns fora da rota interna allowlist/admin-dev.
+
+### MM85 — Real Mobile Narrative Map Shell + Snapshot Review Panel
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM85_REAL_MOBILE_NARRATIVE_MAP_SHELL_SNAPSHOT_REVIEW.md`
+- `../components/videoUpload/appPreview/NarrativeMapMobileShell.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapSnapshotReviewPanel.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx`
+- `../mobile-strategic-profile/page.tsx`
+
+O que faz:
+
+- leva o shell mobile real para `Perfil | Leituras | Oportunidades`;
+- usa `NarrativeMapMobileViewModel` e o selector server-side seguro;
+- mostra Perfil como síntese acumulada;
+- mostra Leituras como evidências por vídeo;
+- mostra Oportunidades como territórios e fit narrativo em formação;
+- adiciona painel interno de snapshot review com auditoria segura.
+
+O que não faz:
+
+- não pluga endpoint real público;
+- não chama Gemini ou storage;
+- não altera upload/cleanup;
+- não altera `MediaKitView`, Comunidade, billing, Stripe, NextAuth, DashboardShell, BoardShell ou sidebar;
+- não cria marcas reais, creators reais ou matches reais;
+- não salva vídeo, thumbnail, signed URL, objectKey, raw response ou transcrição longa.
+
 ### MM1 — Arquitetura narrativa multimodal-first
 
 Status: concluído.

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
@@ -1,0 +1,240 @@
+import { readFileSync } from "fs";
+import path from "path";
+import {
+  buildCreatorNarrativeMapReadingPresentation,
+} from "./creatorNarrativeMapReadingChapters";
+import { buildNarrativeMapReadingDiagnosisFixture } from "./creatorNarrativeMapReadingChaptersFixtures";
+
+const FORBIDDEN_OUTPUT_TERMS = [
+  "score",
+  "nota",
+  "viralizar",
+  "garantido",
+  "certeza",
+  "comprovado",
+  "match real",
+  "publi garantida",
+];
+
+const SENSITIVE_REFERENCE_TERMS = [
+  "objectKey",
+  "signedUrl",
+  "uploadUrl",
+  "thumbnailUrl",
+  "localPath",
+  "storageProviderPath",
+  "X-Amz-Signature",
+  "data:video/mp4;base64",
+];
+
+function serializedPresentation(overrides = {}) {
+  return JSON.stringify(buildCreatorNarrativeMapReadingPresentation({
+    diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+    analyzedVideosCount: 4,
+    accessLevel: "premium",
+    ...overrides,
+  }));
+}
+
+describe("creatorNarrativeMapReadingChapters", () => {
+  it("cria uma apresentacao valida a partir de CreatorVideoNarrativeDiagnosis", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+      analyzedVideosCount: 4,
+      accessLevel: "premium",
+    });
+
+    expect(presentation).toEqual(expect.objectContaining({
+      id: "narrative-map-reading-diagnosis-reading-map-1",
+      diagnosisId: "diagnosis-reading-map-1",
+      headline: "Um padrão começa a aparecer",
+      statusLabel: "Padrão em formação",
+      createdAt: "2026-05-20T10:03:00.000Z",
+    }));
+    expect(presentation.primaryAction.intent).toBe("analyze_another_video");
+    expect(presentation.chapters.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("cria chapters pattern, tension, movement e territory quando ha dados suficientes", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+      analyzedVideosCount: 4,
+    });
+
+    expect(presentation.chapters.map((chapter) => chapter.id)).toEqual(expect.arrayContaining([
+      "pattern",
+      "tension",
+      "movement",
+      "territory",
+    ]));
+    expect(presentation.chapters.find((chapter) => chapter.id === "pattern")).toEqual(expect.objectContaining({
+      title: "Seu padrão",
+      tone: "mirror",
+    }));
+  });
+
+  it("cria capitulos honestos para primeira leitura e baixo contexto", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "low",
+        weight: "low",
+        reason: "Como primeira leitura, o vídeo levanta uma hipótese sem definir o Perfil geral.",
+        profileImpactPreview: "Cria uma primeira pista para acompanhar nas próximas análises.",
+      },
+    });
+
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis,
+      analyzedVideosCount: 1,
+    });
+
+    expect(presentation.statusLabel).toBe("Primeira leitura");
+    expect(presentation.headline).toBe("Seu mapa começou");
+    expect(presentation.subheadline).toBe("Este vídeo já mostra um primeiro sinal, mas ainda é cedo para chamar de padrão.");
+    expect(presentation.chapters.find((chapter) => chapter.id === "pattern")?.preview).toContain("Ainda é cedo");
+  });
+
+  it("transforma profileContribution em profile_impact humano", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture({
+        profileContribution: {
+          type: "commercial_signal",
+          confidence: "medium",
+          weight: "medium",
+          reason: "Este vídeo abre um território comercial em beleza funcional.",
+          profileImpactPreview: "Pode virar evidência futura se o território se repetir.",
+        },
+      }),
+      analyzedVideosCount: 3,
+    });
+
+    const chapter = presentation.chapters.find((item) => item.id === "profile_impact");
+
+    expect(chapter).toEqual(expect.objectContaining({
+      title: "Como pesa no Perfil",
+      badgeLabel: "Sinal comercial",
+      tone: "opportunity",
+    }));
+    expect(chapter?.fullReading).toContain("não atualiza a narrativa principal sozinha");
+  });
+
+  it("nao usa termos proibidos na apresentacao", () => {
+    const output = serializedPresentation().toLowerCase();
+
+    for (const term of FORBIDDEN_OUTPUT_TERMS) {
+      expect(output).not.toContain(term);
+    }
+  });
+
+  it("nao propaga objectKey, signedUrl, uploadUrl, thumbnailUrl, localPath ou storageProviderPath", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
+      videoReading: {
+        ...buildNarrativeMapReadingDiagnosisFixture().videoReading,
+        summary: "objectKey uploads/user/video.mp4 signedUrl https://bucket.s3.amazonaws.com/v.mp4?X-Amz-Signature=abc",
+        whatVideoReveals: "uploadUrl thumbnailUrl localPath storageProviderPath data:video/mp4;base64," + "A".repeat(1300),
+      },
+      commercialReading: {
+        ...buildNarrativeMapReadingDiagnosisFixture().commercialReading,
+        adAdaptationIdea: "Ver em https://cdn.example.com/video.mp4?token=abc",
+      },
+    });
+
+    const output = JSON.stringify(buildCreatorNarrativeMapReadingPresentation({ diagnosis }));
+
+    for (const term of SENSITIVE_REFERENCE_TERMS) {
+      expect(output).not.toContain(term);
+    }
+    expect(output).toContain("referencia removida");
+  });
+
+  it("nao importa Gemini SDK, storage SDK, Mongoose/model direto, endpoints ou client components", () => {
+    const source = readFileSync(path.join(__dirname, "creatorNarrativeMapReadingChapters.ts"), "utf8");
+
+    expect(source).not.toMatch(/@google\/genai|@aws-sdk|from ["']mongoose["']|CreatorVideoNarrativeDiagnosis\.|["']use client["']/);
+    expect(source).not.toMatch(/analyze-real\/route|analyze\/route|videoNarrativeEndpointMockMode|api\/dashboard\/mobile-strategic-profile/);
+  });
+
+  it("nao importa CreatorStrategicProfileSnapshot", () => {
+    const source = readFileSync(path.join(__dirname, "creatorNarrativeMapReadingChapters.ts"), "utf8");
+
+    expect(source).not.toContain("CreatorStrategicProfileSnapshot");
+  });
+
+  it("limita tamanho de preview, fullReading, evidence e action", () => {
+    const longText = "leitura humana ".repeat(120);
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture({
+        videoReading: {
+          ...buildNarrativeMapReadingDiagnosisFixture().videoReading,
+          mainNarrative: longText,
+          dominantInsight: longText,
+        },
+        strategicRecommendation: {
+          ...buildNarrativeMapReadingDiagnosisFixture().strategicRecommendation,
+          nextExperiment: longText,
+        },
+      }),
+      analyzedVideosCount: 4,
+    });
+
+    for (const chapter of presentation.chapters) {
+      expect(chapter.title.length).toBeLessThanOrEqual(56);
+      expect(chapter.preview.length).toBeLessThanOrEqual(180);
+      expect(chapter.fullReading.length).toBeLessThanOrEqual(900);
+      expect(chapter.evidence.length).toBeLessThanOrEqual(4);
+      if (chapter.action) expect(chapter.action.length).toBeLessThanOrEqual(180);
+    }
+  });
+
+  it("gera opportunities sem prometer marca real ou creator real", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture({
+        commercialReading: {
+          ...buildNarrativeMapReadingDiagnosisFixture().commercialReading,
+          brandTerritories: ["rotina real", "apps", "vida adulta"],
+          adAdaptationIdea: "Adaptar para uma cena de rotina real sem citar marca.",
+        },
+      }),
+      analyzedVideosCount: 3,
+    });
+    const opportunities = presentation.chapters.find((chapter) => chapter.id === "opportunities");
+    const text = JSON.stringify(opportunities).toLowerCase();
+
+    expect(text).toContain("território em formação");
+    expect(text).not.toContain("marca real");
+    expect(text).not.toContain("creator real");
+    expect(text).not.toContain("publi garantida");
+  });
+
+  it("altera status e subheadline quando instagramConnected=true", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+      instagramConnected: true,
+      analyzedVideosCount: 4,
+    });
+
+    expect(presentation.statusLabel).toBe("Cruzado com Instagram");
+    expect(presentation.subheadline).toContain("perfil e da audiencia");
+    expect(presentation.subheadline).not.toContain("desempenho garantido");
+  });
+
+  it("inclui safetyNote sobre nao guardar video", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+    });
+
+    expect(presentation.safetyNote).toBe("A D2C guarda a leitura estratégica, não o vídeo.");
+  });
+
+  it("e funcao pura e testavel, sem banco", () => {
+    const source = readFileSync(path.join(__dirname, "creatorNarrativeMapReadingChapters.ts"), "utf8");
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture();
+
+    const first = buildCreatorNarrativeMapReadingPresentation({ diagnosis, analyzedVideosCount: 2 });
+    const second = buildCreatorNarrativeMapReadingPresentation({ diagnosis, analyzedVideosCount: 2 });
+
+    expect(first).toEqual(second);
+    expect(source).not.toMatch(/connectToDatabase|createCreatorVideoNarrativeDiagnosis|findOne|save\(|insert|update/);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
@@ -1,0 +1,376 @@
+import type {
+  CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeDiagnosisProfileContribution,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+
+export type CreatorNarrativeMapReadingChapterId =
+  | "pattern"
+  | "tension"
+  | "movement"
+  | "territory"
+  | "video_reveal"
+  | "profile_impact"
+  | "opportunities";
+
+export type CreatorNarrativeMapReadingChapterTone =
+  | "mirror"
+  | "attention"
+  | "action"
+  | "opportunity"
+  | "neutral";
+
+export interface CreatorNarrativeMapReadingChapter {
+  id: CreatorNarrativeMapReadingChapterId;
+  title: string;
+  preview: string;
+  fullReading: string;
+  evidence: string[];
+  action?: string | null;
+  badgeLabel?: string | null;
+  tone: CreatorNarrativeMapReadingChapterTone;
+  locked?: boolean;
+}
+
+export interface CreatorNarrativeMapReadingPresentation {
+  id: string;
+  diagnosisId: string;
+  headline: string;
+  subheadline: string;
+  statusLabel: string;
+  chapters: CreatorNarrativeMapReadingChapter[];
+  primaryAction: {
+    label: string;
+    intent: "analyze_another_video" | "connect_instagram" | "upgrade" | "open_full_reading";
+    helper: string | null;
+  };
+  safetyNote?: string | null;
+  createdAt: string | null;
+}
+
+export type CreatorNarrativeMapReadingDiagnosisShape = Pick<
+  CreatorVideoNarrativeDiagnosisDocument,
+  | "diagnosisId"
+  | "status"
+  | "videoReading"
+  | "speechReading"
+  | "productionReading"
+  | "commercialReading"
+  | "strategicRecommendation"
+  | "profileContribution"
+  | "createdAt"
+>;
+
+export interface BuildCreatorNarrativeMapReadingPresentationInput {
+  diagnosis: CreatorNarrativeMapReadingDiagnosisShape;
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  instagramConnected?: boolean;
+  analyzedVideosCount?: number;
+}
+
+const TITLE_LIMIT = 56;
+const PREVIEW_LIMIT = 180;
+const FULL_READING_LIMIT = 900;
+const ACTION_LIMIT = 180;
+const MAX_EVIDENCE_ITEMS = 4;
+
+const EMPTY_READING = "Ainda nao ha dado suficiente para uma leitura especifica.";
+
+const UNSAFE_TEXT_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/data:[^;]+;base64,[A-Za-z0-9+/=]+/gi, "referencia removida"],
+  [/[A-Za-z0-9+/=]{1200,}/g, "referencia removida"],
+  [/https?:\/\/[^\s"'<>]+/gi, "referencia removida"],
+  [/\b(?:uploads|video-narrative|mobile-strategic-profile|tmp|temporary)\/[A-Za-z0-9._/-]+\.(mp4|mov|webm|mkv)\b/gi, "referencia removida"],
+  [/\b(?:objectKey|signedUrl|signed URL|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi, "referencia removida"],
+  [/\b(?:storage|raw response|Gemini)\b/gi, "leitura estruturada"],
+  [/\b(?:score|nota|pontos)\b/gi, "leitura"],
+  [/\bviralizar\b/gi, "crescer com consistencia"],
+  [/\bgarantid[oa]\b/gi, "possivel"],
+  [/\bcerteza\b/gi, "hipotese"],
+  [/\bcomprovad[oa]\b/gi, "em observacao"],
+  [/\bmatch\s+real\b/gi, "fit narrativo possivel"],
+  [/\bmatch\s+comprovado\b/gi, "fit narrativo possivel"],
+  [/\bpubli\s+garantida\b/gi, "oportunidade em formacao"],
+];
+
+function cleanText(value: string | null | undefined, fallback = EMPTY_READING): string {
+  const raw = value?.trim() || fallback;
+  const cleaned = UNSAFE_TEXT_REPLACEMENTS.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    raw,
+  );
+
+  return cleaned.replace(/\s+/g, " ").trim();
+}
+
+function limitText(value: string, maxLength: number): string {
+  const text = cleanText(value);
+  if (text.length <= maxLength) return text;
+
+  const slice = text.slice(0, Math.max(0, maxLength - 3)).trim();
+  return `${slice.replace(/[,.!?;:]$/g, "")}...`;
+}
+
+function firstText(values: Array<string | null | undefined>, fallback = EMPTY_READING): string {
+  return cleanText(values.find((value) => value?.trim()), fallback);
+}
+
+function evidenceFrom(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+
+  return values
+    .map((value) => limitText(cleanText(value, ""), PREVIEW_LIMIT))
+    .filter(Boolean)
+    .filter((value) => {
+      const key = value.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, MAX_EVIDENCE_ITEMS);
+}
+
+function isoDate(value: Date | string | undefined): string | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+  }
+
+  return null;
+}
+
+function isFirstReading(input: BuildCreatorNarrativeMapReadingPresentationInput): boolean {
+  const count = input.analyzedVideosCount ?? 1;
+  const contribution = input.diagnosis.profileContribution;
+  return (
+    count <= 1 ||
+    contribution.type === "opens_new_hypothesis" ||
+    contribution.type === "needs_more_samples" ||
+    contribution.confidence === "low"
+  );
+}
+
+function hasPatternSignal(input: BuildCreatorNarrativeMapReadingPresentationInput): boolean {
+  const contribution = input.diagnosis.profileContribution;
+  return (
+    contribution.type === "confirms_existing_pattern" ||
+    contribution.weight === "high" ||
+    (contribution.confidence === "high" && (input.analyzedVideosCount ?? 1) > 1)
+  );
+}
+
+function contributionLabel(contribution: CreatorVideoNarrativeDiagnosisProfileContribution): string {
+  const labels: Record<CreatorVideoNarrativeDiagnosisProfileContribution["type"], string> = {
+    confirms_existing_pattern: "Padrão reforçado",
+    opens_new_hypothesis: "Hipótese inicial",
+    isolated_strong_video: "Vídeo forte isolado",
+    creative_deviation: "Desvio criativo",
+    commercial_signal: "Sinal comercial",
+    weak_positioning_signal: "Sinal fraco",
+    needs_more_samples: "Precisa repetir",
+  };
+
+  return labels[contribution.type];
+}
+
+function buildChapter(params: {
+  id: CreatorNarrativeMapReadingChapterId;
+  title: string;
+  preview: string;
+  fullReading: string;
+  evidence: string[];
+  action?: string | null;
+  badgeLabel?: string | null;
+  tone: CreatorNarrativeMapReadingChapterTone;
+  locked?: boolean;
+}): CreatorNarrativeMapReadingChapter {
+  return {
+    id: params.id,
+    title: limitText(params.title, TITLE_LIMIT),
+    preview: limitText(params.preview, PREVIEW_LIMIT),
+    fullReading: limitText(params.fullReading, FULL_READING_LIMIT),
+    evidence: evidenceFrom(params.evidence),
+    action: params.action ? limitText(params.action, ACTION_LIMIT) : null,
+    badgeLabel: params.badgeLabel ? limitText(params.badgeLabel, 40) : null,
+    tone: params.tone,
+    locked: params.locked ?? false,
+  };
+}
+
+function buildStatus(input: BuildCreatorNarrativeMapReadingPresentationInput): Pick<
+  CreatorNarrativeMapReadingPresentation,
+  "headline" | "subheadline" | "statusLabel"
+> {
+  if (input.instagramConnected) {
+    return {
+      statusLabel: "Cruzado com Instagram",
+      headline: "Seu mapa ganhou contexto",
+      subheadline:
+        "Esta leitura pode ser comparada com sinais do perfil e da audiencia, sem prometer desempenho.",
+    };
+  }
+
+  if (hasPatternSignal(input)) {
+    return {
+      statusLabel: "Padrão em formação",
+      headline: "Um padrão começa a aparecer",
+      subheadline:
+        "Este vídeo reforça uma leitura que ja aparece em outros sinais, mas a síntese do Perfil continua separada.",
+    };
+  }
+
+  return {
+    statusLabel: "Primeira leitura",
+    headline: "Seu mapa começou",
+    subheadline: "Este vídeo já mostra um primeiro sinal, mas ainda é cedo para chamar de padrão.",
+  };
+}
+
+function buildPrimaryAction(
+  input: BuildCreatorNarrativeMapReadingPresentationInput,
+): CreatorNarrativeMapReadingPresentation["primaryAction"] {
+  if (!input.instagramConnected && input.accessLevel === "instagram_optimized") {
+    return {
+      label: "Conectar Instagram",
+      intent: "connect_instagram",
+      helper: "A leitura fica mais precisa quando pode comparar sinais do perfil e da audiencia.",
+    };
+  }
+
+  if (input.accessLevel === "free" && (input.analyzedVideosCount ?? 1) > 1) {
+    return {
+      label: "Abrir mapa mais completo",
+      intent: "upgrade",
+      helper: "Um mapa mais completo ajuda a organizar sinais que ja comecam a se repetir.",
+    };
+  }
+
+  return {
+    label: "Analisar outro vídeo",
+    intent: "analyze_another_video",
+    helper: "Mais vídeos ajudam a separar hipótese inicial de padrão recorrente.",
+  };
+}
+
+export function buildCreatorNarrativeMapReadingPresentation(
+  input: BuildCreatorNarrativeMapReadingPresentationInput,
+): CreatorNarrativeMapReadingPresentation {
+  const diagnosis = input.diagnosis;
+  const video = diagnosis.videoReading;
+  const speech = diagnosis.speechReading;
+  const production = diagnosis.productionReading;
+  const commercial = diagnosis.commercialReading;
+  const recommendation = diagnosis.strategicRecommendation;
+  const contribution = diagnosis.profileContribution;
+  const firstReading = isFirstReading(input);
+  const patternPreview = firstReading
+    ? "Ainda é cedo para cravar um padrão. Este vídeo abre uma hipótese inicial para acompanhar nas próximas leituras."
+    : firstText([video.mainNarrative, contribution.profileImpactPreview]);
+  const territories = commercial.brandTerritories.map((territory) => cleanText(territory, "")).filter(Boolean);
+  const territoryText = territories.length > 0
+    ? `Sua narrativa conversa com ${territories.slice(0, 3).join(", ")} como território de oportunidade futura.`
+    : "Ainda nao ha território comercial forte. O caminho é observar se este tipo de leitura se repete.";
+  const status = buildStatus(input);
+
+  const chapters: CreatorNarrativeMapReadingChapter[] = [
+    buildChapter({
+      id: "pattern",
+      title: "Seu padrão",
+      preview: patternPreview,
+      fullReading: firstReading
+        ? "Você parece estar abrindo uma primeira pista, não uma conclusão sobre o Perfil. Neste vídeo, a leitura mostra um sinal útil, mas ainda precisa aparecer em novas amostras para virar padrão. O próximo movimento é repetir a intenção narrativa em formatos próximos e observar o que volta com força."
+        : `Você parece ter mais força quando ${cleanText(video.mainNarrative).toLowerCase()}. Isso aparece neste vídeo como ${cleanText(video.dominantInsight).toLowerCase()}. O próximo movimento é repetir esse eixo em novas cenas para entender se ele sustenta o Perfil.`,
+      evidence: [video.mainNarrative, video.dominantInsight, contribution.reason],
+      action: recommendation.whatToRepeat,
+      badgeLabel: firstReading ? "Hipótese" : "Padrão",
+      tone: "mirror",
+    }),
+    buildChapter({
+      id: "tension",
+      title: "Sua tensão",
+      preview: firstText([
+        recommendation.whatToAvoid,
+        speech.openingRead,
+        production.firstFrame,
+      ], "A ideia existe, mas a tensão ainda precisa aparecer mais cedo."),
+      fullReading: `A narrativa ganha clareza quando o conflito aparece cedo. Neste vídeo, a tensão principal passa por ${cleanText(recommendation.whatToAvoid).toLowerCase()}. O ajuste é tornar o incômodo mais visível antes de explicar demais a cena.`,
+      evidence: [speech.openingRead, production.firstFrame, recommendation.whatToAvoid],
+      action: recommendation.mainAdjustment,
+      badgeLabel: "Ajuste",
+      tone: "attention",
+    }),
+    buildChapter({
+      id: "movement",
+      title: "Seu movimento",
+      preview: firstText([
+        recommendation.nextExperiment,
+        recommendation.mainAdjustment,
+      ], "Testar uma abertura mais direta e comparar se a leitura fica mais clara."),
+      fullReading: `O próximo teste deve ser simples: ${cleanText(recommendation.nextExperiment).toLowerCase()}. A evidência a observar é ${cleanText(recommendation.successSignal).toLowerCase()}. Isso transforma a leitura em movimento prático, sem tratar um vídeo isolado como verdade final.`,
+      evidence: [recommendation.nextExperiment, recommendation.successSignal, recommendation.mainAdjustment],
+      action: recommendation.nextExperiment,
+      badgeLabel: "Próximo teste",
+      tone: "action",
+    }),
+    buildChapter({
+      id: "territory",
+      title: "Seu território",
+      preview: territoryText,
+      fullReading: `${territoryText} A leitura comercial aqui é de fit narrativo: ${cleanText(commercial.whyItCouldFitBrands).toLowerCase()}. Isso nao indica marca fechada; indica um campo para testar linguagem, formato e repetição.`,
+      evidence: [commercial.summary, ...territories, commercial.whyItCouldFitBrands],
+      action: commercial.adAdaptationIdea,
+      badgeLabel: "Território",
+      tone: "opportunity",
+    }),
+    buildChapter({
+      id: "video_reveal",
+      title: "O que este vídeo revela",
+      preview: firstText([
+        video.whatVideoReveals,
+        video.summary,
+      ], "Este vídeo adiciona uma leitura inicial ao mapa narrativo."),
+      fullReading: `Este vídeo revela ${cleanText(video.whatVideoReveals).toLowerCase()}. A intenção percebida é ${cleanText(video.creatorIntent).toLowerCase()}. Como leitura isolada, ele documenta um sinal; como Perfil, ele ainda precisa ser comparado com novas leituras.`,
+      evidence: [video.summary, video.whatVideoReveals, video.creatorIntent],
+      action: recommendation.whatToRepeat,
+      badgeLabel: "Leitura",
+      tone: "neutral",
+    }),
+    buildChapter({
+      id: "profile_impact",
+      title: "Como pesa no Perfil",
+      preview: contribution.profileImpactPreview,
+      fullReading: `${cleanText(contribution.reason)} Esta contribuição tem confiança ${contribution.confidence} e peso ${contribution.weight}. Ela não atualiza a narrativa principal sozinha; apenas organiza o que o agregador futuro deve considerar.`,
+      evidence: [contribution.reason, contribution.profileImpactPreview],
+      action: firstReading
+        ? "Analise mais vídeos para entender se este sinal se repete."
+        : "Compare este sinal com novas leituras antes de transformar em narrativa principal.",
+      badgeLabel: contributionLabel(contribution),
+      tone: contribution.type === "commercial_signal" ? "opportunity" : "mirror",
+    }),
+    buildChapter({
+      id: "opportunities",
+      title: "Oportunidades em formação",
+      preview: firstText([
+        commercial.adAdaptationIdea,
+        territoryText,
+      ], "A oportunidade ainda esta em formação e depende de repetição narrativa."),
+      fullReading: `A oportunidade aqui ainda é um território em formação. ${cleanText(commercial.adAdaptationIdea)} O limite importante é: ${cleanText(commercial.limitations).toLowerCase()}. O caminho é testar o fit narrativo antes de falar em parceria real.`,
+      evidence: [commercial.summary, commercial.adAdaptationIdea, commercial.limitations, ...territories],
+      action: recommendation.nextExperiment,
+      badgeLabel: "Em formação",
+      tone: "opportunity",
+    }),
+  ];
+
+  return {
+    id: `narrative-map-reading-${diagnosis.diagnosisId}`,
+    diagnosisId: diagnosis.diagnosisId,
+    headline: status.headline,
+    subheadline: status.subheadline,
+    statusLabel: status.statusLabel,
+    chapters,
+    primaryAction: buildPrimaryAction(input),
+    safetyNote: "A D2C guarda a leitura estratégica, não o vídeo.",
+    createdAt: isoDate(diagnosis.createdAt),
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChaptersFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChaptersFixtures.ts
@@ -1,0 +1,24 @@
+import { buildCreatorVideoNarrativeDiagnosisFixture } from "./creatorVideoNarrativeDiagnosisFixtures";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import type { CreatorNarrativeMapReadingDiagnosisShape } from "./creatorNarrativeMapReadingChapters";
+
+export function buildNarrativeMapReadingDiagnosisFixture(
+  overrides: Partial<CreatorNarrativeMapReadingDiagnosisShape> = {},
+): CreatorNarrativeMapReadingDiagnosisShape {
+  const sanitized = sanitizeCreatorVideoNarrativeDiagnosisInput(buildCreatorVideoNarrativeDiagnosisFixture({
+    diagnosisId: "diagnosis-reading-map-1",
+    profileContribution: {
+      type: "confirms_existing_pattern",
+      confidence: "high",
+      weight: "high",
+      reason: "Este vídeo reforça humor cotidiano com identificação rápida, um sinal que ja aparece no Perfil.",
+      profileImpactPreview: "Reforça uma narrativa em formação, sem mudar o Perfil sozinho.",
+    },
+  }));
+
+  return {
+    ...sanitized,
+    createdAt: new Date("2026-05-20T10:03:00.000Z"),
+    ...overrides,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesis.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesis.test.ts
@@ -1,0 +1,156 @@
+import fs from "fs";
+import path from "path";
+import { buildCreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesis";
+import { buildCreatorStrategicProfileSynthesisReadingsFixture } from "./creatorStrategicProfileSynthesisFixtures";
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("creatorStrategicProfileSynthesis", () => {
+  it("retorna empty quando não há leituras", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({ readings: [] });
+
+    expect(synthesis.status).toBe("empty");
+    expect(synthesis.mainNarrative).toBeNull();
+  });
+
+  it("uma leitura gera first_reading e não crava padrão definitivo", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("first_reading"),
+    });
+    const text = serialized(synthesis);
+
+    expect(synthesis.status).toBe("first_reading");
+    expect(synthesis.mainNarrative).toBeNull();
+    expect(text).toContain("primeiro sinal");
+    expect(text).not.toContain("padrão definitivo");
+  });
+
+  it("duas leituras parecidas geram signals_emerging", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("two_related_readings"),
+    });
+
+    expect(synthesis.status).toBe("signals_emerging");
+    expect(synthesis.mainNarrative?.confidence).toBe("medium");
+    expect(synthesis.mainNarrative?.evidenceCount).toBe(2);
+  });
+
+  it("três leituras parecidas geram pattern_in_formation", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(synthesis.status).toBe("pattern_in_formatiOn".toLowerCase());
+    expect(synthesis.mainNarrative?.label).toContain("humor cotidiano");
+    expect(synthesis.recurringPatterns[0]?.evidenceCount).toBe(3);
+  });
+
+  it("confirms_existing_pattern aumenta força de recorrência", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(synthesis.recurringPatterns[0]).toEqual(expect.objectContaining({
+      evidenceCount: 3,
+    }));
+  });
+
+  it("opens_new_hypothesis entra como narrativa em teste", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("first_reading"),
+    });
+
+    expect(synthesis.testedNarratives[0]?.label).toContain("humor cotidiano");
+  });
+
+  it("isolated_strong_video não vira narrativa principal sozinho", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("isolated_strong_video"),
+    });
+
+    expect(synthesis.status).toBe("first_reading");
+    expect(synthesis.mainNarrative).toBeNull();
+    expect(synthesis.strengths.length).toBeGreaterThan(0);
+  });
+
+  it("creative_deviation não sobrescreve narrativa principal", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("creative_deviation"),
+    });
+
+    expect(synthesis.mainNarrative).toBeNull();
+    expect(serialized(synthesis.testedNarratives)).toContain("desvio criativo");
+  });
+
+  it("commercial_signal gera território comercial sem match real", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("commercial_signals"),
+    });
+    const text = serialized(synthesis);
+
+    expect(synthesis.commercialTerritories.length).toBeGreaterThan(0);
+    expect(synthesis.collabTerritories.length).toBeGreaterThan(0);
+    expect(text).not.toContain("match real");
+  });
+
+  it("needs_more_samples gera warning conservador", () => {
+    const readings = buildCreatorStrategicProfileSynthesisReadingsFixture("first_reading").map((reading) => ({
+      ...reading,
+      profileContribution: {
+        ...reading.profileContribution,
+        type: "needs_more_samples" as const,
+      },
+    }));
+
+    const synthesis = buildCreatorStrategicProfileSynthesis({ readings });
+
+    expect(synthesis.warnings.map((warning) => warning.code)).toContain("needs_more_samples");
+    expect(synthesis.status).toBe("first_reading");
+  });
+
+  it("recurringTensions detecta ajustes repetidos", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(synthesis.recurringTensions[0]?.label).toContain("abertura");
+    expect(synthesis.recurringTensions[0]?.evidenceCount).toBe(3);
+  });
+
+  it("nextStrategicMove é gerado quando há padrão ou tensão suficiente", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(synthesis.nextStrategicMove?.label).toBeTruthy();
+    expect(synthesis.nextStrategicMove?.description).toContain("3 vídeos");
+  });
+
+  it("não usa termos proibidos", () => {
+    const synthesis = buildCreatorStrategicProfileSynthesis({
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("commercial_signals"),
+    });
+    const text = serialized(synthesis);
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "viralizar",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "match real",
+      "publi garantida",
+    ]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("agregador é puro e não importa persistência, endpoint, SDK ou Snapshot", () => {
+    const source = fs.readFileSync(path.join(__dirname, "creatorStrategicProfileSynthesis.ts"), "utf8");
+
+    expect(source).not.toMatch(/connectToDatabase|from ["']mongoose["']|@google\/genai|@aws-sdk|api\/|CreatorStrategicProfileSnapshot|createCreatorVideoNarrativeDiagnosis|fetch\(/);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesis.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesis.ts
@@ -1,0 +1,338 @@
+import type { CreatorVideoNarrativeDiagnosisSafeReading } from "./creatorVideoNarrativeDiagnosisReadService";
+
+export type CreatorStrategicProfileSynthesisStatus =
+  | "empty"
+  | "first_reading"
+  | "signals_emerging"
+  | "pattern_in_formation"
+  | "profile_consistent";
+
+export type CreatorStrategicProfileSynthesisConfidence = "low" | "medium" | "high";
+
+export interface CreatorStrategicProfileSynthesisSignal {
+  label: string;
+  summary: string;
+  evidenceCount: number;
+}
+
+export interface CreatorStrategicProfileSynthesis {
+  id: string;
+  status: CreatorStrategicProfileSynthesisStatus;
+  analyzedReadingsCount: number;
+  mainNarrative: (CreatorStrategicProfileSynthesisSignal & {
+    confidence: CreatorStrategicProfileSynthesisConfidence;
+  }) | null;
+  testedNarratives: CreatorStrategicProfileSynthesisSignal[];
+  recurringPatterns: CreatorStrategicProfileSynthesisSignal[];
+  recurringTensions: CreatorStrategicProfileSynthesisSignal[];
+  strengths: CreatorStrategicProfileSynthesisSignal[];
+  commercialTerritories: CreatorStrategicProfileSynthesisSignal[];
+  collabTerritories: CreatorStrategicProfileSynthesisSignal[];
+  nextStrategicMove: {
+    label: string;
+    description: string;
+    reason: string;
+  } | null;
+  warnings: Array<{
+    code: string;
+    message: string;
+  }>;
+  generatedAt: string;
+}
+
+export interface BuildCreatorStrategicProfileSynthesisInput {
+  readings: CreatorVideoNarrativeDiagnosisSafeReading[];
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  instagramConnected?: boolean;
+  generatedAt?: string;
+}
+
+type SignalBucket = {
+  label: string;
+  samples: string[];
+  diagnosisIds: Set<string>;
+};
+
+const GENERATED_AT = "2026-05-20T00:00:00.000Z";
+
+const SAFE_TEXT_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/https?:\/\/[^\s"'<>]+/gi, "referencia removida"],
+  [/\b(?:objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi, "referencia removida"],
+  [/\b(?:storage|raw response|Gemini)\b/gi, "leitura estruturada"],
+  [/\b(?:score|nota|pontuacao|pontuação)\b/gi, "leitura"],
+  [/\bviralizar\b/gi, "crescer com consistencia"],
+  [/\bgarantid[oa]\b/gi, "possivel"],
+  [/\bcerteza\b/gi, "hipotese"],
+  [/\bcomprovad[oa]\b/gi, "em observacao"],
+  [/\bmatch\s+real\b/gi, "fit narrativo possivel"],
+  [/\bpubli\s+garantida\b/gi, "oportunidade em formacao"],
+];
+
+function cleanText(value: string | null | undefined, fallback = ""): string {
+  const raw = value?.trim() || fallback;
+  return SAFE_TEXT_REPLACEMENTS.reduce((text, [pattern, replacement]) => text.replace(pattern, replacement), raw)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function limitText(value: string, maxLength: number): string {
+  const text = cleanText(value);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 3).trim()}...`;
+}
+
+function normalizeKey(value: string): string {
+  return cleanText(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length >= 4)
+    .slice(0, 6)
+    .join(" ");
+}
+
+function firstText(values: Array<string | null | undefined>, fallback: string): string {
+  return cleanText(values.find((value) => value?.trim()), fallback);
+}
+
+function pushBucket(
+  buckets: Map<string, SignalBucket>,
+  params: { label: string; sample: string; diagnosisId: string },
+): void {
+  const label = limitText(params.label, 90);
+  if (!label) return;
+  const key = normalizeKey(label);
+  if (!key) return;
+
+  const current = buckets.get(key) ?? {
+    label,
+    samples: [],
+    diagnosisIds: new Set<string>(),
+  };
+  current.samples.push(cleanText(params.sample, label));
+  current.diagnosisIds.add(params.diagnosisId);
+  buckets.set(key, current);
+}
+
+function signalsFromBuckets(buckets: Map<string, SignalBucket>, maxItems = 4): CreatorStrategicProfileSynthesisSignal[] {
+  return [...buckets.values()]
+    .sort((a, b) => b.diagnosisIds.size - a.diagnosisIds.size || a.label.localeCompare(b.label))
+    .slice(0, maxItems)
+    .map((bucket) => ({
+      label: bucket.label,
+      summary: limitText(bucket.samples[0] ?? bucket.label, 180),
+      evidenceCount: bucket.diagnosisIds.size,
+    }));
+}
+
+function uniqueReadings(readings: CreatorVideoNarrativeDiagnosisSafeReading[]): CreatorVideoNarrativeDiagnosisSafeReading[] {
+  const seen = new Set<string>();
+  return readings.filter((reading) => {
+    if (seen.has(reading.diagnosisId)) return false;
+    seen.add(reading.diagnosisId);
+    return true;
+  });
+}
+
+function statusFor(params: {
+  readingCount: number;
+  strongestNarrativeEvidence: number;
+  strongestPatternEvidence: number;
+}): CreatorStrategicProfileSynthesisStatus {
+  if (params.readingCount === 0) return "empty";
+  if (params.readingCount === 1) return "first_reading";
+  if (params.strongestNarrativeEvidence >= 4 || params.strongestPatternEvidence >= 4) return "profile_consistent";
+  if (params.strongestNarrativeEvidence >= 3 || params.strongestPatternEvidence >= 3) return "pattern_in_formation";
+  return "signals_emerging";
+}
+
+function confidenceFor(evidenceCount: number): CreatorStrategicProfileSynthesisConfidence {
+  if (evidenceCount >= 4) return "high";
+  if (evidenceCount >= 2) return "medium";
+  return "low";
+}
+
+function buildNextStrategicMove(params: {
+  status: CreatorStrategicProfileSynthesisStatus;
+  pattern: CreatorStrategicProfileSynthesisSignal | undefined;
+  tension: CreatorStrategicProfileSynthesisSignal | undefined;
+}): CreatorStrategicProfileSynthesis["nextStrategicMove"] {
+  if (params.status === "empty") return null;
+
+  if (params.tension && params.tension.evidenceCount >= 2) {
+    return {
+      label: "Testar a tensão mais recorrente",
+      description: `Grave 3 vídeos começando direto por "${params.tension.label}" para observar se essa identificação se repete.`,
+      reason: "A mesma tensão apareceu em mais de uma leitura e pode separar padrão de hipótese.",
+    };
+  }
+
+  if (params.pattern && params.pattern.evidenceCount >= 2) {
+    return {
+      label: "Repetir o sinal mais claro",
+      description: `Crie 3 variações de "${params.pattern.label}" mantendo abertura, conflito e fechamento comparáveis.`,
+      reason: "Há sinal recorrente suficiente para testar consistência sem tratar como narrativa definitiva.",
+    };
+  }
+
+  return {
+    label: "Criar mais duas leituras",
+    description: "Analise vídeos com formatos parecidos para descobrir se o primeiro sinal se repete.",
+    reason: "Um vídeo isolado ainda não deve redefinir o Perfil geral.",
+  };
+}
+
+export function buildCreatorStrategicProfileSynthesis(
+  input: BuildCreatorStrategicProfileSynthesisInput,
+): CreatorStrategicProfileSynthesis {
+  const readings = uniqueReadings(input.readings);
+  const generatedAt = input.generatedAt ?? GENERATED_AT;
+  const narrativeBuckets = new Map<string, SignalBucket>();
+  const testedNarrativeBuckets = new Map<string, SignalBucket>();
+  const patternBuckets = new Map<string, SignalBucket>();
+  const tensionBuckets = new Map<string, SignalBucket>();
+  const strengthBuckets = new Map<string, SignalBucket>();
+  const commercialBuckets = new Map<string, SignalBucket>();
+  const collabBuckets = new Map<string, SignalBucket>();
+  const warnings: CreatorStrategicProfileSynthesis["warnings"] = [];
+
+  readings.forEach((reading) => {
+    const diagnosisId = reading.diagnosisId;
+    const narrativeLabel = firstText(
+      [reading.videoReading.mainNarrative, reading.videoReading.dominantInsight, reading.videoReading.title],
+      "Narrativa em observação",
+    );
+    const narrativeSummary = firstText(
+      [reading.videoReading.summary, reading.videoReading.whatVideoReveals, reading.profileContribution.reason],
+      "Sinal narrativo em observação.",
+    );
+
+    if (reading.profileContribution.type === "confirms_existing_pattern") {
+      pushBucket(patternBuckets, { label: narrativeLabel, sample: narrativeSummary, diagnosisId });
+      pushBucket(narrativeBuckets, { label: narrativeLabel, sample: narrativeSummary, diagnosisId });
+    }
+
+    if (reading.profileContribution.type === "opens_new_hypothesis") {
+      pushBucket(testedNarrativeBuckets, { label: narrativeLabel, sample: narrativeSummary, diagnosisId });
+    }
+
+    if (reading.profileContribution.type === "isolated_strong_video") {
+      pushBucket(strengthBuckets, { label: narrativeLabel, sample: narrativeSummary, diagnosisId });
+    }
+
+    if (reading.profileContribution.type === "creative_deviation") {
+      pushBucket(testedNarrativeBuckets, { label: `Desvio criativo: ${narrativeLabel}`, sample: narrativeSummary, diagnosisId });
+    }
+
+    if (reading.profileContribution.type === "commercial_signal") {
+      reading.commercialReading.brandTerritories.forEach((territory) => {
+        pushBucket(commercialBuckets, {
+          label: territory,
+          sample: reading.commercialReading.summary || reading.commercialReading.whyItCouldFitBrands,
+          diagnosisId,
+        });
+      });
+      pushBucket(collabBuckets, {
+        label: "Collab de problema, escolha e consequência",
+        sample: reading.commercialReading.adAdaptationIdea,
+        diagnosisId,
+      });
+    }
+
+    if (reading.profileContribution.type === "weak_positioning_signal") {
+      warnings.push({
+        code: "weak_positioning_signal",
+        message: "Uma leitura ainda está fraca para influenciar o Perfil geral.",
+      });
+    }
+
+    if (reading.profileContribution.type === "needs_more_samples") {
+      warnings.push({
+        code: "needs_more_samples",
+        message: "Ainda faltam leituras para separar hipótese inicial de padrão.",
+      });
+    }
+
+    pushBucket(tensionBuckets, {
+      label: firstText(
+        [
+          reading.strategicRecommendation.mainAdjustment,
+          reading.videoReading.whatVideoReveals,
+          reading.speechReading.openingRead,
+        ],
+        "Abertura precisa chegar mais rápido ao conflito",
+      ),
+      sample: firstText(
+        [reading.strategicRecommendation.nextExperiment, reading.speechReading.suggestedOpening],
+        "Testar uma abertura mais direta em novas leituras.",
+      ),
+      diagnosisId,
+    });
+
+    pushBucket(strengthBuckets, {
+      label: firstText([reading.strategicRecommendation.whatToRepeat, reading.videoReading.dominantInsight], narrativeLabel),
+      sample: firstText([reading.videoReading.summary, reading.profileContribution.profileImpactPreview], narrativeSummary),
+      diagnosisId,
+    });
+  });
+
+  const testedNarratives = signalsFromBuckets(testedNarrativeBuckets);
+  const recurringPatterns = signalsFromBuckets(patternBuckets);
+  const recurringTensions = signalsFromBuckets(tensionBuckets).filter((signal) => signal.evidenceCount >= 2);
+  const strengths = signalsFromBuckets(strengthBuckets);
+  const commercialTerritories = signalsFromBuckets(commercialBuckets);
+  const collabTerritories = signalsFromBuckets(collabBuckets);
+  const narrativeSignals = signalsFromBuckets(narrativeBuckets);
+  const strongestNarrative = narrativeSignals[0];
+  const strongestPattern = recurringPatterns[0];
+  const status = statusFor({
+    readingCount: readings.length,
+    strongestNarrativeEvidence: strongestNarrative?.evidenceCount ?? 0,
+    strongestPatternEvidence: strongestPattern?.evidenceCount ?? 0,
+  });
+  const canHaveMainNarrative =
+    readings.length >= 2 &&
+    Boolean(strongestNarrative) &&
+    (strongestNarrative?.evidenceCount ?? 0) >= 2 &&
+    status !== "first_reading";
+
+  const mainNarrative = canHaveMainNarrative && strongestNarrative
+    ? {
+        label: strongestNarrative.label,
+        summary:
+          status === "signals_emerging"
+            ? limitText(`Sinal em formação: ${strongestNarrative.summary}`, 180)
+            : limitText(`Essa narrativa começa a se repetir: ${strongestNarrative.summary}`, 180),
+        confidence: confidenceFor(strongestNarrative.evidenceCount),
+        evidenceCount: strongestNarrative.evidenceCount,
+      }
+    : null;
+
+  if (readings.length === 1) {
+    warnings.push({
+      code: "single_reading_not_profile",
+      message: "Primeiro sinal: ainda é cedo para chamar de padrão.",
+    });
+  }
+
+  return {
+    id: `profile-synthesis-v1-${readings.length}-${mainNarrative?.evidenceCount ?? 0}`,
+    status,
+    analyzedReadingsCount: readings.length,
+    mainNarrative,
+    testedNarratives,
+    recurringPatterns,
+    recurringTensions,
+    strengths,
+    commercialTerritories,
+    collabTerritories,
+    nextStrategicMove: buildNextStrategicMove({
+      status,
+      pattern: strongestPattern,
+      tension: recurringTensions[0],
+    }),
+    warnings,
+    generatedAt,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisFixtures.ts
@@ -1,0 +1,192 @@
+import { buildCreatorVideoNarrativeDiagnosisFixture } from "./creatorVideoNarrativeDiagnosisFixtures";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import type { CreatorVideoNarrativeDiagnosisSafeReading } from "./creatorVideoNarrativeDiagnosisReadService";
+import type { CreatorVideoNarrativeDiagnosisContributionType } from "./creatorVideoNarrativeDiagnosisTypes";
+
+export type CreatorStrategicProfileSynthesisFixtureState =
+  | "no_readings"
+  | "first_reading"
+  | "two_related_readings"
+  | "three_related_readings"
+  | "isolated_strong_video"
+  | "creative_deviation"
+  | "commercial_signals"
+  | "instagram_contextual";
+
+const USER_ID = "665f0f2c8a0b7d1f2c3a4b5c";
+
+function safeReading(params: {
+  diagnosisId: string;
+  createdAt: string;
+  narrative: string;
+  summary?: string;
+  mainAdjustment?: string;
+  contributionType: CreatorVideoNarrativeDiagnosisContributionType;
+  territories?: string[];
+}): CreatorVideoNarrativeDiagnosisSafeReading {
+  const sanitized = sanitizeCreatorVideoNarrativeDiagnosisInput(buildCreatorVideoNarrativeDiagnosisFixture({
+    userId: USER_ID,
+    diagnosisId: params.diagnosisId,
+    videoMetadata: {
+      analyzedAt: new Date(params.createdAt),
+      uploadedAt: new Date(params.createdAt),
+    },
+    videoReading: {
+      title: `Vídeo sobre ${params.narrative}`,
+      rememberedAs: `Vídeo sobre ${params.narrative}`,
+      summary: params.summary ?? `Esse vídeo mostra ${params.narrative} com identificação rápida.`,
+      whatVideoReveals: `Revela ${params.narrative} como sinal em observação.`,
+      mainNarrative: params.narrative,
+      creatorIntent: "Entender o que esse vídeo acrescenta ao Perfil.",
+      dominantInsight: params.narrative,
+    },
+    commercialReading: {
+      summary: params.territories?.length
+        ? `Há território possível em ${params.territories.join(", ")}.`
+        : "Ainda não há território comercial claro.",
+      brandTerritories: params.territories ?? [],
+      whyItCouldFitBrands: "Pode virar fit narrativo se aparecer em novas leituras.",
+      adAdaptationIdea: "Tipo de collab possível com cena de problema, escolha e consequência.",
+      limitations: "Ainda depende de repetição antes de virar frente principal.",
+    },
+    strategicRecommendation: {
+      mainAdjustment: params.mainAdjustment ?? "A abertura demora para chegar no conflito.",
+      nextExperiment: "Grave 3 vídeos começando direto pelo conflito.",
+      whatToRepeat: `Repetir ${params.narrative} com variações curtas.`,
+      whatToAvoid: "Tratar uma hipótese como padrão definitivo.",
+      successSignal: "Comentários reconhecendo a situação.",
+    },
+    profileContribution: {
+      type: params.contributionType,
+      confidence: params.contributionType === "confirms_existing_pattern" ? "high" : "low",
+      weight: params.contributionType === "confirms_existing_pattern" ? "high" : "low",
+      reason: `Este vídeo adiciona ${params.narrative} ao Perfil como leitura documentada.`,
+      profileImpactPreview: `Pode contribuir para ${params.narrative} se esse sinal se repetir.`,
+    },
+  }));
+
+  return {
+    userId: sanitized.userId,
+    diagnosisId: sanitized.diagnosisId,
+    status: sanitized.status,
+    videoReading: sanitized.videoReading,
+    speechReading: sanitized.speechReading,
+    productionReading: sanitized.productionReading,
+    commercialReading: sanitized.commercialReading,
+    strategicRecommendation: sanitized.strategicRecommendation,
+    profileContribution: sanitized.profileContribution,
+    safetyFlags: sanitized.safetyFlags,
+    createdAt: new Date(params.createdAt),
+    updatedAt: new Date(params.createdAt),
+    analyzedAt: new Date(params.createdAt),
+  };
+}
+
+export function buildCreatorStrategicProfileSynthesisReadingsFixture(
+  state: CreatorStrategicProfileSynthesisFixtureState,
+): CreatorVideoNarrativeDiagnosisSafeReading[] {
+  if (state === "no_readings") return [];
+
+  if (state === "first_reading") {
+    return [
+      safeReading({
+        diagnosisId: "reading-first",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "opens_new_hypothesis",
+      }),
+    ];
+  }
+
+  if (state === "two_related_readings") {
+    return [
+      safeReading({
+        diagnosisId: "reading-related-1",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+      safeReading({
+        diagnosisId: "reading-related-2",
+        createdAt: "2026-05-18T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+    ];
+  }
+
+  if (state === "three_related_readings" || state === "instagram_contextual") {
+    return [
+      safeReading({
+        diagnosisId: "reading-pattern-1",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+      safeReading({
+        diagnosisId: "reading-pattern-2",
+        createdAt: "2026-05-18T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+      safeReading({
+        diagnosisId: "reading-pattern-3",
+        createdAt: "2026-05-16T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+    ];
+  }
+
+  if (state === "isolated_strong_video") {
+    return [
+      safeReading({
+        diagnosisId: "reading-isolated-1",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        narrative: "ensaio reflexivo sobre rotina",
+        contributionType: "isolated_strong_video",
+      }),
+    ];
+  }
+
+  if (state === "creative_deviation") {
+    return [
+      safeReading({
+        diagnosisId: "reading-deviation-1",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        narrative: "humor cotidiano com identificação rápida",
+        contributionType: "confirms_existing_pattern",
+      }),
+      safeReading({
+        diagnosisId: "reading-deviation-2",
+        createdAt: "2026-05-18T10:00:00.000Z",
+        narrative: "experimento visual introspectivo",
+        contributionType: "creative_deviation",
+      }),
+    ];
+  }
+
+  return [
+    safeReading({
+      diagnosisId: "reading-commercial-1",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      narrative: "rotina real com vida adulta",
+      contributionType: "commercial_signal",
+      territories: ["rotina real", "vida adulta", "apps"],
+    }),
+    safeReading({
+      diagnosisId: "reading-commercial-2",
+      createdAt: "2026-05-18T10:00:00.000Z",
+      narrative: "rotina real com vida adulta",
+      contributionType: "commercial_signal",
+      territories: ["rotina real", "vida adulta"],
+    }),
+    safeReading({
+      diagnosisId: "reading-commercial-3",
+      createdAt: "2026-05-16T10:00:00.000Z",
+      narrative: "rotina real com vida adulta",
+      contributionType: "confirms_existing_pattern",
+      territories: ["rotina real"],
+    }),
+  ];
+}

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisPersistenceService.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisPersistenceService.test.ts
@@ -1,0 +1,263 @@
+import fs from "fs";
+import path from "path";
+import { Types } from "mongoose";
+import { buildCreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesis";
+import { buildCreatorStrategicProfileSynthesisReadingsFixture } from "./creatorStrategicProfileSynthesisFixtures";
+import { persistCreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesisPersistenceService";
+import { upsertStrategicProfileSnapshot } from "./mobileStrategicProfileSnapshotService";
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+
+jest.mock("./mobileStrategicProfileSnapshotService", () => ({
+  validateSnapshotPayload: jest.requireActual("./mobileStrategicProfileSnapshotService").validateSnapshotPayload,
+  upsertStrategicProfileSnapshot: jest.fn(),
+}));
+
+const mockUpsertStrategicProfileSnapshot = upsertStrategicProfileSnapshot as jest.Mock;
+
+function synthesisFor(state: Parameters<typeof buildCreatorStrategicProfileSynthesisReadingsFixture>[0]) {
+  return buildCreatorStrategicProfileSynthesis({
+    readings: buildCreatorStrategicProfileSynthesisReadingsFixture(state),
+  });
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("creatorStrategicProfileSynthesisPersistenceService", () => {
+  const userId = new Types.ObjectId().toString();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("faz upsert/update por userId quando mode write e a sintese tem evidencia", async () => {
+    const synthesis = synthesisFor("three_related_readings");
+    mockUpsertStrategicProfileSnapshot.mockResolvedValue({
+      userId,
+      accessLevel: "premium",
+      snapshot: {},
+      source: "video_reading_synthesis_v1",
+      lastAnalyzedAt: new Date(synthesis.generatedAt),
+    });
+
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis,
+      accessLevel: "premium",
+      mode: "write",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockUpsertStrategicProfileSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      userId,
+      accessLevel: "premium",
+      source: "video_reading_synthesis_v1",
+    }));
+  });
+
+  it("nao cria multiplos snapshots ativos indevidos porque usa o upsert unico por userId existente", async () => {
+    const synthesis = synthesisFor("three_related_readings");
+    mockUpsertStrategicProfileSnapshot.mockResolvedValue({
+      userId,
+      accessLevel: "free",
+      snapshot: {},
+      source: "video_reading_synthesis_v1",
+      lastAnalyzedAt: new Date(synthesis.generatedAt),
+    });
+
+    await persistCreatorStrategicProfileSynthesis({ userId, synthesis, mode: "write" });
+
+    expect(mockUpsertStrategicProfileSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockUpsertStrategicProfileSnapshot.mock.calls[0][0]).not.toHaveProperty("status", "inactive");
+  });
+
+  it("retorna resultado seguro", async () => {
+    const synthesis = synthesisFor("two_related_readings");
+    mockUpsertStrategicProfileSnapshot.mockResolvedValue({
+      userId,
+      accessLevel: "free",
+      snapshot: {},
+      source: "video_reading_synthesis_v1",
+      lastAnalyzedAt: new Date(synthesis.generatedAt),
+    });
+
+    const result = await persistCreatorStrategicProfileSynthesis({ userId, synthesis, mode: "write" });
+    const text = serialized(result);
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      userId,
+      synthesisStatus: "signals_emerging",
+      analyzedReadingsCount: 2,
+    }));
+    expect(text).not.toContain("stack");
+    expect(text).not.toContain("objectkey");
+    expect(text).not.toContain("signedurl");
+  });
+
+  it("erro de banco vira erro seguro sem stack trace", async () => {
+    mockUpsertStrategicProfileSnapshot.mockRejectedValue(new Error("database stack trace with token"));
+
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("three_related_readings"),
+      mode: "write",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "synthesis_snapshot_write_failed",
+      message: "Nao foi possivel persistir a sintese do Perfil.",
+    });
+  });
+
+  it("modo dry_run nao escreve no banco", async () => {
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("three_related_readings"),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result).toEqual(expect.objectContaining({ mode: "dry_run" }));
+    expect(mockUpsertStrategicProfileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("nao salva leituras completas no snapshot", async () => {
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("three_related_readings"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const text = serialized(result.payload);
+      expect(text).not.toContain("videoreading");
+      expect(text).not.toContain("speechreading");
+      expect(text).not.toContain("productionreading");
+      expect(text).not.toContain("profilecontribution");
+    }
+  });
+
+  it("nao salva video metadata sensivel", async () => {
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("commercial_signals"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const text = serialized(result.payload);
+      for (const forbidden of ["videometadata", "objectkey", "signedurl", "uploadurl", "thumbnailurl", "localpath", "storageproviderpath"]) {
+        expect(text).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it("nao sobrescreve com empty synthesis por acidente", async () => {
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("no_readings"),
+      mode: "write",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "insufficient_synthesis_evidence",
+      message: "Sintese vazia nao pode sobrescrever o snapshot do Perfil.",
+    });
+    expect(mockUpsertStrategicProfileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("first_reading nao vira narrativa principal definitiva", async () => {
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("first_reading"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.profileState).toBe("first_reading");
+      expect(result.payload.recurringPatterns).toEqual([]);
+      expect(serialized(result.payload)).not.toContain("definitiv");
+    }
+  });
+
+  it("sintese isolada nao apaga padrao existente sem evidencia suficiente", async () => {
+    const previousSnapshot: MobileStrategicProfileSnapshotPayload = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "pattern_in_formation",
+      unlockedSignals: ["Sinal anterior"],
+      pendingSignals: [],
+      recurringPatterns: ["Padrao existente acumulado"],
+      opportunities: [],
+      diagnosisSummary: "Resumo anterior",
+      commercialSummary: "Resumo comercial anterior",
+      lastAnalysisSummary: "Movimento anterior",
+    };
+
+    const result = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("isolated_strong_video"),
+      previousSnapshot,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.recurringPatterns).toEqual(["Padrao existente acumulado"]);
+    }
+  });
+
+  it("valida userId e expectedSource", async () => {
+    const invalidUser = await persistCreatorStrategicProfileSynthesis({
+      userId: "invalido",
+      synthesis: synthesisFor("three_related_readings"),
+      mode: "write",
+    });
+
+    const invalidSource = await persistCreatorStrategicProfileSynthesis({
+      userId,
+      synthesis: synthesisFor("three_related_readings"),
+      expectedSource: "wrong_source" as any,
+      mode: "write",
+    });
+
+    expect(invalidUser).toEqual(expect.objectContaining({ ok: false, errorCode: "invalid_synthesis_input" }));
+    expect(invalidSource).toEqual(expect.objectContaining({ ok: false, errorCode: "invalid_synthesis_input" }));
+    expect(mockUpsertStrategicProfileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("nao importa endpoint real/mock nem chama Gemini/storage", () => {
+    const source = fs.readFileSync(path.join(__dirname, "creatorStrategicProfileSynthesisPersistenceService.ts"), "utf8");
+
+    expect(source).not.toMatch(/api\/|@google\/genai|@aws-sdk|storageProvider|temporaryStorage|fetch\(/);
+  });
+
+  it("selector e preview continuam dry-run sem importar o service de persistencia", () => {
+    const selector = fs.readFileSync(path.join(__dirname, "narrativeMapMobileViewModelServerSelector.ts"), "utf8");
+    const preview = fs.readFileSync(
+      path.join(__dirname, "../components/videoUpload/appPreview/NarrativeMapReadingPreview.tsx"),
+      "utf8",
+    );
+
+    expect(selector).not.toContain("persistCreatorStrategicProfileSynthesis");
+    expect(preview).not.toContain("persistCreatorStrategicProfileSynthesis");
+    expect(preview).not.toContain("CreatorStrategicProfileSnapshot");
+  });
+
+  it("nao integra o write path novo ao caminho direto antigo de analise para snapshot", () => {
+    const realOrchestrator = fs.readFileSync(path.join(__dirname, "videoNarrativeRealAnalysisOrchestrator.ts"), "utf8");
+    const realRoute = fs.readFileSync(
+      path.join(__dirname, "../../../api/dashboard/mobile-strategic-profile/analyze/route.ts"),
+      "utf8",
+    );
+    const internalMockRoute = fs.readFileSync(
+      path.join(__dirname, "../../../api/internal/video-narrative/analyze/route.ts"),
+      "utf8",
+    );
+
+    expect(realOrchestrator).not.toContain("persistCreatorStrategicProfileSynthesis");
+    expect(realRoute).not.toContain("persistCreatorStrategicProfileSynthesis");
+    expect(internalMockRoute).not.toContain("persistCreatorStrategicProfileSynthesis");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisPersistenceService.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisPersistenceService.ts
@@ -1,0 +1,146 @@
+import { Types } from "mongoose";
+import type { CreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesis";
+import {
+  CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE,
+  CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_VERSION,
+  mapCreatorStrategicProfileSynthesisToSnapshotPayload,
+} from "./creatorStrategicProfileSynthesisSnapshotMapper";
+import type {
+  CreatorStrategicProfileSnapshotInput,
+  MobileStrategicProfileSnapshotPayload,
+} from "./mobileStrategicProfileSnapshotTypes";
+import { upsertStrategicProfileSnapshot, validateSnapshotPayload } from "./mobileStrategicProfileSnapshotService";
+
+export type CreatorStrategicProfileSynthesisPersistenceMode = "dry_run" | "write";
+
+export type CreatorStrategicProfileSynthesisPersistenceErrorCode =
+  | "invalid_synthesis_input"
+  | "unsafe_synthesis_payload"
+  | "synthesis_snapshot_write_failed"
+  | "insufficient_synthesis_evidence"
+  | "unknown_synthesis_persistence_error";
+
+export interface PersistCreatorStrategicProfileSynthesisParams {
+  userId: string;
+  synthesis: CreatorStrategicProfileSynthesis;
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  mode?: CreatorStrategicProfileSynthesisPersistenceMode;
+  expectedSource?: typeof CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE;
+  previousSnapshot?: MobileStrategicProfileSnapshotPayload | null;
+}
+
+export interface CreatorStrategicProfileSynthesisPersistenceDeps {
+  upsertSnapshot?: typeof upsertStrategicProfileSnapshot;
+}
+
+export type CreatorStrategicProfileSynthesisPersistenceResult =
+  | {
+      ok: true;
+      mode: CreatorStrategicProfileSynthesisPersistenceMode;
+      userId: string;
+      snapshotId?: string;
+      payload: MobileStrategicProfileSnapshotPayload;
+      synthesisVersion: string;
+      synthesisStatus: CreatorStrategicProfileSynthesis["status"];
+      analyzedReadingsCount: number;
+      updatedAt: string;
+    }
+  | {
+      ok: false;
+      errorCode: CreatorStrategicProfileSynthesisPersistenceErrorCode;
+      message: string;
+    };
+
+function invalidResult(
+  errorCode: CreatorStrategicProfileSynthesisPersistenceErrorCode,
+  message: string,
+): CreatorStrategicProfileSynthesisPersistenceResult {
+  return { ok: false, errorCode, message };
+}
+
+function validateSynthesisInput(params: PersistCreatorStrategicProfileSynthesisParams): CreatorStrategicProfileSynthesisPersistenceResult | null {
+  if (!params.userId || !Types.ObjectId.isValid(params.userId)) {
+    return invalidResult("invalid_synthesis_input", "UserId invalido para persistir sintese do Perfil.");
+  }
+
+  if (params.expectedSource && params.expectedSource !== CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE) {
+    return invalidResult("invalid_synthesis_input", "Origem da sintese nao permitida para este write path.");
+  }
+
+  if (!params.synthesis || typeof params.synthesis !== "object" || !params.synthesis.status) {
+    return invalidResult("invalid_synthesis_input", "Sintese invalida para persistencia do Perfil.");
+  }
+
+  if (!Number.isFinite(params.synthesis.analyzedReadingsCount) || params.synthesis.analyzedReadingsCount < 0) {
+    return invalidResult("invalid_synthesis_input", "Sintese sem contador seguro de leituras analisadas.");
+  }
+
+  return null;
+}
+
+function blocksWrite(synthesis: CreatorStrategicProfileSynthesis): boolean {
+  return synthesis.status === "empty";
+}
+
+export async function persistCreatorStrategicProfileSynthesis(
+  params: PersistCreatorStrategicProfileSynthesisParams,
+  deps: CreatorStrategicProfileSynthesisPersistenceDeps = {},
+): Promise<CreatorStrategicProfileSynthesisPersistenceResult> {
+  const mode = params.mode ?? "dry_run";
+  const invalid = validateSynthesisInput(params);
+  if (invalid) return invalid;
+
+  let payload: MobileStrategicProfileSnapshotPayload;
+  try {
+    payload = validateSnapshotPayload(mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: params.synthesis,
+      previousSnapshot: params.previousSnapshot,
+    }));
+  } catch {
+    return invalidResult("unsafe_synthesis_payload", "A sintese gerou payload inseguro para o snapshot.");
+  }
+
+  if (mode === "dry_run") {
+    return {
+      ok: true,
+      mode,
+      userId: params.userId,
+      payload,
+      synthesisVersion: CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_VERSION,
+      synthesisStatus: params.synthesis.status,
+      analyzedReadingsCount: params.synthesis.analyzedReadingsCount,
+      updatedAt: params.synthesis.generatedAt,
+    };
+  }
+
+  if (blocksWrite(params.synthesis)) {
+    return invalidResult(
+      "insufficient_synthesis_evidence",
+      "Sintese vazia nao pode sobrescrever o snapshot do Perfil.",
+    );
+  }
+
+  try {
+    const upsertSnapshot = deps.upsertSnapshot ?? upsertStrategicProfileSnapshot;
+    const result = await upsertSnapshot({
+      userId: params.userId,
+      accessLevel: params.accessLevel ?? "free",
+      snapshot: payload,
+      source: CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE,
+      lastAnalyzedAt: new Date(params.synthesis.generatedAt),
+    } satisfies CreatorStrategicProfileSnapshotInput);
+
+    return {
+      ok: true,
+      mode,
+      userId: result.userId,
+      payload,
+      synthesisVersion: CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_VERSION,
+      synthesisStatus: params.synthesis.status,
+      analyzedReadingsCount: params.synthesis.analyzedReadingsCount,
+      updatedAt: (result.lastAnalyzedAt ?? new Date(params.synthesis.generatedAt)).toISOString(),
+    };
+  } catch {
+    return invalidResult("synthesis_snapshot_write_failed", "Nao foi possivel persistir a sintese do Perfil.");
+  }
+}

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisSnapshotMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisSnapshotMapper.test.ts
@@ -1,0 +1,127 @@
+import fs from "fs";
+import path from "path";
+import { buildCreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesis";
+import { buildCreatorStrategicProfileSynthesisReadingsFixture } from "./creatorStrategicProfileSynthesisFixtures";
+import { mapCreatorStrategicProfileSynthesisToSnapshotPayload } from "./creatorStrategicProfileSynthesisSnapshotMapper";
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+
+function synthesisFor(state: Parameters<typeof buildCreatorStrategicProfileSynthesisReadingsFixture>[0]) {
+  return buildCreatorStrategicProfileSynthesis({
+    readings: buildCreatorStrategicProfileSynthesisReadingsFixture(state),
+  });
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("creatorStrategicProfileSynthesisSnapshotMapper", () => {
+  it("mapeia first_reading para snapshot com linguagem conservadora", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("first_reading"),
+    });
+
+    expect(payload.profileState).toBe("first_reading");
+    expect(payload.diagnosisSummary).toContain("Primeiro sinal");
+    expect(payload.diagnosisSummary).toContain("cedo");
+    expect(payload.recurringPatterns).toEqual([]);
+  });
+
+  it("mapeia signals_emerging para sinais em formacao sem criar padrao recorrente", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("two_related_readings"),
+    });
+
+    expect(payload.profileState).toBe("signals_emerging");
+    expect(payload.diagnosisSummary).toContain("Sinal em formacao");
+    expect(payload.recurringPatterns).toEqual([]);
+  });
+
+  it("mapeia pattern_in_formation para recurringPatterns", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("three_related_readings"),
+    });
+
+    expect(payload.profileState).toBe("pattern_in_formation");
+    expect(payload.recurringPatterns[0]).toContain("Padrao em formacao");
+    expect(payload.recurringPatterns[0]).toContain("humor cotidiano");
+  });
+
+  it("mapeia commercialTerritories para opportunities/commercialSummary sem match real", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("commercial_signals"),
+    });
+    const text = serialized(payload);
+
+    expect(payload.opportunities.some((item) => item.includes("Territorio em formacao"))).toBe(true);
+    expect(payload.commercialSummary).toContain("Territorios em formacao");
+    expect(text).not.toContain("match real");
+  });
+
+  it("mapeia recurringTensions para pontos de atencao recorrentes", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("three_related_readings"),
+    });
+
+    expect(payload.pendingSignals.some((signal) => signal.includes("Ponto de atencao recorrente"))).toBe(true);
+  });
+
+  it("mapeia nextStrategicMove para recomendacao de proximo movimento", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("three_related_readings"),
+    });
+
+    expect(payload.lastAnalysisSummary).toContain("Testar");
+    expect(payload.lastAnalysisSummary).toContain("3 vídeos");
+  });
+
+  it("nao inclui campos sensiveis", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("commercial_signals"),
+    });
+    const text = serialized(payload);
+
+    for (const forbidden of ["objectkey", "signedurl", "uploadurl", "thumbnailurl", "localpath", "storageproviderpath"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("nao usa termos proibidos no payload", () => {
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("commercial_signals"),
+    });
+    const text = serialized(payload);
+
+    for (const forbidden of ["score", "nota", "viralizar", "garantido", "certeza", "comprovado", "match real", "publi garantida"]) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("preserva padrao existente quando a sintese isolada ainda nao tem evidencia suficiente", () => {
+    const previousSnapshot: MobileStrategicProfileSnapshotPayload = {
+      schemaVersion: "mobile_strategic_profile_snapshot_v1",
+      profileState: "pattern_in_formation",
+      unlockedSignals: ["Sinal anterior"],
+      pendingSignals: [],
+      recurringPatterns: ["Padrao existente acumulado"],
+      opportunities: [],
+      diagnosisSummary: "Resumo anterior",
+      commercialSummary: "Resumo comercial anterior",
+      lastAnalysisSummary: "Movimento anterior",
+    };
+
+    const payload = mapCreatorStrategicProfileSynthesisToSnapshotPayload({
+      synthesis: synthesisFor("isolated_strong_video"),
+      previousSnapshot,
+    });
+
+    expect(payload.recurringPatterns).toEqual(["Padrao existente acumulado"]);
+    expect(payload.diagnosisSummary).toContain("Primeiro sinal");
+  });
+
+  it("mapper puro nao importa banco, endpoint, SDK ou modelo de snapshot", () => {
+    const source = fs.readFileSync(path.join(__dirname, "creatorStrategicProfileSynthesisSnapshotMapper.ts"), "utf8");
+
+    expect(source).not.toMatch(/connectToDatabase|from ["']mongoose["']|@google\/genai|@aws-sdk|api\/|CreatorStrategicProfileSnapshot|fetch\(/);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisSnapshotMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorStrategicProfileSynthesisSnapshotMapper.ts
@@ -1,0 +1,171 @@
+import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+import type {
+  CreatorStrategicProfileSynthesis,
+  CreatorStrategicProfileSynthesisSignal,
+  CreatorStrategicProfileSynthesisStatus,
+} from "./creatorStrategicProfileSynthesis";
+
+export const CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_VERSION = "creator_profile_synthesis_snapshot_v1";
+export const CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE = "video_reading_synthesis_v1";
+
+export interface CreatorStrategicProfileSynthesisSnapshotMappingInput {
+  synthesis: CreatorStrategicProfileSynthesis;
+  previousSnapshot?: MobileStrategicProfileSnapshotPayload | null;
+}
+
+const FORBIDDEN_TEXT_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/https?:\/\/[^\s"'<>]+/gi, "referencia removida"],
+  [/\b(?:objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi, "referencia removida"],
+  [/\b(?:storage|raw response|raw model response|Gemini)\b/gi, "leitura estruturada"],
+  [/\b(?:score|nota|pontuacao|pontuação)\b/gi, "leitura"],
+  [/\bviralizar\b/gi, "crescer com consistencia"],
+  [/\bgarantid[oa]\b/gi, "possivel"],
+  [/\bcerteza\b/gi, "hipotese"],
+  [/\bcomprovad[oa]\b/gi, "em observacao"],
+  [/\bmatch\s+real\b/gi, "fit narrativo possivel"],
+  [/\bpubli\s+garantida\b/gi, "oportunidade em formacao"],
+];
+
+function cleanText(value: string | null | undefined, fallback = ""): string {
+  const raw = value?.trim() || fallback;
+  return FORBIDDEN_TEXT_REPLACEMENTS.reduce((text, [pattern, replacement]) => text.replace(pattern, replacement), raw)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function limitText(value: string, maxLength: number): string {
+  const text = cleanText(value);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 3).trim()}...`;
+}
+
+function unique(values: string[], maxItems: number): string[] {
+  const seen = new Set<string>();
+  return values
+    .map((value) => limitText(value, 180))
+    .filter(Boolean)
+    .filter((value) => {
+      const key = value.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, maxItems);
+}
+
+function signalLine(prefix: string, signal: CreatorStrategicProfileSynthesisSignal): string {
+  return `${prefix}: ${signal.label}`;
+}
+
+function statusLabel(status: CreatorStrategicProfileSynthesisStatus): string {
+  if (status === "empty") return "Sem leituras acumuladas";
+  if (status === "first_reading") return "Primeira leitura";
+  if (status === "signals_emerging") return "Sinais em formacao";
+  if (status === "profile_consistent") return "Perfil consistente";
+  return "Padrao em formacao";
+}
+
+function diagnosisSummaryFor(synthesis: CreatorStrategicProfileSynthesis): string {
+  if (synthesis.status === "empty") {
+    return "Ainda nao ha leituras documentadas suficientes para atualizar o Perfil acumulado.";
+  }
+
+  if (synthesis.status === "first_reading") {
+    const signal = synthesis.testedNarratives[0] ?? synthesis.strengths[0];
+    return signal
+      ? `Primeiro sinal em observacao: ${signal.label}. Ainda e cedo para tratar como padrao do Perfil.`
+      : "Primeira leitura registrada. Ainda e cedo para tratar como padrao do Perfil.";
+  }
+
+  if (synthesis.status === "signals_emerging") {
+    return synthesis.mainNarrative
+      ? `Sinal em formacao: ${synthesis.mainNarrative.label}. A leitura acumulada ainda pede novas evidencias.`
+      : "Sinais em formacao aparecem nas leituras, ainda sem narrativa principal consolidada.";
+  }
+
+  if (synthesis.mainNarrative) {
+    return `Sintese acumulada: ${synthesis.mainNarrative.label}. ${synthesis.mainNarrative.summary}`;
+  }
+
+  return "Padroes em formacao aparecem nas leituras acumuladas, com recomendacao de novos testes.";
+}
+
+function commercialSummaryFor(synthesis: CreatorStrategicProfileSynthesis): string {
+  const territories = synthesis.commercialTerritories.map((territory) => territory.label);
+  if (!territories.length) {
+    return "Ainda nao ha territorio comercial recorrente suficiente; manter oportunidades como hipotese.";
+  }
+
+  return `Territorios em formacao: ${territories.slice(0, 3).join(", ")}. Fit narrativo possivel, sem promessa de acordo comercial.`;
+}
+
+function lastAnalysisSummaryFor(synthesis: CreatorStrategicProfileSynthesis): string {
+  if (synthesis.nextStrategicMove) {
+    return `${synthesis.nextStrategicMove.label}: ${synthesis.nextStrategicMove.description}`;
+  }
+
+  return "Proximo movimento: gerar novas leituras documentadas antes de atualizar a narrativa principal.";
+}
+
+function recurringPatternsFor(
+  synthesis: CreatorStrategicProfileSynthesis,
+  previousSnapshot?: MobileStrategicProfileSnapshotPayload | null,
+): string[] {
+  if (synthesis.status === "empty") {
+    return previousSnapshot?.recurringPatterns ?? [];
+  }
+
+  if (synthesis.status === "first_reading") {
+    return previousSnapshot?.recurringPatterns ?? [];
+  }
+
+  if (synthesis.status === "signals_emerging") {
+    return previousSnapshot?.recurringPatterns ?? [];
+  }
+
+  return unique(synthesis.recurringPatterns.map((signal) => signalLine("Padrao em formacao", signal)), 5);
+}
+
+export function mapCreatorStrategicProfileSynthesisToSnapshotPayload(
+  input: CreatorStrategicProfileSynthesisSnapshotMappingInput,
+): MobileStrategicProfileSnapshotPayload {
+  const { synthesis, previousSnapshot } = input;
+  const recurringPatterns = recurringPatternsFor(synthesis, previousSnapshot);
+  const unlockedSignals = unique([
+    statusLabel(synthesis.status),
+    ...synthesis.strengths.map((signal) => signalLine("Forca observada", signal)),
+    ...(synthesis.mainNarrative ? [signalLine("Narrativa acumulada", synthesis.mainNarrative)] : []),
+  ], 6);
+  const pendingSignals = unique([
+    ...synthesis.testedNarratives.map((signal) => signalLine("Hipotese em teste", signal)),
+    ...synthesis.recurringTensions.map((signal) => signalLine("Ponto de atencao recorrente", signal)),
+    ...synthesis.warnings.map((warning) => warning.message),
+  ], 6);
+  const opportunities = unique([
+    ...synthesis.commercialTerritories.map((signal) => signalLine("Territorio em formacao", signal)),
+    ...synthesis.collabTerritories.map((signal) => signalLine("Tipo de collab possivel", signal)),
+  ], 6);
+
+  return {
+    schemaVersion: "mobile_strategic_profile_snapshot_v1",
+    profileState: synthesis.status,
+    unlockedSignals,
+    pendingSignals,
+    recurringPatterns,
+    opportunities,
+    diagnosisSummary: limitText(diagnosisSummaryFor(synthesis), 2000),
+    commercialSummary: limitText(commercialSummaryFor(synthesis), 1200),
+    lastAnalysisSummary: limitText(lastAnalysisSummaryFor(synthesis), 1200),
+    extraData: {
+      synthesisVersion: CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_VERSION,
+      synthesisUpdatedAt: synthesis.generatedAt,
+      synthesisSource: CREATOR_PROFILE_SYNTHESIS_SNAPSHOT_SOURCE,
+      analyzedReadingsCount: synthesis.analyzedReadingsCount,
+      synthesisStatus: synthesis.status,
+      synthesisWarnings: synthesis.warnings.map((warning) => ({
+        code: cleanText(warning.code),
+        message: cleanText(warning.message),
+      })),
+    },
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisFixtures.ts
@@ -1,0 +1,74 @@
+import type { CreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisTypes";
+
+const FIXTURE_USER_ID = "665f0f2c8a0b7d1f2c3a4b5c";
+
+export function buildCreatorVideoNarrativeDiagnosisFixture(
+  overrides: Partial<CreatorVideoNarrativeDiagnosisInput> = {},
+): CreatorVideoNarrativeDiagnosisInput {
+  return {
+    userId: FIXTURE_USER_ID,
+    diagnosisId: `diagnosis-${Date.now()}`,
+    status: "completed",
+    source: "mock",
+    videoMetadata: {
+      mimeType: "video/mp4",
+      sizeBytes: 12_000_000,
+      durationSeconds: 42,
+      originalFileNameSanitized: "rotina-skincare.mp4",
+      uploadedAt: new Date("2026-05-20T10:00:00.000Z"),
+      analyzedAt: new Date("2026-05-20T10:03:00.000Z"),
+    },
+    creatorGoal: "Entender se este vídeo pode fortalecer posicionamento comercial.",
+    selectedGoalOption: "commercial_positioning",
+    videoReading: {
+      title: "Rotina que vira prova de autoridade",
+      rememberedAs: "Bastidor simples com clareza de recomendação.",
+      summary: "O vídeo comunica rotina real e aproxima a creator de um território de cuidado prático.",
+      whatVideoReveals: "Revela consistência, repertório de produto e capacidade de explicar escolha.",
+      mainNarrative: "Cuidado cotidiano com critério.",
+      creatorIntent: "Mostrar uma rotina confiável sem parecer publi direta.",
+      dominantInsight: "A autoridade aparece melhor quando a creator explica o porquê das escolhas.",
+    },
+    speechReading: {
+      summary: "A fala é direta, mas pode abrir com uma tensão mais específica.",
+      openingRead: "A abertura contextualiza, mas não cria urgência imediata.",
+      clarityRead: "A linha central é compreensível.",
+      pacingRead: "O ritmo sustenta a atenção sem acelerar demais.",
+      suggestedLine: "Eu uso isso quando quero resolver textura sem complicar a rotina.",
+      suggestedOpening: "Se sua pele fica boa só no primeiro dia, olha essa ordem.",
+      suggestedClosing: "Salva essa ordem para testar quando a rotina estiver confusa.",
+    },
+    productionReading: {
+      summary: "Produção simples, suficiente para credibilidade.",
+      framing: "Enquadramento próximo ajuda a leitura dos gestos.",
+      lighting: "Luz funcional, com espaço para mais contraste no primeiro frame.",
+      audio: "Áudio claro.",
+      editingRhythm: "Cortes acompanham a explicação.",
+      firstFrame: "Poderia antecipar o resultado ou o problema.",
+      visualClarity: "Produtos e gestos ficam legíveis.",
+    },
+    commercialReading: {
+      summary: "Há sinal comercial em skincare, beleza acessível e rotina prática.",
+      brandTerritories: ["skincare", "beleza funcional", "rotina prática"],
+      whyItCouldFitBrands: "A creator consegue transformar uso real em argumento simples.",
+      adAdaptationIdea: "Adaptar para uma sequência problema, escolha, uso e resultado esperado.",
+      limitations: "Ainda precisa de mais evidências de performance para sustentar território principal.",
+    },
+    strategicRecommendation: {
+      mainAdjustment: "Abrir com um problema mais reconhecível.",
+      nextExperiment: "Testar primeiro frame com promessa clara antes do produto.",
+      whatToRepeat: "Tom de bastidor e explicação prática.",
+      whatToAvoid: "Começar direto no produto sem tensão narrativa.",
+      successSignal: "Mais salvamentos e respostas perguntando pela ordem da rotina.",
+    },
+    profileContribution: {
+      type: "commercial_signal",
+      confidence: "medium",
+      weight: "medium",
+      reason: "O vídeo mostra potencial comercial, mas ainda não deve redefinir o Perfil geral.",
+      profileImpactPreview: "Pode virar evidência futura de território em beleza funcional se recorrente.",
+    },
+    schemaVersion: "creator_video_narrative_diagnosis_v1",
+    ...overrides,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
@@ -1,0 +1,222 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import { mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisMapper";
+import {
+  buildCreatorVideoNarrativeDiagnosisMapperParams,
+  buildMapperEvolvingDiagnosisFixture,
+  buildMapperStrategicDiagnosisFixture,
+} from "./creatorVideoNarrativeDiagnosisMapperFixtures";
+
+describe("creatorVideoNarrativeDiagnosisMapper", () => {
+  it("cria um CreatorVideoNarrativeDiagnosisInput valido a partir das camadas estruturadas", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams(),
+    );
+
+    expect(result.schemaVersion).toBe("creator_video_narrative_diagnosis_v1");
+    expect(result.userId).toBe("665f0f2c8a0b7d1f2c3a4b5c");
+    expect(result.diagnosisId).toBe("video-narrative-diagnosis-analysis-1");
+    expect(result.videoReading.title).toContain("humor cotidiano");
+    expect(result.speechReading.suggestedOpening).toContain("reuniao");
+    expect(result.productionReading.summary).toContain("producao");
+    expect(result.strategicRecommendation.mainAdjustment.toLowerCase()).toContain("fechar");
+  });
+
+  it("nao aceita raw Gemini response ou raw model output", () => {
+    expect(() =>
+      mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput({
+        ...buildCreatorVideoNarrativeDiagnosisMapperParams(),
+        rawGeminiResponse: { candidates: [{ content: "nao deve entrar" }] },
+      } as any),
+    ).toThrow("raw model output");
+  });
+
+  it("nao propaga objectKey, signedUrl, uploadUrl, thumbnailUrl, localPath ou storageProviderPath", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        safeVideoMetadata: {
+          mimeType: "video/mp4",
+          sizeBytes: 100,
+          objectKey: "uploads/user/video.mp4",
+          signedUrl: "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Signature=abc",
+          uploadUrl: "https://upload.example.com/video.mp4?token=abc",
+          thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+          localPath: "/tmp/video.mp4",
+          storageProviderPath: "r2://bucket/video.mp4",
+        } as any,
+      }),
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(result.videoMetadata).toEqual({
+      mimeType: "video/mp4",
+      sizeBytes: 100,
+      analyzedAt: new Date("2026-05-20T10:00:00.000Z"),
+    });
+    expect(serialized).not.toContain("objectKey");
+    expect(serialized).not.toContain("signedUrl");
+    expect(serialized).not.toContain("uploadUrl");
+    expect(serialized).not.toContain("thumbnailUrl");
+    expect(serialized).not.toContain("localPath");
+    expect(serialized).not.toContain("storageProviderPath");
+  });
+
+  it("preenche profileContribution obrigatoriamente", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams(),
+    );
+
+    expect(result.profileContribution).toEqual(
+      expect.objectContaining({
+        type: expect.any(String),
+        confidence: expect.any(String),
+        weight: expect.any(String),
+        reason: expect.any(String),
+        profileImpactPreview: expect.any(String),
+      }),
+    );
+  });
+
+  it("classifica primeira leitura como hipotese ou needs_more_samples, nunca como padrao definitivo", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        evolvingDiagnosis: buildMapperEvolvingDiagnosisFixture({
+          currentLevel: {
+            id: "first_reading",
+            label: "Primeira leitura",
+            description: "Primeira leitura estrategica.",
+            position: 1,
+          },
+          recurringPatterns: [],
+          profileImpact: {
+            ...buildMapperEvolvingDiagnosisFixture().profileImpact,
+            usefulSignalsCount: 1,
+            recurringSignalsCount: 0,
+            recurringPatternsCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(["opens_new_hypothesis", "needs_more_samples"]).toContain(result.profileContribution.type);
+    expect(result.profileContribution.type).not.toBe("confirms_existing_pattern");
+    expect(result.profileContribution.confidence).toBe("low");
+    expect(result.profileContribution.weight).toBe("low");
+  });
+
+  it("classifica padrao recorrente como confirms_existing_pattern apenas quando ha recorrencia compativel", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        evolvingDiagnosis: buildMapperEvolvingDiagnosisFixture({
+          currentLevel: {
+            id: "narrative_in_formation",
+            label: "Narrativa em formacao",
+            description: "Mapa ja conecta sinais recorrentes.",
+            position: 3,
+          },
+          recurringPatterns: ["sinal recorrente: humor cotidiano com identificacao rapida"],
+          profileImpact: {
+            ...buildMapperEvolvingDiagnosisFixture().profileImpact,
+            usefulSignalsCount: 5,
+            recurringSignalsCount: 2,
+            recurringPatternsCount: 1,
+          },
+        }),
+      }),
+    );
+
+    expect(result.profileContribution.type).toBe("confirms_existing_pattern");
+    expect(result.profileContribution.confidence).toBe("high");
+    expect(result.profileContribution.weight).toBe("high");
+  });
+
+  it("classifica oportunidade comercial como commercial_signal sem prometer match real", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        evolvingDiagnosis: buildMapperEvolvingDiagnosisFixture({
+          currentLevel: {
+            id: "initial_patterns",
+            label: "Padroes iniciais",
+            description: "Primeiros padroes aparecem.",
+            position: 2,
+          },
+          profileImpact: {
+            ...buildMapperEvolvingDiagnosisFixture().profileImpact,
+            usefulSignalsCount: 4,
+            recurringSignalsCount: 1,
+          },
+          recurringPatterns: ["sinal recorrente: formato de cena curta"],
+        }),
+      }),
+    );
+
+    expect(result.profileContribution.type).toBe("commercial_signal");
+    const serialized = JSON.stringify(result).toLowerCase();
+    expect(serialized).not.toContain("match real");
+    expect(serialized).not.toContain("publi garantida");
+    expect(serialized).not.toContain("marca garantida");
+  });
+
+  it("cria rememberedAs seguro sem depender de thumbnail ou arquivo salvo", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        safeVideoMetadata: {
+          originalFileNameSanitized: "nome-sensivel-do-arquivo.mp4",
+          thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+        } as any,
+      }),
+    );
+
+    expect(result.videoReading.rememberedAs).toContain("Video sobre");
+    expect(result.videoReading.rememberedAs).not.toContain("thumb");
+    expect(result.videoReading.rememberedAs).not.toContain("nome-sensivel");
+  });
+
+  it("passa pelo sanitizer do MM74", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams(),
+    );
+
+    expect(() => sanitizeCreatorVideoNarrativeDiagnosisInput(result)).not.toThrow();
+  });
+
+  it("nao importa Mongoose, storage SDK, Gemini SDK ou codigo client-side", () => {
+    const mapperPath = path.join(__dirname, "creatorVideoNarrativeDiagnosisMapper.ts");
+    const source = readFileSync(mapperPath, "utf8");
+
+    expect(source).not.toMatch(/from ["']mongoose["']|@google\/genai|@aws-sdk|["']use client["']/);
+  });
+
+  it("nao importa nem atualiza CreatorStrategicProfileSnapshot", () => {
+    const mapperPath = path.join(__dirname, "creatorVideoNarrativeDiagnosisMapper.ts");
+    const source = readFileSync(mapperPath, "utf8");
+
+    expect(source).not.toContain("CreatorStrategicProfileSnapshot");
+    expect(source).not.toContain("upsertStrategicProfileSnapshot");
+    expect(source).not.toContain("findOneAndUpdate");
+  });
+
+  it("sanitiza input com signed URL, objectKey, base64 grande ou texto de raw response", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        safeVideoMetadata: {
+          objectKey: "uploads/user/video.mp4",
+          signedUrl: "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Signature=abc",
+        } as any,
+        strategicDiagnosis: buildMapperStrategicDiagnosisFixture({
+          mainNarrative:
+            "raw response trouxe data:video/mp4;base64," + "A".repeat(1400) + " e uploads/user/video.mp4",
+          strategicReading: "Nao usar https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Signature=abc no documento.",
+        }),
+      }),
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("X-Amz-Signature");
+    expect(serialized).not.toContain("uploads/user/video.mp4");
+    expect(serialized).not.toContain("data:video/mp4;base64");
+    expect(serialized).toContain("[base64-redacted]");
+    expect(serialized).toContain("[object-key-redacted]");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
@@ -1,0 +1,339 @@
+import type {
+  CreatorVideoNarrativeDiagnosisContributionType,
+  CreatorVideoNarrativeDiagnosisInput,
+  CreatorVideoNarrativeDiagnosisSource,
+  CreatorVideoNarrativeDiagnosisVideoMetadata,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import type { VideoNarrativeStrategicDiagnosis } from "./videoNarrativeDiagnosisLearningModel";
+import type { VideoNarrativeEvolvingDiagnosis } from "./videoNarrativeEvolvingDiagnosisContract";
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+export interface CreatorVideoNarrativeDiagnosisMapperParams {
+  userId: string;
+  source: CreatorVideoNarrativeDiagnosisSource;
+  creatorGoal: string;
+  selectedGoalOption: string;
+  safeVideoMetadata?: CreatorVideoNarrativeDiagnosisVideoMetadata & Record<string, unknown>;
+  strategicDiagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+  presentation: VideoNarrativeDiagnosisPresentation;
+  seed?: PostCreationVideoSeed | null;
+  createdAt?: Date | string | null;
+  analyzedAt?: Date | string | null;
+}
+
+const FALLBACK = {
+  speechLimited: "A leitura de fala ainda e limitada para este video; vale confirmar abertura, ritmo e fechamento em novas amostras.",
+  productionLimited: "A leitura de producao ainda e limitada; os proximos videos ajudam a separar escolha criativa de restricao tecnica.",
+  commercialLimited: "Existe apenas uma oportunidade futura em observacao, sem encaixe comercial real ou promessa comercial.",
+};
+
+const BLOCKED_OUTPUT_TERMS: Array<[RegExp, string]> = [
+  [/data:[^;]+;base64,[A-Za-z0-9+/=]+/gi, "[base64-redacted]"],
+  [/\b(?:uploads|video-narrative|mobile-strategic-profile|tmp|temporary)\/[A-Za-z0-9._/-]+\.(mp4|mov|webm|mkv)\b/gi, "[object-key-redacted]"],
+  [/https?:\/\/[^\s"'<>]+[?&](x-amz-signature|x-goog-signature|signature|expires|token|policy|x-amz-credential)=\S*/gi, "[signed-url-redacted]"],
+  [/\bviralizar\b/gi, "crescer com consistencia"],
+  [/\bscore\b/gi, "leitura"],
+  [/\bnota\b/gi, "leitura"],
+  [/\bmatch\s+real\b/gi, "territorio possivel"],
+  [/\bmatch\s+comprovado\b/gi, "fit narrativo"],
+  [/\bpubli\s+garantida\b/gi, "oportunidade futura"],
+  [/\bpatroc[ií]nio\s+garantido\b/gi, "oportunidade futura"],
+  [/\bgarantid[oa]\b/gi, "possivel"],
+  [/\bcerteza\b/gi, "hipotese"],
+  [/\bGemini\b/g, "modelo"],
+  [/\bstorage\b/gi, "referencia temporaria"],
+  [/\braw response\b/gi, "resposta estruturada"],
+  [/\bobjectKey\b/g, "referencia removida"],
+  [/\bsigned URL\b/gi, "referencia removida"],
+];
+
+const DANGEROUS_PARAM_KEYS = new Set([
+  "rawGeminiResponse",
+  "rawModelResponse",
+  "geminiResponse",
+  "providerResponse",
+  "modelResponse",
+]);
+
+function assertNoRawModelPayload(value: unknown, path = "params"): void {
+  if (!value || typeof value !== "object") return;
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_PARAM_KEYS.has(key)) {
+      throw new Error(`Mapper de leitura de video nao aceita raw model output em ${path}.${key}`);
+    }
+    assertNoRawModelPayload(child, `${path}.${key}`);
+  }
+}
+
+function clean(value: string | null | undefined, fallback = ""): string {
+  const raw = value?.trim() || fallback;
+  const normalized = BLOCKED_OUTPUT_TERMS.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    raw,
+  );
+  return normalized.replace(/\s+/g, " ").trim();
+}
+
+function firstText(values: Array<string | null | undefined>, fallback: string): string {
+  return clean(values.find((value) => value?.trim()), fallback);
+}
+
+function shortText(value: string, maxLength: number): string {
+  const text = clean(value);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trim()}...`;
+}
+
+function dateFrom(value: Date | string | null | undefined): Date | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isFinite(parsed.getTime()) ? parsed : null;
+  }
+  return null;
+}
+
+function dayMonth(value: Date | string | null | undefined): string {
+  const date = dateFrom(value) ?? new Date();
+  return `${String(date.getUTCDate()).padStart(2, "0")}/${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function words(value: string): Set<string> {
+  return new Set(
+    clean(value)
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((word) => word.length >= 4),
+  );
+}
+
+function hasCompatibleRecurringPattern(params: {
+  recurringPatterns: string[];
+  mainNarrative: string;
+  strategicReading: string;
+}): boolean {
+  const candidateWords = new Set([...words(params.mainNarrative), ...words(params.strategicReading)]);
+  if (candidateWords.size === 0) return false;
+
+  return params.recurringPatterns.some((pattern) => {
+    const patternWords = words(pattern);
+    return [...patternWords].some((word) => candidateWords.has(word));
+  });
+}
+
+function commercialTerritories(params: {
+  strategicDiagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+}): string[] {
+  return Array.from(new Set([
+    ...params.strategicDiagnosis.brandPotential.territories,
+    ...params.evolvingDiagnosis.opportunities
+      .filter((opportunity) => opportunity.type === "brand_territory")
+      .map((opportunity) => opportunity.label),
+  ].map((item) => clean(item)).filter(Boolean))).slice(0, 6);
+}
+
+function mapProfileContribution(params: {
+  strategicDiagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+}): CreatorVideoNarrativeDiagnosisInput["profileContribution"] {
+  const mainNarrative = clean(params.strategicDiagnosis.mainNarrative ?? "");
+  const strategicReading = clean(params.strategicDiagnosis.strategicReading ?? "");
+  const recurringPatterns = params.evolvingDiagnosis.recurringPatterns.map((item) => clean(item)).filter(Boolean);
+  const hasRecurringPattern = hasCompatibleRecurringPattern({
+    recurringPatterns,
+    mainNarrative,
+    strategicReading,
+  });
+  const territories = commercialTerritories(params);
+  const hasCommercialSignal = params.strategicDiagnosis.brandPotential.enabled || territories.length > 0;
+  const hasStrongVideoReading = Boolean(
+    params.strategicDiagnosis.strength ||
+      params.strategicDiagnosis.recommendedAdjustment ||
+      params.strategicDiagnosis.blueprint.whatToPost,
+  );
+  const currentLevel = params.evolvingDiagnosis.currentLevel.id;
+  const isFirstReading =
+    currentLevel === "first_reading" ||
+    params.evolvingDiagnosis.profileImpact.usefulSignalsCount <= 1 ||
+    params.evolvingDiagnosis.profileImpact.recurringSignalsCount === 0;
+
+  let type: CreatorVideoNarrativeDiagnosisContributionType = "needs_more_samples";
+  let confidence: "low" | "medium" | "high" = "low";
+  let weight: "low" | "medium" | "high" = "low";
+  let reason = "Este video adiciona uma leitura inicial, mas ainda precisa de mais amostras antes de virar padrao.";
+  let profileImpactPreview = "Entra como sinal em observacao para uma sintese futura do Perfil.";
+
+  if (!mainNarrative && !strategicReading) {
+    type = "weak_positioning_signal";
+    reason = "A narrativa principal ainda esta pouco definida para influenciar o Perfil geral.";
+    profileImpactPreview = "Ajuda a mostrar uma lacuna, mas nao muda a narrativa principal do Perfil.";
+  } else if (hasRecurringPattern) {
+    type = "confirms_existing_pattern";
+    confidence = "high";
+    weight = "high";
+    reason = `Este video reforca um sinal recorrente ja visivel: ${shortText(recurringPatterns[0] ?? "padrao narrativo em formacao", 110)}.`;
+    profileImpactPreview = "Reforca uma narrativa em formacao, mas ainda depende da sintese futura do Perfil.";
+  } else if (hasCommercialSignal && !hasRecurringPattern && !isFirstReading) {
+    type = "commercial_signal";
+    confidence = "medium";
+    weight = "medium";
+    reason = "O video abre um territorio comercial possivel sem indicar encaixe comercial real ou oportunidade fechada.";
+    profileImpactPreview = "Pode alimentar uma oportunidade futura se o mesmo territorio aparecer em mais leituras.";
+  } else if (isFirstReading) {
+    type = hasStrongVideoReading ? "opens_new_hypothesis" : "needs_more_samples";
+    confidence = "low";
+    weight = "low";
+    reason = "Como primeira leitura, o video levanta uma hipotese sem definir o Perfil geral.";
+    profileImpactPreview = "Cria uma primeira pista para acompanhar nas proximas analises.";
+  } else if (hasStrongVideoReading && params.evolvingDiagnosis.profileImpact.recurringSignalsCount === 0) {
+    type = "isolated_strong_video";
+    confidence = "medium";
+    weight = "low";
+    reason = "A leitura do video e forte isoladamente, mas ainda nao aparece como recorrencia no Perfil.";
+    profileImpactPreview = "Pode virar padrao se se repetir; por enquanto fica como leitura isolada.";
+  } else if (params.evolvingDiagnosis.pendingSignals.some((signal) => signal.unlockPath === "analyze_more_videos")) {
+    type = "opens_new_hypothesis";
+    confidence = "medium";
+    weight = "low";
+    reason = "O video aponta uma direcao nova que ainda precisa de repeticao para ganhar peso.";
+    profileImpactPreview = "Abre uma hipotese para o agregador futuro avaliar com mais videos.";
+  }
+
+  return {
+    type,
+    confidence,
+    weight,
+    reason,
+    profileImpactPreview,
+  };
+}
+
+function safeRememberedAs(params: CreatorVideoNarrativeDiagnosisMapperParams): string {
+  const fromPresentation = params.presentation.priorityCards.find((card) => card.id === "main-reading")?.body;
+  const narrative = firstText([
+    params.strategicDiagnosis.mainNarrative,
+    params.strategicDiagnosis.whatVideoCommunicates,
+    fromPresentation,
+  ], "");
+
+  if (narrative) return shortText(`Video sobre ${narrative.replace(/^esse video comunica\s+/i, "")}`, 120);
+  return `Video analisado em ${dayMonth(params.analyzedAt ?? params.createdAt ?? params.strategicDiagnosis.createdAt)}`;
+}
+
+function mapSafeMetadata(params: CreatorVideoNarrativeDiagnosisMapperParams): CreatorVideoNarrativeDiagnosisInput["videoMetadata"] {
+  return {
+    ...params.safeVideoMetadata,
+    analyzedAt: dateFrom(params.analyzedAt) ?? params.safeVideoMetadata?.analyzedAt,
+    uploadedAt: params.safeVideoMetadata?.uploadedAt,
+  };
+}
+
+export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+  params: CreatorVideoNarrativeDiagnosisMapperParams,
+): CreatorVideoNarrativeDiagnosisInput {
+  assertNoRawModelPayload(params);
+
+  const strategic = params.strategicDiagnosis;
+  const evolving = params.evolvingDiagnosis;
+  const presentation = params.presentation;
+  const seed = params.seed;
+  const territories = commercialTerritories({ strategicDiagnosis: strategic, evolvingDiagnosis: evolving });
+  const primaryAdjustment = firstText(
+    [strategic.recommendedAdjustment, presentation.priorityCards.find((card) => card.id === "primary-adjustment")?.body],
+    "Deixar mais claro o que a pessoa deve perceber nos primeiros segundos.",
+  );
+  const nextExperiment = firstText(
+    [strategic.nextActions[0]?.description, seed?.blueprintDraft.whatToPost, evolving.nextSignalsToUnlock[0]?.action],
+    "Testar uma abertura mais direta e comparar a resposta em novas leituras.",
+  );
+
+  const mapped: CreatorVideoNarrativeDiagnosisInput = {
+    userId: params.userId,
+    diagnosisId: strategic.id,
+    status: "completed",
+    source: params.source,
+    videoMetadata: mapSafeMetadata(params),
+    creatorGoal: clean(params.creatorGoal, "Entender o que este video revela estrategicamente."),
+    selectedGoalOption: clean(params.selectedGoalOption, "strategic_reading"),
+    videoReading: {
+      title: shortText(firstText([strategic.mainNarrative, presentation.hero.title], "Leitura estrategica do video"), 140),
+      rememberedAs: safeRememberedAs(params),
+      summary: firstText([strategic.whatVideoCommunicates, presentation.priorityCards[0]?.body], "Este video traz uma leitura inicial para o mapa estrategico."),
+      whatVideoReveals: firstText([evolving.profileImpact.summary, strategic.strength], "Este video revela um sinal inicial sobre a narrativa do creator."),
+      mainNarrative: firstText([strategic.mainNarrative, seed?.detectedNarrative], "Narrativa em formacao."),
+      creatorIntent: firstText([strategic.creatorIntent, params.creatorGoal], "Entender a direcao estrategica deste video."),
+      dominantInsight: firstText([strategic.strategicReading, strategic.strength], "A leitura principal ainda precisa de mais contexto para ganhar peso."),
+    },
+    speechReading: {
+      summary: firstText([strategic.suggestedHook, seed?.scriptDirection.opening], FALLBACK.speechLimited),
+      openingRead: firstText([strategic.suggestedHook, seed?.scriptDirection.opening], "A abertura pode ficar mais explicita para orientar a leitura."),
+      clarityRead: firstText([strategic.strength, strategic.whatVideoCommunicates], "A clareza ainda precisa ser confirmada em novas leituras."),
+      pacingRead: firstText([seed?.scriptDirection.tone], "O ritmo de fala ainda nao tem leitura especifica suficiente."),
+      suggestedLine: firstText([strategic.suggestedHook, seed?.scriptDirection.opening], "Comece pelo ponto que a audiencia reconhece de imediato."),
+      suggestedOpening: firstText([seed?.scriptDirection.opening, strategic.suggestedHook], "Abrir com uma tensao simples antes da explicacao."),
+      suggestedClosing: firstText([seed?.scriptDirection.closing], "Fechar com um proximo passo claro para a audiencia."),
+    },
+    productionReading: {
+      summary: FALLBACK.productionLimited,
+      framing: "Sem leitura especifica suficiente de enquadramento nesta camada estruturada.",
+      lighting: "Sem leitura especifica suficiente de luz nesta camada estruturada.",
+      audio: "Sem leitura especifica suficiente de audio nesta camada estruturada.",
+      editingRhythm: firstText([seed?.blueprintDraft.howItShouldWork], "O ritmo de edicao ainda precisa ser observado em mais detalhes."),
+      firstFrame: firstText([strategic.suggestedHook], "O primeiro frame deve antecipar melhor a promessa do video."),
+      visualClarity: firstText([strategic.whatVideoCommunicates], "A clareza visual ainda precisa ser confirmada por leitura de producao mais completa."),
+    },
+    commercialReading: {
+      summary: territories.length > 0
+        ? "O video sugere territorios comerciais futuros, sem encaixe comercial real ou promessa de publi."
+        : FALLBACK.commercialLimited,
+      brandTerritories: territories,
+      whyItCouldFitBrands: firstText(
+        [strategic.brandPotential.whyItFits, evolving.opportunities.find((item) => item.type === "brand_territory")?.description],
+        "Pode fazer sentido como territorio futuro se a narrativa se repetir e ganhar contexto.",
+      ),
+      adAdaptationIdea: firstText(
+        [strategic.nextActions.find((action) => action.id === "ad_version")?.description, strategic.blueprint.whatToPost],
+        "Adaptar a leitura para uma versao com problema, contexto e escolha do creator.",
+      ),
+      limitations: "Nao ha encaixe comercial real, promessa comercial ou validacao de marca nesta etapa.",
+    },
+    strategicRecommendation: {
+      mainAdjustment: primaryAdjustment,
+      nextExperiment,
+      whatToRepeat: firstText([strategic.strength, strategic.mainNarrative], "Repetir o sinal mais claro que este video ja comunica."),
+      whatToAvoid: firstText([strategic.weakness], "Evitar transformar uma leitura isolada em conclusao geral do Perfil."),
+      successSignal: "Observar se o mesmo sinal aparece de novo em proximas leituras e respostas da audiencia.",
+    },
+    profileContribution: mapProfileContribution({
+      strategicDiagnosis: strategic,
+      evolvingDiagnosis: evolving,
+    }),
+    schemaVersion: "creator_video_narrative_diagnosis_v1",
+  };
+
+  const sanitized = sanitizeCreatorVideoNarrativeDiagnosisInput(mapped);
+
+  return {
+    userId: sanitized.userId,
+    diagnosisId: sanitized.diagnosisId,
+    status: sanitized.status,
+    source: sanitized.source,
+    videoMetadata: sanitized.videoMetadata,
+    creatorGoal: sanitized.creatorGoal,
+    selectedGoalOption: sanitized.selectedGoalOption,
+    videoReading: sanitized.videoReading,
+    speechReading: sanitized.speechReading,
+    productionReading: sanitized.productionReading,
+    commercialReading: sanitized.commercialReading,
+    strategicRecommendation: sanitized.strategicRecommendation,
+    profileContribution: sanitized.profileContribution,
+    schemaVersion: sanitized.schemaVersion,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapperFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapperFixtures.ts
@@ -1,0 +1,266 @@
+import type { CreatorVideoNarrativeDiagnosisMapperParams } from "./creatorVideoNarrativeDiagnosisMapper";
+import type { VideoNarrativeStrategicDiagnosis } from "./videoNarrativeDiagnosisLearningModel";
+import type { VideoNarrativeEvolvingDiagnosis } from "./videoNarrativeEvolvingDiagnosisContract";
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+const now = "2026-05-20T10:00:00.000Z";
+
+export function buildMapperStrategicDiagnosisFixture(
+  overrides: Partial<VideoNarrativeStrategicDiagnosis> = {},
+): VideoNarrativeStrategicDiagnosis {
+  return {
+    id: "video-narrative-diagnosis-analysis-1",
+    accessLevel: "premium",
+    mainNarrative: "humor cotidiano com identificacao rapida",
+    whatVideoCommunicates: "Esse video comunica uma situacao comum com humor simples e reconhecivel.",
+    creatorIntent: "Entender se o video reforca posicionamento de humor cotidiano.",
+    strategicReading: "A leitura principal aponta para humor cotidiano com uma tensao facil de reconhecer.",
+    strength: "A situacao e facil de entender nos primeiros segundos.",
+    weakness: "A conclusao ainda pode ficar mais clara.",
+    recommendedAdjustment: "Fechar com uma frase que transforme a piada em ponto de vista.",
+    suggestedHook: "Quando a reuniao era para ser rapida, mas vira outro projeto.",
+    brandPotential: {
+      enabled: true,
+      territories: ["rotina de trabalho", "produtividade leve"],
+      whyItFits: "O territorio pode interessar marcas que falam de rotina profissional sem perder leveza.",
+      locked: false,
+    },
+    blueprint: {
+      whatToPost: "Transformar a situacao em uma cena curta com virada no final.",
+      whyThisPath: "A identificacao vem da tensao cotidiana.",
+      howItShouldWork: "Abrir no conflito, mostrar a escalada e fechar com ponto de vista.",
+      scenes: ["abertura com promessa", "escalada da reuniao", "fechamento com ponto de vista"],
+      locked: false,
+    },
+    scriptDirection: {
+      opening: "Quando a reuniao era para ser rapida...",
+      development: ["mostrar a interrupcao", "mostrar a nova demanda"],
+      closing: "Da proxima vez, eu mando por email.",
+      tone: "humor observacional",
+      locked: false,
+    },
+    nextActions: [
+      {
+        id: "improve_hook",
+        label: "Melhorar gancho",
+        description: "Testar uma abertura que deixe a tensao clara antes da piada.",
+        locked: false,
+      },
+      {
+        id: "ad_version",
+        label: "Criar versao para publi",
+        description: "Adaptar a cena para um problema de rotina profissional sem citar marca real.",
+        locked: false,
+      },
+    ],
+    lockedSections: [],
+    creatorSignals: [
+      {
+        id: "video-positioning-humor",
+        type: "positioning_signal",
+        value: "humor cotidiano",
+        source: "video_analysis",
+        confidence: "medium",
+        evidence: "A situacao e reconhecivel.",
+        shouldPersistLater: false,
+      },
+    ],
+    instagramComparison: {
+      connected: false,
+      summary: null,
+      matchingNarratives: [],
+      matchingFormats: [],
+      locked: true,
+    },
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function buildMapperEvolvingDiagnosisFixture(
+  overrides: Partial<VideoNarrativeEvolvingDiagnosis> = {},
+): VideoNarrativeEvolvingDiagnosis {
+  return {
+    id: "evolving-video-narrative-diagnosis-analysis-1",
+    accessLevel: "premium",
+    videoDiagnosisId: "video-narrative-diagnosis-analysis-1",
+    currentLevel: {
+      id: "first_reading",
+      label: "Primeira leitura",
+      description: "Primeira leitura estrategica do video.",
+      position: 1,
+    },
+    nextLevel: {
+      id: "initial_patterns",
+      label: "Padroes iniciais",
+      description: "Primeiros padroes comecam a aparecer.",
+      position: 2,
+    },
+    profileImpact: {
+      summary: "Este video adiciona uma primeira leitura ao mapa: humor cotidiano com identificacao rapida.",
+      depth: "limited",
+      usefulSignalsCount: 1,
+      recurringSignalsCount: 0,
+      newSignalsCount: 1,
+      recurringPatternsCount: 0,
+      profileSignalsUsed: false,
+    },
+    unlockedSignals: [
+      {
+        id: "current-positioning-humor",
+        label: "Sinal do video: humor cotidiano",
+        category: "positioning_signal",
+        value: "humor cotidiano",
+        source: "current_video",
+        recurrenceCount: 1,
+      },
+    ],
+    pendingSignals: [
+      {
+        id: "pending-more-videos",
+        label: "Recorrencia narrativa",
+        category: "positioning_signals",
+        reason: "Ainda falta analisar mais videos para confirmar padrao.",
+        unlockPath: "analyze_more_videos",
+      },
+    ],
+    nextSignalsToUnlock: [
+      {
+        id: "next-more-videos",
+        label: "Desbloquear recorrencia narrativa",
+        action: "Analisar mais videos para confirmar recorrencia e variedade.",
+        expectedSignal: "positioning_signals",
+      },
+    ],
+    recurringPatterns: [],
+    opportunities: [
+      {
+        id: "brand-work-routine",
+        type: "brand_territory",
+        label: "Territorio de marca possivel: rotina de trabalho",
+        description: "Indica fit narrativo como oportunidade futura, sem encaixe comercial real.",
+        confidence: "medium",
+        realMatchAvailable: false,
+        requiresPremium: false,
+        requiresInstagram: false,
+      },
+    ],
+    subscriptionUnlocks: [],
+    instagramUnlocks: [],
+    accessSummary: {
+      accessLevel: "premium",
+      isLimited: false,
+      instagramConnected: false,
+      precision: "initial",
+      message: "Mapa estrategico premium liberado sem depender de Instagram real.",
+    },
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function buildMapperPresentationFixture(
+  overrides: Partial<VideoNarrativeDiagnosisPresentation> = {},
+): VideoNarrativeDiagnosisPresentation {
+  return {
+    id: "diagnosis-presentation-evolving-video-narrative-diagnosis-analysis-1",
+    accessLevel: "premium",
+    hero: {
+      title: "Seu mapa estrategico foi atualizado",
+      subtitle: "O diagnostico conecta este video aos sinais do creator.",
+      badge: { id: "premium-complete", label: "Diagnostico completo", tone: "premium" },
+      levelLabel: "Primeira leitura",
+      nextLevelLabel: "Padroes iniciais",
+      precisionLabel: "Mapa estrategico baseado nos sinais do creator",
+    },
+    priorityCards: [
+      {
+        id: "main-reading",
+        title: "O que este video comunica",
+        body: "Este video comunica humor cotidiano com identificacao rapida.",
+        tone: "insight",
+        priority: "high",
+        locked: false,
+      },
+      {
+        id: "primary-adjustment",
+        title: "Ajuste mais importante",
+        body: "O ajuste mais importante e fechar com uma frase que transforme a piada em ponto de vista.",
+        tone: "action",
+        priority: "high",
+        locked: false,
+      },
+    ],
+    sections: [],
+    lockedPreviews: [],
+    primaryCTA: {
+      label: "Analisar outro video",
+      action: "analyze_another_video",
+      helper: "Mais videos ajudam a fortalecer o mapa estrategico.",
+    },
+    secondaryCTA: null,
+    badges: [],
+    readingTimeHint: "Leitura estrategica: 2 minutos",
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function buildMapperSeedFixture(overrides: Partial<PostCreationVideoSeed> = {}): PostCreationVideoSeed {
+  return {
+    id: "seed-analysis-1",
+    source: "video_narrative_analysis",
+    analysisId: "analysis-1",
+    creatorQuestion: "Esse video reforca meu posicionamento?",
+    initialIdea: "Cena curta sobre reuniao que era para ser rapida.",
+    detectedNarrative: "humor cotidiano com identificacao rapida",
+    suggestedFormat: "reel",
+    suggestedProposal: "humor_scene",
+    strategicDiagnosis: "Ponto forte: identificacao rapida. Ajuste sugerido: fechamento mais claro.",
+    blueprintDraft: {
+      whatToPost: "Cena curta sobre reuniao que cresce sem necessidade.",
+      whyThisPath: "A identificacao aparece na situacao cotidiana.",
+      howItShouldWork: "Comecar pela promessa de reuniao rapida e mostrar a escalada.",
+      scenes: ["promessa inicial", "escalada", "fechamento"],
+    },
+    scriptDirection: {
+      opening: "Quando a reuniao era para ser rapida...",
+      development: ["entra uma nova demanda", "a pauta muda completamente"],
+      closing: "Da proxima vez, eu mando por email.",
+      tone: "humor observacional",
+    },
+    brandMatchHints: ["rotina de trabalho"],
+    followUpQuestions: [],
+    evidenceSummary: null,
+    confidence: "medium",
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+export function buildCreatorVideoNarrativeDiagnosisMapperParams(
+  overrides: Partial<CreatorVideoNarrativeDiagnosisMapperParams> = {},
+): CreatorVideoNarrativeDiagnosisMapperParams {
+  return {
+    userId: "665f0f2c8a0b7d1f2c3a4b5c",
+    source: "mock",
+    creatorGoal: "Entender se este video reforca posicionamento de humor cotidiano.",
+    selectedGoalOption: "positioning",
+    safeVideoMetadata: {
+      mimeType: "video/mp4",
+      sizeBytes: 8_000_000,
+      durationSeconds: 28,
+      originalFileNameSanitized: "video-analisado.mp4",
+      uploadedAt: new Date("2026-05-20T09:58:00.000Z"),
+      analyzedAt: new Date(now),
+    },
+    strategicDiagnosis: buildMapperStrategicDiagnosisFixture(),
+    evolvingDiagnosis: buildMapperEvolvingDiagnosisFixture(),
+    presentation: buildMapperPresentationFixture(),
+    seed: buildMapperSeedFixture(),
+    createdAt: now,
+    analyzedAt: now,
+    ...overrides,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMockSaveIntegration.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMockSaveIntegration.ts
@@ -1,0 +1,60 @@
+import { buildCreatorVideoNarrativeDiagnosisMapperParams } from "./creatorVideoNarrativeDiagnosisMapperFixtures";
+import {
+  saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis,
+  type SaveCreatorVideoNarrativeDiagnosisResult,
+} from "./creatorVideoNarrativeDiagnosisSaveOrchestrator";
+import type { VideoNarrativeAnalysis } from "./videoNarrativeAnalysisTypes";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+export interface SaveMockVideoNarrativeReadingParams {
+  userId: string;
+  diagnosisId: string;
+  creatorGoal?: string | null;
+  selectedGoalOption?: string | null;
+  analysis: VideoNarrativeAnalysis;
+  seed: PostCreationVideoSeed;
+  createdAt: string;
+}
+
+export interface SaveMockVideoNarrativeReadingDeps {
+  saveReading?: typeof saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis;
+}
+
+export async function saveMockVideoNarrativeReading(
+  params: SaveMockVideoNarrativeReadingParams,
+  deps: SaveMockVideoNarrativeReadingDeps = {},
+): Promise<SaveCreatorVideoNarrativeDiagnosisResult> {
+  const saveReading = deps.saveReading ?? saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis;
+  const baseMapperParams = buildCreatorVideoNarrativeDiagnosisMapperParams();
+  const mapperParams = buildCreatorVideoNarrativeDiagnosisMapperParams({
+    userId: params.userId,
+    source: "mock",
+    creatorGoal: params.creatorGoal ?? params.seed.creatorQuestion ?? "Entender este vídeo estrategicamente.",
+    selectedGoalOption: params.selectedGoalOption ?? "strategic_reading",
+    strategicDiagnosis: {
+      ...baseMapperParams.strategicDiagnosis,
+      id: params.diagnosisId,
+      creatorIntent: params.seed.creatorQuestion ?? "Entender este vídeo estrategicamente.",
+      mainNarrative: params.analysis.d2cClassification.narrative ?? baseMapperParams.strategicDiagnosis.mainNarrative,
+      whatVideoCommunicates: params.analysis.summary ?? baseMapperParams.strategicDiagnosis.whatVideoCommunicates,
+      createdAt: params.createdAt,
+    },
+    seed: params.seed,
+    createdAt: params.createdAt,
+    analyzedAt: params.createdAt,
+  });
+
+  return saveReading({
+    userId: params.userId,
+    source: "mock",
+    creatorGoal: mapperParams.creatorGoal,
+    selectedGoalOption: mapperParams.selectedGoalOption,
+    safeVideoMetadata: mapperParams.safeVideoMetadata,
+    strategicDiagnosis: mapperParams.strategicDiagnosis,
+    evolvingDiagnosis: mapperParams.evolvingDiagnosis,
+    presentation: mapperParams.presentation,
+    seed: mapperParams.seed,
+    createdAt: mapperParams.createdAt,
+    analyzedAt: mapperParams.analyzedAt,
+  });
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.test.ts
@@ -1,0 +1,150 @@
+import { Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorVideoNarrativeDiagnosis from "@/app/models/CreatorVideoNarrativeDiagnosis";
+import { buildCreatorVideoNarrativeDiagnosisFixture } from "./creatorVideoNarrativeDiagnosisFixtures";
+import {
+  getCreatorVideoNarrativeDiagnosisForUser,
+  listRecentCreatorVideoNarrativeDiagnosesForUser,
+  mapCreatorVideoNarrativeDiagnosisToSafeReading,
+} from "./creatorVideoNarrativeDiagnosisReadService";
+
+jest.mock("@/app/lib/mongoose", () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock("@/app/models/CreatorVideoNarrativeDiagnosis", () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockFind = CreatorVideoNarrativeDiagnosis.find as jest.Mock;
+const mockFindOne = CreatorVideoNarrativeDiagnosis.findOne as jest.Mock;
+
+function doc(params: { userId: string; diagnosisId: string; createdAt: string; analyzedAt?: string }) {
+  const input = buildCreatorVideoNarrativeDiagnosisFixture({
+    userId: params.userId,
+    diagnosisId: params.diagnosisId,
+  });
+  return {
+    ...input,
+    userId: new Types.ObjectId(params.userId),
+    videoMetadata: {
+      ...input.videoMetadata,
+      analyzedAt: params.analyzedAt ? new Date(params.analyzedAt) : undefined,
+      objectKey: "blocked",
+      signedUrl: "blocked",
+      uploadUrl: "blocked",
+      thumbnailUrl: "blocked",
+      localPath: "blocked",
+      storageProviderPath: "blocked",
+    },
+    safetyFlags: {
+      containsPersistedVideoReference: false,
+      containsSignedUrl: false,
+      containsObjectKey: false,
+      containsRawModelResponse: false,
+      containsLongTranscript: false,
+      sanitized: true,
+    },
+    createdAt: new Date(params.createdAt),
+    updatedAt: new Date(params.createdAt),
+    objectKey: "blocked",
+    signedUrl: "blocked",
+    uploadUrl: "blocked",
+    thumbnailUrl: "blocked",
+    localPath: "blocked",
+    storageProviderPath: "blocked",
+  };
+}
+
+function mockFindChain(result: unknown[]) {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(result),
+  };
+  mockFind.mockReturnValue(chain);
+  return chain;
+}
+
+function mockFindOneChain(result: unknown | null) {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(result),
+  };
+  mockFindOne.mockReturnValue(chain);
+  return chain;
+}
+
+describe("creatorVideoNarrativeDiagnosisReadService", () => {
+  const userId = new Types.ObjectId().toString();
+  const otherUserId = new Types.ObjectId().toString();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it("lista leituras recentes por userId com ordenação e limite", async () => {
+    const chain = mockFindChain([
+      doc({ userId, diagnosisId: "newer", createdAt: "2026-05-20T10:00:00.000Z" }),
+      doc({ userId, diagnosisId: "older", createdAt: "2026-05-18T10:00:00.000Z" }),
+    ]);
+
+    const result = await listRecentCreatorVideoNarrativeDiagnosesForUser({ userId, limit: 2 });
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockFind).toHaveBeenCalledWith({ userId: new Types.ObjectId(userId) });
+    expect(chain.sort).toHaveBeenCalledWith({ "videoMetadata.analyzedAt": -1, createdAt: -1 });
+    expect(chain.limit).toHaveBeenCalledWith(2);
+    expect(result.map((reading) => reading.diagnosisId)).toEqual(["newer", "older"]);
+  });
+
+  it("busca leitura por diagnosisId e userId", async () => {
+    mockFindOneChain(doc({ userId, diagnosisId: "diagnosis-safe", createdAt: "2026-05-20T10:00:00.000Z" }));
+
+    const result = await getCreatorVideoNarrativeDiagnosisForUser({ userId, diagnosisId: "diagnosis-safe" });
+
+    expect(mockFindOne).toHaveBeenCalledWith({
+      userId: new Types.ObjectId(userId),
+      diagnosisId: "diagnosis-safe",
+    });
+    expect(result?.diagnosisId).toBe("diagnosis-safe");
+    expect(result?.userId).toBe(userId);
+  });
+
+  it("não retorna leitura de outro userId", async () => {
+    mockFindOneChain(null);
+
+    const result = await getCreatorVideoNarrativeDiagnosisForUser({ userId, diagnosisId: "other-user-reading" });
+
+    expect(result).toBeNull();
+    expect(mockFindOne).not.toHaveBeenCalledWith(expect.objectContaining({ userId: new Types.ObjectId(otherUserId) }));
+  });
+
+  it("retorna apenas shape seguro para UI", () => {
+    const safe = mapCreatorVideoNarrativeDiagnosisToSafeReading(
+      doc({ userId, diagnosisId: "diagnosis-safe-shape", createdAt: "2026-05-20T10:00:00.000Z" }) as any,
+    );
+    const serialized = JSON.stringify(safe);
+
+    expect(safe.videoReading.rememberedAs).toBeTruthy();
+    expect(safe.profileContribution.profileImpactPreview).toBeTruthy();
+    expect(serialized).not.toContain("objectKey");
+    expect(serialized).not.toContain("signedUrl");
+    expect(serialized).not.toContain("uploadUrl");
+    expect(serialized).not.toContain("thumbnailUrl");
+    expect(serialized).not.toContain("localPath");
+    expect(serialized).not.toContain("storageProviderPath");
+  });
+
+  it("limita quantidade de leituras recentes", async () => {
+    const chain = mockFindChain([]);
+
+    await listRecentCreatorVideoNarrativeDiagnosesForUser({ userId, limit: 99 });
+
+    expect(chain.limit).toHaveBeenCalledWith(12);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.ts
@@ -1,0 +1,147 @@
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorVideoNarrativeDiagnosis from "@/app/models/CreatorVideoNarrativeDiagnosis";
+import { Types } from "mongoose";
+import type {
+  CreatorVideoNarrativeDiagnosisCommercialReading,
+  CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeDiagnosisProductionReading,
+  CreatorVideoNarrativeDiagnosisProfileContribution,
+  CreatorVideoNarrativeDiagnosisSafetyFlags,
+  CreatorVideoNarrativeDiagnosisSpeechReading,
+  CreatorVideoNarrativeDiagnosisStatus,
+  CreatorVideoNarrativeDiagnosisStrategicRecommendation,
+  CreatorVideoNarrativeDiagnosisVideoReading,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+
+export interface CreatorVideoNarrativeDiagnosisSafeReading {
+  userId: string;
+  diagnosisId: string;
+  status: CreatorVideoNarrativeDiagnosisStatus;
+  videoReading: CreatorVideoNarrativeDiagnosisVideoReading;
+  speechReading: CreatorVideoNarrativeDiagnosisSpeechReading;
+  productionReading: CreatorVideoNarrativeDiagnosisProductionReading;
+  commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
+  strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
+  profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  safetyFlags: CreatorVideoNarrativeDiagnosisSafetyFlags;
+  createdAt?: Date;
+  updatedAt?: Date;
+  analyzedAt?: Date;
+}
+
+export interface ListCreatorVideoNarrativeDiagnosesForUserParams {
+  userId: string;
+  limit?: number;
+}
+
+export interface GetCreatorVideoNarrativeDiagnosisForUserParams {
+  userId: string;
+  diagnosisId: string;
+}
+
+const DEFAULT_RECENT_LIMIT = 6;
+const MAX_RECENT_LIMIT = 12;
+
+function assertValidUserId(userId: string): void {
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    throw new Error("UserId inválido");
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) return DEFAULT_RECENT_LIMIT;
+  return Math.min(Math.max(Math.trunc(limit ?? DEFAULT_RECENT_LIMIT), 1), MAX_RECENT_LIMIT);
+}
+
+function asDate(value: unknown): Date | undefined {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date : undefined;
+  }
+  return undefined;
+}
+
+export function mapCreatorVideoNarrativeDiagnosisToSafeReading(
+  doc: CreatorVideoNarrativeDiagnosisDocument & { userId?: unknown },
+): CreatorVideoNarrativeDiagnosisSafeReading {
+  return {
+    userId: typeof doc.userId === "string" ? doc.userId : String(doc.userId),
+    diagnosisId: doc.diagnosisId,
+    status: doc.status,
+    videoReading: doc.videoReading,
+    speechReading: doc.speechReading,
+    productionReading: doc.productionReading,
+    commercialReading: doc.commercialReading,
+    strategicRecommendation: doc.strategicRecommendation,
+    profileContribution: doc.profileContribution,
+    safetyFlags: doc.safetyFlags,
+    createdAt: asDate(doc.createdAt),
+    updatedAt: asDate(doc.updatedAt),
+    analyzedAt: asDate(doc.videoMetadata?.analyzedAt),
+  };
+}
+
+function queryProjection() {
+  return {
+    userId: 1,
+    diagnosisId: 1,
+    status: 1,
+    videoReading: 1,
+    speechReading: 1,
+    productionReading: 1,
+    commercialReading: 1,
+    strategicRecommendation: 1,
+    profileContribution: 1,
+    safetyFlags: 1,
+    "videoMetadata.analyzedAt": 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+export async function listCreatorVideoNarrativeDiagnosesForUser(
+  params: ListCreatorVideoNarrativeDiagnosesForUserParams,
+): Promise<CreatorVideoNarrativeDiagnosisSafeReading[]> {
+  assertValidUserId(params.userId);
+  await connectToDatabase();
+
+  const docs = await CreatorVideoNarrativeDiagnosis.find({
+    userId: new Types.ObjectId(params.userId),
+  })
+    .select(queryProjection())
+    .sort({ "videoMetadata.analyzedAt": -1, createdAt: -1 })
+    .limit(normalizeLimit(params.limit))
+    .lean();
+
+  return docs.map((doc) =>
+    mapCreatorVideoNarrativeDiagnosisToSafeReading(doc as unknown as CreatorVideoNarrativeDiagnosisDocument),
+  );
+}
+
+export async function getCreatorVideoNarrativeDiagnosisForUser(
+  params: GetCreatorVideoNarrativeDiagnosisForUserParams,
+): Promise<CreatorVideoNarrativeDiagnosisSafeReading | null> {
+  assertValidUserId(params.userId);
+  if (!params.diagnosisId?.trim()) {
+    throw new Error("DiagnosisId inválido");
+  }
+  await connectToDatabase();
+
+  const doc = await CreatorVideoNarrativeDiagnosis.findOne({
+    userId: new Types.ObjectId(params.userId),
+    diagnosisId: params.diagnosisId.trim(),
+  })
+    .select(queryProjection())
+    .lean();
+
+  return doc
+    ? mapCreatorVideoNarrativeDiagnosisToSafeReading(doc as unknown as CreatorVideoNarrativeDiagnosisDocument)
+    : null;
+}
+
+export async function listRecentCreatorVideoNarrativeDiagnosesForUser(
+  params: ListCreatorVideoNarrativeDiagnosesForUserParams,
+): Promise<CreatorVideoNarrativeDiagnosisSafeReading[]> {
+  return listCreatorVideoNarrativeDiagnosesForUser(params);
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
@@ -1,0 +1,141 @@
+import { buildCreatorVideoNarrativeDiagnosisFixture } from "./creatorVideoNarrativeDiagnosisFixtures";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+
+describe("creatorVideoNarrativeDiagnosisSanitizer", () => {
+  it("cria um documento válido de leitura por vídeo", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(buildCreatorVideoNarrativeDiagnosisFixture());
+
+    expect(result.schemaVersion).toBe("creator_video_narrative_diagnosis_v1");
+    expect(result.videoReading.title).toBe("Rotina que vira prova de autoridade");
+    expect(result.profileContribution.type).toBe("commercial_signal");
+    expect(result.safetyFlags.containsPersistedVideoReference).toBe(false);
+  });
+
+  it("não persiste objectKey, signedUrl, uploadUrl ou localPath em videoMetadata", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        videoMetadata: {
+          mimeType: "video/mp4",
+          sizeBytes: 100,
+          objectKey: "temporary/user/video.mp4",
+          signedUrl: "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Signature=abc",
+          uploadUrl: "https://upload.example.com/video.mp4?token=abc",
+          localPath: "/tmp/video.mp4",
+        } as any,
+      }),
+    );
+
+    expect(result.videoMetadata).toEqual({ mimeType: "video/mp4", sizeBytes: 100 });
+    expect(JSON.stringify(result)).not.toContain("objectKey");
+    expect(JSON.stringify(result)).not.toContain("signedUrl");
+    expect(JSON.stringify(result)).not.toContain("uploadUrl");
+    expect(JSON.stringify(result)).not.toContain("localPath");
+    expect(result.safetyFlags.sanitized).toBe(true);
+  });
+
+  it("redige URLs assinadas e tokens em campos narrativos", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        videoReading: {
+          ...buildCreatorVideoNarrativeDiagnosisFixture().videoReading,
+          summary:
+            "Fonte https://bucket.s3.amazonaws.com/path/video.mp4?X-Amz-Signature=abc123 e Bearer abcdefghijklmnopqrstuvwxyz123456.",
+        },
+      }),
+    );
+
+    expect(result.videoReading.summary).toContain("[signed-url-redacted]");
+    expect(result.videoReading.summary).toContain("[secret-redacted]");
+    expect(result.videoReading.summary).not.toContain("X-Amz-Signature");
+    expect(result.videoReading.summary).not.toContain("Bearer abc");
+    expect(result.safetyFlags.sanitized).toBe(true);
+  });
+
+  it("bloqueia raw model response grande ou explícito", () => {
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput({
+        ...buildCreatorVideoNarrativeDiagnosisFixture(),
+        rawGeminiResponse: { candidates: ["x".repeat(5000)] },
+      } as any),
+    ).toThrow("campo proibido");
+
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput({
+        ...buildCreatorVideoNarrativeDiagnosisFixture(),
+        videoReading: {
+          ...buildCreatorVideoNarrativeDiagnosisFixture().videoReading,
+          summary: "x".repeat(4001),
+        },
+      }),
+    ).toThrow("excede o limite seguro");
+  });
+
+  it("bloqueia transcrição longa", () => {
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput({
+        ...buildCreatorVideoNarrativeDiagnosisFixture(),
+        transcript: "fala ".repeat(1000),
+      } as any),
+    ).toThrow("campo proibido");
+  });
+
+  it("exige profileContribution", () => {
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput({
+        ...buildCreatorVideoNarrativeDiagnosisFixture(),
+        profileContribution: undefined,
+      } as any),
+    ).toThrow("profileContribution é obrigatório");
+  });
+
+  it("aceita em videoMetadata apenas os campos seguros", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        videoMetadata: {
+          mimeType: "video/mp4",
+          sizeBytes: 1000,
+          durationSeconds: 10,
+          originalFileNameSanitized: "video.mp4",
+          uploadedAt: new Date("2026-05-20T10:00:00.000Z"),
+          analyzedAt: new Date("2026-05-20T10:02:00.000Z"),
+          thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+          storageProviderPath: "r2://bucket/video.mp4",
+        } as any,
+      }),
+    );
+
+    expect(Object.keys(result.videoMetadata).sort()).toEqual([
+      "analyzedAt",
+      "durationSeconds",
+      "mimeType",
+      "originalFileNameSanitized",
+      "sizeBytes",
+      "uploadedAt",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("thumbnailUrl");
+    expect(JSON.stringify(result)).not.toContain("storageProviderPath");
+  });
+
+  it("guardrail: não deixa referência persistida a vídeo, thumbnail, signed URL ou objectKey no documento", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        videoMetadata: {
+          mimeType: "video/mp4",
+          objectKey: "uploads/user/video.mp4",
+          thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+        } as any,
+        strategicRecommendation: {
+          ...buildCreatorVideoNarrativeDiagnosisFixture().strategicRecommendation,
+          nextExperiment: "Rever o arquivo uploads/user/video.mp4 antes de postar.",
+        },
+      }),
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("uploads/user/video.mp4");
+    expect(serialized).not.toContain("thumbnailUrl");
+    expect(serialized).not.toContain("objectKey");
+    expect(serialized).not.toContain("signedUrl");
+    expect(serialized).toContain("[object-key-redacted]");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
@@ -1,0 +1,309 @@
+import type {
+  CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeDiagnosisInput,
+  CreatorVideoNarrativeDiagnosisSafetyFlags,
+  CreatorVideoNarrativeDiagnosisVideoMetadata,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+
+const MAX_TEXT_FIELD_LENGTH = 4000;
+const MAX_ARRAY_ITEM_LENGTH = 1000;
+const MAX_SERIALIZED_INPUT_LENGTH = 60000;
+const MAX_TRANSCRIPT_LENGTH = 2000;
+
+const SIGNED_URL_REGEX = /https?:\/\/[^\s"'<>]+[?&](x-amz-signature|x-goog-signature|signature|expires|token|policy|x-amz-credential)=\S*/gi;
+const STORAGE_URL_REGEX = /https?:\/\/[^\s"'<>]*(s3|r2|cloudfront|storage\.googleapis|amazonaws|blob\.core\.windows)[^\s"'<>]*/gi;
+const VIDEO_FILE_URL_REGEX = /https?:\/\/[^\s"'<>]+\.(mp4|mov|quicktime|webm|avi|mkv|flv|wmv)(\?[^\s"'<>]*)?/gi;
+const LARGE_BASE64_REGEX = /(?:data:[^;]+;base64,)?[A-Za-z0-9+/=]{1200,}/g;
+const TOKEN_REGEX = /\b(sk-[A-Za-z0-9_-]{20,}|AIzaSy[A-Za-z0-9_-]{20,}|Bearer\s+[A-Za-z0-9._-]{20,}|(?:api[_-]?key|secret|token)=?[A-Za-z0-9._-]{16,})\b/gi;
+const OBJECT_KEY_VALUE_REGEX = /\b(?:uploads|video-narrative|mobile-strategic-profile|tmp|temporary)\/[A-Za-z0-9._/-]+\.(mp4|mov|webm|mkv)\b/gi;
+
+const DANGEROUS_ANYWHERE_KEYS = new Set([
+  "rawGeminiResponse",
+  "rawModelResponse",
+  "geminiResponse",
+  "providerResponse",
+  "modelResponse",
+  "transcript",
+  "transcription",
+  "fullTranscript",
+  "longTranscript",
+  "headers",
+  "authorization",
+  "cookie",
+  "secret",
+  "token",
+]);
+
+const SAFE_VIDEO_METADATA_KEYS: Array<keyof CreatorVideoNarrativeDiagnosisVideoMetadata> = [
+  "mimeType",
+  "sizeBytes",
+  "durationSeconds",
+  "originalFileNameSanitized",
+  "uploadedAt",
+  "analyzedAt",
+];
+
+const PROFILE_CONTRIBUTION_TYPES = [
+  "confirms_existing_pattern",
+  "opens_new_hypothesis",
+  "isolated_strong_video",
+  "creative_deviation",
+  "commercial_signal",
+  "weak_positioning_signal",
+  "needs_more_samples",
+];
+const PROFILE_CONTRIBUTION_CONFIDENCE = ["low", "medium", "high"];
+const PROFILE_CONTRIBUTION_WEIGHT = ["low", "medium", "high"];
+
+function createSafetyFlags(sanitized: boolean): CreatorVideoNarrativeDiagnosisSafetyFlags {
+  return {
+    containsPersistedVideoReference: false,
+    containsSignedUrl: false,
+    containsObjectKey: false,
+    containsRawModelResponse: false,
+    containsLongTranscript: false,
+    sanitized,
+  };
+}
+
+function assertNoDangerousKeys(value: unknown, path = "input"): void {
+  if (!value || typeof value !== "object") return;
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_ANYWHERE_KEYS.has(key)) {
+      throw new Error(`Leitura de vídeo insegura: campo proibido detectado em ${path}.${key}`);
+    }
+
+    if (/transcri(c|ç)(a|ã)o|transcript/i.test(key) && typeof child === "string" && child.length > MAX_TRANSCRIPT_LENGTH) {
+      throw new Error("Leitura de vídeo insegura: transcrição longa não pode ser persistida");
+    }
+
+    assertNoDangerousKeys(child, `${path}.${key}`);
+  }
+}
+
+function sanitizeText(value: unknown, fieldName: string, maxLength = MAX_TEXT_FIELD_LENGTH): { value: string; sanitized: boolean } {
+  if (typeof value !== "string") {
+    throw new Error(`Leitura de vídeo inválida: ${fieldName} deve ser texto`);
+  }
+
+  if (value.length > maxLength) {
+    throw new Error(`Leitura de vídeo inválida: ${fieldName} excede o limite seguro`);
+  }
+
+  let sanitized = false;
+  let next = value;
+  const replacements: Array<[RegExp, string]> = [
+    [SIGNED_URL_REGEX, "[signed-url-redacted]"],
+    [STORAGE_URL_REGEX, "[storage-url-redacted]"],
+    [VIDEO_FILE_URL_REGEX, "[video-url-redacted]"],
+    [LARGE_BASE64_REGEX, "[base64-redacted]"],
+    [TOKEN_REGEX, "[secret-redacted]"],
+    [OBJECT_KEY_VALUE_REGEX, "[object-key-redacted]"],
+  ];
+
+  for (const [regex, replacement] of replacements) {
+    next = next.replace(regex, () => {
+      sanitized = true;
+      return replacement;
+    });
+  }
+
+  return { value: next.trim(), sanitized };
+}
+
+function sanitizeTextArray(value: unknown, fieldName: string): { value: string[]; sanitized: boolean } {
+  if (!Array.isArray(value)) {
+    throw new Error(`Leitura de vídeo inválida: ${fieldName} deve ser uma lista`);
+  }
+
+  let sanitized = false;
+  const items = value.map((item, index) => {
+    const result = sanitizeText(item, `${fieldName}[${index}]`, MAX_ARRAY_ITEM_LENGTH);
+    sanitized = sanitized || result.sanitized;
+    return result.value;
+  });
+
+  return { value: items, sanitized };
+}
+
+function sanitizeVideoMetadata(
+  input: CreatorVideoNarrativeDiagnosisInput["videoMetadata"],
+): { value: CreatorVideoNarrativeDiagnosisVideoMetadata; sanitized: boolean } {
+  if (!input || typeof input !== "object") return { value: {}, sanitized: false };
+
+  const metadata: CreatorVideoNarrativeDiagnosisVideoMetadata = {};
+  let sanitized = Object.keys(input).some(
+    (key) => !SAFE_VIDEO_METADATA_KEYS.includes(key as keyof CreatorVideoNarrativeDiagnosisVideoMetadata),
+  );
+
+  if (typeof input.mimeType === "string") {
+    metadata.mimeType = sanitizeText(input.mimeType, "videoMetadata.mimeType", 120).value;
+  }
+  if (typeof input.sizeBytes === "number" && Number.isFinite(input.sizeBytes) && input.sizeBytes >= 0) {
+    metadata.sizeBytes = input.sizeBytes;
+  }
+  if (
+    typeof input.durationSeconds === "number" &&
+    Number.isFinite(input.durationSeconds) &&
+    input.durationSeconds >= 0
+  ) {
+    metadata.durationSeconds = input.durationSeconds;
+  }
+  if (typeof input.originalFileNameSanitized === "string") {
+    const fileName = sanitizeText(input.originalFileNameSanitized, "videoMetadata.originalFileNameSanitized", 240);
+    metadata.originalFileNameSanitized = fileName.value;
+    sanitized = sanitized || fileName.sanitized;
+  }
+  if (input.uploadedAt instanceof Date) {
+    metadata.uploadedAt = input.uploadedAt;
+  }
+  if (input.analyzedAt instanceof Date) {
+    metadata.analyzedAt = input.analyzedAt;
+  }
+
+  return { value: metadata, sanitized };
+}
+
+function requireObject<T extends Record<string, unknown>>(value: unknown, fieldName: string): T {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Leitura de vídeo inválida: ${fieldName} deve ser um objeto`);
+  }
+
+  return value as T;
+}
+
+function requireOneOf(value: string, validValues: string[], fieldName: string): string {
+  if (!validValues.includes(value)) {
+    throw new Error(`Leitura de vídeo inválida: ${fieldName} não suportado`);
+  }
+
+  return value;
+}
+
+export function sanitizeCreatorVideoNarrativeDiagnosisInput(
+  input: CreatorVideoNarrativeDiagnosisInput,
+): CreatorVideoNarrativeDiagnosisDocument {
+  if (!input || typeof input !== "object") {
+    throw new Error("Leitura de vídeo inválida: input deve ser um objeto");
+  }
+
+  const serializedInput = JSON.stringify(input);
+  if (serializedInput.length > MAX_SERIALIZED_INPUT_LENGTH) {
+    throw new Error("Leitura de vídeo insegura: payload bruto excede o limite seguro");
+  }
+
+  assertNoDangerousKeys(input);
+
+  const validStatuses = ["draft", "completed", "failed", "discarded"];
+  const validSources = ["mock", "real", "manual", "migration"];
+  if (!validStatuses.includes(input.status)) {
+    throw new Error("Leitura de vídeo inválida: status não suportado");
+  }
+  if (!validSources.includes(input.source)) {
+    throw new Error("Leitura de vídeo inválida: source não suportado");
+  }
+  if (!input.profileContribution) {
+    throw new Error("Leitura de vídeo inválida: profileContribution é obrigatório");
+  }
+
+  let sanitized = false;
+  const text = (value: unknown, fieldName: string) => {
+    const result = sanitizeText(value, fieldName);
+    sanitized = sanitized || result.sanitized;
+    return result.value;
+  };
+  const textArray = (value: unknown, fieldName: string) => {
+    const result = sanitizeTextArray(value, fieldName);
+    sanitized = sanitized || result.sanitized;
+    return result.value;
+  };
+
+  const metadata = sanitizeVideoMetadata(input.videoMetadata);
+  sanitized = sanitized || metadata.sanitized;
+
+  const videoReading = requireObject<Record<string, unknown>>(input.videoReading, "videoReading");
+  const speechReading = requireObject<Record<string, unknown>>(input.speechReading, "speechReading");
+  const productionReading = requireObject<Record<string, unknown>>(input.productionReading, "productionReading");
+  const commercialReading = requireObject<Record<string, unknown>>(input.commercialReading, "commercialReading");
+  const strategicRecommendation = requireObject<Record<string, unknown>>(
+    input.strategicRecommendation,
+    "strategicRecommendation",
+  );
+  const profileContribution = requireObject<Record<string, unknown>>(input.profileContribution, "profileContribution");
+  const profileContributionType = requireOneOf(
+    text(profileContribution.type, "profileContribution.type"),
+    PROFILE_CONTRIBUTION_TYPES,
+    "profileContribution.type",
+  ) as CreatorVideoNarrativeDiagnosisDocument["profileContribution"]["type"];
+  const profileContributionConfidence = requireOneOf(
+    text(profileContribution.confidence, "profileContribution.confidence"),
+    PROFILE_CONTRIBUTION_CONFIDENCE,
+    "profileContribution.confidence",
+  ) as CreatorVideoNarrativeDiagnosisDocument["profileContribution"]["confidence"];
+  const profileContributionWeight = requireOneOf(
+    text(profileContribution.weight, "profileContribution.weight"),
+    PROFILE_CONTRIBUTION_WEIGHT,
+    "profileContribution.weight",
+  ) as CreatorVideoNarrativeDiagnosisDocument["profileContribution"]["weight"];
+
+  return {
+    userId: text(input.userId, "userId"),
+    diagnosisId: text(input.diagnosisId, "diagnosisId"),
+    status: input.status,
+    source: input.source,
+    videoMetadata: metadata.value,
+    creatorGoal: text(input.creatorGoal, "creatorGoal"),
+    selectedGoalOption: text(input.selectedGoalOption, "selectedGoalOption"),
+    videoReading: {
+      title: text(videoReading.title, "videoReading.title"),
+      rememberedAs: text(videoReading.rememberedAs, "videoReading.rememberedAs"),
+      summary: text(videoReading.summary, "videoReading.summary"),
+      whatVideoReveals: text(videoReading.whatVideoReveals, "videoReading.whatVideoReveals"),
+      mainNarrative: text(videoReading.mainNarrative, "videoReading.mainNarrative"),
+      creatorIntent: text(videoReading.creatorIntent, "videoReading.creatorIntent"),
+      dominantInsight: text(videoReading.dominantInsight, "videoReading.dominantInsight"),
+    },
+    speechReading: {
+      summary: text(speechReading.summary, "speechReading.summary"),
+      openingRead: text(speechReading.openingRead, "speechReading.openingRead"),
+      clarityRead: text(speechReading.clarityRead, "speechReading.clarityRead"),
+      pacingRead: text(speechReading.pacingRead, "speechReading.pacingRead"),
+      suggestedLine: text(speechReading.suggestedLine, "speechReading.suggestedLine"),
+      suggestedOpening: text(speechReading.suggestedOpening, "speechReading.suggestedOpening"),
+      suggestedClosing: text(speechReading.suggestedClosing, "speechReading.suggestedClosing"),
+    },
+    productionReading: {
+      summary: text(productionReading.summary, "productionReading.summary"),
+      framing: text(productionReading.framing, "productionReading.framing"),
+      lighting: text(productionReading.lighting, "productionReading.lighting"),
+      audio: text(productionReading.audio, "productionReading.audio"),
+      editingRhythm: text(productionReading.editingRhythm, "productionReading.editingRhythm"),
+      firstFrame: text(productionReading.firstFrame, "productionReading.firstFrame"),
+      visualClarity: text(productionReading.visualClarity, "productionReading.visualClarity"),
+    },
+    commercialReading: {
+      summary: text(commercialReading.summary, "commercialReading.summary"),
+      brandTerritories: textArray(commercialReading.brandTerritories, "commercialReading.brandTerritories"),
+      whyItCouldFitBrands: text(commercialReading.whyItCouldFitBrands, "commercialReading.whyItCouldFitBrands"),
+      adAdaptationIdea: text(commercialReading.adAdaptationIdea, "commercialReading.adAdaptationIdea"),
+      limitations: text(commercialReading.limitations, "commercialReading.limitations"),
+    },
+    strategicRecommendation: {
+      mainAdjustment: text(strategicRecommendation.mainAdjustment, "strategicRecommendation.mainAdjustment"),
+      nextExperiment: text(strategicRecommendation.nextExperiment, "strategicRecommendation.nextExperiment"),
+      whatToRepeat: text(strategicRecommendation.whatToRepeat, "strategicRecommendation.whatToRepeat"),
+      whatToAvoid: text(strategicRecommendation.whatToAvoid, "strategicRecommendation.whatToAvoid"),
+      successSignal: text(strategicRecommendation.successSignal, "strategicRecommendation.successSignal"),
+    },
+    profileContribution: {
+      type: profileContributionType,
+      confidence: profileContributionConfidence,
+      weight: profileContributionWeight,
+      reason: text(profileContribution.reason, "profileContribution.reason"),
+      profileImpactPreview: text(profileContribution.profileImpactPreview, "profileContribution.profileImpactPreview"),
+    },
+    safetyFlags: createSafetyFlags(sanitized),
+    schemaVersion: "creator_video_narrative_diagnosis_v1",
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestrator.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestrator.test.ts
@@ -1,0 +1,250 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisMapper";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import {
+  buildSavedDiagnosisDocumentFixture,
+  buildSaveOrchestratorParams,
+} from "./creatorVideoNarrativeDiagnosisSaveOrchestratorFixtures";
+import {
+  saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis,
+} from "./creatorVideoNarrativeDiagnosisSaveOrchestrator";
+
+describe("creatorVideoNarrativeDiagnosisSaveOrchestrator", () => {
+  it("chama mapper e service com dados validos", async () => {
+    const params = buildSaveOrchestratorParams();
+    const mappedInput = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput({
+      userId: params.userId,
+      source: params.source,
+      creatorGoal: params.creatorGoal ?? "",
+      selectedGoalOption: params.selectedGoalOption ?? "",
+      safeVideoMetadata: params.safeVideoMetadata as any,
+      strategicDiagnosis: params.strategicDiagnosis,
+      evolvingDiagnosis: params.evolvingDiagnosis,
+      presentation: params.presentation,
+      seed: params.seed,
+      analyzedAt: params.analyzedAt,
+      createdAt: params.createdAt,
+    });
+    const mapToDiagnosisInput = jest.fn(() => mappedInput);
+    const createDiagnosis = jest.fn(async (input) => buildSavedDiagnosisDocumentFixture(input));
+
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(params, {
+      mapToDiagnosisInput,
+      createDiagnosis,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mapToDiagnosisInput).toHaveBeenCalledWith(expect.objectContaining({
+      userId: params.userId,
+      source: "mock",
+      selectedGoalOption: "authority",
+    }));
+    expect(createDiagnosis).toHaveBeenCalledWith(expect.objectContaining({
+      diagnosisId: "video-narrative-diagnosis-analysis-1",
+      profileContribution: expect.any(Object),
+    }));
+  });
+
+  it("salva uma leitura por video e retorna diagnosisId", async () => {
+    const createDiagnosis = jest.fn(async () => buildSavedDiagnosisDocumentFixture());
+
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      { createDiagnosis },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      diagnosisId: "video-narrative-diagnosis-analysis-1",
+      documentId: "665f0f2c8a0b7d1f2c3a4b5d",
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "low",
+        weight: "low",
+        profileImpactPreview: "Cria uma primeira pista para acompanhar nas proximas analises.",
+      },
+    });
+  });
+
+  it("exige profileContribution", async () => {
+    const mapToDiagnosisInput = jest.fn(() => {
+      const mapped = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput({
+        ...buildSaveOrchestratorParams(),
+        creatorGoal: "goal",
+        selectedGoalOption: "authority",
+      } as any);
+      return { ...mapped, profileContribution: undefined } as any;
+    });
+    const createDiagnosis = jest.fn();
+
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      { mapToDiagnosisInput, createDiagnosis },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "missing_profile_contribution",
+      message: "A leitura do video precisa de uma contribuicao para o Perfil antes de ser salva.",
+    });
+    expect(createDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("nao atualiza CreatorStrategicProfileSnapshot", async () => {
+    const source = readFileSync(path.join(__dirname, "creatorVideoNarrativeDiagnosisSaveOrchestrator.ts"), "utf8");
+
+    expect(source).not.toContain("CreatorStrategicProfileSnapshot");
+    expect(source).not.toContain("upsertStrategicProfileSnapshot");
+    expect(source).not.toContain("findOneAndUpdate");
+  });
+
+  it("nao importa endpoint real ou mock", () => {
+    const source = readFileSync(path.join(__dirname, "creatorVideoNarrativeDiagnosisSaveOrchestrator.ts"), "utf8");
+
+    expect(source).not.toMatch(/analyze-real\/route|analyze\/route|videoNarrativeEndpointMockMode|api\/dashboard\/mobile-strategic-profile/);
+  });
+
+  it("nao importa Gemini SDK, storage SDK ou client components", () => {
+    const source = readFileSync(path.join(__dirname, "creatorVideoNarrativeDiagnosisSaveOrchestrator.ts"), "utf8");
+
+    expect(source).not.toMatch(/@google\/genai|@aws-sdk|from ["']mongoose["']|["']use client["']/);
+  });
+
+  it("nao propaga objectKey, signedUrl, uploadUrl, thumbnailUrl, localPath ou storageProviderPath", async () => {
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams({
+        safeVideoMetadata: {
+          mimeType: "video/mp4",
+          objectKey: "uploads/user/video.mp4",
+          signedUrl: "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Signature=abc",
+          uploadUrl: "https://upload.example.com/video.mp4?token=abc",
+          thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+          localPath: "/tmp/video.mp4",
+          storageProviderPath: "r2://bucket/video.mp4",
+        } as any,
+      }),
+      {
+        createDiagnosis: jest.fn(async (input) => buildSavedDiagnosisDocumentFixture(input)),
+      },
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(result.ok).toBe(true);
+    expect(serialized).not.toContain("objectKey");
+    expect(serialized).not.toContain("signedUrl");
+    expect(serialized).not.toContain("uploadUrl");
+    expect(serialized).not.toContain("thumbnailUrl");
+    expect(serialized).not.toContain("localPath");
+    expect(serialized).not.toContain("storageProviderPath");
+    expect(serialized).not.toContain("X-Amz-Signature");
+  });
+
+  it("retorna erro seguro quando mapper falha", async () => {
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      {
+        mapToDiagnosisInput: jest.fn(() => {
+          throw new Error("rawGeminiResponse com stack e secret sk-proj-abc");
+        }),
+        createDiagnosis: jest.fn(),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "invalid_video_reading_input",
+      message: "Nao foi possivel preparar a leitura documentada deste video.",
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-proj");
+    expect(JSON.stringify(result)).not.toContain("stack");
+  });
+
+  it("retorna erro seguro quando service falha", async () => {
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      {
+        createDiagnosis: jest.fn(async () => {
+          throw new Error("Mongo stack with signedUrl https://bucket/video.mp4?signature=abc");
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "diagnosis_persistence_failed",
+      message: "Nao foi possivel salvar a leitura documentada deste video agora.",
+    });
+    expect(JSON.stringify(result)).not.toContain("signature");
+    expect(JSON.stringify(result)).not.toContain("Mongo");
+  });
+
+  it("passa pelo sanitizer do MM74/MM75 antes de chamar o service", async () => {
+    const createDiagnosis = jest.fn(async (input) => {
+      expect(() => sanitizeCreatorVideoNarrativeDiagnosisInput(input)).not.toThrow();
+      expect(JSON.stringify(input)).not.toContain("uploads/user/video.mp4");
+      return buildSavedDiagnosisDocumentFixture(input);
+    });
+
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams({
+        strategicDiagnosis: {
+          ...buildSaveOrchestratorParams().strategicDiagnosis,
+          mainNarrative: "Video com data:video/mp4;base64," + "A".repeat(1400) + " e uploads/user/video.mp4",
+        },
+      }),
+      { createDiagnosis },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(createDiagnosis).toHaveBeenCalled();
+  });
+
+  it("mantem source como mock/real/manual/migration sem executar logica especifica de endpoint", async () => {
+    const createDiagnosis = jest.fn(async (input) => buildSavedDiagnosisDocumentFixture(input));
+
+    for (const source of ["mock", "real", "manual", "migration"] as const) {
+      const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+        buildSaveOrchestratorParams({ source }),
+        { createDiagnosis },
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    expect(createDiagnosis).toHaveBeenCalledTimes(4);
+  });
+
+  it("retorno seguro nao contem diagnostico bruto nem raw response", async () => {
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      { createDiagnosis: jest.fn(async () => buildSavedDiagnosisDocumentFixture()) },
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("videoReading");
+    expect(serialized).not.toContain("speechReading");
+    expect(serialized).not.toContain("commercialReading");
+    expect(serialized).not.toContain("rawGeminiResponse");
+    expect(serialized).not.toContain("rawModelResponse");
+  });
+
+  it("integra fixture MM75 com service in-memory sem banco real", async () => {
+    const saved: unknown[] = [];
+    const createDiagnosis = jest.fn(async (input) => {
+      saved.push(input);
+      return buildSavedDiagnosisDocumentFixture(input);
+    });
+
+    const result = await saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+      buildSaveOrchestratorParams(),
+      { createDiagnosis },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toEqual(expect.objectContaining({
+      schemaVersion: "creator_video_narrative_diagnosis_v1",
+      profileContribution: expect.any(Object),
+    }));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestrator.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestrator.ts
@@ -1,0 +1,148 @@
+import { mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisMapper";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import {
+  createCreatorVideoNarrativeDiagnosis,
+} from "./creatorVideoNarrativeDiagnosisService";
+import type {
+  CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeDiagnosisInput,
+  CreatorVideoNarrativeDiagnosisSource,
+  CreatorVideoNarrativeDiagnosisVideoMetadata,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+import type { VideoNarrativeStrategicDiagnosis } from "./videoNarrativeDiagnosisLearningModel";
+import type { VideoNarrativeEvolvingDiagnosis } from "./videoNarrativeEvolvingDiagnosisContract";
+import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
+
+export type SaveCreatorVideoNarrativeDiagnosisErrorCode =
+  | "invalid_video_reading_input"
+  | "unsafe_video_metadata"
+  | "diagnosis_persistence_failed"
+  | "missing_profile_contribution"
+  | "unknown_video_reading_save_error";
+
+export type SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams = {
+  userId: string;
+  source: CreatorVideoNarrativeDiagnosisSource;
+  creatorGoal?: string | null;
+  selectedGoalOption?: "authority" | "retention" | "format_test" | "sponsored_content" | string | null;
+  safeVideoMetadata?: CreatorVideoNarrativeDiagnosisVideoMetadata | (CreatorVideoNarrativeDiagnosisVideoMetadata & Record<string, unknown>);
+  strategicDiagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+  presentation: VideoNarrativeDiagnosisPresentation;
+  seed?: PostCreationVideoSeed | null;
+  analyzedAt?: string | Date | null;
+  createdAt?: string | Date | null;
+};
+
+export type SaveCreatorVideoNarrativeDiagnosisResult =
+  | {
+      ok: true;
+      diagnosisId: string;
+      documentId?: string;
+      profileContribution: {
+        type: CreatorVideoNarrativeDiagnosisInput["profileContribution"]["type"];
+        confidence: CreatorVideoNarrativeDiagnosisInput["profileContribution"]["confidence"];
+        weight: CreatorVideoNarrativeDiagnosisInput["profileContribution"]["weight"];
+        profileImpactPreview: string;
+      };
+    }
+  | {
+      ok: false;
+      errorCode: SaveCreatorVideoNarrativeDiagnosisErrorCode;
+      message: string;
+    };
+
+export type SaveCreatorVideoNarrativeDiagnosisDeps = {
+  createDiagnosis?: typeof createCreatorVideoNarrativeDiagnosis;
+  mapToDiagnosisInput?: typeof mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput;
+};
+
+const SAFE_ERROR_MESSAGES: Record<SaveCreatorVideoNarrativeDiagnosisErrorCode, string> = {
+  invalid_video_reading_input: "Nao foi possivel preparar a leitura documentada deste video.",
+  unsafe_video_metadata: "Os metadados seguros do video nao passaram pela validacao.",
+  diagnosis_persistence_failed: "Nao foi possivel salvar a leitura documentada deste video agora.",
+  missing_profile_contribution: "A leitura do video precisa de uma contribuicao para o Perfil antes de ser salva.",
+  unknown_video_reading_save_error: "Nao foi possivel salvar a leitura documentada deste video agora.",
+};
+
+function safeFailure(errorCode: SaveCreatorVideoNarrativeDiagnosisErrorCode): SaveCreatorVideoNarrativeDiagnosisResult {
+  return {
+    ok: false,
+    errorCode,
+    message: SAFE_ERROR_MESSAGES[errorCode],
+  };
+}
+
+function classifyMappingError(error: unknown): SaveCreatorVideoNarrativeDiagnosisErrorCode {
+  const message = error instanceof Error ? error.message : "";
+  if (/profileContribution/i.test(message)) return "missing_profile_contribution";
+  if (/metadata|objectKey|signed|upload|storage|base64|transcri/i.test(message)) return "unsafe_video_metadata";
+  if (/raw model|rawGemini|rawModel|providerResponse|modelResponse/i.test(message)) return "invalid_video_reading_input";
+  return "invalid_video_reading_input";
+}
+
+function documentIdFrom(doc: CreatorVideoNarrativeDiagnosisDocument): string | undefined {
+  const possibleId = (doc as CreatorVideoNarrativeDiagnosisDocument & { _id?: unknown; id?: unknown }).id ??
+    (doc as CreatorVideoNarrativeDiagnosisDocument & { _id?: unknown })._id;
+  if (!possibleId) return undefined;
+  const text = typeof possibleId === "string" ? possibleId : String(possibleId);
+  return /^[a-f0-9]{24}$/i.test(text) ? text : undefined;
+}
+
+function buildMapperParams(
+  params: SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams,
+): Parameters<typeof mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput>[0] {
+  return {
+    userId: params.userId,
+    source: params.source,
+    creatorGoal: params.creatorGoal?.trim() || "Entender o que este video revela estrategicamente.",
+    selectedGoalOption: params.selectedGoalOption?.trim() || "strategic_reading",
+    safeVideoMetadata: params.safeVideoMetadata as Parameters<typeof mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput>[0]["safeVideoMetadata"],
+    strategicDiagnosis: params.strategicDiagnosis,
+    evolvingDiagnosis: params.evolvingDiagnosis,
+    presentation: params.presentation,
+    seed: params.seed,
+    analyzedAt: params.analyzedAt,
+    createdAt: params.createdAt,
+  };
+}
+
+export async function saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis(
+  params: SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams,
+  deps: SaveCreatorVideoNarrativeDiagnosisDeps = {},
+): Promise<SaveCreatorVideoNarrativeDiagnosisResult> {
+  const mapToDiagnosisInput = deps.mapToDiagnosisInput ?? mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput;
+  const createDiagnosis = deps.createDiagnosis ?? createCreatorVideoNarrativeDiagnosis;
+
+  let mappedInput: CreatorVideoNarrativeDiagnosisInput;
+  try {
+    mappedInput = mapToDiagnosisInput(buildMapperParams(params));
+    mappedInput = sanitizeCreatorVideoNarrativeDiagnosisInput(mappedInput);
+  } catch (error) {
+    return safeFailure(classifyMappingError(error));
+  }
+
+  if (!mappedInput.profileContribution) {
+    return safeFailure("missing_profile_contribution");
+  }
+
+  let created: CreatorVideoNarrativeDiagnosisDocument;
+  try {
+    created = await createDiagnosis(mappedInput);
+  } catch {
+    return safeFailure("diagnosis_persistence_failed");
+  }
+
+  return {
+    ok: true,
+    diagnosisId: created.diagnosisId,
+    documentId: documentIdFrom(created),
+    profileContribution: {
+      type: created.profileContribution.type,
+      confidence: created.profileContribution.confidence,
+      weight: created.profileContribution.weight,
+      profileImpactPreview: created.profileContribution.profileImpactPreview,
+    },
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestratorFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSaveOrchestratorFixtures.ts
@@ -1,0 +1,53 @@
+import type { CreatorVideoNarrativeDiagnosisDocument } from "./creatorVideoNarrativeDiagnosisTypes";
+import {
+  buildCreatorVideoNarrativeDiagnosisMapperParams,
+} from "./creatorVideoNarrativeDiagnosisMapperFixtures";
+import { mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisMapper";
+import type {
+  SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams,
+} from "./creatorVideoNarrativeDiagnosisSaveOrchestrator";
+
+export function buildSaveOrchestratorParams(
+  overrides: Partial<SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams> = {},
+): SaveCreatorVideoNarrativeDiagnosisFromStructuredAnalysisParams {
+  const mapperParams = buildCreatorVideoNarrativeDiagnosisMapperParams();
+  return {
+    userId: mapperParams.userId,
+    source: mapperParams.source,
+    creatorGoal: mapperParams.creatorGoal,
+    selectedGoalOption: "authority",
+    safeVideoMetadata: mapperParams.safeVideoMetadata,
+    strategicDiagnosis: mapperParams.strategicDiagnosis,
+    evolvingDiagnosis: mapperParams.evolvingDiagnosis,
+    presentation: mapperParams.presentation,
+    seed: mapperParams.seed,
+    analyzedAt: mapperParams.analyzedAt,
+    createdAt: mapperParams.createdAt,
+    ...overrides,
+  };
+}
+
+export function buildSavedDiagnosisDocumentFixture(
+  overrides: Partial<CreatorVideoNarrativeDiagnosisDocument> & { _id?: string } = {},
+): CreatorVideoNarrativeDiagnosisDocument & { _id?: string } {
+  const input = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+    buildCreatorVideoNarrativeDiagnosisMapperParams(),
+  );
+  return {
+    ...input,
+    schemaVersion: "creator_video_narrative_diagnosis_v1",
+    videoMetadata: input.videoMetadata ?? {},
+    safetyFlags: {
+      containsPersistedVideoReference: false,
+      containsSignedUrl: false,
+      containsObjectKey: false,
+      containsRawModelResponse: false,
+      containsLongTranscript: false,
+      sanitized: false,
+    },
+    createdAt: new Date("2026-05-20T10:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    _id: "665f0f2c8a0b7d1f2c3a4b5d",
+    ...overrides,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisService.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisService.test.ts
@@ -1,0 +1,106 @@
+import { Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorVideoNarrativeDiagnosis from "@/app/models/CreatorVideoNarrativeDiagnosis";
+import CreatorStrategicProfileSnapshot from "@/app/models/CreatorStrategicProfileSnapshot";
+import { buildCreatorVideoNarrativeDiagnosisFixture } from "./creatorVideoNarrativeDiagnosisFixtures";
+import {
+  createCreatorVideoNarrativeDiagnosis,
+  getCreatorVideoNarrativeDiagnosisByUserAndDiagnosisId,
+} from "./creatorVideoNarrativeDiagnosisService";
+
+jest.mock("@/app/lib/mongoose", () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+jest.mock("@/app/models/CreatorVideoNarrativeDiagnosis", () => ({
+  create: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+jest.mock("@/app/models/CreatorStrategicProfileSnapshot", () => ({
+  findOneAndUpdate: jest.fn(),
+  updateOne: jest.fn(),
+  create: jest.fn(),
+}));
+
+const mockConnect = connectToDatabase as jest.Mock;
+const mockCreate = CreatorVideoNarrativeDiagnosis.create as jest.Mock;
+const mockFindOne = CreatorVideoNarrativeDiagnosis.findOne as jest.Mock;
+const mockSnapshotFindOneAndUpdate = CreatorStrategicProfileSnapshot.findOneAndUpdate as jest.Mock;
+const mockSnapshotUpdateOne = CreatorStrategicProfileSnapshot.updateOne as jest.Mock;
+const mockSnapshotCreate = CreatorStrategicProfileSnapshot.create as jest.Mock;
+
+describe("creatorVideoNarrativeDiagnosisService", () => {
+  const userId = new Types.ObjectId().toString();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it("cria um documento válido de leitura por vídeo", async () => {
+    const input = buildCreatorVideoNarrativeDiagnosisFixture({ userId, diagnosisId: "diagnosis-1" });
+    mockCreate.mockImplementation(async (doc) => ({
+      ...doc,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    }));
+
+    const result = await createCreatorVideoNarrativeDiagnosis(input);
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: new Types.ObjectId(userId),
+        diagnosisId: "diagnosis-1",
+        schemaVersion: "creator_video_narrative_diagnosis_v1",
+      }),
+    );
+    expect(result.userId).toBe(userId);
+    expect(result.profileContribution.type).toBe("commercial_signal");
+  });
+
+  it("consulta por userId e diagnosisId", async () => {
+    const input = buildCreatorVideoNarrativeDiagnosisFixture({ userId, diagnosisId: "diagnosis-2" });
+    mockFindOne.mockReturnValue({
+      lean: () =>
+        Promise.resolve({
+          ...input,
+          userId: new Types.ObjectId(userId),
+          videoMetadata: input.videoMetadata,
+          safetyFlags: {
+            containsPersistedVideoReference: false,
+            containsSignedUrl: false,
+            containsObjectKey: false,
+            containsRawModelResponse: false,
+            containsLongTranscript: false,
+            sanitized: false,
+          },
+          schemaVersion: "creator_video_narrative_diagnosis_v1",
+        }),
+    });
+
+    const result = await getCreatorVideoNarrativeDiagnosisByUserAndDiagnosisId({
+      userId,
+      diagnosisId: "diagnosis-2",
+    });
+
+    expect(mockFindOne).toHaveBeenCalledWith({
+      userId: new Types.ObjectId(userId),
+      diagnosisId: "diagnosis-2",
+    });
+    expect(result?.userId).toBe(userId);
+    expect(result?.diagnosisId).toBe("diagnosis-2");
+  });
+
+  it("não altera CreatorStrategicProfileSnapshot ao criar a leitura do vídeo", async () => {
+    const input = buildCreatorVideoNarrativeDiagnosisFixture({ userId, diagnosisId: "diagnosis-3" });
+    mockCreate.mockImplementation(async (doc) => doc);
+
+    await createCreatorVideoNarrativeDiagnosis(input);
+
+    expect(mockSnapshotFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockSnapshotUpdateOne).not.toHaveBeenCalled();
+    expect(mockSnapshotCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisService.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisService.ts
@@ -1,0 +1,72 @@
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorVideoNarrativeDiagnosis from "@/app/models/CreatorVideoNarrativeDiagnosis";
+import { Types } from "mongoose";
+import { sanitizeCreatorVideoNarrativeDiagnosisInput } from "./creatorVideoNarrativeDiagnosisSanitizer";
+import type {
+  CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeDiagnosisInput,
+} from "./creatorVideoNarrativeDiagnosisTypes";
+
+function assertValidUserId(userId: string): void {
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    throw new Error("UserId inválido");
+  }
+}
+
+function mapDiagnosisDoc(doc: any): CreatorVideoNarrativeDiagnosisDocument {
+  return {
+    userId: doc.userId.toString(),
+    diagnosisId: doc.diagnosisId,
+    status: doc.status,
+    source: doc.source,
+    videoMetadata: doc.videoMetadata ?? {},
+    creatorGoal: doc.creatorGoal,
+    selectedGoalOption: doc.selectedGoalOption,
+    videoReading: doc.videoReading,
+    speechReading: doc.speechReading,
+    productionReading: doc.productionReading,
+    commercialReading: doc.commercialReading,
+    strategicRecommendation: doc.strategicRecommendation,
+    profileContribution: doc.profileContribution,
+    safetyFlags: doc.safetyFlags,
+    schemaVersion: doc.schemaVersion,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}
+
+export async function createCreatorVideoNarrativeDiagnosis(
+  input: CreatorVideoNarrativeDiagnosisInput,
+): Promise<CreatorVideoNarrativeDiagnosisDocument> {
+  assertValidUserId(input.userId);
+
+  const sanitized = sanitizeCreatorVideoNarrativeDiagnosisInput(input);
+
+  await connectToDatabase();
+
+  const createdDoc = await CreatorVideoNarrativeDiagnosis.create({
+    ...sanitized,
+    userId: new Types.ObjectId(sanitized.userId),
+  });
+
+  return mapDiagnosisDoc(createdDoc);
+}
+
+export async function getCreatorVideoNarrativeDiagnosisByUserAndDiagnosisId(params: {
+  userId: string;
+  diagnosisId: string;
+}): Promise<CreatorVideoNarrativeDiagnosisDocument | null> {
+  assertValidUserId(params.userId);
+  if (!params.diagnosisId?.trim()) {
+    throw new Error("DiagnosisId inválido");
+  }
+
+  await connectToDatabase();
+
+  const doc = await CreatorVideoNarrativeDiagnosis.findOne({
+    userId: new Types.ObjectId(params.userId),
+    diagnosisId: params.diagnosisId.trim(),
+  }).lean();
+
+  return doc ? mapDiagnosisDoc(doc) : null;
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
@@ -1,0 +1,114 @@
+export type CreatorVideoNarrativeDiagnosisStatus = "draft" | "completed" | "failed" | "discarded";
+
+export type CreatorVideoNarrativeDiagnosisSource = "mock" | "real" | "manual" | "migration";
+
+export type CreatorVideoNarrativeDiagnosisConfidence = "low" | "medium" | "high";
+
+export type CreatorVideoNarrativeDiagnosisContributionType =
+  | "confirms_existing_pattern"
+  | "opens_new_hypothesis"
+  | "isolated_strong_video"
+  | "creative_deviation"
+  | "commercial_signal"
+  | "weak_positioning_signal"
+  | "needs_more_samples";
+
+export type CreatorVideoNarrativeDiagnosisWeight = "low" | "medium" | "high";
+
+export interface CreatorVideoNarrativeDiagnosisVideoMetadata {
+  mimeType?: string;
+  sizeBytes?: number;
+  durationSeconds?: number;
+  originalFileNameSanitized?: string;
+  uploadedAt?: Date;
+  analyzedAt?: Date;
+}
+
+export interface CreatorVideoNarrativeDiagnosisVideoReading {
+  title: string;
+  rememberedAs: string;
+  summary: string;
+  whatVideoReveals: string;
+  mainNarrative: string;
+  creatorIntent: string;
+  dominantInsight: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisSpeechReading {
+  summary: string;
+  openingRead: string;
+  clarityRead: string;
+  pacingRead: string;
+  suggestedLine: string;
+  suggestedOpening: string;
+  suggestedClosing: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisProductionReading {
+  summary: string;
+  framing: string;
+  lighting: string;
+  audio: string;
+  editingRhythm: string;
+  firstFrame: string;
+  visualClarity: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisCommercialReading {
+  summary: string;
+  brandTerritories: string[];
+  whyItCouldFitBrands: string;
+  adAdaptationIdea: string;
+  limitations: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisStrategicRecommendation {
+  mainAdjustment: string;
+  nextExperiment: string;
+  whatToRepeat: string;
+  whatToAvoid: string;
+  successSignal: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisProfileContribution {
+  type: CreatorVideoNarrativeDiagnosisContributionType;
+  confidence: CreatorVideoNarrativeDiagnosisConfidence;
+  weight: CreatorVideoNarrativeDiagnosisWeight;
+  reason: string;
+  profileImpactPreview: string;
+}
+
+export interface CreatorVideoNarrativeDiagnosisSafetyFlags {
+  containsPersistedVideoReference: boolean;
+  containsSignedUrl: boolean;
+  containsObjectKey: boolean;
+  containsRawModelResponse: boolean;
+  containsLongTranscript: boolean;
+  sanitized: boolean;
+}
+
+export interface CreatorVideoNarrativeDiagnosisInput {
+  userId: string;
+  diagnosisId: string;
+  status: CreatorVideoNarrativeDiagnosisStatus;
+  source: CreatorVideoNarrativeDiagnosisSource;
+  videoMetadata?: CreatorVideoNarrativeDiagnosisVideoMetadata | (CreatorVideoNarrativeDiagnosisVideoMetadata & Record<string, unknown>);
+  creatorGoal: string;
+  selectedGoalOption: string;
+  videoReading: CreatorVideoNarrativeDiagnosisVideoReading;
+  speechReading: CreatorVideoNarrativeDiagnosisSpeechReading;
+  productionReading: CreatorVideoNarrativeDiagnosisProductionReading;
+  commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
+  strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
+  profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  schemaVersion?: "creator_video_narrative_diagnosis_v1";
+}
+
+export interface CreatorVideoNarrativeDiagnosisDocument
+  extends Omit<CreatorVideoNarrativeDiagnosisInput, "schemaVersion" | "videoMetadata"> {
+  schemaVersion: "creator_video_narrative_diagnosis_v1";
+  videoMetadata: CreatorVideoNarrativeDiagnosisVideoMetadata;
+  safetyFlags: CreatorVideoNarrativeDiagnosisSafetyFlags;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.test.ts
@@ -1,0 +1,278 @@
+import fs from "fs";
+import path from "path";
+import { buildCreatorStrategicProfileSynthesis } from "./creatorStrategicProfileSynthesis";
+import { buildCreatorStrategicProfileSynthesisReadingsFixture } from "./creatorStrategicProfileSynthesisFixtures";
+import {
+  runControlledVideoReadingSynthesisSnapshotWrite,
+  type ControlledVideoReadingSynthesisSnapshotWriteResult,
+} from "./creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator";
+import type { CreatorVideoNarrativeDiagnosisSafeReading } from "./creatorVideoNarrativeDiagnosisReadService";
+
+const USER_ID = "665f0f2c8a0b7d1f2c3a4b5c";
+
+function readings(state: Parameters<typeof buildCreatorStrategicProfileSynthesisReadingsFixture>[0]) {
+  return buildCreatorStrategicProfileSynthesisReadingsFixture(state);
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+function expectSafeAuditResult(result: ControlledVideoReadingSynthesisSnapshotWriteResult): void {
+  const text = serialized(result);
+
+  expect(text).not.toContain("snapshotjson");
+  expect(text).not.toContain("payload");
+  expect(text).not.toContain("videoreading");
+  expect(text).not.toContain("speechreading");
+  expect(text).not.toContain("objectkey");
+  expect(text).not.toContain("signedurl");
+  expect(text).not.toContain("uploadurl");
+  expect(text).not.toContain("thumbnailurl");
+  expect(text).not.toContain("localpath");
+  expect(text).not.toContain("storageproviderpath");
+}
+
+describe("creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator", () => {
+  it("nao escreve snapshot quando enableSnapshotWrite=false", async () => {
+    const persistSynthesisSnapshot = jest.fn();
+
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-pattern-1",
+      enableSnapshotWrite: false,
+      source: "mock_internal",
+    }, { persistSynthesisSnapshot });
+
+    expect(result).toEqual({
+      attempted: false,
+      written: false,
+      skippedReason: "synthesis_write_disabled",
+    });
+    expect(persistSynthesisSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("escreve snapshot quando enableSnapshotWrite=true e ha leituras suficientes", async () => {
+    const listReadingsForUser = jest.fn().mockResolvedValue(readings("three_related_readings"));
+    const persistSynthesisSnapshot = jest.fn().mockResolvedValue({
+      ok: true,
+      mode: "write",
+      userId: USER_ID,
+      synthesisVersion: "creator_profile_synthesis_snapshot_v1",
+      synthesisStatus: "pattern_in_formation",
+      analyzedReadingsCount: 3,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-pattern-1",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, { listReadingsForUser, persistSynthesisSnapshot });
+
+    expect(result).toEqual({
+      attempted: true,
+      written: true,
+      synthesisStatus: "pattern_in_formation",
+      analyzedReadingsCount: 3,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+    expect(persistSynthesisSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      userId: USER_ID,
+      mode: "write",
+      expectedSource: "video_reading_synthesis_v1",
+    }));
+  });
+
+  it("retorna skipped quando nao ha leitura salva", async () => {
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "missing-reading",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(readings("three_related_readings")),
+      persistSynthesisSnapshot: jest.fn(),
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      written: false,
+      skippedReason: "saved_reading_not_found",
+    });
+  });
+
+  it("retorna skipped quando synthesis.status=empty", async () => {
+    const savedOnly = readings("first_reading").slice(0, 1);
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-first",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(savedOnly),
+      buildSynthesis: jest.fn(() => buildCreatorStrategicProfileSynthesis({ readings: [] })),
+      persistSynthesisSnapshot: jest.fn(),
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      written: false,
+      skippedReason: "synthesis_empty",
+      synthesisStatus: "empty",
+      analyzedReadingsCount: 0,
+    });
+  });
+
+  it("first_reading escreve apenas estado inicial e nao padrao definitivo", async () => {
+    const persistSynthesisSnapshot = jest.fn().mockResolvedValue({
+      ok: true,
+      mode: "write",
+      userId: USER_ID,
+      synthesisVersion: "creator_profile_synthesis_snapshot_v1",
+      synthesisStatus: "first_reading",
+      analyzedReadingsCount: 1,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-first",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(readings("first_reading")),
+      persistSynthesisSnapshot,
+    });
+    const synthesisArg = persistSynthesisSnapshot.mock.calls[0][0].synthesis;
+
+    expect(result.synthesisStatus).toBe("first_reading");
+    expect(synthesisArg.mainNarrative).toBeNull();
+    expect(serialized(result)).not.toContain("definitiv");
+  });
+
+  it("tres leituras recorrentes escrevem pattern_in_formation", async () => {
+    const persistSynthesisSnapshot = jest.fn().mockResolvedValue({
+      ok: true,
+      mode: "write",
+      userId: USER_ID,
+      synthesisVersion: "creator_profile_synthesis_snapshot_v1",
+      synthesisStatus: "pattern_in_formation",
+      analyzedReadingsCount: 3,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-pattern-2",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(readings("three_related_readings")),
+      persistSynthesisSnapshot,
+    });
+
+    expect(result.written).toBe(true);
+    expect(result.synthesisStatus).toBe("pattern_in_formation");
+  });
+
+  it("erro de persistencia vira erro seguro", async () => {
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-pattern-1",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(readings("three_related_readings")),
+      persistSynthesisSnapshot: jest.fn().mockResolvedValue({
+        ok: false,
+        errorCode: "synthesis_snapshot_write_failed",
+        message: "stack trace escondido",
+      }),
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      written: false,
+      skippedReason: "synthesis_snapshot_write_failed",
+      synthesisStatus: "pattern_in_formation",
+      analyzedReadingsCount: 3,
+    });
+  });
+
+  it("resultado nao contem snapshot completo nem metadados sensiveis", async () => {
+    const result = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-commercial-1",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, {
+      listReadingsForUser: jest.fn().mockResolvedValue(readings("commercial_signals")),
+      persistSynthesisSnapshot: jest.fn().mockResolvedValue({
+        ok: true,
+        mode: "write",
+        userId: USER_ID,
+        payload: { snapshotJson: "nao deve voltar" },
+        synthesisVersion: "creator_profile_synthesis_snapshot_v1",
+        synthesisStatus: "signals_emerging",
+        analyzedReadingsCount: 3,
+        updatedAt: "2026-05-20T00:00:00.000Z",
+      }),
+    });
+
+    expectSafeAuditResult(result);
+  });
+
+  it("nao chama Gemini/storage nem importa endpoint real", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts"),
+      "utf8",
+    );
+
+    expect(source).not.toMatch(/@google\/genai|@aws-sdk|api\/dashboard|analyze-real|storageProvider|temporaryStorage|fetch\(/);
+  });
+
+  it("isolated_strong_video e creative_deviation nao geram auditoria proibida", async () => {
+    const isolated = readings("isolated_strong_video");
+    const deviation = readings("creative_deviation");
+    const listReadingsForUser = jest
+      .fn<Promise<CreatorVideoNarrativeDiagnosisSafeReading[]>, [{ userId: string; limit?: number }]>()
+      .mockResolvedValueOnce(isolated)
+      .mockResolvedValueOnce(deviation);
+    const persistSynthesisSnapshot = jest.fn().mockResolvedValue({
+      ok: true,
+      mode: "write",
+      userId: USER_ID,
+      synthesisVersion: "creator_profile_synthesis_snapshot_v1",
+      synthesisStatus: "first_reading",
+      analyzedReadingsCount: 1,
+      updatedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    const isolatedResult = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-isolated-1",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, { listReadingsForUser, persistSynthesisSnapshot });
+    const deviationResult = await runControlledVideoReadingSynthesisSnapshotWrite({
+      userId: USER_ID,
+      savedDiagnosisId: "reading-deviation-2",
+      enableSnapshotWrite: true,
+      source: "mock_internal",
+    }, { listReadingsForUser, persistSynthesisSnapshot });
+
+    for (const result of [isolatedResult, deviationResult]) {
+      const text = serialized(result);
+      expect(text).not.toContain("score");
+      expect(text).not.toContain("nota");
+      expect(text).not.toContain("viralizar");
+      expect(text).not.toContain("garantido");
+      expect(text).not.toContain("certeza");
+      expect(text).not.toContain("comprovado");
+      expect(text).not.toContain("match real");
+      expect(text).not.toContain("publi garantida");
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts
@@ -1,0 +1,136 @@
+import {
+  buildCreatorStrategicProfileSynthesis,
+  type CreatorStrategicProfileSynthesis,
+} from "./creatorStrategicProfileSynthesis";
+import {
+  listRecentCreatorVideoNarrativeDiagnosesForUser,
+  type CreatorVideoNarrativeDiagnosisSafeReading,
+} from "./creatorVideoNarrativeDiagnosisReadService";
+import {
+  persistCreatorStrategicProfileSynthesis,
+  type CreatorStrategicProfileSynthesisPersistenceResult,
+} from "./creatorStrategicProfileSynthesisPersistenceService";
+
+export type ControlledVideoReadingSynthesisSnapshotWriteErrorCode =
+  | "synthesis_write_disabled"
+  | "saved_reading_not_found"
+  | "synthesis_empty"
+  | "synthesis_snapshot_write_failed"
+  | "insufficient_evidence"
+  | "unknown_synthesis_write_error";
+
+export interface ControlledVideoReadingSynthesisSnapshotWriteParams {
+  userId: string;
+  savedDiagnosisId: string;
+  enableSnapshotWrite: boolean;
+  source: "mock_internal";
+  requestId?: string | null;
+}
+
+export interface ControlledVideoReadingSynthesisSnapshotWriteResult {
+  attempted: boolean;
+  written: boolean;
+  skippedReason?: ControlledVideoReadingSynthesisSnapshotWriteErrorCode;
+  synthesisStatus?: CreatorStrategicProfileSynthesis["status"];
+  analyzedReadingsCount?: number;
+  snapshotId?: string;
+  updatedAt?: string;
+}
+
+export interface ControlledVideoReadingSynthesisSnapshotWriteDeps {
+  listReadingsForUser?: (params: { userId: string; limit?: number }) => Promise<CreatorVideoNarrativeDiagnosisSafeReading[]>;
+  buildSynthesis?: typeof buildCreatorStrategicProfileSynthesis;
+  persistSynthesisSnapshot?: typeof persistCreatorStrategicProfileSynthesis;
+}
+
+function skipped(
+  params: Omit<ControlledVideoReadingSynthesisSnapshotWriteResult, "written">,
+): ControlledVideoReadingSynthesisSnapshotWriteResult {
+  return {
+    ...params,
+    written: false,
+  };
+}
+
+function mapPersistenceFailure(
+  result: Extract<CreatorStrategicProfileSynthesisPersistenceResult, { ok: false }>,
+): ControlledVideoReadingSynthesisSnapshotWriteErrorCode {
+  if (result.errorCode === "insufficient_synthesis_evidence") return "insufficient_evidence";
+  if (result.errorCode === "synthesis_snapshot_write_failed") return "synthesis_snapshot_write_failed";
+  return "unknown_synthesis_write_error";
+}
+
+export async function runControlledVideoReadingSynthesisSnapshotWrite(
+  params: ControlledVideoReadingSynthesisSnapshotWriteParams,
+  deps: ControlledVideoReadingSynthesisSnapshotWriteDeps = {},
+): Promise<ControlledVideoReadingSynthesisSnapshotWriteResult> {
+  if (params.enableSnapshotWrite !== true) {
+    return skipped({
+      attempted: false,
+      skippedReason: "synthesis_write_disabled",
+    });
+  }
+
+  if (params.source !== "mock_internal" || !params.userId.trim() || !params.savedDiagnosisId.trim()) {
+    return skipped({
+      attempted: true,
+      skippedReason: "saved_reading_not_found",
+    });
+  }
+
+  try {
+    const listReadingsForUser = deps.listReadingsForUser ?? listRecentCreatorVideoNarrativeDiagnosesForUser;
+    const readings = await listReadingsForUser({ userId: params.userId, limit: 12 });
+    const savedReading = readings.find((reading) => reading.diagnosisId === params.savedDiagnosisId);
+
+    if (!savedReading) {
+      return skipped({
+        attempted: true,
+        skippedReason: "saved_reading_not_found",
+      });
+    }
+
+    const buildSynthesis = deps.buildSynthesis ?? buildCreatorStrategicProfileSynthesis;
+    const synthesis = buildSynthesis({ readings });
+
+    if (synthesis.status === "empty") {
+      return skipped({
+        attempted: true,
+        skippedReason: "synthesis_empty",
+        synthesisStatus: synthesis.status,
+        analyzedReadingsCount: synthesis.analyzedReadingsCount,
+      });
+    }
+
+    const persistSynthesisSnapshot = deps.persistSynthesisSnapshot ?? persistCreatorStrategicProfileSynthesis;
+    const persistResult = await persistSynthesisSnapshot({
+      userId: params.userId,
+      synthesis,
+      mode: "write",
+      expectedSource: "video_reading_synthesis_v1",
+    });
+
+    if (!persistResult.ok) {
+      return skipped({
+        attempted: true,
+        skippedReason: mapPersistenceFailure(persistResult),
+        synthesisStatus: synthesis.status,
+        analyzedReadingsCount: synthesis.analyzedReadingsCount,
+      });
+    }
+
+    return {
+      attempted: true,
+      written: true,
+      synthesisStatus: persistResult.synthesisStatus,
+      analyzedReadingsCount: persistResult.analyzedReadingsCount,
+      snapshotId: persistResult.snapshotId,
+      updatedAt: persistResult.updatedAt,
+    };
+  } catch {
+    return skipped({
+      attempted: true,
+      skippedReason: "unknown_synthesis_write_error",
+    });
+  }
+}

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotTypes.ts
@@ -19,6 +19,7 @@ export interface CreatorStrategicProfileSnapshotInput {
   source:
     | "manual_seed"
     | "mock_analysis"
+    | "video_reading_synthesis_v1"
     | "future_video_analysis"
     | "gemini_ready"
     | "gemini_fixture"

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { buildNarrativeMapMobileViewModelFixture } from "./narrativeMapMobileViewModelFixtures";
+
+function text(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe("narrativeMapMobileViewModel", () => {
+  it("gera view model valido com Perfil, Leituras e Oportunidades", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture();
+
+    expect(viewModel.profileHeader.displayName).toBe("Lívia Linhares");
+    expect(viewModel.hero.title).toBe("Seu mapa narrativo");
+    expect(viewModel.profile.chapters.length).toBeGreaterThan(0);
+    expect(viewModel.readings.items.length).toBeGreaterThan(0);
+    expect(viewModel.opportunities.items.length).toBeGreaterThan(0);
+  });
+
+  it("tabs sao exatamente Perfil, Leituras e Oportunidades", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("default", { activeTab: "readings" });
+
+    expect(viewModel.tabs).toEqual([
+      { id: "profile", label: "Perfil", active: false },
+      { id: "readings", label: "Leituras", active: true },
+      { id: "opportunities", label: "Oportunidades", active: false },
+    ]);
+  });
+
+  it("CTA principal e Nova leitura", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture();
+
+    expect(viewModel.profile.primaryAction).toEqual(expect.objectContaining({
+      label: "Nova leitura",
+      intent: "analyze_new_video",
+      priority: "primary",
+    }));
+  });
+
+  it("CTA secundario e Ler diagnostico completo quando ha apresentacao", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture();
+
+    expect(viewModel.profile.secondaryAction).toEqual(expect.objectContaining({
+      label: "Ler diagnóstico completo",
+      intent: "open_full_diagnosis",
+      priority: "secondary",
+    }));
+  });
+
+  it("metricas usam Leituras, Padroes e Oportunidades sem Matches", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture();
+
+    expect(viewModel.profileHeader.metrics.map((metric) => metric.label)).toEqual([
+      "Leituras",
+      "Padrões",
+      "Oportunidades",
+    ]);
+    expect(text(viewModel.profileHeader.metrics)).not.toContain("matches");
+  });
+
+  it("primeira leitura nao usa linguagem definitiva", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("first_reading");
+    const output = text(viewModel);
+
+    expect(viewModel.hero.headline).toBe("Seu mapa começou");
+    expect(viewModel.profileHeader.statusLabel).toBe("Primeira leitura");
+    expect(output).toContain("ainda é cedo");
+    expect(output).not.toContain("padrão confirmado");
+    expect(output).not.toContain("sua narrativa principal é");
+  });
+
+  it("Instagram conectado altera badge/status, mas nao cria aba Instagram", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("instagram_connected");
+
+    expect(viewModel.hero.badgeLabel).toBe("Cruzado com Instagram");
+    expect(viewModel.profileHeader.statusLabel).toBe("Cruzado com Instagram");
+    expect(viewModel.tabs.map((tab) => tab.label)).not.toContain("Instagram");
+    expect(text(viewModel)).toContain("sinais do perfil");
+  });
+
+  it("oportunidades nao prometem match real, marca real ou creator real", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("opportunities_limited");
+    const output = text(viewModel.opportunities);
+
+    expect(output).toContain("fit narrativo");
+    expect(output).toContain("tipo de collab");
+    expect(output).not.toContain("match real");
+    expect(output).not.toContain("marca real");
+    expect(output).not.toContain("creator real");
+    expect(output).not.toContain("publi garantida");
+  });
+
+  it("leituras usam rememberedAs e nao thumbnail, filename bruto ou url", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("default", {
+      recentReadings: [
+        {
+          diagnosisId: "unsafe-reading",
+          rememberedAs: "Vídeo sobre reunião que era para ser rápida https://cdn.example.com/video.mp4?token=abc",
+          createdAt: "2026-05-20T10:00:00.000Z",
+          profileContribution: {
+            type: "opens_new_hypothesis",
+            confidence: "low",
+            weight: "low",
+            profileImpactPreview: "Sinal inicial.",
+          },
+        },
+      ],
+    });
+    const item = viewModel.readings.items[0];
+    const output = text(viewModel.readings);
+
+    expect(item.rememberedAs).toContain("Vídeo sobre reunião");
+    expect(output).not.toContain("https://");
+    expect(output).not.toContain(".mp4");
+    expect(output).not.toContain("thumbnail");
+    expect(output).not.toContain("filename");
+  });
+
+  it("safetyNote nao usa termos tecnicos", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture();
+
+    expect(viewModel.safetyNote).toBe("A D2C guarda a leitura estratégica, não o vídeo.");
+    expect(text(viewModel.safetyNote)).not.toMatch(/objectkey|signedurl|storage|raw response|gemini/);
+  });
+
+  it("adapter nao importa endpoint real ou mock", () => {
+    const source = readFileSync(path.join(__dirname, "narrativeMapMobileViewModel.ts"), "utf8");
+
+    expect(source).not.toMatch(/analyze-real\/route|analyze\/route|api\/dashboard\/mobile-strategic-profile|videoNarrativeEndpointMockMode/);
+  });
+
+  it("adapter nao importa persistencia, Mongoose, SDKs ou CreatorStrategicProfileSnapshot", () => {
+    const source = readFileSync(path.join(__dirname, "narrativeMapMobileViewModel.ts"), "utf8");
+
+    expect(source).not.toMatch(/creatorVideoNarrativeDiagnosisService|from ["']mongoose["']|@google\/genai|@aws-sdk|CreatorStrategicProfileSnapshot|CreatorVideoNarrativeDiagnosis\./);
+  });
+
+  it("adapter nao chama banco", () => {
+    const source = readFileSync(path.join(__dirname, "narrativeMapMobileViewModel.ts"), "utf8");
+
+    expect(source).not.toMatch(/connectToDatabase|findOne|find\(|save\(|insert|update|aggregate/);
+  });
+
+  it("adapter nao atualiza Perfil geral", () => {
+    const source = readFileSync(path.join(__dirname, "narrativeMapMobileViewModel.ts"), "utf8");
+
+    expect(source).not.toMatch(/CreatorStrategicProfileSnapshot|upsertStrategicProfileSnapshot|profile snapshot/i);
+  });
+
+  it("guardrail textual para termos proibidos", () => {
+    const output = text(buildNarrativeMapMobileViewModelFixture("opportunities_limited"));
+
+    for (const forbidden of [
+      "score",
+      "nota",
+      "viralizar",
+      "garantido",
+      "certeza",
+      "comprovado",
+      "match real",
+      "publi garantida",
+      "gemini",
+      "objectkey",
+      "signedurl",
+      "uploadurl",
+      "thumbnailurl",
+      "localpath",
+      "storageproviderpath",
+    ]) {
+      expect(output).not.toContain(forbidden);
+    }
+  });
+
+  it("no_readings gera empty state elegante", () => {
+    const viewModel = buildNarrativeMapMobileViewModelFixture("no_readings");
+
+    expect(viewModel.readings.items).toHaveLength(0);
+    expect(viewModel.readings.emptyState).toEqual(expect.objectContaining({
+      title: "Nenhuma leitura documentada ainda",
+      action: expect.objectContaining({ label: "Nova leitura" }),
+    }));
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
@@ -1,0 +1,469 @@
+import type {
+  CreatorNarrativeMapReadingChapter,
+  CreatorNarrativeMapReadingPresentation,
+} from "./creatorNarrativeMapReadingChapters";
+import type {
+  CreatorStrategicProfileSynthesis,
+  CreatorStrategicProfileSynthesisSignal,
+} from "./creatorStrategicProfileSynthesis";
+
+export type NarrativeMapMobileTabId = "profile" | "readings" | "opportunities";
+
+export interface NarrativeMapMobileMetric {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface NarrativeMapMobileAction {
+  id: string;
+  label: string;
+  intent:
+    | "analyze_new_video"
+    | "open_full_diagnosis"
+    | "open_reading"
+    | "connect_instagram"
+    | "upgrade"
+    | "open_media_kit";
+  priority: "primary" | "secondary" | "tertiary";
+  disabled?: boolean;
+  helper?: string | null;
+}
+
+export interface NarrativeMapMobileReadingItem {
+  id: string;
+  diagnosisId: string;
+  rememberedAs: string;
+  dateLabel: string;
+  contributionLabel: string;
+  profileImpactPreview: string;
+  statusLabel: string;
+  action: NarrativeMapMobileAction;
+}
+
+export interface NarrativeMapMobileOpportunityItem {
+  id: string;
+  title: string;
+  preview: string;
+  type: "brand_territory" | "collab_type" | "media_kit_bridge" | "instagram_precision";
+  badgeLabel?: string | null;
+  action?: NarrativeMapMobileAction | null;
+  locked?: boolean;
+}
+
+export interface NarrativeMapMobileViewModel {
+  id: string;
+  profileHeader: {
+    displayName: string;
+    displayHandle: string | null;
+    statusLabel: string;
+    metrics: NarrativeMapMobileMetric[];
+  };
+  hero: {
+    title: string;
+    headline: string;
+    subheadline: string;
+    badgeLabel?: string | null;
+  };
+  tabs: Array<{
+    id: NarrativeMapMobileTabId;
+    label: string;
+    active: boolean;
+  }>;
+  profile: {
+    chapters: CreatorNarrativeMapReadingChapter[];
+    primaryAction: NarrativeMapMobileAction;
+    secondaryAction: NarrativeMapMobileAction | null;
+  };
+  readings: {
+    title: string;
+    description: string;
+    items: NarrativeMapMobileReadingItem[];
+    emptyState?: {
+      title: string;
+      description: string;
+      action: NarrativeMapMobileAction;
+    } | null;
+  };
+  opportunities: {
+    title: string;
+    description: string;
+    items: NarrativeMapMobileOpportunityItem[];
+    emptyState?: {
+      title: string;
+      description: string;
+      action?: NarrativeMapMobileAction | null;
+    } | null;
+  };
+  safetyNote?: string | null;
+}
+
+export interface NarrativeMapMobileRecentReadingInput {
+  diagnosisId: string;
+  rememberedAs: string;
+  createdAt?: string | Date | null;
+  profileContribution: {
+    type: string;
+    confidence: string;
+    weight: string;
+    profileImpactPreview: string;
+  };
+}
+
+export interface BuildNarrativeMapMobileViewModelInput {
+  displayName: string;
+  displayHandle?: string | null;
+  currentPresentation: CreatorNarrativeMapReadingPresentation;
+  recentReadings?: NarrativeMapMobileRecentReadingInput[];
+  profileSynthesis?: CreatorStrategicProfileSynthesis | null;
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  instagramConnected?: boolean;
+  mediaKitAvailable?: boolean;
+  activeTab?: NarrativeMapMobileTabId;
+}
+
+const SAFE_TEXT_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/https?:\/\/[^\s"'<>]+/gi, "referencia removida"],
+  [/\b(?:objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi, "referencia removida"],
+  [/\b(?:storage|raw response|Gemini)\b/gi, "leitura"],
+  [/\b(?:score|nota)\b/gi, "leitura"],
+  [/\bviralizar\b/gi, "crescer com consistencia"],
+  [/\bgarantid[oa]\b/gi, "possivel"],
+  [/\bcerteza\b/gi, "hipotese"],
+  [/\bcomprovad[oa]\b/gi, "em observacao"],
+  [/\bmatch\s+real\b/gi, "fit narrativo possivel"],
+  [/\bpubli\s+garantida\b/gi, "oportunidade em formacao"],
+];
+
+function cleanText(value: string | null | undefined, fallback: string): string {
+  const raw = value?.trim() || fallback;
+  return SAFE_TEXT_REPLACEMENTS.reduce((text, [pattern, replacement]) => text.replace(pattern, replacement), raw)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function dateLabel(value: string | Date | null | undefined): string {
+  const date = value instanceof Date ? value : typeof value === "string" ? new Date(value) : null;
+  if (!date || !Number.isFinite(date.getTime())) return "Sem data";
+  return `${String(date.getUTCDate()).padStart(2, "0")}/${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function contributionLabel(type: string): string {
+  const labels: Record<string, string> = {
+    confirms_existing_pattern: "Narrativa reforçada",
+    opens_new_hypothesis: "Hipótese em teste",
+    isolated_strong_video: "Vídeo forte isolado",
+    creative_deviation: "Desvio criativo",
+    commercial_signal: "Fit narrativo possível",
+    weak_positioning_signal: "Sinal fraco",
+    needs_more_samples: "Precisa repetir",
+  };
+
+  return labels[type] ?? "Leitura documentada";
+}
+
+function action(params: NarrativeMapMobileAction): NarrativeMapMobileAction {
+  return {
+    ...params,
+    helper: params.helper ? cleanText(params.helper, "") : null,
+  };
+}
+
+function countPatternReadings(readings: NarrativeMapMobileRecentReadingInput[]): number {
+  return readings.filter((reading) =>
+    ["confirms_existing_pattern", "opens_new_hypothesis"].includes(reading.profileContribution.type),
+  ).length;
+}
+
+function opportunityChapters(presentation: CreatorNarrativeMapReadingPresentation): CreatorNarrativeMapReadingChapter[] {
+  return presentation.chapters.filter((chapter) => chapter.id === "territory" || chapter.id === "opportunities");
+}
+
+function synthesisStatusLabel(synthesis: CreatorStrategicProfileSynthesis | null | undefined): string | null {
+  if (!synthesis) return null;
+  const labels: Record<CreatorStrategicProfileSynthesis["status"], string> = {
+    empty: "Sem leituras",
+    first_reading: "Primeira leitura",
+    signals_emerging: "Sinais em formação",
+    pattern_in_formation: "Padrão em formação",
+    profile_consistent: "Perfil consistente",
+  };
+  return labels[synthesis.status];
+}
+
+function synthesisHeadline(synthesis: CreatorStrategicProfileSynthesis | null | undefined, fallback: string): string {
+  if (!synthesis) return fallback;
+  if (synthesis.status === "empty" || synthesis.status === "first_reading") return "Seu mapa começou";
+  if (synthesis.status === "signals_emerging") return "Um sinal começa a aparecer";
+  return "Um padrão começa a se repetir";
+}
+
+function synthesisSubheadline(synthesis: CreatorStrategicProfileSynthesis | null | undefined, fallback: string): string {
+  if (!synthesis) return fallback;
+  if (synthesis.status === "empty") {
+    return "Analise um vídeo para criar a primeira leitura documentada do Perfil.";
+  }
+  if (synthesis.status === "first_reading") {
+    return "Primeiro sinal: ainda é cedo para chamar de padrão, mas a leitura já orienta o próximo teste.";
+  }
+  if (synthesis.status === "signals_emerging") {
+    return "Duas leituras começam a apontar uma direção, ainda em formação.";
+  }
+  return synthesis.mainNarrative?.summary ?? "As leituras começam a mostrar uma narrativa recorrente, sem virar promessa definitiva.";
+}
+
+function synthesisChapter(params: {
+  id: CreatorNarrativeMapReadingChapter["id"];
+  title: string;
+  signal?: CreatorStrategicProfileSynthesisSignal | null;
+  fallback: string;
+  action?: string | null;
+  tone: CreatorNarrativeMapReadingChapter["tone"];
+}): CreatorNarrativeMapReadingChapter {
+  const signal = params.signal;
+  return {
+    id: params.id,
+    title: params.title,
+    preview: cleanText(signal?.summary, params.fallback),
+    fullReading: cleanText(
+      signal
+        ? `${signal.summary} Essa leitura aparece em ${signal.evidenceCount} vídeo(s) documentado(s), ainda como síntese dry-run.`
+        : params.fallback,
+      params.fallback,
+    ),
+    evidence: signal ? [`${signal.evidenceCount} leitura(s) documentada(s)`] : [],
+    action: params.action,
+    badgeLabel: signal ? `${signal.evidenceCount} sinais` : "Em formação",
+    tone: params.tone,
+    locked: false,
+  };
+}
+
+function profileChaptersFromSynthesis(
+  synthesis: CreatorStrategicProfileSynthesis | null | undefined,
+  fallbackChapters: CreatorNarrativeMapReadingChapter[],
+): CreatorNarrativeMapReadingChapter[] {
+  if (!synthesis) return fallbackChapters;
+
+  return [
+    synthesisChapter({
+      id: "pattern",
+      title: "Seu padrão",
+      signal: synthesis.mainNarrative ?? synthesis.recurringPatterns[0] ?? synthesis.testedNarratives[0],
+      fallback: synthesis.status === "empty"
+        ? "O Perfil ainda precisa da primeira leitura documentada."
+        : "Primeiro sinal em observação; ainda é cedo para chamar de padrão.",
+      action: synthesis.nextStrategicMove?.description ?? null,
+      tone: "mirror",
+    }),
+    synthesisChapter({
+      id: "tension",
+      title: "Sua tensão",
+      signal: synthesis.recurringTensions[0],
+      fallback: "Ainda não há tensão recorrente suficiente entre as leituras.",
+      action: synthesis.nextStrategicMove?.reason ?? null,
+      tone: "attention",
+    }),
+    synthesisChapter({
+      id: "movement",
+      title: "Seu movimento",
+      signal: synthesis.strengths[0],
+      fallback: synthesis.nextStrategicMove?.description ?? "A próxima leitura ajuda a separar hipótese de padrão.",
+      action: synthesis.nextStrategicMove?.description ?? null,
+      tone: "action",
+    }),
+    synthesisChapter({
+      id: "territory",
+      title: "Seu território",
+      signal: synthesis.commercialTerritories[0] ?? synthesis.collabTerritories[0],
+      fallback: "Territórios em formação aparecem quando sinais comerciais se repetem.",
+      action: "Use apenas como direção para Mídia Kit, sem tratar como oportunidade fechada.",
+      tone: "opportunity",
+    }),
+  ];
+}
+
+function buildOpportunities(input: BuildNarrativeMapMobileViewModelInput): NarrativeMapMobileOpportunityItem[] {
+  if (input.profileSynthesis) {
+    const commercialItems = input.profileSynthesis.commercialTerritories.map((territory, index): NarrativeMapMobileOpportunityItem => ({
+      id: `synthesis-commercial-${index}`,
+      title: cleanText(territory.label, "Território em formação"),
+      preview: cleanText(territory.summary, "Fit narrativo possível para observar em novas leituras."),
+      type: "brand_territory",
+      badgeLabel: `${territory.evidenceCount} sinais`,
+      action: null,
+    }));
+    const collabItems = input.profileSynthesis.collabTerritories.map((territory, index): NarrativeMapMobileOpportunityItem => ({
+      id: `synthesis-collab-${index}`,
+      title: cleanText(territory.label, "Tipo de collab possível"),
+      preview: cleanText(territory.summary, "Tipo de collab possível, ainda sem parceria real."),
+      type: "collab_type",
+      badgeLabel: `${territory.evidenceCount} sinais`,
+      action: null,
+    }));
+    const synthesisItems = [...commercialItems, ...collabItems];
+    if (synthesisItems.length > 0) return synthesisItems;
+  }
+
+  const items = opportunityChapters(input.currentPresentation).map((chapter): NarrativeMapMobileOpportunityItem => ({
+    id: `opportunity-${chapter.id}`,
+    title: cleanText(chapter.title, "Oportunidade em formação"),
+    preview: cleanText(chapter.preview, "Território possível para observar em novas leituras."),
+    type: chapter.id === "territory" ? "brand_territory" : "collab_type",
+    badgeLabel: chapter.badgeLabel ?? "Em formação",
+    action: chapter.action
+      ? action({
+          id: `action-${chapter.id}`,
+          label: "Ver caminho",
+          intent: "open_full_diagnosis",
+          priority: "tertiary",
+          helper: chapter.action,
+        })
+      : null,
+    locked: chapter.locked,
+  }));
+
+  if (input.instagramConnected) {
+    items.push({
+      id: "instagram-precision",
+      title: "Leitura com mais contexto",
+      preview: "O Instagram ajuda a comparar esta leitura com sinais do Perfil e da audiencia.",
+      type: "instagram_precision",
+      badgeLabel: "Precisão",
+      action: null,
+    });
+  }
+
+  if (input.mediaKitAvailable) {
+    items.push({
+      id: "media-kit-bridge",
+      title: "Ponte para Mídia Kit",
+      preview: "Use o Mídia Kit para organizar territórios possíveis quando houver fit narrativo mais claro.",
+      type: "media_kit_bridge",
+      badgeLabel: "Apresentação",
+      action: action({
+        id: "open-media-kit",
+        label: "Abrir Mídia Kit",
+        intent: "open_media_kit",
+        priority: "secondary",
+        helper: "Mostra o perfil para conversas comerciais futuras.",
+      }),
+    });
+  }
+
+  return items;
+}
+
+export function buildNarrativeMapMobileViewModel(
+  input: BuildNarrativeMapMobileViewModelInput,
+): NarrativeMapMobileViewModel {
+  const recentReadings = input.recentReadings ?? [];
+  const activeTab = input.activeTab ?? "profile";
+  const opportunities = buildOpportunities(input);
+  const synthesisLabel = synthesisStatusLabel(input.profileSynthesis);
+  const primaryAction = action({
+    id: "analyze-new-video",
+    label: "Nova leitura",
+    intent: "analyze_new_video",
+    priority: "primary",
+    helper: "Analise outro vídeo para separar hipótese inicial de padrão.",
+  });
+  const secondaryAction = action({
+    id: "open-full-diagnosis",
+    label: "Ler diagnóstico completo",
+    intent: "open_full_diagnosis",
+    priority: "secondary",
+    helper: "Abre todos os capítulos em sequência.",
+  });
+
+  return {
+    id: `narrative-map-mobile-${input.currentPresentation.diagnosisId}`,
+    profileHeader: {
+      displayName: cleanText(input.displayName, "Creator"),
+      displayHandle: input.displayHandle ? cleanText(input.displayHandle, "") : null,
+      statusLabel: synthesisLabel ?? input.currentPresentation.statusLabel,
+      metrics: [
+        { id: "readings", label: "Leituras", value: String(recentReadings.length) },
+        {
+          id: "patterns",
+          label: "Padrões",
+          value: String(input.profileSynthesis?.recurringPatterns.length ?? countPatternReadings(recentReadings)),
+        },
+        { id: "opportunities", label: "Oportunidades", value: String(opportunities.length) },
+      ],
+    },
+    hero: {
+      title: "Seu mapa narrativo",
+      headline: synthesisHeadline(input.profileSynthesis, input.currentPresentation.headline),
+      subheadline: synthesisSubheadline(input.profileSynthesis, input.currentPresentation.subheadline),
+      badgeLabel: input.instagramConnected ? "Cruzado com Instagram" : synthesisLabel ?? input.currentPresentation.statusLabel,
+    },
+    tabs: [
+      { id: "profile", label: "Perfil", active: activeTab === "profile" },
+      { id: "readings", label: "Leituras", active: activeTab === "readings" },
+      { id: "opportunities", label: "Oportunidades", active: activeTab === "opportunities" },
+    ],
+    profile: {
+      chapters: profileChaptersFromSynthesis(
+        input.profileSynthesis,
+        input.currentPresentation.chapters.filter((chapter) =>
+          ["pattern", "tension", "movement", "territory"].includes(chapter.id),
+        ),
+      ),
+      primaryAction,
+      secondaryAction,
+    },
+    readings: {
+      title: "Leituras documentadas",
+      description:
+        "Cada vídeo enviado vira uma leitura. O Perfil junta essas leituras para separar padrão, hipótese, desvio criativo e oportunidade.",
+      items: recentReadings.map((reading): NarrativeMapMobileReadingItem => ({
+        id: `reading-${reading.diagnosisId}`,
+        diagnosisId: reading.diagnosisId,
+        rememberedAs: cleanText(reading.rememberedAs, "Vídeo analisado"),
+        dateLabel: dateLabel(reading.createdAt),
+        contributionLabel: contributionLabel(reading.profileContribution.type),
+        profileImpactPreview: cleanText(
+          reading.profileContribution.profileImpactPreview,
+          "Sinal em observação para leituras futuras.",
+        ),
+        statusLabel: reading.profileContribution.confidence === "low" ? "Em observação" : "Leitura salva",
+        action: action({
+          id: `open-reading-${reading.diagnosisId}`,
+          label: "Ver leitura",
+          intent: "open_reading",
+          priority: "tertiary",
+          helper: null,
+        }),
+      })),
+      emptyState:
+        recentReadings.length === 0
+          ? {
+              title: "Nenhuma leitura documentada ainda",
+              description: "Envie um vídeo para começar o mapa com um primeiro sinal.",
+              action: primaryAction,
+            }
+          : null,
+    },
+    opportunities: {
+      title: "Territórios em formação",
+      description: "Fit narrativo possível, tipo de collab possível e ponte para Mídia Kit.",
+      items: opportunities,
+      emptyState:
+        opportunities.length === 0
+          ? {
+              title: "Ainda não há território claro",
+              description: "Mais leituras ajudam a diferenciar hipótese de caminho comercial.",
+              action: input.instagramConnected ? null : action({
+                id: "connect-instagram",
+                label: "Conectar Instagram",
+                intent: "connect_instagram",
+                priority: "tertiary",
+                helper: "Adiciona contexto para comparar sinais do Perfil.",
+              }),
+            }
+          : null,
+    },
+    safetyNote: "A D2C guarda a leitura estratégica, não o vídeo.",
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelFixtures.ts
@@ -1,0 +1,126 @@
+import {
+  buildCreatorNarrativeMapReadingPresentation,
+  type CreatorNarrativeMapReadingPresentation,
+} from "./creatorNarrativeMapReadingChapters";
+import { buildNarrativeMapReadingDiagnosisFixture } from "./creatorNarrativeMapReadingChaptersFixtures";
+import {
+  buildNarrativeMapMobileViewModel,
+  type BuildNarrativeMapMobileViewModelInput,
+  type NarrativeMapMobileRecentReadingInput,
+  type NarrativeMapMobileViewModel,
+} from "./narrativeMapMobileViewModel";
+
+export type NarrativeMapMobileViewModelFixtureState =
+  | "default"
+  | "first_reading"
+  | "instagram_connected"
+  | "no_readings"
+  | "opportunities_limited";
+
+function defaultReadings(): NarrativeMapMobileRecentReadingInput[] {
+  return [
+    {
+      diagnosisId: "reading-1",
+      rememberedAs: "Vídeo sobre reunião que era para ser rápida",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      profileContribution: {
+        type: "confirms_existing_pattern",
+        confidence: "high",
+        weight: "high",
+        profileImpactPreview: "Reforça humor cotidiano com identificação rápida.",
+      },
+    },
+    {
+      diagnosisId: "reading-2",
+      rememberedAs: "Vídeo sobre rotina adulta virando cena de reconhecimento",
+      createdAt: "2026-05-18T10:00:00.000Z",
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "low",
+        weight: "low",
+        profileImpactPreview: "Abre uma hipótese para observar nas próximas leituras.",
+      },
+    },
+    {
+      diagnosisId: "reading-3",
+      rememberedAs: "Vídeo de bastidor com explicação prática",
+      createdAt: "2026-05-15T10:00:00.000Z",
+      profileContribution: {
+        type: "commercial_signal",
+        confidence: "medium",
+        weight: "medium",
+        profileImpactPreview: "Pode alimentar oportunidade futura se o território se repetir.",
+      },
+    },
+  ];
+}
+
+function presentationFor(state: NarrativeMapMobileViewModelFixtureState): CreatorNarrativeMapReadingPresentation {
+  const baseDiagnosis = buildNarrativeMapReadingDiagnosisFixture();
+
+  if (state === "first_reading" || state === "no_readings") {
+    return buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: {
+        ...baseDiagnosis,
+        profileContribution: {
+          type: "opens_new_hypothesis",
+          confidence: "low",
+          weight: "low",
+          reason: "Como primeira leitura, este vídeo abre uma hipótese sem definir o Perfil geral.",
+          profileImpactPreview: "Cria uma primeira pista para acompanhar nas próximas análises.",
+        },
+      },
+      accessLevel: "free",
+      analyzedVideosCount: state === "no_readings" ? 0 : 1,
+    });
+  }
+
+  if (state === "opportunities_limited") {
+    return buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: {
+        ...baseDiagnosis,
+        commercialReading: {
+          ...baseDiagnosis.commercialReading,
+          brandTerritories: [],
+          summary: "Ainda há apenas um território possível em observação.",
+          whyItCouldFitBrands: "A leitura sugere fit narrativo inicial, mas precisa repetir antes de virar caminho comercial.",
+          adAdaptationIdea: "Testar tipo de collab possível com uma cena simples de problema e solução.",
+          limitations: "Ainda é cedo para tratar como frente principal.",
+        },
+      },
+      accessLevel: "premium",
+      analyzedVideosCount: 2,
+    });
+  }
+
+  return buildCreatorNarrativeMapReadingPresentation({
+    diagnosis: baseDiagnosis,
+    accessLevel: state === "instagram_connected" ? "instagram_optimized" : "premium",
+    instagramConnected: state === "instagram_connected",
+    analyzedVideosCount: 7,
+  });
+}
+
+export function buildNarrativeMapMobileViewModelFixture(
+  state: NarrativeMapMobileViewModelFixtureState = "default",
+  overrides: Partial<BuildNarrativeMapMobileViewModelInput> = {},
+): NarrativeMapMobileViewModel {
+  const recentReadings =
+    state === "no_readings"
+      ? []
+      : state === "first_reading"
+        ? defaultReadings().slice(0, 1)
+        : defaultReadings();
+
+  return buildNarrativeMapMobileViewModel({
+    displayName: "Lívia Linhares",
+    displayHandle: "@livialinharess",
+    currentPresentation: presentationFor(state),
+    recentReadings,
+    accessLevel: state === "first_reading" ? "free" : state === "instagram_connected" ? "instagram_optimized" : "premium",
+    instagramConnected: state === "instagram_connected",
+    mediaKitAvailable: state === "default",
+    activeTab: "profile",
+    ...overrides,
+  });
+}

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.test.ts
@@ -1,0 +1,215 @@
+import fs from "fs";
+import path from "path";
+import { buildNarrativeMapReadingDiagnosisFixture } from "./creatorNarrativeMapReadingChaptersFixtures";
+import { buildCreatorStrategicProfileSynthesisReadingsFixture } from "./creatorStrategicProfileSynthesisFixtures";
+import type { CreatorVideoNarrativeDiagnosisSafeReading } from "./creatorVideoNarrativeDiagnosisReadService";
+import { buildNarrativeMapMobileViewModelFromReadings } from "./narrativeMapMobileViewModelServerSelector";
+
+function reading(overrides: Partial<CreatorVideoNarrativeDiagnosisSafeReading> = {}): CreatorVideoNarrativeDiagnosisSafeReading {
+  const base = buildNarrativeMapReadingDiagnosisFixture();
+  return {
+    userId: "665f0f2c8a0b7d1f2c3a4b5c",
+    diagnosisId: base.diagnosisId,
+    status: base.status,
+    videoReading: base.videoReading,
+    speechReading: base.speechReading,
+    productionReading: base.productionReading,
+    commercialReading: base.commercialReading,
+    strategicRecommendation: base.strategicRecommendation,
+    profileContribution: base.profileContribution,
+    safetyFlags: {
+      containsPersistedVideoReference: false,
+      containsSignedUrl: false,
+      containsObjectKey: false,
+      containsRawModelResponse: false,
+      containsLongTranscript: false,
+      sanitized: true,
+    },
+    createdAt: new Date("2026-05-20T10:00:00.000Z"),
+    analyzedAt: new Date("2026-05-20T10:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("narrativeMapMobileViewModelServerSelector", () => {
+  const userId = "665f0f2c8a0b7d1f2c3a4b5c";
+
+  it("escolhe leitura atual quando diagnosisId é informado", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      diagnosisId: "target",
+      displayName: "Lívia",
+      readings: [
+        reading({ diagnosisId: "latest", analyzedAt: new Date("2026-05-20T10:00:00.000Z") }),
+        reading({ diagnosisId: "target", analyzedAt: new Date("2026-05-18T10:00:00.000Z") }),
+      ],
+    });
+
+    expect(result.currentReading?.diagnosisId).toBe("target");
+    expect(result.currentPresentation.diagnosisId).toBe("target");
+  });
+
+  it("usa leitura mais recente quando diagnosisId não é informado", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: [
+        reading({ diagnosisId: "older", analyzedAt: new Date("2026-05-18T10:00:00.000Z") }),
+        reading({ diagnosisId: "latest", analyzedAt: new Date("2026-05-20T10:00:00.000Z") }),
+      ],
+    });
+
+    expect(result.currentReading?.diagnosisId).toBe("latest");
+  });
+
+  it("monta presentation MM77 e view model MM80", async () => {
+    const buildReadingPresentation = jest.fn((input) => ({
+      id: "presentation",
+      diagnosisId: input.diagnosis.diagnosisId,
+      headline: "headline",
+      subheadline: "subheadline",
+      statusLabel: "status",
+      chapters: [],
+      primaryAction: { label: "Analisar outro vídeo", intent: "analyze_another_video", helper: null },
+      createdAt: null,
+    }));
+    const buildViewModel = jest.fn((input) => ({
+      id: "vm",
+      profileHeader: { displayName: input.displayName, displayHandle: null, statusLabel: "status", metrics: [] },
+      hero: { title: "Seu mapa narrativo", headline: "headline", subheadline: "subheadline" },
+      tabs: [
+        { id: "profile", label: "Perfil", active: true },
+        { id: "readings", label: "Leituras", active: false },
+        { id: "opportunities", label: "Oportunidades", active: false },
+      ],
+      profile: { chapters: [], primaryAction: { id: "a", label: "Nova leitura", intent: "analyze_new_video", priority: "primary" }, secondaryAction: null },
+      readings: { title: "Leituras", description: "", items: [], emptyState: null },
+      opportunities: { title: "Territórios em formação", description: "", items: [], emptyState: null },
+    }));
+
+    await buildNarrativeMapMobileViewModelFromReadings(
+      { userId, displayName: "Lívia", readings: [reading()] },
+      { buildReadingPresentation: buildReadingPresentation as any, buildViewModel: buildViewModel as any },
+    );
+
+    expect(buildReadingPresentation).toHaveBeenCalled();
+    expect(buildViewModel).toHaveBeenCalled();
+  });
+
+  it("retorna empty state elegante quando não há leituras", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: [],
+    });
+
+    expect(result.currentReading).toBeNull();
+    expect(result.viewModel.readings.items).toHaveLength(0);
+    expect(result.viewModel.readings.emptyState?.title).toContain("Nenhuma leitura");
+  });
+
+  it("não cria aba Instagram e não promete match real", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: [reading()],
+      instagramConnected: true,
+    });
+    const serialized = JSON.stringify(result.viewModel).toLowerCase();
+
+    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Perfil", "Leituras", "Oportunidades"]);
+    expect(serialized).not.toContain("match real");
+  });
+
+  it("selector monta view model usando synthesis dry-run", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(result.profileSynthesis.status).toBe("pattern_in_formation");
+    expect(result.viewModel.profile.chapters.map((chapter) => chapter.title)).toEqual([
+      "Seu padrão",
+      "Sua tensão",
+      "Seu movimento",
+      "Seu território",
+    ]);
+  });
+
+  it("view model mostra Seu mapa começou para primeira leitura", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("first_reading"),
+    });
+
+    expect(result.viewModel.hero.headline).toBe("Seu mapa começou");
+    expect(result.viewModel.profileHeader.statusLabel).toBe("Primeira leitura");
+  });
+
+  it("view model mostra sinal emergente para duas leituras", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("two_related_readings"),
+    });
+
+    expect(result.viewModel.hero.headline).toBe("Um sinal começa a aparecer");
+    expect(result.viewModel.profileHeader.statusLabel).toBe("Sinais em formação");
+  });
+
+  it("view model mostra padrão em formação para três leituras", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(result.viewModel.hero.headline).toBe("Um padrão começa a se repetir");
+    expect(result.viewModel.profileHeader.statusLabel).toBe("Padrão em formação");
+  });
+
+  it("Instagram conectado altera badge/status sem criar aba Instagram", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("instagram_contextual"),
+      instagramConnected: true,
+      accessLevel: "instagram_optimized",
+    });
+
+    expect(result.viewModel.hero.badgeLabel).toBe("Cruzado com Instagram");
+    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Perfil", "Leituras", "Oportunidades"]);
+  });
+
+  it("oportunidades não prometem marca real, creator real ou match real", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("commercial_signals"),
+    });
+    const text = JSON.stringify(result.viewModel.opportunities).toLowerCase();
+
+    expect(text).toContain("fit narrativo");
+    expect(text).not.toContain("marca real");
+    expect(text).not.toContain("creator real");
+    expect(text).not.toContain("match real");
+  });
+
+  it("safety note continua segura", async () => {
+    const result = await buildNarrativeMapMobileViewModelFromReadings({
+      userId,
+      displayName: "Lívia",
+      readings: buildCreatorStrategicProfileSynthesisReadingsFixture("three_related_readings"),
+    });
+
+    expect(result.viewModel.safetyNote).toBe("A D2C guarda a leitura estratégica, não o vídeo.");
+  });
+
+  it("não importa SDKs, endpoints, client components, Snapshot ou Mongoose direto", () => {
+    const source = fs.readFileSync(path.join(__dirname, "narrativeMapMobileViewModelServerSelector.ts"), "utf8");
+
+    expect(source).not.toMatch(/@google\/genai|@aws-sdk|api\/internal|CreatorStrategicProfileSnapshot|from ["']mongoose["']|"use client"|\.tsx/);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.ts
@@ -1,0 +1,197 @@
+import {
+  buildCreatorNarrativeMapReadingPresentation,
+  type CreatorNarrativeMapReadingDiagnosisShape,
+  type CreatorNarrativeMapReadingPresentation,
+} from "./creatorNarrativeMapReadingChapters";
+import {
+  listRecentCreatorVideoNarrativeDiagnosesForUser,
+  type CreatorVideoNarrativeDiagnosisSafeReading,
+} from "./creatorVideoNarrativeDiagnosisReadService";
+import {
+  buildCreatorStrategicProfileSynthesis,
+  type CreatorStrategicProfileSynthesis,
+} from "./creatorStrategicProfileSynthesis";
+import {
+  buildNarrativeMapMobileViewModel,
+  type NarrativeMapMobileRecentReadingInput,
+  type NarrativeMapMobileTabId,
+  type NarrativeMapMobileViewModel,
+} from "./narrativeMapMobileViewModel";
+
+export interface BuildNarrativeMapMobileViewModelFromReadingsParams {
+  userId: string;
+  diagnosisId?: string | null;
+  displayName: string;
+  displayHandle?: string | null;
+  readings?: CreatorVideoNarrativeDiagnosisSafeReading[];
+  recentLimit?: number;
+  accessLevel?: "free" | "premium" | "instagram_optimized";
+  instagramConnected?: boolean;
+  mediaKitAvailable?: boolean;
+  activeTab?: NarrativeMapMobileTabId;
+}
+
+export interface NarrativeMapMobileViewModelServerSelectorDeps {
+  listRecentReadings?: typeof listRecentCreatorVideoNarrativeDiagnosesForUser;
+  buildReadingPresentation?: typeof buildCreatorNarrativeMapReadingPresentation;
+  buildViewModel?: typeof buildNarrativeMapMobileViewModel;
+  buildProfileSynthesis?: typeof buildCreatorStrategicProfileSynthesis;
+}
+
+export interface NarrativeMapMobileViewModelServerSelectorResult {
+  viewModel: NarrativeMapMobileViewModel;
+  currentReading: CreatorVideoNarrativeDiagnosisSafeReading | null;
+  currentPresentation: CreatorNarrativeMapReadingPresentation;
+  profileSynthesis: CreatorStrategicProfileSynthesis;
+}
+
+function sortReadings(
+  readings: CreatorVideoNarrativeDiagnosisSafeReading[],
+): CreatorVideoNarrativeDiagnosisSafeReading[] {
+  return [...readings].sort((a, b) => {
+    const dateA = (a.analyzedAt ?? a.createdAt)?.getTime?.() ?? 0;
+    const dateB = (b.analyzedAt ?? b.createdAt)?.getTime?.() ?? 0;
+    return dateB - dateA;
+  });
+}
+
+function toDiagnosisShape(reading: CreatorVideoNarrativeDiagnosisSafeReading): CreatorNarrativeMapReadingDiagnosisShape {
+  return {
+    diagnosisId: reading.diagnosisId,
+    status: reading.status,
+    videoReading: reading.videoReading,
+    speechReading: reading.speechReading,
+    productionReading: reading.productionReading,
+    commercialReading: reading.commercialReading,
+    strategicRecommendation: reading.strategicRecommendation,
+    profileContribution: reading.profileContribution,
+    createdAt: reading.createdAt,
+  };
+}
+
+function toRecentReading(reading: CreatorVideoNarrativeDiagnosisSafeReading): NarrativeMapMobileRecentReadingInput {
+  return {
+    diagnosisId: reading.diagnosisId,
+    rememberedAs: reading.videoReading.rememberedAs,
+    createdAt: reading.analyzedAt ?? reading.createdAt ?? null,
+    profileContribution: {
+      type: reading.profileContribution.type,
+      confidence: reading.profileContribution.confidence,
+      weight: reading.profileContribution.weight,
+      profileImpactPreview: reading.profileContribution.profileImpactPreview,
+    },
+  };
+}
+
+function buildEmptyReading(userId: string): CreatorVideoNarrativeDiagnosisSafeReading {
+  return {
+    userId,
+    diagnosisId: "empty-reading-state",
+    status: "completed",
+    videoReading: {
+      title: "Primeira leitura ainda não criada",
+      rememberedAs: "Primeiro vídeo ainda não analisado",
+      summary: "A primeira leitura aparece aqui depois de uma análise mock salva.",
+      whatVideoReveals: "Ainda não há vídeo suficiente para separar padrão, hipótese e oportunidade.",
+      mainNarrative: "Mapa narrativo em formação.",
+      creatorIntent: "Começar uma leitura documentada por vídeo.",
+      dominantInsight: "A próxima análise cria a primeira pista do Perfil.",
+    },
+    speechReading: {
+      summary: "Ainda sem leitura de fala.",
+      openingRead: "Ainda sem abertura analisada.",
+      clarityRead: "Ainda sem clareza analisada.",
+      pacingRead: "Ainda sem ritmo analisado.",
+      suggestedLine: "Comece com um vídeo simples para gerar a primeira leitura.",
+      suggestedOpening: "Escolha um vídeo que represente sua fase atual.",
+      suggestedClosing: "Depois da primeira leitura, o mapa mostra os próximos sinais.",
+    },
+    productionReading: {
+      summary: "Ainda sem leitura de produção.",
+      framing: "Sem enquadramento analisado.",
+      lighting: "Sem luz analisada.",
+      audio: "Sem áudio analisado.",
+      editingRhythm: "Sem ritmo visual analisado.",
+      firstFrame: "Sem primeiro frame analisado.",
+      visualClarity: "Sem clareza visual analisada.",
+    },
+    commercialReading: {
+      summary: "Territórios em formação aparecem depois de leituras repetidas.",
+      brandTerritories: [],
+      whyItCouldFitBrands: "Ainda não há fit narrativo possível para organizar.",
+      adAdaptationIdea: "A ponte para Mídia Kit depende de leituras futuras.",
+      limitations: "Sem leitura salva, não há oportunidade a apresentar.",
+    },
+    strategicRecommendation: {
+      mainAdjustment: "Salvar uma primeira leitura mock.",
+      nextExperiment: "Analisar um vídeo que represente a fase atual.",
+      whatToRepeat: "Escolher vídeos com intenção clara.",
+      whatToAvoid: "Tratar uma hipótese inicial como padrão.",
+      successSignal: "Aparecer uma primeira leitura documentada.",
+    },
+    profileContribution: {
+      type: "needs_more_samples",
+      confidence: "low",
+      weight: "low",
+      reason: "Ainda não há leitura salva.",
+      profileImpactPreview: "O Perfil aguarda a primeira leitura documentada.",
+    },
+    safetyFlags: {
+      containsPersistedVideoReference: false,
+      containsSignedUrl: false,
+      containsObjectKey: false,
+      containsRawModelResponse: false,
+      containsLongTranscript: false,
+      sanitized: true,
+    },
+  };
+}
+
+export async function buildNarrativeMapMobileViewModelFromReadings(
+  params: BuildNarrativeMapMobileViewModelFromReadingsParams,
+  deps: NarrativeMapMobileViewModelServerSelectorDeps = {},
+): Promise<NarrativeMapMobileViewModelServerSelectorResult> {
+  const listRecentReadings = deps.listRecentReadings ?? listRecentCreatorVideoNarrativeDiagnosesForUser;
+  const buildReadingPresentation = deps.buildReadingPresentation ?? buildCreatorNarrativeMapReadingPresentation;
+  const buildViewModel = deps.buildViewModel ?? buildNarrativeMapMobileViewModel;
+  const buildProfileSynthesis = deps.buildProfileSynthesis ?? buildCreatorStrategicProfileSynthesis;
+  const queriedReadings = params.readings ?? await listRecentReadings({
+    userId: params.userId,
+    limit: params.recentLimit,
+  });
+  const readings = sortReadings(queriedReadings).filter((reading) => reading.userId === params.userId);
+  const currentReading =
+    (params.diagnosisId
+      ? readings.find((reading) => reading.diagnosisId === params.diagnosisId)
+      : readings[0]) ?? null;
+  const presentationSource = currentReading ?? buildEmptyReading(params.userId);
+  const profileSynthesis = buildProfileSynthesis({
+    readings,
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+  });
+  const currentPresentation = buildReadingPresentation({
+    diagnosis: toDiagnosisShape(presentationSource),
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+    analyzedVideosCount: readings.length,
+  });
+  const viewModel = buildViewModel({
+    displayName: params.displayName,
+    displayHandle: params.displayHandle,
+    currentPresentation,
+    recentReadings: readings.map(toRecentReading),
+    profileSynthesis,
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+    mediaKitAvailable: params.mediaKitAvailable,
+    activeTab: params.activeTab,
+  });
+
+  return {
+    viewModel,
+    currentReading,
+    currentPresentation,
+    profileSynthesis,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
@@ -57,6 +57,24 @@ export interface VideoNarrativeSafeObservabilitySummary {
   }>;
 }
 
+export interface VideoNarrativeReadingSaveSummary {
+  attempted: boolean;
+  ok: boolean;
+  diagnosisId: string | null;
+  errorCode: string | null;
+  message: string | null;
+}
+
+export interface VideoNarrativeSynthesisSnapshotWriteSummary {
+  attempted: boolean;
+  written: boolean;
+  skippedReason?: string | null;
+  synthesisStatus?: string | null;
+  analyzedReadingsCount?: number | null;
+  snapshotId?: string | null;
+  updatedAt?: string | null;
+}
+
 export interface VideoNarrativeSafeResponse {
   ok: boolean;
   status: VideoNarrativeSafeResponseStatus;
@@ -68,6 +86,8 @@ export interface VideoNarrativeSafeResponse {
   guardSummary: VideoNarrativeSafeGuardSummary | null;
   usageSummary: VideoNarrativeSafeUsageSummary | null;
   observabilitySummary: VideoNarrativeSafeObservabilitySummary | null;
+  readingSaveSummary?: VideoNarrativeReadingSaveSummary | null;
+  synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
 }
 
 export interface VideoNarrativeSafeResponseInput {
@@ -85,6 +105,8 @@ export interface VideoNarrativeSafeResponseInput {
   usageDecision?: VideoNarrativeUsageConsumptionDecision | null;
   quotaGuard?: VideoNarrativeQuotaGuardResult | null;
   observabilityEvents?: VideoNarrativeObservabilityEventPayload[] | null;
+  readingSaveSummary?: VideoNarrativeReadingSaveSummary | null;
+  synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
 }
 
 const SAFE_RESPONSE_STATUSES: VideoNarrativeSafeResponseStatus[] = [
@@ -324,6 +346,8 @@ export function buildVideoNarrativeSafeResponse(
       quotaGuard: input.quotaGuard,
     }),
     observabilitySummary: buildObservabilitySummary(input.observabilityEvents),
+    readingSaveSummary: input.readingSaveSummary ? sanitizeDeep(input.readingSaveSummary) : null,
+    synthesisSnapshotWrite: input.synthesisSnapshotWrite ? sanitizeDeep(input.synthesisSnapshotWrite) : null,
   };
 
   return redactVideoNarrativeSafeResponse(response);

--- a/src/app/models/CreatorStrategicProfileSnapshot.ts
+++ b/src/app/models/CreatorStrategicProfileSnapshot.ts
@@ -5,6 +5,7 @@ export type CreatorStrategicProfileSnapshotStatus = "active" | "inactive" | "arc
 export type CreatorStrategicProfileSnapshotSource =
   | "manual_seed"
   | "mock_analysis"
+  | "video_reading_synthesis_v1"
   | "future_video_analysis"
   | "imported"
   | "unknown";
@@ -47,7 +48,7 @@ const CreatorStrategicProfileSnapshotSchema = new Schema<ICreatorStrategicProfil
     },
     source: {
       type: String,
-      enum: ["manual_seed", "mock_analysis", "future_video_analysis", "imported", "unknown"],
+      enum: ["manual_seed", "mock_analysis", "video_reading_synthesis_v1", "future_video_analysis", "imported", "unknown"],
       default: "manual_seed",
       required: true,
     },

--- a/src/app/models/CreatorVideoNarrativeDiagnosis.ts
+++ b/src/app/models/CreatorVideoNarrativeDiagnosis.ts
@@ -1,0 +1,196 @@
+import mongoose, { Schema, Types, Document, model } from "mongoose";
+import type {
+  CreatorVideoNarrativeDiagnosisCommercialReading,
+  CreatorVideoNarrativeDiagnosisProfileContribution,
+  CreatorVideoNarrativeDiagnosisProductionReading,
+  CreatorVideoNarrativeDiagnosisSafetyFlags,
+  CreatorVideoNarrativeDiagnosisSource,
+  CreatorVideoNarrativeDiagnosisSpeechReading,
+  CreatorVideoNarrativeDiagnosisStatus,
+  CreatorVideoNarrativeDiagnosisStrategicRecommendation,
+  CreatorVideoNarrativeDiagnosisVideoMetadata,
+  CreatorVideoNarrativeDiagnosisVideoReading,
+} from "@/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes";
+
+export interface ICreatorVideoNarrativeDiagnosis extends Document {
+  userId: Types.ObjectId;
+  diagnosisId: string;
+  status: CreatorVideoNarrativeDiagnosisStatus;
+  source: CreatorVideoNarrativeDiagnosisSource;
+  videoMetadata: CreatorVideoNarrativeDiagnosisVideoMetadata;
+  creatorGoal: string;
+  selectedGoalOption: string;
+  videoReading: CreatorVideoNarrativeDiagnosisVideoReading;
+  speechReading: CreatorVideoNarrativeDiagnosisSpeechReading;
+  productionReading: CreatorVideoNarrativeDiagnosisProductionReading;
+  commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
+  strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
+  profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  safetyFlags: CreatorVideoNarrativeDiagnosisSafetyFlags;
+  schemaVersion: "creator_video_narrative_diagnosis_v1";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const VideoMetadataSchema = new Schema<CreatorVideoNarrativeDiagnosisVideoMetadata>(
+  {
+    mimeType: { type: String },
+    sizeBytes: { type: Number },
+    durationSeconds: { type: Number },
+    originalFileNameSanitized: { type: String },
+    uploadedAt: { type: Date },
+    analyzedAt: { type: Date },
+  },
+  { _id: false, strict: true },
+);
+
+const VideoReadingSchema = new Schema<CreatorVideoNarrativeDiagnosisVideoReading>(
+  {
+    title: { type: String, required: true },
+    rememberedAs: { type: String, required: true },
+    summary: { type: String, required: true },
+    whatVideoReveals: { type: String, required: true },
+    mainNarrative: { type: String, required: true },
+    creatorIntent: { type: String, required: true },
+    dominantInsight: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const SpeechReadingSchema = new Schema<CreatorVideoNarrativeDiagnosisSpeechReading>(
+  {
+    summary: { type: String, required: true },
+    openingRead: { type: String, required: true },
+    clarityRead: { type: String, required: true },
+    pacingRead: { type: String, required: true },
+    suggestedLine: { type: String, required: true },
+    suggestedOpening: { type: String, required: true },
+    suggestedClosing: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const ProductionReadingSchema = new Schema<CreatorVideoNarrativeDiagnosisProductionReading>(
+  {
+    summary: { type: String, required: true },
+    framing: { type: String, required: true },
+    lighting: { type: String, required: true },
+    audio: { type: String, required: true },
+    editingRhythm: { type: String, required: true },
+    firstFrame: { type: String, required: true },
+    visualClarity: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const CommercialReadingSchema = new Schema<CreatorVideoNarrativeDiagnosisCommercialReading>(
+  {
+    summary: { type: String, required: true },
+    brandTerritories: { type: [String], required: true, default: [] },
+    whyItCouldFitBrands: { type: String, required: true },
+    adAdaptationIdea: { type: String, required: true },
+    limitations: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const StrategicRecommendationSchema = new Schema<CreatorVideoNarrativeDiagnosisStrategicRecommendation>(
+  {
+    mainAdjustment: { type: String, required: true },
+    nextExperiment: { type: String, required: true },
+    whatToRepeat: { type: String, required: true },
+    whatToAvoid: { type: String, required: true },
+    successSignal: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const ProfileContributionSchema = new Schema<CreatorVideoNarrativeDiagnosisProfileContribution>(
+  {
+    type: {
+      type: String,
+      enum: [
+        "confirms_existing_pattern",
+        "opens_new_hypothesis",
+        "isolated_strong_video",
+        "creative_deviation",
+        "commercial_signal",
+        "weak_positioning_signal",
+        "needs_more_samples",
+      ],
+      required: true,
+    },
+    confidence: { type: String, enum: ["low", "medium", "high"], required: true },
+    weight: { type: String, enum: ["low", "medium", "high"], required: true },
+    reason: { type: String, required: true },
+    profileImpactPreview: { type: String, required: true },
+  },
+  { _id: false, strict: true },
+);
+
+const SafetyFlagsSchema = new Schema<CreatorVideoNarrativeDiagnosisSafetyFlags>(
+  {
+    containsPersistedVideoReference: { type: Boolean, required: true, default: false },
+    containsSignedUrl: { type: Boolean, required: true, default: false },
+    containsObjectKey: { type: Boolean, required: true, default: false },
+    containsRawModelResponse: { type: Boolean, required: true, default: false },
+    containsLongTranscript: { type: Boolean, required: true, default: false },
+    sanitized: { type: Boolean, required: true, default: false },
+  },
+  { _id: false, strict: true },
+);
+
+const CreatorVideoNarrativeDiagnosisSchema = new Schema<ICreatorVideoNarrativeDiagnosis>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
+    diagnosisId: { type: String, required: true, index: true },
+    status: {
+      type: String,
+      enum: ["draft", "completed", "failed", "discarded"],
+      required: true,
+      default: "draft",
+      index: true,
+    },
+    source: {
+      type: String,
+      enum: ["mock", "real", "manual", "migration"],
+      required: true,
+    },
+    videoMetadata: { type: VideoMetadataSchema, required: true, default: () => ({}) },
+    creatorGoal: { type: String, required: true },
+    selectedGoalOption: { type: String, required: true },
+    videoReading: { type: VideoReadingSchema, required: true },
+    speechReading: { type: SpeechReadingSchema, required: true },
+    productionReading: { type: ProductionReadingSchema, required: true },
+    commercialReading: { type: CommercialReadingSchema, required: true },
+    strategicRecommendation: { type: StrategicRecommendationSchema, required: true },
+    profileContribution: { type: ProfileContributionSchema, required: true },
+    safetyFlags: { type: SafetyFlagsSchema, required: true },
+    schemaVersion: {
+      type: String,
+      enum: ["creator_video_narrative_diagnosis_v1"],
+      required: true,
+      default: "creator_video_narrative_diagnosis_v1",
+    },
+  },
+  {
+    timestamps: true,
+    collection: "creatorvideonarrativediagnoses",
+    strict: true,
+  },
+);
+
+CreatorVideoNarrativeDiagnosisSchema.index(
+  { userId: 1, diagnosisId: 1 },
+  { unique: true, name: "creator_video_narrative_diagnosis_user_diagnosis_unique" },
+);
+CreatorVideoNarrativeDiagnosisSchema.index({ userId: 1, createdAt: -1 });
+
+const CreatorVideoNarrativeDiagnosis =
+  (mongoose.models.CreatorVideoNarrativeDiagnosis as mongoose.Model<ICreatorVideoNarrativeDiagnosis>) ||
+  model<ICreatorVideoNarrativeDiagnosis>(
+    "CreatorVideoNarrativeDiagnosis",
+    CreatorVideoNarrativeDiagnosisSchema,
+  );
+
+export default CreatorVideoNarrativeDiagnosis;


### PR DESCRIPTION
## Summary

Consolidates MM74-MM85 into one PR after the work was implemented locally as uncommitted changes and then committed together.

Includes:
- MM74 — secure per-video reading document foundation
- MM75 — structured analysis to video reading mapper
- MM76 — server-side save orchestrator
- MM77 — narrative map reading chapters contract
- MM78 — internal preview harness
- MM79 — preview UX/copy polish
- MM80 — NarrativeMapMobileViewModel adapter
- MM81 — mock reading save + retrieval + preview wiring
- MM82 — profile synthesis dry-run + preview
- MM83 — guarded synthesis persistence to CreatorStrategicProfileSnapshot
- MM84 — controlled mock/internal synthesis snapshot write
- MM85 — real mobile shell for Perfil | Leituras | Oportunidades + safe internal snapshot review panel

## Product direction

This PR supports the new thesis:

> Each video generates a documented reading. The Strategic Profile synthesizes accumulated readings into the creator's living diagnosis.

The video diagnosis is no longer treated as the overall profile diagnosis.

## Guardrails

- Does not store video files.
- Does not store thumbnails.
- Does not persist signed URLs, upload URLs, object keys, local paths, storage provider paths, raw Gemini/model responses, long transcripts, secrets, tokens, or headers.
- Keeps the real endpoint public rollout gated.
- Keeps common users blocked by existing gates.
- Does not touch MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell, or sidebar.
- Does not create real brand/creator matches.
- Snapshot updates are routed through accumulated profile synthesis, not a direct last-video overwrite.

## Validation reported locally

- MM85 focused tests passed: 4 suites / 59 tests.
- MM74-MM85 focused tests passed: 19 suites / 236 tests.
- npm run typecheck passed.
- npm run build passed with existing unrelated warnings.
- git diff --check passed.

## Next product concern

Before continuing real endpoint expansion, we should review the diagnostic writing quality. The next milestone should focus on Evidence Anchors / Diagnostic Writer Quality so the output references specific creator quotes, scenes, hooks, and concrete moments from the analyzed video instead of sounding generic.