### PR TITLE
MM87 — Structured Provider Parser Evidence Anchors

### DIFF
--- a/src/app/dashboard/boards/videoUpload/MM87_STRUCTURED_PROVIDER_PARSER_EVIDENCE_ANCHORS.md
+++ b/src/app/dashboard/boards/videoUpload/MM87_STRUCTURED_PROVIDER_PARSER_EVIDENCE_ANCHORS.md
@@ -1,0 +1,61 @@
+# MM87 — Structured Provider Parser Evidence Anchors
+
+Status: concluído.
+
+## Objetivo
+
+O MM86 criou o contrato seguro de `evidenceAnchors`. O MM87 ensina o prompt, schema e parser do provider multimodal a produzir anchors reais quando houver evidência concreta no vídeo.
+
+O objetivo é reduzir diagnóstico genérico: o texto final deve poder apontar falas curtas, cenas, viradas e intenção, sem depender de transcrição bruta ou metadados de storage.
+
+## O que mudou
+
+- O prompt do provider real pede `evidenceAnchors` estruturados.
+- O schema de resposta aceita `speechQuotes`, `sceneAnchors` e `creatorIntentAnchor`.
+- O parser valida anchors, limita arrays e remove conteúdo inseguro.
+- Anchors inválidos são descartados sem quebrar a análise inteira.
+- O mapper preserva anchors reais antes de usar fallback conservador.
+- `creator_spoken` só é preservado quando vem do parser como fala observada.
+- `ai_suggested` continua reservado para sugestões geradas pela D2C.
+
+## Fala real vs sugestão
+
+`creator_spoken` significa fala curta que o modelo observou com segurança no vídeo. O provider não deve inventar frases nem transformar sugestão editorial em fala real.
+
+Quando não houver segurança suficiente, `speechQuotes` deve vir vazio. Sugestões de fala seguem no fallback do mapper como `ai_suggested`.
+
+## Cenas e intenção
+
+`sceneAnchors` descrevem momentos observados, por exemplo abertura, conflito, virada narrativa, sinal visual, ritmo ou produção. Eles não usam timestamp técnico e não mencionam arquivo, URL, upload ou storage.
+
+`creatorIntentAnchor` diferencia:
+
+- `statedGoal`: objetivo informado pelo creator/fluxo;
+- `interpretedGoal`: leitura estratégica do modelo;
+- `whyItMatters`: por que essa diferença muda a leitura.
+
+## Guardrails
+
+Não salvamos:
+
+- transcrição bruta;
+- raw Gemini response;
+- raw model response;
+- vídeo;
+- thumbnail;
+- signed URL;
+- upload URL;
+- objectKey;
+- localPath;
+- storageProviderPath;
+- arquivo local.
+
+O parser remove URLs, signed URLs, paths de storage, tokens, base64 grande e blobs parecidos com transcript. Anchors são limitados a 4 falas e 4 cenas.
+
+## Compatibilidade
+
+`evidenceAnchors` é opcional. Respostas antigas continuam válidas, e o mapper mantém fallback conservador quando não há anchors reais.
+
+## Próximo passo
+
+Um próximo PR pode ligar a exibição de anchors reais no fluxo allowlist/admin-dev de ponta a ponta, medindo qualidade textual sem abrir endpoint real para usuários comuns.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -38,6 +38,41 @@ O que não faz:
 - não salva vídeo, thumbnail, signed URL, objectKey, raw response ou transcrição longa;
 - não altera upload, cleanup, billing/Stripe, NextAuth, MediaKitView, Comunidade, DashboardShell, BoardShell, sidebar ou matches reais.
 
+### MM87 — Structured Provider Parser Evidence Anchors
+
+Status: concluído.
+
+Arquivos principais:
+
+- `MM87_STRUCTURED_PROVIDER_PARSER_EVIDENCE_ANCHORS.md`
+- `videoNarrativeGeminiPromptBuilder.ts`
+- `videoNarrativeGeminiResponseParser.ts`
+- `videoNarrativeGeminiProvider.ts`
+- `videoNarrativeGeminiSnapshotMapper.ts`
+- `geminiVideoNarrativePrompt.ts`
+- `geminiVideoNarrativeSchema.ts`
+- `videoNarrativeAnalysisTypes.ts`
+- `videoNarrativeAiProviderTypes.ts`
+- `videoNarrativeDiagnosisLearningModel.ts`
+- `creatorVideoNarrativeDiagnosisMapper.ts`
+
+O que faz:
+
+- ensina o prompt/schema/parser do provider a produzir anchors estruturados;
+- aceita falas reais curtas como `creator_spoken` apenas quando o parser recebeu fala observada;
+- aceita cenas `model_observed`/`derived_scene` sem timestamp técnico ou metadata de storage;
+- preserva `creatorIntentAnchor` com objetivo declarado e interpretação estratégica;
+- mantém compatibilidade quando `evidenceAnchors` não vier na resposta;
+- limpa anchors inválidos sem derrubar a análise inteira;
+- faz o mapper priorizar anchors reais antes do fallback `ai_suggested`.
+
+O que não faz:
+
+- não abre endpoint real para usuários comuns;
+- não remove allowlist/admin-dev;
+- não altera usage limits, upload, cleanup, billing/Stripe, NextAuth, MediaKitView, Comunidade, DashboardShell, BoardShell ou sidebar;
+- não salva vídeo, thumbnail, signed URL, upload URL, objectKey, localPath, storageProviderPath, raw response ou transcrição longa.
+
 ### MM74 — Video Reading Document Foundation
 
 Status: concluído.

--- a/src/app/dashboard/boards/videoUpload/__fixtures__/geminiVideoNarrativeResponse.fixture.ts
+++ b/src/app/dashboard/boards/videoUpload/__fixtures__/geminiVideoNarrativeResponse.fixture.ts
@@ -18,6 +18,34 @@ export const geminiVideoNarrativeResponseFixture: VideoNarrativeAiAnalysis = {
   creatorSignals: ["Didática prática", "Autoridade acessível", "Bastidor como prova"],
   brandTerritories: ["Cuidados pessoais", "Educação prática", "Rotina inteligente"],
   collabOpportunities: ["Collabs com creators de rotina", "Séries com especialistas convidados"],
+  evidenceAnchors: {
+    speechQuotes: [
+      {
+        quote: "rapidinho",
+        source: "creator_spoken",
+        quoteRole: "hook",
+        whyItMatters: "A palavra cria uma promessa pequena para a abertura.",
+        chapterHint: "pattern",
+      },
+    ],
+    sceneAnchors: [
+      {
+        description: "A cena começa como rotina simples e vira explicação de escolha.",
+        source: "model_observed",
+        momentRole: "turning_point",
+        whyItMatters: "A virada sustenta a leitura de autoridade acessível.",
+        chapterHint: "tension",
+      },
+    ],
+    creatorIntentAnchor: {
+      source: "creator_goal",
+      statedGoal: "Reforçar confiança e aproximar a audiência.",
+      interpretedGoal: "Testar se a rotina prática pode virar autoridade acessível.",
+      whyItMatters: "A intenção muda a leitura do gancho para entregar confiança antes da explicação.",
+    },
+    profilePatternAnchors: [],
+    instagramAnchors: [],
+  },
 };
 
 export const geminiVideoNarrativeRawJsonFixture = JSON.stringify(geminiVideoNarrativeResponseFixture);

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.test.ts
@@ -268,6 +268,49 @@ describe("creatorNarrativeMapReadingChapters", () => {
     );
   });
 
+  it("prioriza quote creator_spoken e cena model_observed sem expor source tecnico", () => {
+    const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
+      evidenceAnchors: {
+        speechQuotes: [
+          {
+            quote: "sugestão menor",
+            source: "ai_suggested",
+            quoteRole: "hook",
+            whyItMatters: "Sugestão de teste.",
+            chapterHint: "pattern",
+          },
+          {
+            quote: "rapidinho",
+            source: "creator_spoken",
+            quoteRole: "hook",
+            whyItMatters: "Fala real que sustenta a promessa.",
+            chapterHint: "pattern",
+          },
+        ],
+        sceneAnchors: [
+          {
+            description: "A virada aparece quando a explicação vira situação.",
+            source: "model_observed",
+            momentRole: "turning_point",
+            whyItMatters: "Sustenta a tensão.",
+            chapterHint: "tension",
+          },
+        ],
+        creatorIntentAnchor: null,
+        profilePatternAnchors: [],
+        instagramAnchors: [],
+      },
+    });
+    const presentation = buildCreatorNarrativeMapReadingPresentation({ diagnosis, analyzedVideosCount: 4 });
+    const serialized = JSON.stringify(presentation);
+
+    expect(presentation.chapters.find((chapter) => chapter.id === "pattern")?.fullReading).toContain('Fala: "rapidinho"');
+    expect(presentation.chapters.find((chapter) => chapter.id === "pattern")?.fullReading).not.toContain("sugestão menor");
+    expect(presentation.chapters.find((chapter) => chapter.id === "tension")?.fullReading).toContain("A virada aparece");
+    expect(serialized).not.toContain("creator_spoken");
+    expect(serialized).not.toContain("model_observed");
+  });
+
   it("diferencia fala real de sugestao da IA em movement", () => {
     const diagnosis = buildNarrativeMapReadingDiagnosisFixture({
       evidenceAnchors: {

--- a/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorNarrativeMapReadingChapters.ts
@@ -142,10 +142,14 @@ function anchorForChapter(
   anchors: CreatorVideoNarrativeEvidenceAnchors | undefined,
   chapterId: CreatorNarrativeMapReadingChapterId,
 ): string | null {
-  const speech = anchors?.speechQuotes.find((anchor) => anchor.chapterHint === chapterId);
+  const speech =
+    anchors?.speechQuotes.find((anchor) => anchor.chapterHint === chapterId && anchor.source === "creator_spoken") ??
+    anchors?.speechQuotes.find((anchor) => anchor.chapterHint === chapterId);
   if (speech) return speechAnchorLabel(speech);
 
-  const scene = anchors?.sceneAnchors.find((anchor) => anchor.chapterHint === chapterId);
+  const scene =
+    anchors?.sceneAnchors.find((anchor) => anchor.chapterHint === chapterId && anchor.source === "model_observed") ??
+    anchors?.sceneAnchors.find((anchor) => anchor.chapterHint === chapterId);
   if (scene) return `Cena: ${scene.description}`;
 
   if (chapterId === "profile_impact" && anchors?.profilePatternAnchors?.[0]) {

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.test.ts
@@ -214,6 +214,54 @@ describe("creatorVideoNarrativeDiagnosisMapper", () => {
     expect(result.evidenceAnchors?.speechQuotes.some((anchor) => anchor.source === "creator_spoken")).toBe(false);
   });
 
+  it("preserva creator_spoken real vindo do parser e nao sobrescreve com ai_suggested", () => {
+    const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisMapperParams({
+        strategicDiagnosis: buildMapperStrategicDiagnosisFixture({
+          suggestedHook: "Sugestão que não deve sobrescrever quote real.",
+          evidenceAnchors: {
+            speechQuotes: [
+              {
+                quote: "rapidinho",
+                source: "creator_spoken",
+                quoteRole: "hook",
+                whyItMatters: "A palavra cria promessa pequena.",
+                chapterHint: "pattern",
+              },
+            ],
+            sceneAnchors: [
+              {
+                description: "A cena gira em torno de uma conversa curta que vira situação maior.",
+                source: "model_observed",
+                momentRole: "turning_point",
+                whyItMatters: "A virada sustenta o humor.",
+                chapterHint: "tension",
+              },
+            ],
+            creatorIntentAnchor: {
+              source: "creator_goal",
+              statedGoal: "gerar identificação e comentários",
+              interpretedGoal: "testar humor de reconhecimento rápido",
+              whyItMatters: "A intenção muda a leitura do gancho.",
+            },
+            profilePatternAnchors: [],
+            instagramAnchors: [],
+          },
+        }),
+      }),
+    );
+
+    expect(result.evidenceAnchors?.speechQuotes).toEqual([
+      expect.objectContaining({ quote: "rapidinho", source: "creator_spoken" }),
+    ]);
+    expect(result.evidenceAnchors?.speechQuotes.some((anchor) => anchor.source === "ai_suggested")).toBe(false);
+    expect(result.evidenceAnchors?.sceneAnchors[0]).toEqual(expect.objectContaining({
+      source: "model_observed",
+      description: expect.stringContaining("conversa curta"),
+    }));
+    expect(result.evidenceAnchors?.creatorIntentAnchor?.statedGoal).toBe("gerar identificação e comentários");
+  });
+
   it("mapeia rememberedAs como sceneAnchor seguro", () => {
     const result = mapVideoNarrativeDiagnosisToCreatorVideoNarrativeDiagnosisInput(
       buildCreatorVideoNarrativeDiagnosisMapperParams(),

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisMapper.ts
@@ -270,6 +270,27 @@ function mapEvidenceAnchors(params: {
   rememberedAs: string;
   profileContribution: CreatorVideoNarrativeDiagnosisInput["profileContribution"];
 }): CreatorVideoNarrativeEvidenceAnchors {
+  const providerAnchors = params.strategicDiagnosis.evidenceAnchors;
+  const hasProviderAnchors = Boolean(
+    providerAnchors &&
+      (
+        providerAnchors.speechQuotes.length > 0 ||
+        providerAnchors.sceneAnchors.length > 0 ||
+        providerAnchors.creatorIntentAnchor ||
+        (providerAnchors.profilePatternAnchors?.length ?? 0) > 0 ||
+        (providerAnchors.instagramAnchors?.length ?? 0) > 0
+      ),
+  );
+  if (providerAnchors && hasProviderAnchors) {
+    return {
+      speechQuotes: providerAnchors.speechQuotes.slice(0, 4),
+      sceneAnchors: providerAnchors.sceneAnchors.slice(0, 4),
+      creatorIntentAnchor: providerAnchors.creatorIntentAnchor ?? null,
+      profilePatternAnchors: providerAnchors.profilePatternAnchors ?? [],
+      instagramAnchors: providerAnchors.instagramAnchors ?? [],
+    };
+  }
+
   const speechQuotes = [
     buildAiSuggestedQuoteAnchor({
       quote: params.strategicDiagnosis.suggestedHook,

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.test.ts
@@ -205,6 +205,33 @@ describe("creatorVideoNarrativeDiagnosisSanitizer", () => {
     expect(JSON.stringify(result)).not.toContain("https://example.com");
   });
 
+  it("aceita sceneAnchor model_observed seguro", () => {
+    const result = sanitizeCreatorVideoNarrativeDiagnosisInput(
+      buildCreatorVideoNarrativeDiagnosisFixture({
+        evidenceAnchors: {
+          speechQuotes: [],
+          sceneAnchors: [
+            {
+              description: "A abertura demora a mostrar o conflito principal.",
+              source: "model_observed",
+              momentRole: "opening",
+              whyItMatters: "Mostra onde a tensão atrasa.",
+              chapterHint: "tension",
+            },
+          ],
+          creatorIntentAnchor: null,
+          profilePatternAnchors: [],
+          instagramAnchors: [],
+        },
+      }),
+    );
+
+    expect(result.evidenceAnchors?.sceneAnchors[0]).toEqual(expect.objectContaining({
+      source: "model_observed",
+      momentRole: "opening",
+    }));
+  });
+
   it("bloqueia base64 grande e transcrição longa dentro de anchors", () => {
     expect(() =>
       sanitizeCreatorVideoNarrativeDiagnosisInput(

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisSanitizer.ts
@@ -63,7 +63,7 @@ const PROFILE_CONTRIBUTION_CONFIDENCE = ["low", "medium", "high"];
 const PROFILE_CONTRIBUTION_WEIGHT = ["low", "medium", "high"];
 const QUOTE_SOURCES = ["creator_spoken", "ai_suggested"];
 const QUOTE_ROLES = ["hook", "promise", "turning_point", "closing", "example", "context", "other"];
-const SCENE_SOURCES = ["derived_scene"];
+const SCENE_SOURCES = ["model_observed", "derived_scene"];
 const MOMENT_ROLES = ["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"];
 const CHAPTER_HINTS = ["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"];
 
@@ -266,7 +266,7 @@ function sanitizeEvidenceAnchors(
         text(scene.source, `evidenceAnchors.sceneAnchors[${index}].source`, 40),
         SCENE_SOURCES,
         `evidenceAnchors.sceneAnchors[${index}].source`,
-      ) as "derived_scene",
+      ) as CreatorVideoNarrativeEvidenceAnchors["sceneAnchors"][number]["source"],
       momentRole: requireOneOf(
         text(scene.momentRole, `evidenceAnchors.sceneAnchors[${index}].momentRole`, 40),
         MOMENT_ROLES,

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeDiagnosisTypes.ts
@@ -43,7 +43,7 @@ export interface CreatorVideoNarrativeDiagnosisSpeechQuoteAnchor {
 
 export interface CreatorVideoNarrativeDiagnosisSceneAnchor {
   description: string;
-  source: "derived_scene";
+  source: "model_observed" | "derived_scene";
   momentRole:
     | "opening"
     | "conflict"

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.test.ts
@@ -79,7 +79,27 @@ describe("geminiVideoNarrativePrompt", () => {
       "blueprintSuggestion",
       "brandMatch",
       "evidence",
+      "evidenceAnchors",
     ].forEach((field) => expect(instruction).toContain(field));
+  });
+
+  it("asks for real short quotes and empty arrays when uncertain", () => {
+    const instruction = buildGeminiVideoNarrativeUserInstruction({ creatorQuestion: "Quero melhorar retenção." });
+
+    expect(instruction).toContain("falas curtas realmente ditas");
+    expect(instruction).toContain("Não transcreva o vídeo");
+    expect(instruction).toContain("Não invente frases");
+    expect(instruction).toContain("speechQuotes vazio");
+  });
+
+  it("asks for specific scenes without technical timestamps or storage metadata", () => {
+    const prompt = buildGeminiVideoNarrativePrompt({ creatorQuestion: null });
+    const content = `${prompt.userInstruction} ${prompt.responseFormatInstruction}`;
+
+    expect(content).toContain("cenas ou momentos específicos observados");
+    expect(content).toContain("sem timestamp técnico");
+    expect(content).toContain("objectKey");
+    expect(content).toContain("Não retorne transcript bruto");
   });
 
   it("states that the video is a content piece in progress", () => {

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativePrompt.ts
@@ -19,6 +19,7 @@ export function buildGeminiVideoNarrativeSystemInstruction(): string {
     "Você atua como estrategista de conteúdo da D2C.",
     "Analise o vídeo como uma peça de conteúdo em construção, não como simples extração técnica.",
     "Avalie gancho, resumo, tópicos falados, textos na tela, elementos visuais, estrutura de cenas, classificação D2C, diagnóstico, blueprint, brand match, evidências e sinais futuros de perfil.",
+    "Extraia evidence anchors concretos quando houver segurança: falas curtas realmente ditas, cenas específicas, virada narrativa e intenção do creator.",
     "Evite prometer performance e evite linguagem absoluta.",
     "Quando faltar contexto, reduza a confiança, deixe lacunas explícitas e proponha ajustes em vez de inventar.",
   ].join(" ");
@@ -50,6 +51,9 @@ export function buildGeminiVideoNarrativeUserInstruction(input: GeminiVideoNarra
     "Taxonomia conceitual de formato: reel, photo, carousel, long_video, unknown.",
     "Taxonomia conceitual de proposta: tips, review, humor_scene, positioning_authority, behind_the_scenes, comparison, announcement, comment_to_post, ad_adaptation, collab_narrative, unknown.",
     "Se o contexto visual ou sonoro for insuficiente, retorne baixa confiança e ajustes úteis.",
+    "Extraia até 4 falas curtas realmente ditas pelo criador que ajudem a sustentar a leitura estratégica. Não transcreva o vídeo. Não invente frases. Se não houver segurança suficiente de que uma frase foi dita, retorne speechQuotes vazio.",
+    "Descreva até 4 cenas ou momentos específicos observados, sem timestamp técnico, filename, URL, objectKey, signedUrl, uploadUrl, localPath ou metadata de storage.",
+    "Explique por que cada fala ou cena importa para a narrativa e indique o capítulo em que ela ajuda.",
   );
 
   return parts.join(" ");
@@ -60,7 +64,10 @@ export function buildGeminiVideoNarrativeResponseFormatInstruction(): string {
     "Retorne apenas JSON válido.",
     "Não use markdown.",
     "Não escreva texto fora do JSON.",
-    'Use o shape: {"hook":{"detected":null,"strength":"unknown","why":null},"summary":null,"spokenTopics":[],"onScreenText":[],"visualElements":[],"sceneStructure":[],"d2cClassification":{"format":"unknown","proposal":"unknown","context":null,"tone":null,"reference":null,"intent":null,"narrative":null},"diagnosis":{"strengths":[],"weaknesses":[],"recommendedAdjustments":[]},"blueprintSuggestion":{"whatToPost":null,"whyThisPath":null,"howItShouldWork":null,"scenes":[]},"brandMatch":{"enabled":false,"territories":[],"whyBrandsWouldFit":null},"evidence":{"transcript":null,"ocr":[],"frames":[],"technicalSignals":[]},"profileSignals":[],"confidence":"unknown"}.',
+    'Use o shape: {"hook":{"detected":null,"strength":"unknown","why":null},"summary":null,"spokenTopics":[],"onScreenText":[],"visualElements":[],"sceneStructure":[],"d2cClassification":{"format":"unknown","proposal":"unknown","context":null,"tone":null,"reference":null,"intent":null,"narrative":null},"diagnosis":{"strengths":[],"weaknesses":[],"recommendedAdjustments":[]},"blueprintSuggestion":{"whatToPost":null,"whyThisPath":null,"howItShouldWork":null,"scenes":[]},"brandMatch":{"enabled":false,"territories":[],"whyBrandsWouldFit":null},"evidence":{"transcript":null,"ocr":[],"frames":[],"technicalSignals":[]},"evidenceAnchors":{"speechQuotes":[],"sceneAnchors":[],"creatorIntentAnchor":null},"profileSignals":[],"confidence":"unknown"}.',
+    "evidenceAnchors é opcional para compatibilidade, mas preferido quando houver evidência concreta.",
+    "speechQuotes aceita apenas source creator_spoken; sceneAnchors aceita source model_observed ou derived_scene.",
+    "Não retorne transcript bruto, raw notes, timestamps técnicos, URLs ou metadata de upload/storage.",
   ].join(" ");
 }
 

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.test.ts
@@ -156,6 +156,82 @@ describe("geminiVideoNarrativeSchema", () => {
     });
   });
 
+  it("normalizes evidenceAnchors without requiring them for compatibility", () => {
+    const withoutAnchors = normalize({ summary: "Resumo útil." });
+    expect(withoutAnchors.ok).toBe(true);
+    expect(withoutAnchors.analysis?.evidenceAnchors).toBeUndefined();
+
+    const withAnchors = normalize({
+      summary: "Resumo útil.",
+      evidenceAnchors: {
+        speechQuotes: [
+          {
+            quote: "rapidinho",
+            source: "creator_spoken",
+            quoteRole: "hook",
+            whyItMatters: "Cria promessa pequena.",
+            chapterHint: "pattern",
+          },
+        ],
+        sceneAnchors: [
+          {
+            description: "A cena gira em torno de uma promessa pequena.",
+            source: "model_observed",
+            momentRole: "turning_point",
+            whyItMatters: "Mostra a virada narrativa.",
+            chapterHint: "tension",
+          },
+        ],
+        creatorIntentAnchor: {
+          statedGoal: "gerar identificação",
+          interpretedGoal: "testar humor de reconhecimento rápido",
+          whyItMatters: "Orienta a leitura do gancho.",
+        },
+      },
+    });
+
+    expect(withAnchors.ok).toBe(true);
+    expect(withAnchors.analysis?.evidenceAnchors?.speechQuotes[0].source).toBe("creator_spoken");
+    expect(withAnchors.analysis?.evidenceAnchors?.sceneAnchors[0].source).toBe("model_observed");
+    expect(withAnchors.analysis?.evidenceAnchors?.creatorIntentAnchor?.source).toBe("creator_goal");
+  });
+
+  it("cleans invalid evidenceAnchors without failing the analysis", () => {
+    const result = normalize({
+      summary: "Resumo útil.",
+      evidenceAnchors: {
+        speechQuotes: [
+          {
+            quote: "data:video/mp4;base64," + "A".repeat(1500),
+            source: "creator_spoken",
+            quoteRole: "hook",
+            whyItMatters: "nao persistir",
+            chapterHint: "pattern",
+          },
+        ],
+        sceneAnchors: [
+          {
+            description: "Aos 00:12 no arquivo uploads/user/video.mp4",
+            source: "model_observed",
+            momentRole: "opening",
+            whyItMatters: "signedUrl uploadUrl localPath storageProviderPath",
+            chapterHint: "tension",
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues.map((item) => item.code)).toContain("invalid_evidence_anchors");
+    const serialized = JSON.stringify(result.analysis);
+    expect(serialized).not.toContain("data:video/mp4;base64");
+    expect(serialized).not.toContain("uploads/user/video.mp4");
+    expect(serialized).not.toContain("signedUrl");
+    expect(serialized).not.toContain("uploadUrl");
+    expect(serialized).not.toContain("localPath");
+    expect(serialized).not.toContain("storageProviderPath");
+  });
+
   it("sanitizes unsafe language and records the adjustment", () => {
     const result = normalize({ summary: "Resultado garantido com certeza e caminho comprovado." });
     expect(result.analysis?.summary).toBe("Resultado indicado com leitura e caminho observado.");

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeSchema.ts
@@ -22,6 +22,7 @@ export type GeminiVideoNarrativeRawResponse = {
   blueprintSuggestion?: unknown;
   brandMatch?: unknown;
   evidence?: unknown;
+  evidenceAnchors?: unknown;
   profileSignals?: unknown;
   confidence?: unknown;
 };
@@ -33,6 +34,7 @@ export type GeminiVideoNarrativeSchemaIssueCode =
   | "invalid_classification"
   | "invalid_diagnosis"
   | "invalid_blueprint"
+  | "invalid_evidence_anchors"
   | "unsafe_language"
   | "insufficient_context";
 
@@ -83,6 +85,16 @@ const profileSignalTypes = new Set([
   "unknown",
 ]);
 const unsafeLanguageTerms = ["viralizar garantido", "sempre performa", "garantido", "certeza", "comprovado"];
+const MAX_ANCHOR_ITEMS = 4;
+const MAX_QUOTE_LENGTH = 180;
+const MAX_ANCHOR_TEXT_LENGTH = 260;
+const LARGE_BASE64_REGEX = /(?:data:[^;]+;base64,)?[A-Za-z0-9+/=]{1200,}/;
+const URL_REGEX = /https?:\/\/[^\s"'<>]+/gi;
+const STORAGE_PATH_REGEX = /\b(?:uploads|video-narrative|mobile-strategic-profile|tmp|temporary)\/[A-Za-z0-9._/-]+\.(mp4|mov|webm|mkv)\b/gi;
+const STORAGE_FIELD_REGEX = /\b(?:objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi;
+const quoteRoles = new Set(["hook", "promise", "turning_point", "closing", "example", "context", "other"]);
+const momentRoles = new Set(["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"]);
+const chapterHints = new Set(["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"]);
 
 function issue(code: GeminiVideoNarrativeSchemaIssueCode, message: string): GeminiVideoNarrativeSchemaIssue {
   return { code, message };
@@ -101,6 +113,110 @@ function readString(value: unknown): string | null {
 function readStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.map(readString).filter((item): item is string => Boolean(item));
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trim()}...`;
+}
+
+function readAnchorString(value: unknown, maxLength = MAX_ANCHOR_TEXT_LENGTH): string | null {
+  if (typeof value !== "string") return null;
+  if (LARGE_BASE64_REGEX.test(value)) return null;
+  const lineCount = value.split(/\n+/).filter(Boolean).length;
+  const timestampCount = (value.match(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g) ?? []).length;
+  if (value.length > 2000 || lineCount >= 12 || timestampCount >= 6) return null;
+  const sanitized = sanitizeVideoNarrativeAnalysisText(value)
+    .replace(URL_REGEX, "[url-redigida]")
+    .replace(STORAGE_PATH_REGEX, "[storage-redigido]")
+    .replace(STORAGE_FIELD_REGEX, "[storage-redigido]")
+    .replace(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return sanitized ? truncateText(sanitized, maxLength) : null;
+}
+
+function readEnum<T extends string>(value: unknown, valid: Set<string>, fallback: T): T {
+  return typeof value === "string" && valid.has(value) ? (value as T) : fallback;
+}
+
+function normalizeEvidenceAnchors(value: unknown): {
+  anchors: VideoNarrativeAnalysis["evidenceAnchors"];
+  invalid: boolean;
+} {
+  if (value === undefined || value === null) return { anchors: undefined, invalid: false };
+  if (!isRecord(value)) return { anchors: undefined, invalid: true };
+  let invalid = false;
+
+  const speechQuotes = (Array.isArray(value.speechQuotes) ? value.speechQuotes : [])
+    .slice(0, MAX_ANCHOR_ITEMS)
+    .filter(isRecord)
+    .map((item) => {
+      const quote = readAnchorString(item.quote, MAX_QUOTE_LENGTH);
+      const whyItMatters = readAnchorString(item.whyItMatters);
+      if (!quote || !whyItMatters || item.source !== "creator_spoken") {
+        invalid = true;
+        return null;
+      }
+      return {
+        quote,
+        source: "creator_spoken" as const,
+        quoteRole: readEnum(item.quoteRole, quoteRoles, "other"),
+        whyItMatters,
+        chapterHint: readEnum(item.chapterHint, chapterHints, "video_reveal"),
+      };
+    })
+    .filter(Boolean) as NonNullable<VideoNarrativeAnalysis["evidenceAnchors"]>["speechQuotes"];
+
+  const sceneAnchors = (Array.isArray(value.sceneAnchors) ? value.sceneAnchors : [])
+    .slice(0, MAX_ANCHOR_ITEMS)
+    .filter(isRecord)
+    .map((item) => {
+      const description = readAnchorString(item.description);
+      const whyItMatters = readAnchorString(item.whyItMatters);
+      if (!description || !whyItMatters) {
+        invalid = true;
+        return null;
+      }
+      return {
+        description,
+        source: item.source === "derived_scene" ? "derived_scene" as const : "model_observed" as const,
+        momentRole: readEnum(item.momentRole, momentRoles, "other"),
+        whyItMatters,
+        chapterHint: readEnum(item.chapterHint, chapterHints, "video_reveal"),
+      };
+    })
+    .filter(Boolean) as NonNullable<VideoNarrativeAnalysis["evidenceAnchors"]>["sceneAnchors"];
+
+  const rawIntent = isRecord(value.creatorIntentAnchor) ? value.creatorIntentAnchor : null;
+  const creatorIntentAnchor = rawIntent
+    ? (() => {
+        const statedGoal = readAnchorString(rawIntent.statedGoal);
+        const interpretedGoal = readAnchorString(rawIntent.interpretedGoal);
+        const whyItMatters = readAnchorString(rawIntent.whyItMatters);
+        if (!statedGoal || !interpretedGoal || !whyItMatters) {
+          invalid = true;
+          return null;
+        }
+        return {
+          source: "creator_goal" as const,
+          statedGoal,
+          interpretedGoal,
+          whyItMatters,
+        };
+      })()
+    : null;
+
+  return {
+    anchors: {
+      speechQuotes,
+      sceneAnchors,
+      creatorIntentAnchor,
+      profilePatternAnchors: [],
+      instagramAnchors: [],
+    },
+    invalid,
+  };
 }
 
 function containsUnsafeLanguage(value: unknown): boolean {
@@ -302,6 +418,10 @@ export function normalizeGeminiVideoNarrativeResponse(params: {
 
   const brandMatch = isRecord(raw.brandMatch) ? raw.brandMatch : {};
   const evidence = isRecord(raw.evidence) ? raw.evidence : {};
+  const evidenceAnchors = normalizeEvidenceAnchors(raw.evidenceAnchors);
+  if (evidenceAnchors.invalid) {
+    issues.push(issue("invalid_evidence_anchors", "Evidence anchors inválidos foram descartados ou limpos."));
+  }
   const analysis: VideoNarrativeAnalysis = {
     ...base,
     summary: readString(raw.summary),
@@ -324,6 +444,7 @@ export function normalizeGeminiVideoNarrativeResponse(params: {
       frames: readStringArray(evidence.frames),
       technicalSignals: readStringArray(evidence.technicalSignals),
     },
+    evidenceAnchors: evidenceAnchors.anchors,
     profileSignals: normalizeProfileSignals(raw.profileSignals),
     confidence:
       typeof raw.confidence === "string" && confidenceValues.has(raw.confidence as VideoNarrativeConfidence)
@@ -340,7 +461,7 @@ export function normalizeGeminiVideoNarrativeResponse(params: {
   }
 
   return {
-    ok: issues.length === 0 || issues.every((item) => item.code === "unsafe_language"),
+    ok: issues.length === 0 || issues.every((item) => item.code === "unsafe_language" || item.code === "invalid_evidence_anchors"),
     analysis,
     issues,
   };

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAiProviderTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAiProviderTypes.ts
@@ -1,4 +1,5 @@
 import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
+import type { CreatorVideoNarrativeEvidenceAnchors } from "./creatorVideoNarrativeDiagnosisTypes";
 
 export type VideoNarrativeAiProviderGoalOption =
   | "authority"
@@ -46,6 +47,7 @@ export type VideoNarrativeAiAnalysis = {
   creatorSignals: string[];
   brandTerritories: string[];
   collabOpportunities: string[];
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
 };
 
 export type VideoNarrativeAiProviderResult = {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeAnalysisTypes.ts
@@ -105,6 +105,7 @@ export type VideoNarrativeAnalysis = {
   blueprintSuggestion: VideoNarrativeBlueprintSuggestion;
   brandMatch: VideoNarrativeBrandMatch;
   evidence: VideoNarrativeEvidence;
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
   profileSignals: VideoNarrativeProfileSignal[];
   confidence: VideoNarrativeConfidence;
   createdAt: string | null;
@@ -158,6 +159,7 @@ export function createEmptyVideoNarrativeAnalysis(params: {
       frames: [],
       technicalSignals: [],
     },
+    evidenceAnchors: undefined,
     profileSignals: [],
     confidence: "unknown",
     createdAt: params.createdAt ?? null,
@@ -227,3 +229,4 @@ export function sanitizeVideoNarrativeAnalysisText(value: string): string {
     .replace(/comprovado/gi, "observado")
     .trim();
 }
+import type { CreatorVideoNarrativeEvidenceAnchors } from "./creatorVideoNarrativeDiagnosisTypes";

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeDiagnosisLearningModel.ts
@@ -2,6 +2,7 @@ import {
   sanitizeVideoNarrativeAnalysisText,
   type VideoNarrativeAnalysis,
 } from "./videoNarrativeAnalysisTypes";
+import type { CreatorVideoNarrativeEvidenceAnchors } from "./creatorVideoNarrativeDiagnosisTypes";
 import type { PostCreationVideoSeed } from "./videoNarrativePostCreationSeed";
 
 export type VideoNarrativeDiagnosisAccessLevel = "free" | "premium" | "instagram_optimized";
@@ -153,6 +154,7 @@ export interface VideoNarrativeStrategicDiagnosis {
     matchingFormats: string[];
     locked: boolean;
   };
+  evidenceAnchors?: CreatorVideoNarrativeEvidenceAnchors;
   createdAt: string | null;
 }
 
@@ -594,6 +596,7 @@ export function buildVideoNarrativeStrategicDiagnosis(
     }),
     creatorSignals: extractVideoNarrativeCreatorSignals(input),
     instagramComparison,
+    evidenceAnchors: input.analysis.evidenceAnchors,
     createdAt: input.analysis.createdAt ?? input.seed.createdAt ?? null,
   };
 }

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiPromptBuilder.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiPromptBuilder.test.ts
@@ -29,6 +29,7 @@ describe("videoNarrativeGeminiPromptBuilder", () => {
     const prompt = buildVideoNarrativeGeminiPrompt(input());
     expect(prompt.responseSchemaInstruction).toContain("mainNarrative");
     expect(prompt.responseSchemaInstruction).toContain("nextActions");
+    expect(prompt.responseSchemaInstruction).toContain("evidenceAnchors");
     expect(prompt.systemInstruction).toContain("JSON válido e estrito");
   });
 
@@ -55,6 +56,27 @@ describe("videoNarrativeGeminiPromptBuilder", () => {
     const prompt = buildVideoNarrativeGeminiPrompt(input());
     expect(prompt.userInstruction).not.toContain("temporary/video-narrative");
     expect(prompt.userInstruction).not.toContain("objectKey");
+    expect(prompt.userInstruction).not.toContain("uploadSessionId");
+  });
+
+  it("pede falas curtas reais sem transcrição e sem inventar fala", () => {
+    const prompt = buildVideoNarrativeGeminiPrompt(input());
+    const content = `${prompt.userInstruction}\n${prompt.responseSchemaInstruction}`;
+
+    expect(content).toContain("falas curtas realmente ditas");
+    expect(content).toContain("Não invente falas");
+    expect(content).toContain("Não transcreva o vídeo");
+    expect(content).toContain("retorne speechQuotes como array vazio");
+  });
+
+  it("pede cenas especificas sem timestamp técnico ou storage metadata", () => {
+    const prompt = buildVideoNarrativeGeminiPrompt(input());
+    const content = `${prompt.systemInstruction}\n${prompt.userInstruction}\n${prompt.responseSchemaInstruction}`;
+
+    expect(content).toContain("cenas ou momentos observados");
+    expect(content).toContain("sem timestamp técnico");
+    expect(content).toContain("Não inclua transcript");
+    expect(content).toContain("metadata de upload/storage");
   });
 
   it("inclui instruções contra promessa de viralização/marca", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiPromptBuilder.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiPromptBuilder.ts
@@ -21,6 +21,31 @@ const schemaExample = {
   creatorSignals: ["string"],
   brandTerritories: ["string"],
   collabOpportunities: ["string"],
+  evidenceAnchors: {
+    speechQuotes: [
+      {
+        quote: "string curta realmente dita pelo creator",
+        source: "creator_spoken",
+        quoteRole: "hook",
+        whyItMatters: "string",
+        chapterHint: "pattern",
+      },
+    ],
+    sceneAnchors: [
+      {
+        description: "cena ou momento observado sem timestamp técnico",
+        source: "model_observed",
+        momentRole: "opening",
+        whyItMatters: "string",
+        chapterHint: "video_reveal",
+      },
+    ],
+    creatorIntentAnchor: {
+      statedGoal: "string",
+      interpretedGoal: "string",
+      whyItMatters: "string",
+    },
+  },
 };
 
 function safeString(value: string | undefined | null, fallback = "Não informado"): string {
@@ -44,7 +69,6 @@ export function buildVideoNarrativeGeminiPrompt(input: VideoNarrativeAiProviderI
     ? [
         `- mimeType: ${safeString(input.temporaryUpload.mimeType)}`,
         `- sizeBytes: ${input.temporaryUpload.sizeBytes}`,
-        `- uploadSessionId: ${safeString(input.temporaryUpload.uploadSessionId)}`,
       ].join("\n")
     : "- Sem upload temporário informado.";
 
@@ -57,6 +81,7 @@ export function buildVideoNarrativeGeminiPrompt(input: VideoNarrativeAiProviderI
       "Não prometa viralização, contrato de marca, patrocínio, certeza de performance, ranking, nota, score ou resultado garantido.",
       "Não faça diagnóstico médico, psicológico, jurídico ou financeiro.",
       "Não retorne conteúdo privado bruto, transcrição longa, URL, signed URL, token, API key ou identificador de storage.",
+      "Não retorne transcrição completa, timestamps técnicos, nome de arquivo, objectKey, uploadUrl, signedUrl, localPath ou storageProviderPath.",
       "Não mencione o nome do provedor de IA na resposta.",
     ].join("\n"),
     userInstruction: [
@@ -74,11 +99,25 @@ export function buildVideoNarrativeGeminiPrompt(input: VideoNarrativeAiProviderI
       videoMetadata,
       `- hasTemporaryUpload: ${hasTemporaryUpload}`,
       "Tarefa: gere uma leitura estratégica curta, humana e acionável para atualizar o Perfil da D2C.",
+      "Evidence anchors:",
+      "- Extraia até 4 falas curtas realmente ditas pelo creator que sustentem a leitura estratégica.",
+      "- Use source creator_spoken apenas quando tiver confiança de que a frase foi dita no vídeo.",
+      "- Não invente falas e não transforme sugestão sua em fala real.",
+      "- Se não houver certeza sobre uma fala, retorne speechQuotes como array vazio.",
+      "- Não transcreva o vídeo; use apenas trechos curtos.",
+      "- Descreva até 4 cenas ou momentos observados que respondam onde a D2C percebeu isso.",
+      "- Cenas não devem ter timestamp técnico, storage metadata, URL, filename ou caminho de arquivo.",
+      "- Diferencie statedGoal do creator de interpretedGoal da leitura estratégica.",
     ].join("\n"),
     responseSchemaInstruction: [
       "Retorne exatamente um objeto JSON com este schema:",
       JSON.stringify(schemaExample, null, 2),
       "Todas as strings devem ser curtas. Arrays devem ter no máximo 5 itens.",
+      "evidenceAnchors é opcional, mas preferido; se não houver evidência concreta, use speechQuotes: [] e sceneAnchors: [].",
+      "Valores aceitos em quoteRole: hook, promise, turning_point, closing, example, context, other.",
+      "Valores aceitos em momentRole: opening, conflict, turning_point, visual_signal, pacing_signal, production_signal, other.",
+      "Valores aceitos em chapterHint: pattern, tension, movement, territory, video_reveal, profile_impact, opportunities.",
+      "Não inclua transcript, raw notes, timestamps técnicos, URLs ou metadata de upload/storage.",
     ].join("\n"),
   };
 }

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiProvider.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiProvider.test.ts
@@ -74,6 +74,10 @@ describe("videoNarrativeGeminiProvider", () => {
     );
     expect(result.ok).toBe(true);
     expect(result.analysis?.mainNarrative).toContain("Rotina prática");
+    expect(result.analysis?.evidenceAnchors?.speechQuotes[0]).toEqual(expect.objectContaining({
+      quote: "rapidinho",
+      source: "creator_spoken",
+    }));
     expect(JSON.stringify(result)).not.toContain("rawText");
     expect(JSON.stringify(result)).not.toContain("rawResponse");
   });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiResponseParser.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiResponseParser.test.ts
@@ -7,6 +7,10 @@ describe("videoNarrativeGeminiResponseParser", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.analysis.mainNarrative).toContain("Rotina prática");
+      expect(result.analysis.evidenceAnchors?.speechQuotes[0]).toEqual(expect.objectContaining({
+        quote: "rapidinho",
+        source: "creator_spoken",
+      }));
     }
   });
 
@@ -70,6 +74,109 @@ describe("videoNarrativeGeminiResponseParser", () => {
     const result = parseVideoNarrativeGeminiResponse(JSON.stringify(raw));
     expect(result.ok).toBe(false);
     expect(result.issues[0].code).toBe("raw_transcript");
+  });
+
+  it("aceita speechQuotes, sceneAnchors e creatorIntentAnchor seguros", () => {
+    const raw = JSON.parse(geminiVideoNarrativeRawJsonFixture);
+    raw.evidenceAnchors = {
+      speechQuotes: [
+        {
+          quote: "rapidinho",
+          source: "creator_spoken",
+          quoteRole: "hook",
+          whyItMatters: "Cria promessa pequena.",
+          chapterHint: "pattern",
+        },
+      ],
+      sceneAnchors: [
+        {
+          description: "A abertura demora a mostrar o conflito principal.",
+          source: "model_observed",
+          momentRole: "opening",
+          whyItMatters: "Mostra onde a tensão atrasa.",
+          chapterHint: "tension",
+        },
+      ],
+      creatorIntentAnchor: {
+        statedGoal: "gerar identificação e comentários",
+        interpretedGoal: "testar humor de reconhecimento rápido",
+        whyItMatters: "Muda a leitura do gancho.",
+      },
+    };
+
+    const result = parseVideoNarrativeGeminiResponse(JSON.stringify(raw));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.analysis.evidenceAnchors?.speechQuotes[0].source).toBe("creator_spoken");
+    expect(result.analysis.evidenceAnchors?.sceneAnchors[0].source).toBe("model_observed");
+    expect(result.analysis.evidenceAnchors?.creatorIntentAnchor?.source).toBe("creator_goal");
+  });
+
+  it("limpa anchors inseguros sem quebrar a analise", () => {
+    const raw = JSON.parse(geminiVideoNarrativeRawJsonFixture);
+    raw.evidenceAnchors = {
+      speechQuotes: Array.from({ length: 6 }, (_, index) => ({
+        quote: index === 0 ? "https://storage.test/video.mp4?signature=abc" : `fala segura ${index}`,
+        source: "creator_spoken",
+        quoteRole: "hook",
+        whyItMatters: "objectKey uploads/user/video.mp4",
+        chapterHint: "pattern",
+      })),
+      sceneAnchors: [
+        {
+          description: "Cena com uploadUrl e localPath removidos.",
+          source: "model_observed",
+          momentRole: "opening",
+          whyItMatters: "storageProviderPath deve sumir.",
+          chapterHint: "tension",
+        },
+      ],
+      creatorIntentAnchor: null,
+    };
+
+    const result = parseVideoNarrativeGeminiResponse(JSON.stringify(raw));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const serialized = JSON.stringify(result.analysis);
+    expect(result.analysis.evidenceAnchors?.speechQuotes.length).toBeLessThanOrEqual(4);
+    expect(serialized).not.toContain("https://storage.test");
+    expect(serialized).not.toContain("uploads/user/video.mp4");
+    expect(serialized).not.toContain("objectKey");
+    expect(serialized).not.toContain("uploadUrl");
+    expect(serialized).not.toContain("localPath");
+    expect(serialized).not.toContain("storageProviderPath");
+  });
+
+  it("descarta base64 grande e blobs parecidos com transcript em anchors", () => {
+    const raw = JSON.parse(geminiVideoNarrativeRawJsonFixture);
+    raw.evidenceAnchors = {
+      speechQuotes: [
+        {
+          quote: "data:video/mp4;base64," + "A".repeat(1500),
+          source: "creator_spoken",
+          quoteRole: "hook",
+          whyItMatters: "não persistir",
+          chapterHint: "pattern",
+        },
+      ],
+      sceneAnchors: [
+        {
+          description: Array.from({ length: 12 }, (_, index) => `00:${String(index).padStart(2, "0")} fala`).join("\n"),
+          source: "model_observed",
+          momentRole: "opening",
+          whyItMatters: "não persistir",
+          chapterHint: "tension",
+        },
+      ],
+      creatorIntentAnchor: null,
+    };
+
+    const result = parseVideoNarrativeGeminiResponse(JSON.stringify(raw));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.analysis.evidenceAnchors?.speechQuotes).toEqual([]);
+    expect(result.analysis.evidenceAnchors?.sceneAnchors).toEqual([]);
+    expect(result.issues.map((item) => item.code)).toContain("invalid_evidence_anchors");
   });
 
   it("não retorna raw response", () => {

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiResponseParser.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiResponseParser.ts
@@ -1,4 +1,5 @@
 import type { VideoNarrativeAiAnalysis, VideoNarrativeAiIssue } from "./videoNarrativeAiProviderTypes";
+import type { CreatorVideoNarrativeEvidenceAnchors } from "./creatorVideoNarrativeDiagnosisTypes";
 
 const REQUIRED_FIELDS: Array<keyof VideoNarrativeAiAnalysis> = [
   "mainNarrative",
@@ -62,6 +63,16 @@ const API_KEY_PATTERN = /(AIzaSy[A-Za-z0-9-_]{20,}|sk-[A-Za-z0-9-_]{20,}|api[_-]
 const RAW_TRANSCRIPT_KEYS = new Set(["rawTranscript", "transcript", "fullTranscript"]);
 const MAX_STRING_LENGTH = 420;
 const MAX_ARRAY_ITEMS = 5;
+const MAX_ANCHOR_ITEMS = 4;
+const MAX_QUOTE_LENGTH = 180;
+const MAX_ANCHOR_TEXT_LENGTH = 260;
+const LARGE_BASE64_PATTERN = /(?:data:[^;]+;base64,)?[A-Za-z0-9+/=]{1200,}/;
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
+const STORAGE_PATH_PATTERN = /\b(?:uploads|video-narrative|mobile-strategic-profile|tmp|temporary)\/[A-Za-z0-9._/-]+\.(mp4|mov|webm|mkv)\b/gi;
+const STORAGE_FIELD_PATTERN = /\b(?:objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath)\b/gi;
+const VALID_QUOTE_ROLES = new Set(["hook", "promise", "turning_point", "closing", "example", "context", "other"]);
+const VALID_MOMENT_ROLES = new Set(["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"]);
+const VALID_CHAPTER_HINTS = new Set(["pattern", "tension", "movement", "territory", "video_reveal", "profile_impact", "opportunities"]);
 
 export type VideoNarrativeGeminiResponseParseResult =
   | { ok: true; analysis: VideoNarrativeAiAnalysis; issues: VideoNarrativeAiIssue[] }
@@ -95,6 +106,7 @@ function containsForbiddenPayload(value: unknown): "signed_url" | "api_key" | "r
   }
   if (isRecord(value)) {
     for (const [key, nested] of Object.entries(value)) {
+      if (key === "evidenceAnchors") continue;
       if (RAW_TRANSCRIPT_KEYS.has(key) && typeof nested === "string" && nested.length > 600) {
         return "raw_transcript";
       }
@@ -110,7 +122,117 @@ function sanitizeText(value: string): string {
   for (const [pattern, replacement] of FORBIDDEN_REPLACEMENTS) {
     output = output.replace(pattern, replacement);
   }
+  output = output
+    .replace(URL_PATTERN, "[url-redigida]")
+    .replace(STORAGE_PATH_PATTERN, "[storage-redigido]")
+    .replace(STORAGE_FIELD_PATTERN, "[storage-redigido]")
+    .replace(LARGE_BASE64_PATTERN, "[base64-redigido]");
   return output.slice(0, MAX_STRING_LENGTH).trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trim()}...`;
+}
+
+function sanitizeAnchorText(value: unknown, maxLength = MAX_ANCHOR_TEXT_LENGTH): string | null {
+  if (typeof value !== "string") return null;
+  if (LARGE_BASE64_PATTERN.test(value)) return null;
+  const lineCount = value.split(/\n+/).filter(Boolean).length;
+  const timestampCount = (value.match(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g) ?? []).length;
+  if (value.length > 2000 || lineCount >= 12 || timestampCount >= 6) return null;
+  const sanitized = sanitizeText(value).replace(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g, "").replace(/\s+/g, " ").trim();
+  return sanitized ? truncate(sanitized, maxLength) : null;
+}
+
+function readEnum<T extends string>(value: unknown, valid: Set<string>, fallback: T): T {
+  return typeof value === "string" && valid.has(value) ? (value as T) : fallback;
+}
+
+function readEvidenceAnchors(value: unknown): {
+  anchors?: CreatorVideoNarrativeEvidenceAnchors;
+  issues: VideoNarrativeAiIssue[];
+} {
+  if (value === undefined || value === null) return { anchors: undefined, issues: [] };
+  if (!isRecord(value)) {
+    return { anchors: undefined, issues: [issue("invalid_evidence_anchors", "Evidence anchors inválidos foram descartados.", "warning")] };
+  }
+
+  const issues: VideoNarrativeAiIssue[] = [];
+  try {
+    const speechQuotes = (Array.isArray(value.speechQuotes) ? value.speechQuotes : [])
+      .slice(0, MAX_ANCHOR_ITEMS)
+      .filter(isRecord)
+      .map((item) => {
+        const quote = sanitizeAnchorText(item.quote, MAX_QUOTE_LENGTH);
+        const whyItMatters = sanitizeAnchorText(item.whyItMatters);
+        const source = item.source === "creator_spoken" ? "creator_spoken" : null;
+        if (!quote || !whyItMatters || !source) return null;
+        return {
+          quote,
+          source,
+          quoteRole: readEnum(item.quoteRole, VALID_QUOTE_ROLES, "other"),
+          whyItMatters,
+          chapterHint: readEnum(item.chapterHint, VALID_CHAPTER_HINTS, "video_reveal"),
+        };
+      })
+      .filter(Boolean) as CreatorVideoNarrativeEvidenceAnchors["speechQuotes"];
+
+    const sceneAnchors = (Array.isArray(value.sceneAnchors) ? value.sceneAnchors : [])
+      .slice(0, MAX_ANCHOR_ITEMS)
+      .filter(isRecord)
+      .map((item) => {
+        const description = sanitizeAnchorText(item.description);
+        const whyItMatters = sanitizeAnchorText(item.whyItMatters);
+        const source = item.source === "model_observed" || item.source === "derived_scene" ? item.source : "model_observed";
+        if (!description || !whyItMatters) return null;
+        return {
+          description,
+          source,
+          momentRole: readEnum(item.momentRole, VALID_MOMENT_ROLES, "other"),
+          whyItMatters,
+          chapterHint: readEnum(item.chapterHint, VALID_CHAPTER_HINTS, "video_reveal"),
+        };
+      })
+      .filter(Boolean) as CreatorVideoNarrativeEvidenceAnchors["sceneAnchors"];
+
+    const rawIntent = isRecord(value.creatorIntentAnchor) ? value.creatorIntentAnchor : null;
+    const creatorIntentAnchor = rawIntent
+      ? (() => {
+          const statedGoal = sanitizeAnchorText(rawIntent.statedGoal);
+          const interpretedGoal = sanitizeAnchorText(rawIntent.interpretedGoal);
+          const whyItMatters = sanitizeAnchorText(rawIntent.whyItMatters);
+          if (!statedGoal || !interpretedGoal || !whyItMatters) return null;
+          return {
+            source: "creator_goal" as const,
+            statedGoal,
+            interpretedGoal,
+            whyItMatters,
+          };
+        })()
+      : null;
+
+    if (
+      (Array.isArray(value.speechQuotes) && speechQuotes.length < Math.min(value.speechQuotes.length, MAX_ANCHOR_ITEMS)) ||
+      (Array.isArray(value.sceneAnchors) && sceneAnchors.length < Math.min(value.sceneAnchors.length, MAX_ANCHOR_ITEMS)) ||
+      (rawIntent && !creatorIntentAnchor)
+    ) {
+      issues.push(issue("invalid_evidence_anchors", "Parte dos evidence anchors foi descartada por segurança.", "warning"));
+    }
+
+    return {
+      anchors: {
+        speechQuotes,
+        sceneAnchors,
+        creatorIntentAnchor,
+        profilePatternAnchors: [],
+        instagramAnchors: [],
+      },
+      issues,
+    };
+  } catch {
+    return { anchors: undefined, issues: [issue("invalid_evidence_anchors", "Evidence anchors inválidos foram descartados.", "warning")] };
+  }
 }
 
 function readRequiredString(raw: Record<string, unknown>, field: keyof VideoNarrativeAiAnalysis): string | null {
@@ -169,6 +291,7 @@ export function parseVideoNarrativeGeminiResponse(rawText: string): VideoNarrati
   if (Object.values(arrays).some((value) => !value)) {
     return { ok: false, issues: [issue("invalid_required_array", "Resposta do provider multimodal tem listas inválidas.")] };
   }
+  const evidenceAnchors = readEvidenceAnchors(parsed.evidenceAnchors);
 
   return {
     ok: true,
@@ -186,7 +309,8 @@ export function parseVideoNarrativeGeminiResponse(rawText: string): VideoNarrati
       creatorSignals: arrays.creatorSignals!,
       brandTerritories: arrays.brandTerritories!,
       collabOpportunities: arrays.collabOpportunities!,
+      ...(evidenceAnchors.anchors ? { evidenceAnchors: evidenceAnchors.anchors } : {}),
     },
-    issues: [],
+    issues: evidenceAnchors.issues,
   };
 }

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiSnapshotMapper.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiSnapshotMapper.test.ts
@@ -22,6 +22,18 @@ describe("videoNarrativeGeminiSnapshotMapper", () => {
     expect(JSON.stringify(result)).not.toContain("rawText");
   });
 
+  it("snapshot preserva evidenceAnchors seguros do parser", () => {
+    const result = mapGeminiAnalysisToStrategicProfileSnapshot({
+      analysis: geminiVideoNarrativeResponseFixture,
+      promptVersion: "mm87_v1",
+    });
+
+    expect(result.snapshot.extraData?.evidenceAnchors?.speechQuotes[0]).toEqual(expect.objectContaining({
+      quote: "rapidinho",
+      source: "creator_spoken",
+    }));
+  });
+
   it("snapshot não inclui uploadUrl/objectKey/signed URL/transcript longo", () => {
     const result = mapGeminiAnalysisToStrategicProfileSnapshot({
       analysis: geminiVideoNarrativeResponseFixture,

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiSnapshotMapper.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeGeminiSnapshotMapper.ts
@@ -50,6 +50,7 @@ export function mapGeminiAnalysisToStrategicProfileSnapshot(params: {
         source,
         promptVersion: params.promptVersion,
         adapterVersion: "mm65_gemini_snapshot_adapter_v1",
+        ...(params.analysis.evidenceAnchors ? { evidenceAnchors: params.analysis.evidenceAnchors } : {}),
       },
     },
   };

--- a/src/app/models/CreatorVideoNarrativeDiagnosis.ts
+++ b/src/app/models/CreatorVideoNarrativeDiagnosis.ts
@@ -160,7 +160,7 @@ const EvidenceAnchorsSchema = new Schema<CreatorVideoNarrativeEvidenceAnchors>(
         new Schema(
           {
             description: { type: String, required: true },
-            source: { type: String, enum: ["derived_scene"], required: true },
+            source: { type: String, enum: ["model_observed", "derived_scene"], required: true },
             momentRole: {
               type: String,
               enum: ["opening", "conflict", "turning_point", "visual_signal", "pacing_signal", "production_signal", "other"],


### PR DESCRIPTION
## Summary

Updates the structured video narrative provider/parser layer so the analysis can produce real multimodal Evidence Anchors when available.

Includes:
- provider/prompt/schema updates for short creator-spoken quotes, observed scenes, creator intent, and narrative moments
- parser validation and sanitization for evidenceAnchors
- mapper updates to consume real anchors before conservative fallbacks
- Gemini prompt/schema/parser fixtures and tests
- snapshot mapper/test updates where needed
- documentation in MM87_STRUCTURED_PROVIDER_PARSER_EVIDENCE_ANCHORS.md

## Product direction

MM86 created the safe place for anchors. MM87 teaches the provider/parser to actually produce them.

The goal is to make the diagnostic output feel like D2C truly watched the video by referencing concrete moments, without turning the analysis into transcript storage.

## Guardrails

- Does not open the public real endpoint.
- Does not remove allowlist/admin-dev gates.
- Does not alter billing/Stripe, NextAuth, DashboardShell, BoardShell, sidebar, MediaKitView, Comunidade, upload/cleanup, or usage limits.
- Does not store video, thumbnail, signed/upload URL, objectKey, localPath, storageProviderPath, raw Gemini/model response, raw transcript, or long transcript.
- Differentiates creator-spoken quotes from AI-suggested lines.
- Keeps anchors short, structured, sanitized, and optional.

## Validation reported locally

- Focused/impacted tests: 188 passed.
- npm run typecheck passed.
- npm run build passed with existing warnings only.
- git diff --check passed.

## Next milestone

MM88 should combine gated real endpoint integration with an E2E beta runbook: upload temporary video → Gemini with anchors → documented reading → accumulated synthesis → guarded snapshot write → mobile shell, all behind allowlist/admin-dev and explicit flags.