### PR TITLE
MM86 — Diagnostic Writer Evidence Anchors

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx
@@ -36,6 +36,18 @@ export function NarrativeMapReadingFullDiagnosisModal({
 
         <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
           <div className="grid gap-5">
+            {presentation.evidenceSummaryItems.length > 0 ? (
+              <section className="border-b border-zinc-200 pb-5" aria-label="Onde a D2C percebeu isso">
+                <h3 className="text-sm font-semibold text-zinc-950">Onde a D2C percebeu isso</h3>
+                <ul className="mt-3 grid gap-2">
+                  {presentation.evidenceSummaryItems.map((item) => (
+                    <li key={item} className="rounded-lg bg-zinc-50 px-3 py-2 text-xs leading-5 text-zinc-700">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
             {presentation.chapters.map((chapter) => (
               <article key={chapter.id} className="border-b border-zinc-200 pb-5 last:border-b-0">
                 <div className="flex items-start justify-between gap-3">

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapReadingPreview.test.tsx
@@ -127,6 +127,7 @@ describe("NarrativeMapReadingPreview", () => {
     expect(within(dialog).getByText("O que este vídeo revela")).toBeInTheDocument();
     expect(within(dialog).getByText("Como pesa no Perfil")).toBeInTheDocument();
     expect(within(dialog).getByText("Oportunidades em formação")).toBeInTheDocument();
+    expect(within(dialog).getByText("Onde a D2C percebeu isso")).toBeInTheDocument();
     expect(within(dialog).getByText(/Capítulos em sequência/)).toBeInTheDocument();
   });
 

--- a/src/app/dashboard/boards/videoUpload/MM86_DIAGNOSTIC_WRITER_EVIDENCE_ANCHORS.md
+++ b/src/app/dashboard/boards/videoUpload/MM86_DIAGNOSTIC_WRITER_EVIDENCE_ANCHORS.md
@@ -1,0 +1,77 @@
+# MM86 — Diagnostic Writer Evidence Anchors
+
+Status: concluído.
+
+## Objetivo
+
+Reduzir diagnóstico genérico na leitura documentada por vídeo. A D2C deve ler o vídeo, não apenas classificá-lo: falas curtas, cenas, intenção declarada e sinais de Perfil precisam sustentar os capítulos do mapa narrativo.
+
+## Conceito
+
+`evidenceAnchors` é um campo seguro de `CreatorVideoNarrativeDiagnosis`. Ele guarda apenas evidências curtas e sanitizadas:
+
+- `speechQuotes`: falas curtas ou sugestões de fala.
+- `sceneAnchors`: cenas/momentos descritos de forma curta.
+- `creatorIntentAnchor`: intenção declarada e interpretação.
+- `profilePatternAnchors`: relação com sinais acumulados do Perfil.
+- `instagramAnchors`: sinais de precisão quando Instagram existir.
+
+Quote real e sugestão da IA são coisas diferentes:
+
+- `creator_spoken`: pode ser lido como “quando você diz...”.
+- `ai_suggested`: deve aparecer como “teste uma frase como...” ou “sugestão de fala”.
+
+O fallback conservador do mapper usa `suggestedHook`/`scriptDirection.opening` como `ai_suggested`, `rememberedAs` como `derived_scene`, `creatorGoal` como `creator_goal` e `profileContribution.reason` como anchor de Perfil. Ele não inventa fala real.
+
+## Fórmula editorial
+
+Os capítulos principais seguem:
+
+1. Espelho: “Você parece...”
+2. Âncora: “Isso aparece quando você diz/faz/mostra...”
+3. Leitura: “O que isso revela é...”
+4. Movimento: “Por isso, teste...”
+
+Quando não há anchor suficiente, o capítulo assume a limitação em vez de preencher com frase genérica.
+
+## Guardrails
+
+Não salvamos:
+
+- transcrição longa;
+- raw transcript;
+- raw Gemini response;
+- vídeo;
+- thumbnail;
+- signed URL;
+- upload URL;
+- objectKey;
+- localPath;
+- storageProviderPath;
+- metadados de storage.
+
+O sanitizer remove URLs, signed URLs, paths de storage, tokens/headers e limita arrays. Quotes são limitadas a 180 caracteres e anchors a listas curtas.
+
+## QA anti-genérico
+
+`creatorVideoNarrativeDiagnosticSpecificityQa.ts` adiciona helpers internos:
+
+- `hasSpecificEvidenceAnchor(text, anchors)`
+- `isProbablyGenericDiagnosticText(text, anchors)`
+
+Eles não criam score de UI. O objetivo é testar que frases amplas como “Seu conteúdo gera conexão” só passam quando acompanhadas de evidência específica.
+
+## UI
+
+A modal de diagnóstico completo pode mostrar “Onde a D2C percebeu isso” com itens curtos:
+
+- `Fala: "..."`
+- `Sugestão de fala: "..."`
+- `Cena: ...`
+- `Intenção: ...`
+
+Ela não mostra transcript, player, thumbnail persistida ou timestamp técnico.
+
+## Próximo passo
+
+Este PR prepara a qualidade textual antes de expandir endpoint real. O próximo PR pode fazer o provider preencher anchors estruturados quando houver leitura multimodal mais rica, mantendo os mesmos guardrails.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,38 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM86 — Diagnostic Writer Evidence Anchors
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM86_DIAGNOSTIC_WRITER_EVIDENCE_ANCHORS.md`
+- `creatorVideoNarrativeDiagnosisTypes.ts`
+- `creatorVideoNarrativeDiagnosisSanitizer.ts`
+- `creatorVideoNarrativeDiagnosisMapper.ts`
+- `creatorNarrativeMapReadingChapters.ts`
+- `creatorVideoNarrativeDiagnosticSpecificityQa.ts`
+- `../components/videoUpload/appPreview/NarrativeMapReadingFullDiagnosisModal.tsx`
+
+O que faz:
+
+- adiciona `evidenceAnchors` seguro ao diagnóstico documentado;
+- diferencia fala real do creator (`creator_spoken`) de sugestão da IA (`ai_suggested`);
+- sanitiza quotes, cenas, intenção, sinais de Perfil e sinais de Instagram;
+- faz o mapper preencher anchors conservadores quando só há dados estruturados;
+- atualiza capítulos para priorizar fala, cena ou intenção específica;
+- adiciona QA anti-genérico sem expor score para o usuário;
+- mostra “Onde a D2C percebeu isso” na modal quando houver anchors.
+
+O que não faz:
+
+- não pluga endpoint real público;
+- não chama Gemini real;
+- não chama storage/R2;
+- não salva vídeo, thumbnail, signed URL, objectKey, raw response ou transcrição longa;
+- não altera upload, cleanup, billing/Stripe, NextAuth, MediaKitView, Comunidade, DashboardShell, BoardShell, sidebar ou matches reais.
+
 ### MM74 — Video Reading Document Foundation
 
 Status: concluído.

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
@@ -3,6 +3,10 @@ import path from "path";
 import {
   buildCreatorNarrativeMapReadingPresentation,
 } from "./creatorNarrativeMapReadingChapters";
+import {
+  hasSpecificEvidenceAnchor,
+  isProbablyGenericDiagnosticText,
+} from "./creatorVideoNarrativeDiagnosticSpecificityQa";
 import { buildNarrativeMapReadingDiagnosisFixture } from "./creatorNarrativeMapReadingChaptersFixtures";
 
 const FORBIDDEN_OUTPUT_TERMS = [
@@ -116,7 +120,8 @@ describe("creatorNarrativeMapReadingChapters", () => {
       badgeLabel: "Sinal comercial",
       tone: "opportunity",
     }));
-    expect(chapter?.fullReading).toContain("não atualiza a narrativa principal sozinha");
+    expect(chapter?.fullReading).toContain("sem atualizar a narrativa principal sozinha");
+    expect(chapter?.fullReading).not.toMatch(/confiança|peso|low|medium|high/i);
   });
 
   it("nao usa termos proibidos na apresentacao", () => {
@@ -225,6 +230,106 @@ describe("creatorNarrativeMapReadingChapters", () => {
     });
 
     expect(presentation.safetyNote).toBe("A D2C guarda a leitura estratégica, não o vídeo.");
+  });
+
+  it("usa anchor especifica nos capitulos pattern e tension quando disponivel", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
+      evidenceAnchors: {
+        speechQuotes: [
+          {
+            quote: "rapidinho",
+            source: "creator_spoken",
+            quoteRole: "hook",
+            whyItMatters: "A palavra cria promessa pequena.",
+            chapterHint: "tension",
+          },
+        ],
+        sceneAnchors: [
+          {
+            description: "promessa de conversa curta que vira conversa longa",
+            source: "derived_scene",
+            momentRole: "turning_point",
+            whyItMatters: "A virada sustenta o humor.",
+            chapterHint: "pattern",
+          },
+        ],
+        creatorIntentAnchor: null,
+        profilePatternAnchors: [],
+        instagramAnchors: [],
+      },
+    });
+
+    const presentation = buildCreatorNarrativeMapReadingPresentation({ diagnosis, analyzedVideosCount: 4 });
+    expect(presentation.chapters.find((chapter) => chapter.id === "pattern")?.fullReading).toContain(
+      "promessa de conversa curta",
+    );
+    expect(presentation.chapters.find((chapter) => chapter.id === "tension")?.fullReading).toContain(
+      'Fala: "rapidinho"',
+    );
+  });
+
+  it("diferencia fala real de sugestao da IA em movement", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
+      evidenceAnchors: {
+        speechQuotes: [
+          {
+            quote: "Quando a reunião era para ser rápida...",
+            source: "ai_suggested",
+            quoteRole: "promise",
+            whyItMatters: "Teste de frase para abertura.",
+            chapterHint: "movement",
+          },
+        ],
+        sceneAnchors: [],
+        creatorIntentAnchor: null,
+        profilePatternAnchors: [],
+        instagramAnchors: [],
+      },
+    });
+    const presentation = buildCreatorNarrativeMapReadingPresentation({ diagnosis });
+
+    expect(presentation.chapters.find((chapter) => chapter.id === "movement")?.fullReading).toContain(
+      "Sugestão de fala",
+    );
+    expect(presentation.chapters.find((chapter) => chapter.id === "movement")?.fullReading).not.toContain(
+      "quando você diz",
+    );
+  });
+
+  it("capitulos sem anchors assumem limitacao em vez de ficarem genericos", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({ evidenceAnchors: undefined });
+    const presentation = buildCreatorNarrativeMapReadingPresentation({ diagnosis });
+
+    expect(presentation.chapters[0].fullReading).toContain("Ainda falta uma fala ou cena curta");
+  });
+
+  it("expoe resumo de evidencias para modal como Onde a D2C percebeu isso", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+    });
+
+    expect(presentation.evidenceSummaryItems.length).toBeGreaterThan(0);
+    expect(presentation.evidenceSummaryItems.join(" ")).toContain("Sugestão de fala");
+  });
+
+  it("detecta diagnostico generico sem evidencia e permite frase ampla com anchor", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture();
+    const text = "Seu conteúdo gera conexão.";
+    const anchored = `${text} Isso aparece em: Cena: Bastidor simples com clareza de recomendação.`;
+
+    expect(isProbablyGenericDiagnosticText(text, diagnosis.evidenceAnchors)).toBe(true);
+    expect(hasSpecificEvidenceAnchor(anchored, diagnosis.evidenceAnchors)).toBe(true);
+    expect(isProbablyGenericDiagnosticText(anchored, diagnosis.evidenceAnchors)).toBe(false);
+  });
+
+  it("texto final nao serve para qualquer creator sem evidencia especifica", () => {
+    const presentation = buildCreatorNarrativeMapReadingPresentation({
+      diagnosis: buildNarrativeMapReadingDiagnosisFixture(),
+    });
+    const serialized = JSON.stringify(presentation);
+
+    expect(serialized).toMatch(/Bastidor simples|Eu uso isso|Intenção:/);
+    expect(isProbablyGenericDiagnosticText(serialized, buildNarrativeMapReadingDiagnosisFixture().evidenceAnchors)).toBe(false);
   });
 
   it("e funcao pura e testavel, sem banco", () => {

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
@@ -1,5 +1,6 @@
 import type {
   CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeEvidenceAnchors,
   CreatorVideoNarrativeDiagnosisProfileContribution,
 } from "./creatorVideoNarrativeDiagnosisTypes";
 
@@ -43,6 +44,7 @@ export interface CreatorNarrativeMapReadingPresentation {
     intent: "analyze_another_video" | "connect_instagram" | "upgrade" | "open_full_reading";
     helper: string | null;
   };
+  evidenceSummaryItems: string[];
   safetyNote?: string | null;
   createdAt: string | null;
 }
@@ -57,6 +59,7 @@ export type CreatorNarrativeMapReadingDiagnosisShape = Pick<
   | "commercialReading"
   | "strategicRecommendation"
   | "profileContribution"
+  | "evidenceAnchors"
   | "createdAt"
 >;
 
@@ -129,6 +132,54 @@ function evidenceFrom(values: Array<string | null | undefined>): string[] {
     .slice(0, MAX_EVIDENCE_ITEMS);
 }
 
+function speechAnchorLabel(anchor: CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number]): string {
+  return anchor.source === "creator_spoken"
+    ? `Fala: "${anchor.quote}"`
+    : `Sugestão de fala: "${anchor.quote}"`;
+}
+
+function anchorForChapter(
+  anchors: CreatorVideoNarrativeEvidenceAnchors | undefined,
+  chapterId: CreatorNarrativeMapReadingChapterId,
+): string | null {
+  const speech = anchors?.speechQuotes.find((anchor) => anchor.chapterHint === chapterId);
+  if (speech) return speechAnchorLabel(speech);
+
+  const scene = anchors?.sceneAnchors.find((anchor) => anchor.chapterHint === chapterId);
+  if (scene) return `Cena: ${scene.description}`;
+
+  if (chapterId === "profile_impact" && anchors?.profilePatternAnchors?.[0]) {
+    return `Perfil: ${anchors.profilePatternAnchors[0].whyThisVideoRelates}`;
+  }
+
+  if (chapterId === "opportunities" && anchors?.instagramAnchors?.[0]) {
+    return `Instagram: ${anchors.instagramAnchors[0].evidenceSummary}`;
+  }
+
+  if (chapterId === "video_reveal" && anchors?.creatorIntentAnchor) {
+    return `Intenção: ${anchors.creatorIntentAnchor.statedGoal}`;
+  }
+
+  return null;
+}
+
+function anchorSentence(anchor: string | null): string {
+  if (!anchor) {
+    return "Ainda falta uma fala ou cena curta suficiente para sustentar esta parte com precisão.";
+  }
+  return `Isso aparece em: ${anchor}.`;
+}
+
+function evidenceSummaryItemsFrom(anchors: CreatorVideoNarrativeEvidenceAnchors | undefined): string[] {
+  if (!anchors) return [];
+  return [
+    ...anchors.speechQuotes.slice(0, 2).map(speechAnchorLabel),
+    ...anchors.sceneAnchors.slice(0, 2).map((anchor) => `Cena: ${anchor.description}`),
+    ...(anchors.creatorIntentAnchor ? [`Intenção: ${anchors.creatorIntentAnchor.statedGoal}`] : []),
+    ...(anchors.instagramAnchors?.slice(0, 1).map((anchor) => `Instagram: ${anchor.evidenceSummary}`) ?? []),
+  ].map((item) => limitText(item, PREVIEW_LIMIT)).slice(0, MAX_EVIDENCE_ITEMS);
+}
+
 function isoDate(value: Date | string | undefined): string | null {
   if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
   if (typeof value === "string") {
@@ -178,7 +229,7 @@ function buildChapter(params: {
   title: string;
   preview: string;
   fullReading: string;
-  evidence: string[];
+  evidence: Array<string | null | undefined>;
   action?: string | null;
   badgeLabel?: string | null;
   tone: CreatorNarrativeMapReadingChapterTone;
@@ -262,7 +313,15 @@ export function buildCreatorNarrativeMapReadingPresentation(
   const commercial = diagnosis.commercialReading;
   const recommendation = diagnosis.strategicRecommendation;
   const contribution = diagnosis.profileContribution;
+  const anchors = diagnosis.evidenceAnchors;
   const firstReading = isFirstReading(input);
+  const patternAnchor = anchorForChapter(anchors, "pattern");
+  const tensionAnchor = anchorForChapter(anchors, "tension");
+  const movementAnchor = anchorForChapter(anchors, "movement");
+  const territoryAnchor = anchorForChapter(anchors, "territory");
+  const videoRevealAnchor = anchorForChapter(anchors, "video_reveal");
+  const profileImpactAnchor = anchorForChapter(anchors, "profile_impact");
+  const opportunitiesAnchor = anchorForChapter(anchors, "opportunities");
   const patternPreview = firstReading
     ? "Ainda é cedo para cravar um padrão. Este vídeo abre uma hipótese inicial para acompanhar nas próximas leituras."
     : firstText([video.mainNarrative, contribution.profileImpactPreview]);
@@ -278,9 +337,9 @@ export function buildCreatorNarrativeMapReadingPresentation(
       title: "Seu padrão",
       preview: patternPreview,
       fullReading: firstReading
-        ? "Você parece estar abrindo uma primeira pista, não uma conclusão sobre o Perfil. Neste vídeo, a leitura mostra um sinal útil, mas ainda precisa aparecer em novas amostras para virar padrão. O próximo movimento é repetir a intenção narrativa em formatos próximos e observar o que volta com força."
-        : `Você parece ter mais força quando ${cleanText(video.mainNarrative).toLowerCase()}. Isso aparece neste vídeo como ${cleanText(video.dominantInsight).toLowerCase()}. O próximo movimento é repetir esse eixo em novas cenas para entender se ele sustenta o Perfil.`,
-      evidence: [video.mainNarrative, video.dominantInsight, contribution.reason],
+        ? `Você parece estar abrindo uma primeira pista, não uma conclusão sobre o Perfil. ${anchorSentence(patternAnchor)} O que isso revela é um sinal útil, mas ainda precisa aparecer em novas amostras para virar padrão. Por isso, teste a mesma intenção narrativa em formatos próximos e observe o que volta com força.`
+        : `Você parece ter mais força quando ${cleanText(video.mainNarrative).toLowerCase()}. ${anchorSentence(patternAnchor)} O que isso revela é ${cleanText(video.dominantInsight).toLowerCase()}. Por isso, repita esse eixo em novas cenas para entender se ele sustenta o Perfil.`,
+      evidence: [patternAnchor, video.mainNarrative, video.dominantInsight, contribution.reason],
       action: recommendation.whatToRepeat,
       badgeLabel: firstReading ? "Hipótese" : "Padrão",
       tone: "mirror",
@@ -293,8 +352,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
         speech.openingRead,
         production.firstFrame,
       ], "A ideia existe, mas a tensão ainda precisa aparecer mais cedo."),
-      fullReading: `A narrativa ganha clareza quando o conflito aparece cedo. Neste vídeo, a tensão principal passa por ${cleanText(recommendation.whatToAvoid).toLowerCase()}. O ajuste é tornar o incômodo mais visível antes de explicar demais a cena.`,
-      evidence: [speech.openingRead, production.firstFrame, recommendation.whatToAvoid],
+      fullReading: `Você parece ganhar clareza quando o conflito aparece cedo. ${anchorSentence(tensionAnchor)} O que isso revela é que a tensão principal passa por ${cleanText(recommendation.whatToAvoid).toLowerCase()}. Por isso, torne o incômodo mais visível antes de explicar demais a cena.`,
+      evidence: [tensionAnchor, speech.openingRead, production.firstFrame, recommendation.whatToAvoid],
       action: recommendation.mainAdjustment,
       badgeLabel: "Ajuste",
       tone: "attention",
@@ -306,8 +365,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
         recommendation.nextExperiment,
         recommendation.mainAdjustment,
       ], "Testar uma abertura mais direta e comparar se a leitura fica mais clara."),
-      fullReading: `O próximo teste deve ser simples: ${cleanText(recommendation.nextExperiment).toLowerCase()}. A evidência a observar é ${cleanText(recommendation.successSignal).toLowerCase()}. Isso transforma a leitura em movimento prático, sem tratar um vídeo isolado como verdade final.`,
-      evidence: [recommendation.nextExperiment, recommendation.successSignal, recommendation.mainAdjustment],
+      fullReading: `Você parece pronto para transformar a leitura em teste. ${anchorSentence(movementAnchor)} O que isso revela é um caminho prático: ${cleanText(recommendation.nextExperiment).toLowerCase()}. Por isso, observe ${cleanText(recommendation.successSignal).toLowerCase()}, sem tratar um vídeo isolado como verdade final.`,
+      evidence: [movementAnchor, recommendation.nextExperiment, recommendation.successSignal, recommendation.mainAdjustment],
       action: recommendation.nextExperiment,
       badgeLabel: "Próximo teste",
       tone: "action",
@@ -316,8 +375,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
       id: "territory",
       title: "Seu território",
       preview: territoryText,
-      fullReading: `${territoryText} A leitura comercial aqui é de fit narrativo: ${cleanText(commercial.whyItCouldFitBrands).toLowerCase()}. Isso nao indica marca fechada; indica um campo para testar linguagem, formato e repetição.`,
-      evidence: [commercial.summary, ...territories, commercial.whyItCouldFitBrands],
+      fullReading: `Você parece se aproximar de um território, não de uma promessa comercial. ${anchorSentence(territoryAnchor)} O que isso revela é fit narrativo possível: ${cleanText(commercial.whyItCouldFitBrands).toLowerCase()}. Por isso, teste linguagem, formato e repetição antes de falar em marca fechada.`,
+      evidence: [territoryAnchor, commercial.summary, ...territories, commercial.whyItCouldFitBrands],
       action: commercial.adAdaptationIdea,
       badgeLabel: "Território",
       tone: "opportunity",
@@ -329,8 +388,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
         video.whatVideoReveals,
         video.summary,
       ], "Este vídeo adiciona uma leitura inicial ao mapa narrativo."),
-      fullReading: `Este vídeo revela ${cleanText(video.whatVideoReveals).toLowerCase()}. A intenção percebida é ${cleanText(video.creatorIntent).toLowerCase()}. Como leitura isolada, ele documenta um sinal; como Perfil, ele ainda precisa ser comparado com novas leituras.`,
-      evidence: [video.summary, video.whatVideoReveals, video.creatorIntent],
+      fullReading: `Você parece estar mostrando mais do que o tema do vídeo. ${anchorSentence(videoRevealAnchor)} O que isso revela é ${cleanText(video.whatVideoReveals).toLowerCase()}. Por isso, compare a intenção percebida, ${cleanText(video.creatorIntent).toLowerCase()}, com novas leituras antes de transformar isso em Perfil.`,
+      evidence: [videoRevealAnchor, video.summary, video.whatVideoReveals, video.creatorIntent],
       action: recommendation.whatToRepeat,
       badgeLabel: "Leitura",
       tone: "neutral",
@@ -339,8 +398,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
       id: "profile_impact",
       title: "Como pesa no Perfil",
       preview: contribution.profileImpactPreview,
-      fullReading: `${cleanText(contribution.reason)} Esta contribuição tem confiança ${contribution.confidence} e peso ${contribution.weight}. Ela não atualiza a narrativa principal sozinha; apenas organiza o que o agregador futuro deve considerar.`,
-      evidence: [contribution.reason, contribution.profileImpactPreview],
+      fullReading: `Você parece adicionar um sinal ao Perfil, não uma conclusão final. ${anchorSentence(profileImpactAnchor)} O que isso revela é: ${cleanText(contribution.reason).toLowerCase()} Por isso, trate esta leitura como insumo para o agregador futuro, sem atualizar a narrativa principal sozinha.`,
+      evidence: [profileImpactAnchor, contribution.reason, contribution.profileImpactPreview],
       action: firstReading
         ? "Analise mais vídeos para entender se este sinal se repete."
         : "Compare este sinal com novas leituras antes de transformar em narrativa principal.",
@@ -354,8 +413,8 @@ export function buildCreatorNarrativeMapReadingPresentation(
         commercial.adAdaptationIdea,
         territoryText,
       ], "A oportunidade ainda esta em formação e depende de repetição narrativa."),
-      fullReading: `A oportunidade aqui ainda é um território em formação. ${cleanText(commercial.adAdaptationIdea)} O limite importante é: ${cleanText(commercial.limitations).toLowerCase()}. O caminho é testar o fit narrativo antes de falar em parceria real.`,
-      evidence: [commercial.summary, commercial.adAdaptationIdea, commercial.limitations, ...territories],
+      fullReading: `Você parece ter um território em formação, ainda dependente de repetição. ${anchorSentence(opportunitiesAnchor)} O que isso revela é uma adaptação possível: ${cleanText(commercial.adAdaptationIdea).toLowerCase()} Por isso, teste o fit narrativo antes de falar em parceria real; o limite é ${cleanText(commercial.limitations).toLowerCase()}.`,
+      evidence: [opportunitiesAnchor, commercial.summary, commercial.adAdaptationIdea, commercial.limitations, ...territories],
       action: recommendation.nextExperiment,
       badgeLabel: "Em formação",
       tone: "opportunity",
@@ -370,6 +429,7 @@ export function buildCreatorNarrativeMapReadingPresentation(
     statusLabel: status.statusLabel,
     chapters,
     primaryAction: buildPrimaryAction(input),
+    evidenceSummaryItems: evidenceSummaryItemsFrom(anchors),
     safetyNote: "A D2C guarda a leitura estratégica, não o vídeo.",
     createdAt: isoDate(diagnosis.createdAt),
   };

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisFixtures.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisFixtures.ts
@@ -68,6 +68,40 @@ export function buildCreatorVideoNarrativeDiagnosisFixture(
       reason: "O vídeo mostra potencial comercial, mas ainda não deve redefinir o Perfil geral.",
       profileImpactPreview: "Pode virar evidência futura de território em beleza funcional se recorrente.",
     },
+    evidenceAnchors: {
+      speechQuotes: [
+        {
+          quote: "Eu uso isso quando quero resolver textura sem complicar a rotina.",
+          source: "ai_suggested",
+          quoteRole: "example",
+          whyItMatters: "E uma sugestao curta para transformar escolha de produto em promessa clara.",
+          chapterHint: "movement",
+        },
+      ],
+      sceneAnchors: [
+        {
+          description: "Bastidor simples com clareza de recomendação.",
+          source: "derived_scene",
+          momentRole: "visual_signal",
+          whyItMatters: "A cena documenta uso real sem depender de vídeo ou thumbnail persistidos.",
+          chapterHint: "pattern",
+        },
+      ],
+      creatorIntentAnchor: {
+        source: "creator_goal",
+        statedGoal: "Entender se este vídeo pode fortalecer posicionamento comercial.",
+        interpretedGoal: "Mostrar uma rotina confiável sem parecer publi direta.",
+        whyItMatters: "Compara a intenção declarada com a leitura estratégica do vídeo.",
+      },
+      profilePatternAnchors: [
+        {
+          patternLabel: "beleza funcional com rotina prática",
+          whyThisVideoRelates: "O vídeo conecta cuidado cotidiano, critério e explicação simples.",
+          evidenceCount: 1,
+        },
+      ],
+      instagramAnchors: [],
+    },
     schemaVersion: "creator_video_narrative_diagnosis_v1",
     ...overrides,
   };

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
@@ -181,6 +181,51 @@ describe("creatorVideoNarrativeDiagnosisMapper", () => {
     expect(() => sanitizeCreatorVideoNarrativeDiagnosisInput(result)).not.toThrow();
   });
 
+  it("mapeia creatorGoal para creatorIntentAnchor", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        creatorGoal: "Quero entender se a piada de reunião reforça meu humor cotidiano.",
+      }),
+    );
+
+    expect(result.evidenceAnchors?.creatorIntentAnchor).toEqual(expect.objectContaining({
+      source: "creator_goal",
+      statedGoal: "Quero entender se a piada de reunião reforça meu humor cotidiano.",
+    }));
+  });
+
+  it("mapeia suggestedHook como ai_suggested e nao inventa creator_spoken", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        strategicDiagnosis: buildMapperStrategicDiagnosisFixture({
+          suggestedHook: "Quando a reunião era para ser rapidinha...",
+        }),
+      }),
+    );
+
+    expect(result.evidenceAnchors?.speechQuotes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          quote: "Quando a reunião era para ser rapidinha...",
+          source: "ai_suggested",
+        }),
+      ]),
+    );
+    expect(result.evidenceAnchors?.speechQuotes.some((anchor) => anchor.source === "creator_spoken")).toBe(false);
+  });
+
+  it("mapeia rememberedAs como sceneAnchor seguro", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams(),
+    );
+
+    expect(result.evidenceAnchors?.sceneAnchors[0]).toEqual(expect.objectContaining({
+      source: "derived_scene",
+      chapterHint: "pattern",
+    }));
+    expect(result.evidenceAnchors?.sceneAnchors[0].description).toContain("Video sobre");
+  });
+
   it("nao importa Mongoose, storage SDK, Gemini SDK ou codigo client-side", () => {
     const mapperPath = path.join(__dirname, "creatorVideoNarrativeDiagnosisMapper.ts");
     const source = readFileSync(mapperPath, "utf8");

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
@@ -1,5 +1,7 @@
 import type {
   CreatorVideoNarrativeDiagnosisContributionType,
+  CreatorVideoNarrativeEvidenceAnchors,
+  CreatorVideoNarrativeEvidenceChapterHint,
   CreatorVideoNarrativeDiagnosisInput,
   CreatorVideoNarrativeDiagnosisSource,
   CreatorVideoNarrativeDiagnosisVideoMetadata,
@@ -86,6 +88,32 @@ function shortText(value: string, maxLength: number): string {
   const text = clean(value);
   if (text.length <= maxLength) return text;
   return `${text.slice(0, maxLength - 1).trim()}...`;
+}
+
+function isShortSpeechCandidate(value: string | null | undefined): value is string {
+  const text = clean(value ?? "");
+  if (!text || text.length > 180) return false;
+  if (text.split(/\s+/).length > 24) return false;
+  if (/https?:\/\/|objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath|raw response/i.test(text)) {
+    return false;
+  }
+  return true;
+}
+
+function buildAiSuggestedQuoteAnchor(params: {
+  quote: string | null | undefined;
+  quoteRole: CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number]["quoteRole"];
+  chapterHint: CreatorVideoNarrativeEvidenceChapterHint;
+  whyItMatters: string;
+}): CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number] | null {
+  if (!isShortSpeechCandidate(params.quote)) return null;
+  return {
+    quote: shortText(params.quote, 180),
+    source: "ai_suggested",
+    quoteRole: params.quoteRole,
+    whyItMatters: shortText(params.whyItMatters, 260),
+    chapterHint: params.chapterHint,
+  };
 }
 
 function dateFrom(value: Date | string | null | undefined): Date | null {
@@ -235,6 +263,79 @@ function mapSafeMetadata(params: CreatorVideoNarrativeDiagnosisMapperParams): Cr
   };
 }
 
+function mapEvidenceAnchors(params: {
+  creatorGoal: string;
+  strategicDiagnosis: VideoNarrativeStrategicDiagnosis;
+  evolvingDiagnosis: VideoNarrativeEvolvingDiagnosis;
+  rememberedAs: string;
+  profileContribution: CreatorVideoNarrativeDiagnosisInput["profileContribution"];
+}): CreatorVideoNarrativeEvidenceAnchors {
+  const speechQuotes = [
+    buildAiSuggestedQuoteAnchor({
+      quote: params.strategicDiagnosis.suggestedHook,
+      quoteRole: "hook",
+      chapterHint: "tension",
+      whyItMatters: "E uma sugestao de abertura para explicitar a promessa da cena; nao e tratada como fala real do creator.",
+    }),
+    buildAiSuggestedQuoteAnchor({
+      quote: params.strategicDiagnosis.scriptDirection.opening,
+      quoteRole: "promise",
+      chapterHint: "movement",
+      whyItMatters: "Serve como teste de frase para deixar a virada narrativa mais visivel.",
+    }),
+  ].filter((item): item is CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number] => Boolean(item));
+
+  const sceneAnchors: CreatorVideoNarrativeEvidenceAnchors["sceneAnchors"] = params.rememberedAs
+    ? [{
+        description: shortText(params.rememberedAs, 260),
+        source: "derived_scene",
+        momentRole: "opening",
+        whyItMatters: "Resume a cena documentada sem salvar video, thumbnail ou transcricao longa.",
+        chapterHint: "pattern",
+      }]
+    : [];
+
+  const creatorIntentAnchor = clean(params.creatorGoal)
+    ? {
+        source: "creator_goal" as const,
+        statedGoal: shortText(params.creatorGoal, 260),
+        interpretedGoal: shortText(params.strategicDiagnosis.creatorIntent ?? params.creatorGoal, 260),
+        whyItMatters: "Ajuda a comparar a intencao declarada com a leitura do video.",
+      }
+    : null;
+
+  const profilePatternAnchors = params.profileContribution.reason
+    ? [{
+        patternLabel: shortText(params.profileContribution.profileImpactPreview, 180),
+        whyThisVideoRelates: shortText(params.profileContribution.reason, 260),
+        evidenceCount: Math.max(1, params.evolvingDiagnosis.profileImpact.usefulSignalsCount),
+      }]
+    : [];
+
+  const instagramAnchors = params.strategicDiagnosis.instagramComparison.connected
+    ? [
+        ...params.strategicDiagnosis.instagramComparison.matchingNarratives.map((signal) => ({
+          signalLabel: shortText(signal, 180),
+          whyItMatters: "Sinal do Instagram usado apenas como precisao contextual, nao como aba nova.",
+          evidenceSummary: shortText(params.strategicDiagnosis.instagramComparison.summary ?? signal, 260),
+        })),
+        ...params.strategicDiagnosis.instagramComparison.matchingFormats.map((signal) => ({
+          signalLabel: shortText(signal, 180),
+          whyItMatters: "Formato observado no Instagram para comparar recorrencia narrativa.",
+          evidenceSummary: shortText(params.strategicDiagnosis.instagramComparison.summary ?? signal, 260),
+        })),
+      ].slice(0, 4)
+    : [];
+
+  return {
+    speechQuotes: speechQuotes.slice(0, 4),
+    sceneAnchors: sceneAnchors.slice(0, 4),
+    creatorIntentAnchor,
+    profilePatternAnchors,
+    instagramAnchors,
+  };
+}
+
 export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
   params: CreatorVideoNarrativeDiagnosisMapperParams,
 ): CreatorVideoNarrativeDiagnosisInput {
@@ -253,6 +354,11 @@ export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
     [strategic.nextActions[0]?.description, seed?.blueprintDraft.whatToPost, evolving.nextSignalsToUnlock[0]?.action],
     "Testar uma abertura mais direta e comparar a resposta em novas leituras.",
   );
+  const profileContribution = mapProfileContribution({
+    strategicDiagnosis: strategic,
+    evolvingDiagnosis: evolving,
+  });
+  const rememberedAs = safeRememberedAs(params);
 
   const mapped: CreatorVideoNarrativeDiagnosisInput = {
     userId: params.userId,
@@ -264,7 +370,7 @@ export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
     selectedGoalOption: clean(params.selectedGoalOption, "strategic_reading"),
     videoReading: {
       title: shortText(firstText([strategic.mainNarrative, presentation.hero.title], "Leitura estrategica do video"), 140),
-      rememberedAs: safeRememberedAs(params),
+      rememberedAs,
       summary: firstText([strategic.whatVideoCommunicates, presentation.priorityCards[0]?.body], "Este video traz uma leitura inicial para o mapa estrategico."),
       whatVideoReveals: firstText([evolving.profileImpact.summary, strategic.strength], "Este video revela um sinal inicial sobre a narrativa do creator."),
       mainNarrative: firstText([strategic.mainNarrative, seed?.detectedNarrative], "Narrativa em formacao."),
@@ -311,9 +417,13 @@ export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
       whatToAvoid: firstText([strategic.weakness], "Evitar transformar uma leitura isolada em conclusao geral do Perfil."),
       successSignal: "Observar se o mesmo sinal aparece de novo em proximas leituras e respostas da audiencia.",
     },
-    profileContribution: mapProfileContribution({
+    profileContribution,
+    evidenceAnchors: mapEvidenceAnchors({
+      creatorGoal: params.creatorGoal,
       strategicDiagnosis: strategic,
       evolvingDiagnosis: evolving,
+      rememberedAs,
+      profileContribution,
     }),
     schemaVersion: "creator_video_narrative_diagnosis_v1",
   };
@@ -334,6 +444,7 @@ export function mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
     commercialReading: sanitized.commercialReading,
     strategicRecommendation: sanitized.strategicRecommendation,
     profileContribution: sanitized.profileContribution,
+    evidenceAnchors: sanitized.evidenceAnchors,
     schemaVersion: sanitized.schemaVersion,
   };
 }

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisReadService.ts
@@ -4,6 +4,7 @@ import { Types } from "mongoose";
 import type {
   CreatorVideoNarrativeDiagnosisCommercialReading,
   CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeEvidenceAnchors,
   CreatorVideoNarrativeDiagnosisProductionReading,
   CreatorVideoNarrativeDiagnosisProfileContribution,
   CreatorVideoNarrativeDiagnosisSafetyFlags,
@@ -23,6 +24,7 @@ export interface CreatorVideoNarrativeDiagnosisSafeReading {
   commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
   strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
   profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
   safetyFlags: CreatorVideoNarrativeDiagnosisSafetyFlags;
   createdAt?: Date;
   updatedAt?: Date;
@@ -75,6 +77,7 @@ export function mapCreatorVideoNarrativeDiagnosisToSafeReading(
     commercialReading: doc.commercialReading,
     strategicRecommendation: doc.strategicRecommendation,
     profileContribution: doc.profileContribution,
+    evidenceAnchors: doc.evidenceAnchors,
     safetyFlags: doc.safetyFlags,
     createdAt: asDate(doc.createdAt),
     updatedAt: asDate(doc.updatedAt),
@@ -93,6 +96,7 @@ function queryProjection() {
     commercialReading: 1,
     strategicRecommendation: 1,
     profileContribution: 1,
+    evidenceAnchors: 1,
     safetyFlags: 1,
     "videoMetadata.analyzedAt": 1,
     createdAt: 1,

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
@@ -138,4 +138,116 @@ describe("creatorVideoNarrativeDiagnosisSanitizer", () => {
     expect(serialized).not.toContain("signedUrl");
     expect(serialized).toContain("[object-key-redacted]");
   });
+
+  it("aceita speechQuote curta e diferencia source creator_spoken de ai_suggested", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        evidenceAnchors: {
+          speechQuotes: [
+            {
+              quote: "rapidinho",
+              source: "creator_spoken",
+              quoteRole: "hook",
+              whyItMatters: "A palavra cria promessa pequena para a cena.",
+              chapterHint: "pattern",
+            },
+            {
+              quote: "Quando a reunião era para ser rápida...",
+              source: "ai_suggested",
+              quoteRole: "promise",
+              whyItMatters: "E sugestao de frase, nao fala real.",
+              chapterHint: "movement",
+            },
+          ],
+          sceneAnchors: [],
+          creatorIntentAnchor: null,
+          profilePatternAnchors: [],
+          instagramAnchors: [],
+        },
+      }),
+    );
+
+    expect(result.evidenceAnchors?.speechQuotes[0]).toEqual(expect.objectContaining({
+      quote: "rapidinho",
+      source: "creator_spoken",
+    }));
+    expect(result.evidenceAnchors?.speechQuotes[1].source).toBe("ai_suggested");
+  });
+
+  it("trunca quote longa, remove URLs e limita quantidade de anchors", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        evidenceAnchors: {
+          speechQuotes: Array.from({ length: 6 }, (_, index) => ({
+            quote: `${"frase longa ".repeat(30)} https://example.com/video.mp4?token=abc ${index}`,
+            source: "ai_suggested",
+            quoteRole: "example",
+            whyItMatters: "Remove URL e limita frase.",
+            chapterHint: "movement",
+          })),
+          sceneAnchors: Array.from({ length: 6 }, (_, index) => ({
+            description: `Cena segura ${index}`,
+            source: "derived_scene",
+            momentRole: "opening",
+            whyItMatters: "Limita cenas.",
+            chapterHint: "pattern",
+          })),
+          creatorIntentAnchor: null,
+          profilePatternAnchors: [],
+          instagramAnchors: [],
+        },
+      }),
+    );
+
+    expect(result.evidenceAnchors?.speechQuotes).toHaveLength(4);
+    expect(result.evidenceAnchors?.sceneAnchors).toHaveLength(4);
+    expect(result.evidenceAnchors?.speechQuotes[0].quote.length).toBeLessThanOrEqual(180);
+    expect(JSON.stringify(result)).not.toContain("https://example.com");
+  });
+
+  it("bloqueia base64 grande e transcrição longa dentro de anchors", () => {
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput(
+        buildCreatorVideoNarrativeDiagnosisFixture({
+          evidenceAnchors: {
+            speechQuotes: [
+              {
+                quote: "data:video/mp4;base64," + "A".repeat(1500),
+                source: "creator_spoken",
+                quoteRole: "hook",
+                whyItMatters: "nao deve persistir",
+                chapterHint: "pattern",
+              },
+            ],
+            sceneAnchors: [],
+            creatorIntentAnchor: null,
+            profilePatternAnchors: [],
+            instagramAnchors: [],
+          },
+        }),
+      ),
+    ).toThrow("base64 grande");
+
+    expect(() =>
+      sanitizeCreatorVideoNarrativeDiagnosisInput(
+        buildCreatorVideoNarrativeDiagnosisFixture({
+          evidenceAnchors: {
+            speechQuotes: [],
+            sceneAnchors: [
+              {
+                description: Array.from({ length: 12 }, (_, index) => `00:${String(index).padStart(2, "0")} fala`).join("\n"),
+                source: "derived_scene",
+                momentRole: "opening",
+                whyItMatters: "nao deve persistir",
+                chapterHint: "pattern",
+              },
+            ],
+            creatorIntentAnchor: null,
+            profilePatternAnchors: [],
+            instagramAnchors: [],
+          },
+        }),
+      ),
+    ).toThrow("transcrição longa");
+  });
 });

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
@@ -1,5 +1,6 @@
 import type {
   CreatorVideoNarrativeDiagnosisDocument,
+  CreatorVideoNarrativeEvidenceAnchors,
   CreatorVideoNarrativeDiagnosisInput,
   CreatorVideoNarrativeDiagnosisSafetyFlags,
   CreatorVideoNarrativeDiagnosisVideoMetadata,
@@ -9,6 +10,12 @@ const MAX_TEXT_FIELD_LENGTH = 4000;
 const MAX_ARRAY_ITEM_LENGTH = 1000;
 const MAX_SERIALIZED_INPUT_LENGTH = 60000;
 const MAX_TRANSCRIPT_LENGTH = 2000;
+const MAX_SPEECH_QUOTES = 4;
+const MAX_SCENE_ANCHORS = 4;
+const MAX_PROFILE_PATTERN_ANCHORS = 4;
+const MAX_INSTAGRAM_ANCHORS = 4;
+const MAX_QUOTE_LENGTH = 180;
+const MAX_ANCHOR_TEXT_LENGTH = 260;
 
 const SIGNED_URL_REGEX = /https?:\/\/[^\s"'<>]+[?&](x-amz-signature|x-goog-signature|signature|expires|token|policy|x-amz-credential)=\S*/gi;
 const STORAGE_URL_REGEX = /https?:\/\/[^\s"'<>]*(s3|r2|cloudfront|storage\.googleapis|amazonaws|blob\.core\.windows)[^\s"'<>]*/gi;
@@ -54,6 +61,24 @@ const PROFILE_CONTRIBUTION_TYPES = [
 ];
 const PROFILE_CONTRIBUTION_CONFIDENCE = ["low", "medium", "high"];
 const PROFILE_CONTRIBUTION_WEIGHT = ["low", "medium", "high"];
+const QUOTE_SOURCES = ["creator_spoken", "ai_suggested"];
+const QUOTE_ROLES = ["hook", "promise", "turning_point", "closing", "example", "context", "other"];
+const SCENE_SOURCES = ["derived_scene"];
+const MOMENT_ROLES = ["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"];
+const CHAPTER_HINTS = ["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"];
+
+function truncateSafeText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trim()}...`;
+}
+
+function looksLikeTranscriptBlob(value: string): boolean {
+  const normalized = value.trim();
+  if (normalized.length > MAX_TRANSCRIPT_LENGTH) return true;
+  const lineCount = normalized.split(/\n+/).filter(Boolean).length;
+  const timestampLikeCount = (normalized.match(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g) ?? []).length;
+  return lineCount >= 12 || timestampLikeCount >= 6;
+}
 
 function createSafetyFlags(sanitized: boolean): CreatorVideoNarrativeDiagnosisSafetyFlags {
   return {
@@ -181,6 +206,130 @@ function requireOneOf(value: string, validValues: string[], fieldName: string): 
   return value;
 }
 
+function sanitizeEvidenceAnchors(
+  input: unknown,
+  text: (value: unknown, fieldName: string, maxLength?: number) => string,
+): CreatorVideoNarrativeEvidenceAnchors | undefined {
+  if (input === undefined || input === null) return undefined;
+  const anchors = requireObject<Record<string, unknown>>(input, "evidenceAnchors");
+
+  const speechQuotes = Array.isArray(anchors.speechQuotes) ? anchors.speechQuotes.slice(0, MAX_SPEECH_QUOTES) : [];
+  const sceneAnchors = Array.isArray(anchors.sceneAnchors) ? anchors.sceneAnchors.slice(0, MAX_SCENE_ANCHORS) : [];
+
+  const sanitizedSpeechQuotes = speechQuotes.map((item, index) => {
+    const quote = requireObject<Record<string, unknown>>(item, `evidenceAnchors.speechQuotes[${index}]`);
+    if (typeof quote.quote === "string" && /[A-Za-z0-9+/=]{1200,}/.test(quote.quote)) {
+      throw new Error("Leitura de vídeo insegura: base64 grande não pode ser persistido em evidenceAnchors");
+    }
+    const cleanedQuote = text(quote.quote, `evidenceAnchors.speechQuotes[${index}].quote`, MAX_ARRAY_ITEM_LENGTH);
+    if (looksLikeTranscriptBlob(cleanedQuote)) {
+      throw new Error("Leitura de vídeo insegura: transcrição longa não pode ser persistida em evidenceAnchors");
+    }
+
+    return {
+      quote: truncateSafeText(cleanedQuote, MAX_QUOTE_LENGTH),
+      source: requireOneOf(
+        text(quote.source, `evidenceAnchors.speechQuotes[${index}].source`, 40),
+        QUOTE_SOURCES,
+        `evidenceAnchors.speechQuotes[${index}].source`,
+      ) as CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number]["source"],
+      quoteRole: requireOneOf(
+        text(quote.quoteRole, `evidenceAnchors.speechQuotes[${index}].quoteRole`, 40),
+        QUOTE_ROLES,
+        `evidenceAnchors.speechQuotes[${index}].quoteRole`,
+      ) as CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number]["quoteRole"],
+      whyItMatters: truncateSafeText(
+        text(quote.whyItMatters, `evidenceAnchors.speechQuotes[${index}].whyItMatters`, MAX_ANCHOR_TEXT_LENGTH),
+        MAX_ANCHOR_TEXT_LENGTH,
+      ),
+      chapterHint: requireOneOf(
+        text(quote.chapterHint, `evidenceAnchors.speechQuotes[${index}].chapterHint`, 40),
+        CHAPTER_HINTS,
+        `evidenceAnchors.speechQuotes[${index}].chapterHint`,
+      ) as CreatorVideoNarrativeEvidenceAnchors["speechQuotes"][number]["chapterHint"],
+    };
+  });
+
+  const sanitizedSceneAnchors = sceneAnchors.map((item, index) => {
+    const scene = requireObject<Record<string, unknown>>(item, `evidenceAnchors.sceneAnchors[${index}]`);
+    if (typeof scene.description === "string" && /[A-Za-z0-9+/=]{1200,}/.test(scene.description)) {
+      throw new Error("Leitura de vídeo insegura: base64 grande não pode ser persistido em evidenceAnchors");
+    }
+    const description = text(scene.description, `evidenceAnchors.sceneAnchors[${index}].description`, MAX_ARRAY_ITEM_LENGTH);
+    if (looksLikeTranscriptBlob(description)) {
+      throw new Error("Leitura de vídeo insegura: transcrição longa não pode ser persistida em evidenceAnchors");
+    }
+
+    return {
+      description: truncateSafeText(description, MAX_ANCHOR_TEXT_LENGTH),
+      source: requireOneOf(
+        text(scene.source, `evidenceAnchors.sceneAnchors[${index}].source`, 40),
+        SCENE_SOURCES,
+        `evidenceAnchors.sceneAnchors[${index}].source`,
+      ) as "derived_scene",
+      momentRole: requireOneOf(
+        text(scene.momentRole, `evidenceAnchors.sceneAnchors[${index}].momentRole`, 40),
+        MOMENT_ROLES,
+        `evidenceAnchors.sceneAnchors[${index}].momentRole`,
+      ) as CreatorVideoNarrativeEvidenceAnchors["sceneAnchors"][number]["momentRole"],
+      whyItMatters: truncateSafeText(
+        text(scene.whyItMatters, `evidenceAnchors.sceneAnchors[${index}].whyItMatters`, MAX_ANCHOR_TEXT_LENGTH),
+        MAX_ANCHOR_TEXT_LENGTH,
+      ),
+      chapterHint: requireOneOf(
+        text(scene.chapterHint, `evidenceAnchors.sceneAnchors[${index}].chapterHint`, 40),
+        CHAPTER_HINTS,
+        `evidenceAnchors.sceneAnchors[${index}].chapterHint`,
+      ) as CreatorVideoNarrativeEvidenceAnchors["sceneAnchors"][number]["chapterHint"],
+    };
+  });
+
+  const creatorIntentAnchor = anchors.creatorIntentAnchor && typeof anchors.creatorIntentAnchor === "object"
+    ? (() => {
+        const intent = requireObject<Record<string, unknown>>(anchors.creatorIntentAnchor, "evidenceAnchors.creatorIntentAnchor");
+        return {
+          source: "creator_goal" as const,
+          statedGoal: truncateSafeText(text(intent.statedGoal, "evidenceAnchors.creatorIntentAnchor.statedGoal", MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          interpretedGoal: truncateSafeText(text(intent.interpretedGoal, "evidenceAnchors.creatorIntentAnchor.interpretedGoal", MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          whyItMatters: truncateSafeText(text(intent.whyItMatters, "evidenceAnchors.creatorIntentAnchor.whyItMatters", MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+        };
+      })()
+    : null;
+
+  const profilePatternAnchors = Array.isArray(anchors.profilePatternAnchors)
+    ? anchors.profilePatternAnchors.slice(0, MAX_PROFILE_PATTERN_ANCHORS).map((item, index) => {
+        const pattern = requireObject<Record<string, unknown>>(item, `evidenceAnchors.profilePatternAnchors[${index}]`);
+        const evidenceCount = typeof pattern.evidenceCount === "number" && Number.isFinite(pattern.evidenceCount)
+          ? Math.max(0, Math.trunc(pattern.evidenceCount))
+          : undefined;
+        return {
+          patternLabel: truncateSafeText(text(pattern.patternLabel, `evidenceAnchors.profilePatternAnchors[${index}].patternLabel`, MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          whyThisVideoRelates: truncateSafeText(text(pattern.whyThisVideoRelates, `evidenceAnchors.profilePatternAnchors[${index}].whyThisVideoRelates`, MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          ...(evidenceCount === undefined ? {} : { evidenceCount }),
+        };
+      })
+    : [];
+
+  const instagramAnchors = Array.isArray(anchors.instagramAnchors)
+    ? anchors.instagramAnchors.slice(0, MAX_INSTAGRAM_ANCHORS).map((item, index) => {
+        const signal = requireObject<Record<string, unknown>>(item, `evidenceAnchors.instagramAnchors[${index}]`);
+        return {
+          signalLabel: truncateSafeText(text(signal.signalLabel, `evidenceAnchors.instagramAnchors[${index}].signalLabel`, MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          whyItMatters: truncateSafeText(text(signal.whyItMatters, `evidenceAnchors.instagramAnchors[${index}].whyItMatters`, MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+          evidenceSummary: truncateSafeText(text(signal.evidenceSummary, `evidenceAnchors.instagramAnchors[${index}].evidenceSummary`, MAX_ANCHOR_TEXT_LENGTH), MAX_ANCHOR_TEXT_LENGTH),
+        };
+      })
+    : [];
+
+  return {
+    speechQuotes: sanitizedSpeechQuotes,
+    sceneAnchors: sanitizedSceneAnchors,
+    creatorIntentAnchor,
+    profilePatternAnchors,
+    instagramAnchors,
+  };
+}
+
 export function sanitizeCreatorVideoNarrativeDiagnosisInput(
   input: CreatorVideoNarrativeDiagnosisInput,
 ): CreatorVideoNarrativeDiagnosisDocument {
@@ -208,8 +357,8 @@ export function sanitizeCreatorVideoNarrativeDiagnosisInput(
   }
 
   let sanitized = false;
-  const text = (value: unknown, fieldName: string) => {
-    const result = sanitizeText(value, fieldName);
+  const text = (value: unknown, fieldName: string, maxLength = MAX_TEXT_FIELD_LENGTH) => {
+    const result = sanitizeText(value, fieldName, maxLength);
     sanitized = sanitized || result.sanitized;
     return result.value;
   };
@@ -231,6 +380,7 @@ export function sanitizeCreatorVideoNarrativeDiagnosisInput(
     "strategicRecommendation",
   );
   const profileContribution = requireObject<Record<string, unknown>>(input.profileContribution, "profileContribution");
+  const evidenceAnchors = sanitizeEvidenceAnchors(input.evidenceAnchors, text);
   const profileContributionType = requireOneOf(
     text(profileContribution.type, "profileContribution.type"),
     PROFILE_CONTRIBUTION_TYPES,
@@ -303,6 +453,7 @@ export function sanitizeCreatorVideoNarrativeDiagnosisInput(
       reason: text(profileContribution.reason, "profileContribution.reason"),
       profileImpactPreview: text(profileContribution.profileImpactPreview, "profileContribution.profileImpactPreview"),
     },
+    ...(evidenceAnchors ? { evidenceAnchors } : {}),
     safetyFlags: createSafetyFlags(sanitized),
     schemaVersion: "creator_video_narrative_diagnosis_v1",
   };

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
@@ -15,6 +15,68 @@ export type CreatorVideoNarrativeDiagnosisContributionType =
 
 export type CreatorVideoNarrativeDiagnosisWeight = "low" | "medium" | "high";
 
+export type CreatorVideoNarrativeEvidenceChapterHint =
+  | "pattern"
+  | "tension"
+  | "movement"
+  | "territory"
+  | "video_reveal"
+  | "profile_impact"
+  | "opportunities";
+
+export type CreatorVideoNarrativeSpeechQuoteSource = "creator_spoken" | "ai_suggested";
+
+export interface CreatorVideoNarrativeDiagnosisSpeechQuoteAnchor {
+  quote: string;
+  source: CreatorVideoNarrativeSpeechQuoteSource;
+  quoteRole:
+    | "hook"
+    | "promise"
+    | "turning_point"
+    | "closing"
+    | "example"
+    | "context"
+    | "other";
+  whyItMatters: string;
+  chapterHint: CreatorVideoNarrativeEvidenceChapterHint;
+}
+
+export interface CreatorVideoNarrativeDiagnosisSceneAnchor {
+  description: string;
+  source: "derived_scene";
+  momentRole:
+    | "opening"
+    | "conflict"
+    | "turning_point"
+    | "visual_signal"
+    | "pacing_signal"
+    | "production_signal"
+    | "other";
+  whyItMatters: string;
+  chapterHint: CreatorVideoNarrativeEvidenceChapterHint;
+}
+
+export interface CreatorVideoNarrativeEvidenceAnchors {
+  speechQuotes: CreatorVideoNarrativeDiagnosisSpeechQuoteAnchor[];
+  sceneAnchors: CreatorVideoNarrativeDiagnosisSceneAnchor[];
+  creatorIntentAnchor?: {
+    source: "creator_goal";
+    statedGoal: string;
+    interpretedGoal: string;
+    whyItMatters: string;
+  } | null;
+  profilePatternAnchors?: Array<{
+    patternLabel: string;
+    whyThisVideoRelates: string;
+    evidenceCount?: number;
+  }>;
+  instagramAnchors?: Array<{
+    signalLabel: string;
+    whyItMatters: string;
+    evidenceSummary: string;
+  }>;
+}
+
 export interface CreatorVideoNarrativeDiagnosisVideoMetadata {
   mimeType?: string;
   sizeBytes?: number;
@@ -101,6 +163,7 @@ export interface CreatorVideoNarrativeDiagnosisInput {
   commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
   strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
   profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
   schemaVersion?: "creator_video_narrative_diagnosis_v1";
 }
 

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosticSpecificityQa.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosticSpecificityQa.ts
@@ -1,0 +1,52 @@
+import type { CreatorVideoNarrativeEvidenceAnchors } from "./creatorVideoNarrativeDiagnosisTypes";
+
+const GENERIC_DIAGNOSTIC_PATTERNS = [
+  /comunica[cç][aã]o aut[eê]ntica/i,
+  /conte[uú]do gera conex[aã]o/i,
+  /conte[uú]dos relevantes/i,
+  /narrativa [ée] forte/i,
+  /v[ií]deo tem potencial/i,
+  /audi[eê]ncia pode se identificar/i,
+  /conte[uú]do [ée] humanizado/i,
+];
+
+function normalize(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function anchorTexts(anchors: CreatorVideoNarrativeEvidenceAnchors | undefined): string[] {
+  if (!anchors) return [];
+  return [
+    ...anchors.speechQuotes.map((anchor) => anchor.quote),
+    ...anchors.sceneAnchors.map((anchor) => anchor.description),
+    ...(anchors.creatorIntentAnchor ? [anchors.creatorIntentAnchor.statedGoal, anchors.creatorIntentAnchor.interpretedGoal] : []),
+    ...(anchors.profilePatternAnchors?.flatMap((anchor) => [anchor.patternLabel, anchor.whyThisVideoRelates]) ?? []),
+    ...(anchors.instagramAnchors?.flatMap((anchor) => [anchor.signalLabel, anchor.evidenceSummary]) ?? []),
+  ].filter(Boolean);
+}
+
+export function hasSpecificEvidenceAnchor(
+  text: string,
+  anchors: CreatorVideoNarrativeEvidenceAnchors | undefined,
+): boolean {
+  const normalizedText = normalize(text);
+  return anchorTexts(anchors).some((anchor) => {
+    const normalizedAnchor = normalize(anchor);
+    if (!normalizedAnchor || normalizedAnchor.length < 8) return false;
+    return normalizedText.includes(normalizedAnchor) || normalizedAnchor.split(" ").some((word) => word.length >= 8 && normalizedText.includes(word));
+  });
+}
+
+export function isProbablyGenericDiagnosticText(
+  text: string,
+  anchors?: CreatorVideoNarrativeEvidenceAnchors,
+): boolean {
+  const hasGenericPhrase = GENERIC_DIAGNOSTIC_PATTERNS.some((pattern) => pattern.test(text));
+  if (!hasGenericPhrase) return false;
+  return !hasSpecificEvidenceAnchor(text, anchors);
+}

--- a/src/app/models/CreatorVideoNarrativeDiagnosis.ts
+++ b/src/app/models/CreatorVideoNarrativeDiagnosis.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Types, Document, model } from "mongoose";
 import type {
   CreatorVideoNarrativeDiagnosisCommercialReading,
+  CreatorVideoNarrativeEvidenceAnchors,
   CreatorVideoNarrativeDiagnosisProfileContribution,
   CreatorVideoNarrativeDiagnosisProductionReading,
   CreatorVideoNarrativeDiagnosisSafetyFlags,
@@ -26,6 +27,7 @@ export interface ICreatorVideoNarrativeDiagnosis extends Document {
   commercialReading: CreatorVideoNarrativeDiagnosisCommercialReading;
   strategicRecommendation: CreatorVideoNarrativeDiagnosisStrategicRecommendation;
   profileContribution: CreatorVideoNarrativeDiagnosisProfileContribution;
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
   safetyFlags: CreatorVideoNarrativeDiagnosisSafetyFlags;
   schemaVersion: "creator_video_narrative_diagnosis_v1";
   createdAt: Date;
@@ -128,6 +130,96 @@ const ProfileContributionSchema = new Schema<CreatorVideoNarrativeDiagnosisProfi
   { _id: false, strict: true },
 );
 
+const EvidenceAnchorsSchema = new Schema<CreatorVideoNarrativeEvidenceAnchors>(
+  {
+    speechQuotes: {
+      type: [
+        new Schema(
+          {
+            quote: { type: String, required: true },
+            source: { type: String, enum: ["creator_spoken", "ai_suggested"], required: true },
+            quoteRole: {
+              type: String,
+              enum: ["hook", "promise", "turning_point", "closing", "example", "context", "other"],
+              required: true,
+            },
+            whyItMatters: { type: String, required: true },
+            chapterHint: {
+              type: String,
+              enum: ["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"],
+              required: true,
+            },
+          },
+          { _id: false, strict: true },
+        ),
+      ],
+      default: [],
+    },
+    sceneAnchors: {
+      type: [
+        new Schema(
+          {
+            description: { type: String, required: true },
+            source: { type: String, enum: ["derived_scene"], required: true },
+            momentRole: {
+              type: String,
+              enum: ["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"],
+              required: true,
+            },
+            whyItMatters: { type: String, required: true },
+            chapterHint: {
+              type: String,
+              enum: ["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"],
+              required: true,
+            },
+          },
+          { _id: false, strict: true },
+        ),
+      ],
+      default: [],
+    },
+    creatorIntentAnchor: {
+      type: new Schema(
+        {
+          source: { type: String, enum: ["creator_goal"], required: true },
+          statedGoal: { type: String, required: true },
+          interpretedGoal: { type: String, required: true },
+          whyItMatters: { type: String, required: true },
+        },
+        { _id: false, strict: true },
+      ),
+      default: null,
+    },
+    profilePatternAnchors: {
+      type: [
+        new Schema(
+          {
+            patternLabel: { type: String, required: true },
+            whyThisVideoRelates: { type: String, required: true },
+            evidenceCount: { type: Number },
+          },
+          { _id: false, strict: true },
+        ),
+      ],
+      default: [],
+    },
+    instagramAnchors: {
+      type: [
+        new Schema(
+          {
+            signalLabel: { type: String, required: true },
+            whyItMatters: { type: String, required: true },
+            evidenceSummary: { type: String, required: true },
+          },
+          { _id: false, strict: true },
+        ),
+      ],
+      default: [],
+    },
+  },
+  { _id: false, strict: true },
+);
+
 const SafetyFlagsSchema = new Schema<CreatorVideoNarrativeDiagnosisSafetyFlags>(
   {
     containsPersistedVideoReference: { type: Boolean, required: true, default: false },
@@ -165,6 +257,7 @@ const CreatorVideoNarrativeDiagnosisSchema = new Schema<ICreatorVideoNarrativeDi
     commercialReading: { type: CommercialReadingSchema, required: true },
     strategicRecommendation: { type: StrategicRecommendationSchema, required: true },
     profileContribution: { type: ProfileContributionSchema, required: true },
+    evidenceAnchors: { type: EvidenceAnchorsSchema, required: false },
     safetyFlags: { type: SafetyFlagsSchema, required: true },
     schemaVersion: {
       type: String,


### PR DESCRIPTION
## Summary

Adds safe Evidence Anchors to the video narrative diagnosis so the D2C diagnostic writer can reference concrete creator moments instead of producing generic strategic copy.

Includes:
- evidenceAnchors on CreatorVideoNarrativeDiagnosis
- safe speech, scene, creator-intent, profile, and Instagram anchors
- sanitizer/validator updates for short anchors only
- mapper updates that do not invent creator-spoken quotes
- chapter builder updates using the formula: espelho → âncora → leitura → movimento
- modal evidence display with “Onde a D2C percebeu isso”
- internal anti-generic QA helpers: hasSpecificEvidenceAnchor and isProbablyGenericDiagnosticText

## Product direction

The product should not only classify a video. It should read the video.

This PR improves the feeling that:

> A D2C really watched and understood this creator's content.

It creates the foundation for diagnostics that can cite short creator quotes, specific scenes, intent, and profile/Instagram signals without storing long transcripts or sensitive media metadata.

## Guardrails

- Does not store video files.
- Does not store thumbnails.
- Does not persist signed URLs, upload URLs, object keys, local paths, storage provider paths, raw Gemini/model responses, raw transcripts, long transcripts, secrets, tokens, or headers.
- Does not call Gemini real.
- Does not call storage/R2.
- Does not alter upload/cleanup.
- Does not touch MediaKitView, Comunidade, billing/Stripe, NextAuth, DashboardShell, BoardShell, or sidebar.
- Does not create real brand/creator matches.
- Differentiates creator-spoken quote from AI-suggested line.

## Validation reported locally

- Focused MM86 tests passed: 45/45.
- Impacted MM74-MM85 tests passed: 70/70.
- npx jest sanitizer/mapper/chapters/preview focused suite passed: 70/70.
- npm run typecheck passed.
- npm run build passed with existing unrelated warnings.
- git diff --check passed.

## Next milestone

MM87 should update the structured provider/parser prompt so Gemini can produce real multimodal evidence anchors when available, still passing through the same sanitizer and without persisting raw transcript, raw response, video, thumbnail, or storage metadata.