### PR TITLE
MM88 — Gated Real Endpoint + E2E Beta Runbook

### DIFF
--- a/src/app/api/dashboard/mobile-strategic-profile/analyze-real/route.test.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/analyze-real/route.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 import "next/dist/server/node-polyfill-fetch";
+import fs from "fs";
+import path from "path";
 import { NextRequest } from "next/server";
 import { POST, GET, PUT, PATCH, DELETE } from "./route";
 import { isMobileStrategicProfileEnabled } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileFeatureFlag";
@@ -81,9 +83,14 @@ describe("POST /api/dashboard/mobile-strategic-profile/analyze-real", () => {
     });
     runOrchestrator.mockResolvedValue({
       ok: true,
-      snapshotUpdated: true,
+      realAnalysis: true,
       source: "gemini_real_allowlist",
-      snapshot: { schemaVersion: "mobile_strategic_profile_snapshot_v1" },
+      videoReadingPersistence: { attempted: false, saved: false, skippedReason: "persist_reading_disabled" },
+      synthesisSnapshotWrite: { attempted: false, written: false, skippedReason: "synthesis_write_disabled" },
+      evidenceAnchorsUsed: true,
+      cleanupAttempted: true,
+      usageLimitChecked: true,
+      allowlistGatePassed: true,
     });
   });
 
@@ -142,6 +149,7 @@ describe("POST /api/dashboard/mobile-strategic-profile/analyze-real", () => {
     const body = await res.json();
     expect(JSON.stringify(body)).not.toContain("admin@example.com");
     expect(JSON.stringify(body)).not.toContain("temporary/video-narrative");
+    expect(JSON.stringify(body)).not.toContain("gemini");
   });
 
   it("retorna snapshot seguro no sucesso", async () => {
@@ -149,7 +157,20 @@ describe("POST /api/dashboard/mobile-strategic-profile/analyze-real", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(body.source).toBe("gemini_real_allowlist");
+    expect(body.source).toBeUndefined();
+    expect(body.snapshot).toBeUndefined();
+    expect(body.videoReadingPersistence).toEqual({
+      attempted: false,
+      saved: false,
+      skippedReason: "persist_reading_disabled",
+    });
+    expect(body.e2eBetaAudit).toEqual({
+      realAnalysis: true,
+      evidenceAnchorsUsed: true,
+      cleanupAttempted: true,
+      usageLimitChecked: true,
+      allowlistGatePassed: true,
+    });
     expect(runOrchestrator).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
@@ -158,5 +179,23 @@ describe("POST /api/dashboard/mobile-strategic-profile/analyze-real", () => {
         }),
       }),
     );
+  });
+});
+
+describe("MM88 runbook", () => {
+  it("documenta checklist E2E, rollback e verificação de cleanup sem secrets", () => {
+    const runbookPath = path.join(
+      process.cwd(),
+      "src/app/dashboard/boards/videoUpload/MM88_GATED_REAL_ENDPOINT_E2E_BETA_RUNBOOK.md",
+    );
+    const content = fs.readFileSync(runbookPath, "utf8");
+
+    expect(content).toContain("Checklist Antes de Testar");
+    expect(content).toContain("Rollback");
+    expect(content).toContain("Verificação de Cleanup");
+    expect(content).toContain("leitura");
+    expect(content).toContain("síntese");
+    expect(content).toContain("snapshot");
+    expect(content).not.toMatch(/AIza|secret=|GEMINI_API_KEY=|GOOGLE_GENAI_API_KEY=/i);
   });
 });

--- a/src/app/api/dashboard/mobile-strategic-profile/analyze-real/route.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/analyze-real/route.ts
@@ -25,6 +25,10 @@ type MobileStrategicProfileRealAnalysisSession = {
   };
 } | null;
 
+function safeResponseCode(code: string | undefined): string | undefined {
+  return code?.replace(/gemini/gi, "provider");
+}
+
 export async function GET() {
   return NextResponse.json({ message: "Método não permitido." }, { status: 405 });
 }
@@ -106,7 +110,16 @@ export async function POST(request: Request) {
         {
           ok: false,
           message: result.message,
-          code: result.safeIssueCode,
+          code: safeResponseCode(result.safeIssueCode),
+          videoReadingPersistence: result.videoReadingPersistence,
+          synthesisSnapshotWrite: result.synthesisSnapshotWrite,
+          e2eBetaAudit: {
+            realAnalysis: false,
+            evidenceAnchorsUsed: Boolean(result.evidenceAnchorsUsed),
+            cleanupAttempted: Boolean(result.cleanupAttempted),
+            usageLimitChecked: Boolean(result.usageLimitChecked),
+            allowlistGatePassed: Boolean(result.allowlistGatePassed),
+          },
           cleanupWarning: result.cleanupWarning,
         },
         { status },
@@ -115,9 +128,15 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       ok: true,
-      snapshotUpdated: true,
-      snapshot: result.snapshot,
-      source: result.source,
+      videoReadingPersistence: result.videoReadingPersistence,
+      synthesisSnapshotWrite: result.synthesisSnapshotWrite,
+      e2eBetaAudit: {
+        realAnalysis: result.realAnalysis,
+        evidenceAnchorsUsed: result.evidenceAnchorsUsed,
+        cleanupAttempted: result.cleanupAttempted,
+        usageLimitChecked: result.usageLimitChecked,
+        allowlistGatePassed: result.allowlistGatePassed,
+      },
       cleanupWarning: result.cleanupWarning,
     });
   } catch {

--- a/src/app/dashboard/boards/videoUpload/MM88_GATED_REAL_ENDPOINT_E2E_BETA_RUNBOOK.md
+++ b/src/app/dashboard/boards/videoUpload/MM88_GATED_REAL_ENDPOINT_E2E_BETA_RUNBOOK.md
@@ -1,0 +1,125 @@
+# MM88 - Gated Real Endpoint + E2E Beta Runbook
+
+## Objetivo
+
+O MM88 conecta o endpoint real de análise de vídeo ao pipeline completo de leitura documentada, síntese acumulada e snapshot guardado. O fluxo continua restrito a usuários allowlist/admin-dev e só escreve dados quando flags explícitas são enviadas no payload.
+
+O último vídeo não sobrescreve o Perfil geral diretamente. A análise real gera uma leitura documentada; o Perfil geral só muda depois da síntese acumulada de leituras recentes.
+
+## Fluxo
+
+1. Upload temporário já existente.
+2. Referência temporária validada pelo endpoint gated.
+3. Provider multimodal real.
+4. Parser com `evidenceAnchors` seguros.
+5. Diagnóstico estruturado.
+6. `persistReading=true`: salva `CreatorVideoNarrativeDiagnosis`.
+7. `persistSynthesisSnapshot=true`: consulta leituras recentes, gera síntese acumulada e escreve snapshot pelo guard.
+8. Cleanup temporário é tentado independentemente da persistência.
+9. Response retorna apenas auditoria segura.
+
+## Flags do Payload
+
+- Sem flags: roda a análise real segura e cleanup, mas não salva leitura nem snapshot.
+- `persistReading=true`: salva a leitura documentada, se a análise for válida.
+- `persistReading=true` + `persistSynthesisSnapshot=true`: salva leitura, roda síntese acumulada e escreve snapshot guardado.
+- `persistSynthesisSnapshot=true` sem `persistReading=true`: não escreve snapshot; retorna skipped seguro.
+
+## Habilitação Gated
+
+Confirme no ambiente interno/beta:
+
+- Mobile Strategic Profile habilitado.
+- Upload temporário habilitado.
+- Upload real habilitado.
+- Real analysis E2E habilitado.
+- Provider real habilitado.
+- Allowlist/admin-dev habilitado.
+- Usage limits beta habilitados.
+
+Não inclua valores de secrets no runbook, logs, payloads ou screenshots.
+
+## Teste E2E Com Usuário Allowlist/Admin-Dev
+
+1. Entre com um usuário de allowlist ou admin-dev.
+2. Faça upload temporário de um vídeo curto.
+3. Chame o endpoint real com `persistReading=true`.
+4. Confirme `videoReadingPersistence.attempted=true`.
+5. Confirme `videoReadingPersistence.saved=true`.
+6. Confirme que `diagnosisId` foi retornado.
+7. Confirme que a leitura salva contém `evidenceAnchors` quando o provider conseguiu extrair falas/cenas.
+8. Chame novamente com `persistReading=true` e `persistSynthesisSnapshot=true`.
+9. Confirme `synthesisSnapshotWrite.attempted=true`.
+10. Confirme `synthesisSnapshotWrite.written=true` ou um `skippedReason` seguro.
+11. Abra o shell mobile e confirme que Perfil | Leituras | Oportunidades renderizam.
+
+## Verificação de Não Persistência de Mídia
+
+Confirme que a leitura, snapshot e response não incluem:
+
+- vídeo
+- thumbnail
+- signed URL
+- upload URL
+- object key
+- local path
+- storage provider path
+- raw model response
+- raw transcript
+- transcrição longa
+
+## Verificação de Cleanup
+
+1. Confirme `e2eBetaAudit.cleanupAttempted=true`.
+2. Verifique no provider temporário que o objeto temporário foi removido ou expirado conforme política.
+3. Se `cleanupWarning` aparecer, trate como incidente operacional beta: a leitura pode ter sido salva, mas a mídia temporária precisa de verificação manual.
+
+## Como Interpretar `videoReadingPersistence`
+
+- `attempted=false`: a flag de persistência não foi enviada ou o fluxo não tinha leitura segura para salvar.
+- `saved=true`: a leitura documentada foi persistida.
+- `diagnosisId`: identificador seguro para auditoria interna da leitura.
+- `skippedReason`: motivo seguro para não tentar salvar.
+- `errorCode`: erro seguro de persistência, sem stack trace.
+
+## Como Interpretar `synthesisSnapshotWrite`
+
+- `attempted=false`: snapshot write não foi solicitado ou não havia leitura salva.
+- `written=true`: síntese acumulada foi persistida como snapshot guardado.
+- `synthesisStatus`: estado editorial da síntese.
+- `analyzedReadingsCount`: quantidade de leituras consideradas.
+- `updatedAt`: momento seguro do write.
+- `skippedReason`: motivo seguro quando o snapshot não foi escrito.
+
+## Falhas Operacionais
+
+- Falha no provider real: não salvar leitura, não rodar síntese, não escrever snapshot.
+- Falha no parser de anchors: limpar anchors inválidos e manter análise segura quando possível.
+- Falha no save reading: não rodar síntese, não escrever snapshot.
+- Falha na síntese: não escrever snapshot.
+- Falha no snapshot write: manter leitura salva e retornar auditoria segura.
+- Falha no cleanup: retornar `cleanupWarning` e verificar storage temporário.
+
+## Rollback
+
+Desligue as flags internas do beta:
+
+- real analysis E2E
+- provider real
+- upload real, se necessário
+- snapshot write via payload, removendo `persistSynthesisSnapshot`
+- reading persistence via payload, removendo `persistReading`
+
+Sem flags explícitas de payload, o endpoint não escreve leitura nem snapshot.
+
+## Checklist Antes de Testar Com 2 ou 3 Creators Reais
+
+- Usuários estão na allowlist/admin-dev.
+- Usage limits beta estão ativos.
+- Payload não contém mídia bruta, URL assinada ou metadata de storage fora da referência temporária validada.
+- Vídeo é curto e autorizado para teste.
+- Cleanup é verificado depois da execução.
+- Leitura salva contém anchors seguros quando disponíveis.
+- Snapshot só é escrito depois de síntese acumulada.
+- Shell mobile renderiza Perfil | Leituras | Oportunidades.
+- Nenhuma resposta de UI mostra termos técnicos do provider/parser ou metadata de storage.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -2576,3 +2576,13 @@ O que não faz:
 - não muda Gemini, upload, storage, cleanup, usage limits ou endpoints;
 - não altera Mídia Kit real, Comunidade real, navegação global, shells, LoginClient, NextAuth ou billing;
 - não cria histórico visual de vídeos, galeria, player ou thumbnail.
+
+### MM88 — Gated Real Endpoint + E2E Beta Runbook
+
+Status: concluído.
+
+MM88 conecta o endpoint real gated ao pipeline seguro de leitura documentada. Com `persistReading=true`, a análise real estruturada salva `CreatorVideoNarrativeDiagnosis` com anchors seguros vindos do provider/parser quando disponíveis. Com `persistReading=true` e `persistSynthesisSnapshot=true`, o fluxo consulta leituras recentes, gera síntese acumulada e escreve snapshot pelo guard de síntese, evitando que um único vídeo sobrescreva diretamente o Perfil geral.
+
+O response do beta retorna apenas `videoReadingPersistence`, `synthesisSnapshotWrite` e `e2eBetaAudit`; não retorna snapshot completo, leitura completa, raw response, transcrição, vídeo, thumbnail, signed URL, upload URL, objectKey, localPath ou metadata de storage. O cleanup temporário e os usage limits existentes permanecem no caminho real.
+
+Runbook operacional: `MM88_GATED_REAL_ENDPOINT_E2E_BETA_RUNBOOK.md`.

--- a/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator.ts
@@ -23,7 +23,7 @@ export interface ControlledVideoReadingSynthesisSnapshotWriteParams {
   userId: string;
   savedDiagnosisId: string;
   enableSnapshotWrite: boolean;
-  source: "mock_internal";
+  source: "mock_internal" | "real_internal";
   requestId?: string | null;
 }
 
@@ -71,7 +71,7 @@ export async function runControlledVideoReadingSynthesisSnapshotWrite(
     });
   }
 
-  if (params.source !== "mock_internal" || !params.userId.trim() || !params.savedDiagnosisId.trim()) {
+  if (!["mock_internal", "real_internal"].includes(params.source) || !params.userId.trim() || !params.savedDiagnosisId.trim()) {
     return skipped({
       attempted: true,
       skippedReason: "saved_reading_not_found",

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisDiagnosisPipeline.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisDiagnosisPipeline.ts
@@ -1,0 +1,168 @@
+import {
+  createEmptyVideoNarrativeAnalysis,
+  sanitizeVideoNarrativeAnalysisText,
+  type VideoNarrativeAnalysis,
+  type VideoNarrativeConfidence,
+} from "./videoNarrativeAnalysisTypes";
+import type { VideoNarrativeAiAnalysis } from "./videoNarrativeAiProviderTypes";
+import { buildPostCreationVideoSeedFromAnalysis } from "./videoNarrativePostCreationSeed";
+import {
+  buildVideoNarrativeStrategicDiagnosis,
+  type VideoNarrativeDiagnosisAccessLevel,
+} from "./videoNarrativeDiagnosisLearningModel";
+import { buildVideoNarrativeEvolvingDiagnosis } from "./videoNarrativeEvolvingDiagnosisContract";
+import { buildVideoNarrativeAccessTierDiagnosisRules } from "./videoNarrativeAccessTierDiagnosisRules";
+import { buildVideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagnosisPresentationModel";
+
+function clean(value: string | null | undefined): string | null {
+  if (!value?.trim()) return null;
+  return sanitizeVideoNarrativeAnalysisText(value).trim() || null;
+}
+
+function cleanList(values: string[] | undefined): string[] {
+  return (values ?? []).map(clean).filter((value): value is string => Boolean(value)).slice(0, 8);
+}
+
+function confidenceFromAnalysis(analysis: VideoNarrativeAiAnalysis): VideoNarrativeConfidence {
+  const usefulSignals = [
+    analysis.mainNarrative,
+    analysis.whatVideoCommunicates,
+    analysis.strategicReading,
+    analysis.strengthPoint,
+    analysis.attentionPoint,
+  ].filter((value) => clean(value)).length;
+
+  if (usefulSignals >= 4) return "high";
+  if (usefulSignals >= 2) return "medium";
+  return "low";
+}
+
+export function mapRealProviderAnalysisToVideoNarrativeAnalysis(params: {
+  id: string;
+  analysis: VideoNarrativeAiAnalysis;
+  createdAt: string;
+}): VideoNarrativeAnalysis {
+  const base = createEmptyVideoNarrativeAnalysis({
+    id: params.id,
+    createdAt: params.createdAt,
+  });
+  const scenes = cleanList([
+    params.analysis.whatVideoCommunicates,
+    params.analysis.strategicReading,
+    params.analysis.attentionPoint,
+  ]);
+
+  return {
+    ...base,
+    summary: clean(params.analysis.whatVideoCommunicates) ?? clean(params.analysis.strategicReading),
+    hook: {
+      detected: clean(params.analysis.suggestedHook),
+      strength: params.analysis.suggestedHook ? "medium" : "unknown",
+      why: clean(params.analysis.strengthPoint),
+    },
+    spokenTopics: cleanList(params.analysis.creatorSignals),
+    visualElements: cleanList(params.analysis.evidenceAnchors?.sceneAnchors.map((anchor) => anchor.description)),
+    sceneStructure: scenes.map((description, index) => ({
+      id: `${params.id}-scene-${index + 1}`,
+      timestampLabel: null,
+      role: index === 0 ? "hook" : index === 1 ? "development" : "turning_point",
+      description,
+      suggestedAdjustment: clean(params.analysis.recommendedAdjustment),
+    })),
+    d2cClassification: {
+      format: "reel",
+      proposal: "positioning_authority",
+      context: clean(params.analysis.whatVideoCommunicates),
+      tone: clean(params.analysis.creatorIntention),
+      reference: null,
+      intent: clean(params.analysis.creatorIntention),
+      narrative: clean(params.analysis.mainNarrative),
+    },
+    diagnosis: {
+      strengths: cleanList([params.analysis.strengthPoint]),
+      weaknesses: cleanList([params.analysis.attentionPoint]),
+      recommendedAdjustments: cleanList([params.analysis.recommendedAdjustment]),
+    },
+    blueprintSuggestion: {
+      whatToPost: clean(params.analysis.recommendedAdjustment),
+      whyThisPath: clean(params.analysis.strategicReading),
+      howItShouldWork: clean(params.analysis.suggestedHook),
+      scenes: cleanList(params.analysis.nextActions),
+    },
+    brandMatch: {
+      enabled: cleanList(params.analysis.brandTerritories).length > 0 || Boolean(clean(params.analysis.commercialPotential)),
+      territories: cleanList(params.analysis.brandTerritories),
+      whyBrandsWouldFit: clean(params.analysis.commercialPotential),
+    },
+    evidence: {
+      transcript: null,
+      ocr: [],
+      frames: [],
+      technicalSignals: [],
+    },
+    evidenceAnchors: params.analysis.evidenceAnchors,
+    profileSignals: cleanList(params.analysis.creatorSignals).map((value) => ({
+      type: "positioning_signal",
+      value,
+      confidence: "medium",
+      shouldPersistLater: false,
+    })),
+    confidence: confidenceFromAnalysis(params.analysis),
+  };
+}
+
+export function buildRealProviderDiagnosisArtifacts(params: {
+  analysisId: string;
+  providerAnalysis: VideoNarrativeAiAnalysis;
+  creatorGoal: string;
+  selectedGoalOption: string;
+  accessLevel: VideoNarrativeDiagnosisAccessLevel;
+  instagramConnected: boolean;
+  createdAt: string;
+}) {
+  const analysis = mapRealProviderAnalysisToVideoNarrativeAnalysis({
+    id: params.analysisId,
+    analysis: params.providerAnalysis,
+    createdAt: params.createdAt,
+  });
+  const seed = buildPostCreationVideoSeedFromAnalysis({
+    id: `${params.analysisId}-seed`,
+    analysis,
+    creatorQuestion: params.creatorGoal,
+    createdAt: params.createdAt,
+  });
+  const strategicDiagnosis = buildVideoNarrativeStrategicDiagnosis({
+    accessLevel: params.accessLevel,
+    analysis,
+    seed,
+    creatorQuestion: params.creatorGoal,
+    instagramContext: {
+      connected: params.instagramConnected,
+    },
+  });
+  const evolvingDiagnosis = buildVideoNarrativeEvolvingDiagnosis({
+    diagnosis: strategicDiagnosis,
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+    analyzedVideosCount: 1,
+    createdAt: params.createdAt,
+  });
+  const accessRules = buildVideoNarrativeAccessTierDiagnosisRules({
+    evolvingDiagnosis,
+    accessLevel: params.accessLevel,
+    instagramConnected: params.instagramConnected,
+  });
+  const presentation = buildVideoNarrativeDiagnosisPresentation({
+    diagnosis: strategicDiagnosis,
+    evolvingDiagnosis,
+    accessRules,
+  });
+
+  return {
+    analysis,
+    seed,
+    strategicDiagnosis,
+    evolvingDiagnosis,
+    presentation,
+  };
+}

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.test.ts
@@ -195,7 +195,7 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
     expect(usageDeps.recordUsageAttempt).not.toHaveBeenCalled();
   });
 
-  it("chama provider fake, mapeia, salva snapshot e aciona cleanup", async () => {
+  it("sem flags chama provider fake, não persiste leitura/snapshot e aciona cleanup", async () => {
     const runProvider = jest.fn().mockResolvedValue({
       ok: true,
       provider: "gemini",
@@ -204,7 +204,8 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
       analysis: geminiVideoNarrativeResponseFixture,
       issues: [],
     });
-    const upsertSnapshot = jest.fn(async (input) => input);
+    const saveReading = jest.fn();
+    const runSynthesisSnapshotWrite = jest.fn();
     const cleanupTemporaryUpload = jest.fn().mockResolvedValue(undefined);
 
     const result = await runVideoNarrativeRealAnalysisOrchestrator({
@@ -215,7 +216,8 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
         requestId: "req-test",
         now: () => new Date("2026-05-19T20:00:00.000Z"),
         runProvider,
-        upsertSnapshot,
+        saveReading,
+        runSynthesisSnapshotWrite,
         cleanupTemporaryUpload,
         ...usageDeps,
       },
@@ -231,20 +233,23 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
         }),
       }),
     );
-    expect(upsertSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: user.id,
-        source: "gemini_real_allowlist",
-        snapshot: expect.not.objectContaining({
-          objectKey: expect.anything(),
-          uploadUrl: expect.anything(),
-          rawResponse: expect.anything(),
-        }),
-      }),
-    );
-    const snapshotArg = upsertSnapshot.mock.calls[0][0].snapshot;
-    expect(JSON.stringify(snapshotArg)).not.toContain("temporary/video-narrative");
-    expect(JSON.stringify(snapshotArg)).not.toContain("uploadUrl");
+    expect(saveReading).not.toHaveBeenCalled();
+    expect(runSynthesisSnapshotWrite).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.videoReadingPersistence).toEqual({
+        attempted: false,
+        saved: false,
+        skippedReason: "persist_reading_disabled",
+      });
+      expect(result.synthesisSnapshotWrite).toEqual({
+        attempted: false,
+        written: false,
+        skippedReason: "synthesis_write_disabled",
+      });
+      expect(result.evidenceAnchorsUsed).toBe(true);
+    }
+    expect(JSON.stringify(result)).not.toContain("temporary/video-narrative");
+    expect(JSON.stringify(result)).not.toContain("uploadUrl");
     expect(cleanupTemporaryUpload).toHaveBeenCalledWith(
       expect.objectContaining({
         uploadSessionId: payload.uploadSessionId,
@@ -258,6 +263,81 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
     expect(usageDeps.recordUsageSuccess).toHaveBeenCalledWith(
       expect.objectContaining({ userId: user.id }),
     );
+  });
+
+  it("com flags salva leitura, roda síntese acumulada e escreve snapshot guardado", async () => {
+    const saveReading = jest.fn().mockResolvedValue({
+      ok: true,
+      diagnosisId: "diagnosis-real-1",
+      profileContribution: {
+        type: "opens_new_hypothesis",
+        confidence: "medium",
+        weight: "low",
+        profileImpactPreview: "Nova hipótese de leitura.",
+      },
+    });
+    const runSynthesisSnapshotWrite = jest.fn().mockResolvedValue({
+      attempted: true,
+      written: true,
+      synthesisStatus: "first_reading",
+      analyzedReadingsCount: 1,
+      snapshotId: "snapshot-1",
+      updatedAt: "2026-05-19T20:00:00.000Z",
+    });
+
+    const result = await runVideoNarrativeRealAnalysisOrchestrator({
+      payload: { ...payload, persistReading: true, persistSynthesisSnapshot: true },
+      user,
+      deps: {
+        env,
+        requestId: "req-test",
+        now: () => new Date("2026-05-19T20:00:00.000Z"),
+        runProvider: jest.fn().mockResolvedValue({
+          ok: true,
+          provider: "gemini",
+          mode: "ready",
+          promptVersion: "video_narrative_gemini_mm66_v1",
+          analysis: geminiVideoNarrativeResponseFixture,
+          issues: [],
+        }),
+        saveReading,
+        runSynthesisSnapshotWrite,
+        ...usageDeps,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(saveReading).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: user.id,
+        source: "real",
+        strategicDiagnosis: expect.objectContaining({
+          evidenceAnchors: expect.objectContaining({
+            speechQuotes: expect.arrayContaining([
+              expect.objectContaining({ source: "creator_spoken" }),
+            ]),
+          }),
+        }),
+        safeVideoMetadata: expect.not.objectContaining({
+          objectKey: expect.anything(),
+          uploadUrl: expect.anything(),
+          signedUrl: expect.anything(),
+        }),
+      }),
+    );
+    expect(runSynthesisSnapshotWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: user.id,
+        savedDiagnosisId: "diagnosis-real-1",
+        enableSnapshotWrite: true,
+        source: "real_internal",
+      }),
+    );
+    if (result.ok) {
+      expect(result.videoReadingPersistence.saved).toBe(true);
+      expect(result.synthesisSnapshotWrite.written).toBe(true);
+    }
+    expect(JSON.stringify(result)).not.toContain("temporary/video-narrative");
   });
 
   it("erro do provider vira mensagem segura e tenta cleanup", async () => {
@@ -289,9 +369,9 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
     );
   });
 
-  it("erro do snapshot não vaza stack trace", async () => {
+  it("erro de snapshot guardado não vaza stack trace", async () => {
     const result = await runVideoNarrativeRealAnalysisOrchestrator({
-      payload,
+      payload: { ...payload, persistReading: true, persistSynthesisSnapshot: true },
       user,
       deps: {
         env,
@@ -302,7 +382,21 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
           promptVersion: "v1",
           analysis: geminiVideoNarrativeResponseFixture,
         }),
-        upsertSnapshot: jest.fn().mockRejectedValue(new Error("mongo stack secret")),
+        saveReading: jest.fn().mockResolvedValue({
+          ok: true,
+          diagnosisId: "diagnosis-real-1",
+          profileContribution: {
+            type: "opens_new_hypothesis",
+            confidence: "medium",
+            weight: "low",
+            profileImpactPreview: "Nova hipótese de leitura.",
+          },
+        }),
+        runSynthesisSnapshotWrite: jest.fn().mockResolvedValue({
+          attempted: true,
+          written: false,
+          skippedReason: "synthesis_snapshot_write_failed",
+        }),
         ...usageDeps,
       },
     });
@@ -310,7 +404,7 @@ describe("runVideoNarrativeRealAnalysisOrchestrator", () => {
     expect(result.ok).toBe(false);
     expect(JSON.stringify(result)).not.toContain("mongo stack secret");
     expect(usageDeps.recordUsageFailure).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "snapshot_save_failed" }),
+      expect.objectContaining({ reason: "synthesis_snapshot_write_failed" }),
     );
   });
 });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisOrchestrator.ts
@@ -1,11 +1,8 @@
-import type { CreatorStrategicProfileSnapshotInput } from "./mobileStrategicProfileSnapshotTypes";
-import {
-  upsertStrategicProfileSnapshot,
-} from "./mobileStrategicProfileSnapshotService";
 import type {
   VideoNarrativeAiProviderInput,
   VideoNarrativeAiProviderResult,
 } from "./videoNarrativeAiProviderTypes";
+import type { VideoNarrativeReadingPersistenceSummary, VideoNarrativeSynthesisSnapshotWriteSummary } from "./videoNarrativeSafeResponseBuilder";
 import type { VideoNarrativeGeminiAllowlistUser } from "./videoNarrativeGeminiAllowlist";
 import { evaluateVideoNarrativeGeminiAllowlist } from "./videoNarrativeGeminiAllowlist";
 import {
@@ -13,7 +10,7 @@ import {
   type VideoNarrativeGeminiProviderConfig,
 } from "./videoNarrativeGeminiProviderConfig";
 import { runVideoNarrativeGeminiProvider, type VideoNarrativeGeminiClientAdapter } from "./videoNarrativeGeminiProvider";
-import { mapGeminiAnalysisToStrategicProfileSnapshot } from "./videoNarrativeGeminiSnapshotMapper";
+import { buildRealProviderDiagnosisArtifacts } from "./videoNarrativeRealAnalysisDiagnosisPipeline";
 import type { VideoNarrativeRealAnalysisPayload } from "./videoNarrativeRealAnalysisTypes";
 import {
   assertCanRunVideoNarrativeRealAnalysis,
@@ -26,15 +23,28 @@ import {
 } from "./videoNarrativeRealAnalysisUserFacingErrors";
 import { resolveVideoNarrativeTemporaryStorageObject } from "./videoNarrativeTemporaryStorageRuntimeResolver";
 import { resolveVideoNarrativeTemporaryStorageInput } from "./videoNarrativeTemporaryStorageRuntimeAdapter";
+import {
+  saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis,
+  type SaveCreatorVideoNarrativeDiagnosisResult,
+} from "./creatorVideoNarrativeDiagnosisSaveOrchestrator";
+import {
+  runControlledVideoReadingSynthesisSnapshotWrite,
+  type ControlledVideoReadingSynthesisSnapshotWriteResult,
+} from "./creatorVideoNarrativeMockSynthesisSnapshotWriteOrchestrator";
 
 type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
 export type VideoNarrativeRealAnalysisOrchestratorResult =
   | {
       ok: true;
-      snapshotUpdated: true;
-      snapshot: CreatorStrategicProfileSnapshotInput["snapshot"];
+      realAnalysis: true;
       source: "gemini_real_allowlist";
+      videoReadingPersistence: VideoNarrativeReadingPersistenceSummary;
+      synthesisSnapshotWrite: VideoNarrativeSynthesisSnapshotWriteSummary;
+      evidenceAnchorsUsed: boolean;
+      cleanupAttempted: boolean;
+      usageLimitChecked: boolean;
+      allowlistGatePassed: boolean;
       cleanupWarning?: string;
     }
   | {
@@ -42,6 +52,12 @@ export type VideoNarrativeRealAnalysisOrchestratorResult =
       status: "blocked" | "failed";
       message: string;
       safeIssueCode?: string;
+      videoReadingPersistence?: VideoNarrativeReadingPersistenceSummary;
+      synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary;
+      evidenceAnchorsUsed?: boolean;
+      cleanupAttempted?: boolean;
+      usageLimitChecked?: boolean;
+      allowlistGatePassed?: boolean;
       cleanupWarning?: string;
     };
 
@@ -58,7 +74,8 @@ export type VideoNarrativeRealAnalysisOrchestratorDeps = {
     config?: VideoNarrativeGeminiProviderConfig;
     client?: VideoNarrativeGeminiClientAdapter | null;
   }) => Promise<VideoNarrativeAiProviderResult>;
-  upsertSnapshot?: typeof upsertStrategicProfileSnapshot;
+  saveReading?: typeof saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis;
+  runSynthesisSnapshotWrite?: typeof runControlledVideoReadingSynthesisSnapshotWrite;
   assertCanRunRealAnalysis?: typeof assertCanRunVideoNarrativeRealAnalysis;
   recordUsageAttempt?: typeof recordVideoNarrativeRealAnalysisAttempt;
   recordUsageSuccess?: typeof recordVideoNarrativeRealAnalysisSuccess;
@@ -74,6 +91,12 @@ function safeFailure(params: {
   status?: "blocked" | "failed";
   message?: string;
   safeIssueCode?: string;
+  videoReadingPersistence?: VideoNarrativeReadingPersistenceSummary;
+  synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary;
+  evidenceAnchorsUsed?: boolean;
+  cleanupAttempted?: boolean;
+  usageLimitChecked?: boolean;
+  allowlistGatePassed?: boolean;
   cleanupWarning?: string;
 }): VideoNarrativeRealAnalysisOrchestratorResult {
   return {
@@ -81,8 +104,71 @@ function safeFailure(params: {
     status: params.status ?? "failed",
     message: params.message ?? "Não foi possível atualizar o diagnóstico real agora.",
     safeIssueCode: params.safeIssueCode,
+    videoReadingPersistence: params.videoReadingPersistence,
+    synthesisSnapshotWrite: params.synthesisSnapshotWrite,
+    evidenceAnchorsUsed: params.evidenceAnchorsUsed,
+    cleanupAttempted: params.cleanupAttempted,
+    usageLimitChecked: params.usageLimitChecked,
+    allowlistGatePassed: params.allowlistGatePassed,
     cleanupWarning: params.cleanupWarning,
   };
+}
+
+function skippedReading(reason: string): VideoNarrativeReadingPersistenceSummary {
+  return {
+    attempted: false,
+    saved: false,
+    skippedReason: reason,
+  };
+}
+
+function skippedSnapshot(reason: string): VideoNarrativeSynthesisSnapshotWriteSummary {
+  return {
+    attempted: false,
+    written: false,
+    skippedReason: reason,
+  };
+}
+
+function mapSaveResult(result: SaveCreatorVideoNarrativeDiagnosisResult): VideoNarrativeReadingPersistenceSummary {
+  if (result.ok) {
+    return {
+      attempted: true,
+      saved: true,
+      diagnosisId: result.diagnosisId,
+    };
+  }
+
+  return {
+    attempted: true,
+    saved: false,
+    errorCode: result.errorCode,
+  };
+}
+
+function mapSynthesisResult(
+  result: ControlledVideoReadingSynthesisSnapshotWriteResult,
+): VideoNarrativeSynthesisSnapshotWriteSummary {
+  return {
+    attempted: result.attempted,
+    written: result.written,
+    skippedReason: result.skippedReason ?? null,
+    synthesisStatus: result.synthesisStatus ?? null,
+    analyzedReadingsCount: result.analyzedReadingsCount ?? null,
+    snapshotId: result.snapshotId ?? null,
+    updatedAt: result.updatedAt ?? null,
+  };
+}
+
+function hasEvidenceAnchors(analysis: VideoNarrativeAiProviderResult["analysis"]): boolean {
+  return Boolean(
+    analysis?.evidenceAnchors &&
+      (
+        analysis.evidenceAnchors.speechQuotes.length > 0 ||
+        analysis.evidenceAnchors.sceneAnchors.length > 0 ||
+        analysis.evidenceAnchors.creatorIntentAnchor
+      ),
+  );
 }
 
 async function tryCleanup(params: {
@@ -134,6 +220,7 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
   const deps = params.deps ?? {};
   const env = deps.env ?? process.env;
   const now = deps.now?.() ?? new Date();
+  const createdAt = now.toISOString();
   const configResult = deps.geminiConfig
     ? { config: deps.geminiConfig, issues: [] }
     : resolveVideoNarrativeGeminiProviderConfig(env);
@@ -157,6 +244,7 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
   }
 
   let usageAttemptRecorded = false;
+  let usageLimitChecked = false;
   const assertCanRunRealAnalysis = deps.assertCanRunRealAnalysis ?? assertCanRunVideoNarrativeRealAnalysis;
   try {
     const usageDecision = await assertCanRunRealAnalysis({
@@ -164,6 +252,7 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
       env,
       now,
     });
+    usageLimitChecked = true;
 
     if (!usageDecision.ok) {
       return safeFailure({
@@ -301,54 +390,128 @@ export async function runVideoNarrativeRealAnalysisOrchestrator(params: {
         safeProviderIssueCode,
       ),
       safeIssueCode: safeProviderIssueCode,
+      evidenceAnchorsUsed: false,
+      cleanupAttempted: Boolean(deps.cleanupTemporaryUpload),
+      usageLimitChecked,
+      allowlistGatePassed: true,
       cleanupWarning,
     });
   }
 
-  const mapped = mapGeminiAnalysisToStrategicProfileSnapshot({
-    analysis: providerResult.analysis,
-    promptVersion: providerResult.promptVersion,
-    source: "gemini_real_allowlist",
+  const evidenceAnchorsUsed = hasEvidenceAnchors(providerResult.analysis);
+  const artifacts = buildRealProviderDiagnosisArtifacts({
+    analysisId: `real-video-narrative-${params.payload.uploadSessionId}`,
+    providerAnalysis: providerResult.analysis,
+    creatorGoal: params.payload.creatorGoal,
+    selectedGoalOption: params.payload.selectedGoalOption,
+    accessLevel: params.user.planStatus === "active" ? "premium" : "free",
+    instagramConnected: Boolean(params.user.instagramConnected || params.user.isInstagramConnected),
+    createdAt,
   });
-  const upsertSnapshot = deps.upsertSnapshot ?? upsertStrategicProfileSnapshot;
 
-  try {
-    const upserted = await upsertSnapshot({
+  const cleanupWarning = await tryCleanup({ deps, payload: params.payload, reason: "analysis_completed" });
+  const cleanupAttempted = Boolean(deps.cleanupTemporaryUpload);
+  const saveReading = deps.saveReading ?? saveCreatorVideoNarrativeDiagnosisFromStructuredAnalysis;
+  let videoReadingPersistence = skippedReading("persist_reading_disabled");
+  let synthesisSnapshotWrite = skippedSnapshot("synthesis_write_disabled");
+
+  if (params.payload.persistReading === true) {
+    const saveResult = await saveReading({
       userId: params.user.id ?? "",
-      status: "active",
-      accessLevel: params.user.planStatus === "active" ? "premium" : "free",
-      snapshot: mapped.snapshot,
-      source: mapped.source,
-      lastAnalyzedAt: now,
+      source: "real",
+      creatorGoal: params.payload.creatorGoal,
+      selectedGoalOption: params.payload.selectedGoalOption,
+      safeVideoMetadata: {
+        mimeType: params.payload.temporaryUpload?.mimeType,
+        sizeBytes: params.payload.temporaryUpload?.sizeBytes,
+        uploadedAt: params.payload.temporaryUpload?.uploadedAt ? new Date(params.payload.temporaryUpload.uploadedAt) : undefined,
+        analyzedAt: now,
+      },
+      strategicDiagnosis: artifacts.strategicDiagnosis,
+      evolvingDiagnosis: artifacts.evolvingDiagnosis,
+      presentation: artifacts.presentation,
+      seed: artifacts.seed,
+      analyzedAt: now,
+      createdAt: now,
     });
-    const cleanupWarning = await tryCleanup({ deps, payload: params.payload, reason: "analysis_completed" });
-    if (usageAttemptRecorded && params.user.id) {
-      try {
-        await (deps.recordUsageSuccess ?? recordVideoNarrativeRealAnalysisSuccess)({
-          userId: params.user.id,
-          now,
-        });
-      } catch {
-        // Usage telemetry should not turn a completed snapshot into a user-facing failure.
+    videoReadingPersistence = mapSaveResult(saveResult);
+
+    if (!saveResult.ok) {
+      if (usageAttemptRecorded) {
+        await recordFailureSafely({ deps, userId: params.user.id, reason: saveResult.errorCode, now });
       }
+      return safeFailure({
+        status: "failed",
+        message: saveResult.message,
+        safeIssueCode: saveResult.errorCode,
+        videoReadingPersistence,
+        synthesisSnapshotWrite: skippedSnapshot("saved_reading_not_found"),
+        evidenceAnchorsUsed,
+        cleanupAttempted,
+        usageLimitChecked,
+        allowlistGatePassed: true,
+        cleanupWarning,
+      });
     }
 
-    return {
-      ok: true,
-      snapshotUpdated: true,
-      snapshot: upserted.snapshot,
-      source: "gemini_real_allowlist",
-      cleanupWarning,
-    };
-  } catch {
-    const cleanupWarning = await tryCleanup({ deps, payload: params.payload, reason: "analysis_failed" });
-    if (usageAttemptRecorded) {
-      await recordFailureSafely({ deps, userId: params.user.id, reason: "snapshot_save_failed", now });
+    if (params.payload.persistSynthesisSnapshot === true && saveResult.diagnosisId) {
+      const runSynthesisSnapshotWrite = deps.runSynthesisSnapshotWrite ?? runControlledVideoReadingSynthesisSnapshotWrite;
+      synthesisSnapshotWrite = mapSynthesisResult(await runSynthesisSnapshotWrite({
+        userId: params.user.id ?? "",
+        savedDiagnosisId: saveResult.diagnosisId,
+        enableSnapshotWrite: true,
+        source: "real_internal",
+        requestId: deps.requestId,
+      }));
+
+      if (!synthesisSnapshotWrite.written) {
+        if (usageAttemptRecorded) {
+          await recordFailureSafely({
+            deps,
+            userId: params.user.id,
+            reason: synthesisSnapshotWrite.skippedReason ?? "unknown_synthesis_write_error",
+            now,
+          });
+        }
+        return safeFailure({
+          status: "failed",
+          message: "A leitura foi salva, mas a síntese acumulada não foi atualizada agora.",
+          safeIssueCode: synthesisSnapshotWrite.skippedReason ?? "unknown_synthesis_write_error",
+          videoReadingPersistence,
+          synthesisSnapshotWrite,
+          evidenceAnchorsUsed,
+          cleanupAttempted,
+          usageLimitChecked,
+          allowlistGatePassed: true,
+          cleanupWarning,
+        });
+      }
+    } else if (params.payload.persistSynthesisSnapshot === true) {
+      synthesisSnapshotWrite = skippedSnapshot("saved_reading_not_found");
     }
-    return safeFailure({
-      message: getVideoNarrativeRealAnalysisUserFacingMessage("snapshot_save_failed"),
-      safeIssueCode: "snapshot_upsert_failed",
-      cleanupWarning,
-    });
   }
+
+  if (usageAttemptRecorded && params.user.id) {
+    try {
+      await (deps.recordUsageSuccess ?? recordVideoNarrativeRealAnalysisSuccess)({
+        userId: params.user.id,
+        now,
+      });
+    } catch {
+      // Usage telemetry should not turn a completed safe analysis into a user-facing failure.
+    }
+  }
+
+  return {
+    ok: true,
+    realAnalysis: true,
+    source: "gemini_real_allowlist",
+    videoReadingPersistence,
+    synthesisSnapshotWrite,
+    evidenceAnchorsUsed,
+    cleanupAttempted,
+    usageLimitChecked,
+    allowlistGatePassed: true,
+    cleanupWarning,
+  };
 }

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisTypes.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisTypes.test.ts
@@ -23,6 +23,26 @@ describe("validateVideoNarrativeRealAnalysisPayload", () => {
     }
   });
 
+  it("aceita flags explícitas de persistência sem exigir snapshot por padrão", () => {
+    const withoutFlags = validateVideoNarrativeRealAnalysisPayload(validPayload);
+    expect(withoutFlags.ok).toBe(true);
+    if (withoutFlags.ok) {
+      expect(withoutFlags.payload.persistReading).toBeUndefined();
+      expect(withoutFlags.payload.persistSynthesisSnapshot).toBeUndefined();
+    }
+
+    const withFlags = validateVideoNarrativeRealAnalysisPayload({
+      ...validPayload,
+      persistReading: true,
+      persistSynthesisSnapshot: true,
+    });
+    expect(withFlags.ok).toBe(true);
+    if (withFlags.ok) {
+      expect(withFlags.payload.persistReading).toBe(true);
+      expect(withFlags.payload.persistSynthesisSnapshot).toBe(true);
+    }
+  });
+
   it("bloqueia campos proibidos", () => {
     for (const forbidden of ["file", "video", "uploadUrl", "signedUrl", "base64", "rawModelResponse", "bucket", "token"]) {
       const result = validateVideoNarrativeRealAnalysisPayload({ ...validPayload, [forbidden]: "x" });

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisTypes.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeRealAnalysisTypes.ts
@@ -12,6 +12,8 @@ export type VideoNarrativeRealAnalysisPayload = {
   selectedGoalOption: VideoNarrativeAiProviderGoalOption;
   quickAnswers?: Array<{ id: string; value: string }>;
   consentTextVersion: string;
+  persistReading?: boolean;
+  persistSynthesisSnapshot?: boolean;
 };
 
 export type VideoNarrativeRealAnalysisPayloadValidationResult =
@@ -172,6 +174,8 @@ export function validateVideoNarrativeRealAnalysisPayload(
       selectedGoalOption: selectedGoalOption as VideoNarrativeAiProviderGoalOption,
       quickAnswers: readQuickAnswers(body.quickAnswers),
       consentTextVersion: consentTextVersion.slice(0, 80),
+      ...(body.persistReading === true ? { persistReading: true } : {}),
+      ...(body.persistSynthesisSnapshot === true ? { persistSynthesisSnapshot: true } : {}),
     },
   };
 }

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.test.ts
@@ -175,6 +175,41 @@ describe("videoNarrativeSafeResponseBuilder", () => {
     });
   });
 
+  it("inclui auditoria beta e persistência segura sem snapshot completo", () => {
+    const response = buildVideoNarrativeSafeResponse({
+      analysis: createAnalysis(),
+      videoReadingPersistence: {
+        attempted: true,
+        saved: true,
+        diagnosisId: "diagnosis-safe-1",
+      },
+      synthesisSnapshotWrite: {
+        attempted: true,
+        written: true,
+        synthesisStatus: "first_reading",
+        analyzedReadingsCount: 1,
+        updatedAt: CREATED_AT,
+      },
+      e2eBetaAudit: {
+        realAnalysis: true,
+        evidenceAnchorsUsed: true,
+        cleanupAttempted: true,
+        usageLimitChecked: true,
+        allowlistGatePassed: true,
+      },
+    });
+
+    expect(response.videoReadingPersistence).toEqual({
+      attempted: true,
+      saved: true,
+      diagnosisId: "diagnosis-safe-1",
+    });
+    expect(response.synthesisSnapshotWrite?.written).toBe(true);
+    expect(response.e2eBetaAudit?.cleanupAttempted).toBe(true);
+    expect(JSON.stringify(response)).not.toContain("schemaVersion");
+    expect(JSON.stringify(response)).not.toContain("objectKey");
+  });
+
   it("observabilitySummary inclui apenas requestId e eventos mínimos", () => {
     const response = buildVideoNarrativeSafeResponse({
       analysis: createAnalysis(),
@@ -307,8 +342,8 @@ describe("videoNarrativeSafeResponseBuilder", () => {
     });
   });
 
-  it("validateVideoNarrativeSafeResponse rejeita signedUrl/videoUrl em qualquer nível", () => {
-    ["signedUrl", "videoUrl"].forEach((key) => {
+  it("validateVideoNarrativeSafeResponse rejeita storage metadata em qualquer nível", () => {
+    ["signedUrl", "uploadUrl", "thumbnailUrl", "objectKey", "localPath", "storageProviderPath", "videoUrl"].forEach((key) => {
       const response = {
         ...buildVideoNarrativeSafeResponse({ analysis: createAnalysis() }),
         analysis: { ...createAnalysis(), [key]: "https://cdn.example/video.mp4?token=abc123" },

--- a/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
+++ b/src/app/dashboard/boards/videoUpload/videoNarrativeSafeResponseBuilder.ts
@@ -65,6 +65,14 @@ export interface VideoNarrativeReadingSaveSummary {
   message: string | null;
 }
 
+export interface VideoNarrativeReadingPersistenceSummary {
+  attempted: boolean;
+  saved: boolean;
+  diagnosisId?: string;
+  skippedReason?: string;
+  errorCode?: string;
+}
+
 export interface VideoNarrativeSynthesisSnapshotWriteSummary {
   attempted: boolean;
   written: boolean;
@@ -73,6 +81,14 @@ export interface VideoNarrativeSynthesisSnapshotWriteSummary {
   analyzedReadingsCount?: number | null;
   snapshotId?: string | null;
   updatedAt?: string | null;
+}
+
+export interface VideoNarrativeE2EBetaAudit {
+  realAnalysis: boolean;
+  evidenceAnchorsUsed: boolean;
+  cleanupAttempted: boolean;
+  usageLimitChecked: boolean;
+  allowlistGatePassed: boolean;
 }
 
 export interface VideoNarrativeSafeResponse {
@@ -87,7 +103,9 @@ export interface VideoNarrativeSafeResponse {
   usageSummary: VideoNarrativeSafeUsageSummary | null;
   observabilitySummary: VideoNarrativeSafeObservabilitySummary | null;
   readingSaveSummary?: VideoNarrativeReadingSaveSummary | null;
+  videoReadingPersistence?: VideoNarrativeReadingPersistenceSummary | null;
   synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  e2eBetaAudit?: VideoNarrativeE2EBetaAudit | null;
 }
 
 export interface VideoNarrativeSafeResponseInput {
@@ -106,7 +124,9 @@ export interface VideoNarrativeSafeResponseInput {
   quotaGuard?: VideoNarrativeQuotaGuardResult | null;
   observabilityEvents?: VideoNarrativeObservabilityEventPayload[] | null;
   readingSaveSummary?: VideoNarrativeReadingSaveSummary | null;
+  videoReadingPersistence?: VideoNarrativeReadingPersistenceSummary | null;
   synthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  e2eBetaAudit?: VideoNarrativeE2EBetaAudit | null;
 }
 
 const SAFE_RESPONSE_STATUSES: VideoNarrativeSafeResponseStatus[] = [
@@ -126,6 +146,14 @@ const DANGEROUS_KEYS = [
   "video",
   "videoUrl",
   "signedUrl",
+  "uploadUrl",
+  "objectKey",
+  "thumbnailUrl",
+  "localPath",
+  "storageProviderPath",
+  "rawTranscript",
+  "rawModelResponse",
+  "rawGeminiResponse",
   "apiKey",
   "GEMINI_API_KEY",
   "GOOGLE_GENAI_API_KEY",
@@ -347,7 +375,9 @@ export function buildVideoNarrativeSafeResponse(
     }),
     observabilitySummary: buildObservabilitySummary(input.observabilityEvents),
     readingSaveSummary: input.readingSaveSummary ? sanitizeDeep(input.readingSaveSummary) : null,
+    videoReadingPersistence: input.videoReadingPersistence ? sanitizeDeep(input.videoReadingPersistence) : null,
     synthesisSnapshotWrite: input.synthesisSnapshotWrite ? sanitizeDeep(input.synthesisSnapshotWrite) : null,
+    e2eBetaAudit: input.e2eBetaAudit ? sanitizeDeep(input.e2eBetaAudit) : null,
   };
 
   return redactVideoNarrativeSafeResponse(response);


### PR DESCRIPTION
## Summary

Connects the gated real video analysis endpoint to the documented reading + accumulated profile synthesis pipeline.

Includes:
- gated real flow with explicit `persistReading` and `persistSynthesisSnapshot` flags
- real analysis artifacts mapped into documented video readings
- saved CreatorVideoNarrativeDiagnosis from the real endpoint path
- accumulated profile synthesis after a saved reading
- guarded snapshot write without direct last-video overwrite
- safe response metadata for `videoReadingPersistence`, `synthesisSnapshotWrite`, and `e2eBetaAudit`
- reinforced sanitization/validation against storage metadata and raw payloads
- MM88 gated E2E beta runbook

## Product direction

The real video generates a documented reading. The Strategic Profile is updated only through accumulated synthesis, not by overwriting the profile with the latest video.

This PR keeps the full real flow gated behind allowlist/admin-dev and explicit flags.

## Guardrails

- Does not open the real endpoint for common users.
- Does not remove allowlist/admin-dev gates.
- Preserves usage limits and cleanup.
- Does not store video, thumbnail, signed/upload URL, objectKey, localPath, storageProviderPath, raw Gemini/model response, raw transcript, or long transcript.
- Does not alter billing/Stripe, NextAuth, MediaKitView, Comunidade, DashboardShell, BoardShell, or sidebar.
- Does not create real brand/creator matches.

## Validation reported locally

- MM88 endpoint/orchestrator/safe response tests passed.
- MM87 provider/parser/mapper/chapter builder impacted tests passed.
- Save/read service, synthesis, snapshot write, shell/view model impacted tests passed.
- Mock/internal endpoint tests passed.
- npm run typecheck passed.
- npm run build passed with existing warnings only.
- git diff --check passed.

## Next milestone

MM89 — Pro Access, Reading Quota, Instagram and Community UX: 1 free reading, 10 monthly Pro readings, Instagram as Pro feature, profile status balloon, and compact community consultation access banner while keeping Comunidade as the creator marketplace/list.