### PR TITLE
MM89 — Pro Access, Reading Quota, Instagram and Community UX

### DIFF
--- a/src/app/api/dashboard/mobile-strategic-profile/upload-session/route.test.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/upload-session/route.test.ts
@@ -27,6 +27,14 @@ jest.mock("@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryUploadFeatu
   isRealUploadEnabled: jest.fn(),
 }));
 
+jest.mock("@/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService", () => ({
+  assertCanStartNarrativeMapReading: jest.fn(),
+}));
+
+jest.mock("@/app/lib/planGuard", () => ({
+  ensurePlannerAccess: jest.fn(),
+}));
+
 jest.mock("@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageSignedUrlProvider", () => {
   const actual = jest.requireActual("@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageSignedUrlProvider");
   return {
@@ -39,6 +47,10 @@ const getServerSession = require("next-auth/next").getServerSession as jest.Mock
 const createServerSideSignedUploadUrlSigner =
   require("@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageSignedUrlProvider")
     .createServerSideSignedUploadUrlSigner as jest.Mock;
+const assertCanStartNarrativeMapReading =
+  require("@/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService")
+    .assertCanStartNarrativeMapReading as jest.Mock;
+const ensurePlannerAccess = require("@/app/lib/planGuard").ensurePlannerAccess as jest.Mock;
 const ROUTE_SOURCE_PATH = path.join(__dirname, "route.ts");
 const originalEnv = process.env;
 
@@ -101,6 +113,13 @@ describe("POST /api/dashboard/mobile-strategic-profile/upload-session", () => {
     (isTemporaryUploadSessionEnabled as jest.Mock).mockReturnValue(true);
     (isRealUploadEnabled as jest.Mock).mockReturnValue(false);
     (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "usr_123" } });
+    ensurePlannerAccess.mockResolvedValue({ ok: true, normalizedStatus: null, source: "database" });
+    assertCanStartNarrativeMapReading.mockResolvedValue({
+      ok: true,
+      state: "free_unused",
+      quota: { monthKey: "2026-05", usedTotal: 0, usedThisMonth: 0, freeTotalLimit: 1, proMonthlyLimit: 10 },
+      message: "Leitura disponível.",
+    });
   });
 
   afterAll(() => {
@@ -126,6 +145,21 @@ describe("POST /api/dashboard/mobile-strategic-profile/upload-session", () => {
 
     const res = await POST(createRequest("POST", validBasePayload));
     expect(res.status).toBe(403);
+  });
+
+  it("POST bloqueia antes do upload quando quota de leitura está indisponível", async () => {
+    assertCanStartNarrativeMapReading.mockResolvedValue({
+      ok: false,
+      state: "free_preview_used",
+      quota: { monthKey: "2026-05", usedTotal: 1, usedThisMonth: 1, freeTotalLimit: 1, proMonthlyLimit: 10 },
+      message: "Limite de leituras indisponível.",
+    });
+
+    const res = await POST(createRequest("POST", validBasePayload));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.reason).toBe("reading_quota_unavailable");
+    expect(body.accessState).toBe("free_preview_used");
   });
 
   it("POST bloqueia provider real / storage real se allowlist estiver desligada", async () => {

--- a/src/app/api/dashboard/mobile-strategic-profile/upload-session/route.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/upload-session/route.ts
@@ -10,6 +10,9 @@ import { validateTemporaryUploadInput } from "@/app/dashboard/boards/videoUpload
 import { evaluateVideoNarrativeSignedUploadAllowlist } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageAllowlist";
 import { createVideoNarrativeTemporaryStorageProvider } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageProviderFactory";
 import { createServerSideSignedUploadUrlSigner } from "@/app/dashboard/boards/videoUpload/videoNarrativeTemporaryStorageSignedUrlProvider";
+import { assertCanStartNarrativeMapReading } from "@/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService";
+import { ensurePlannerAccess } from "@/app/lib/planGuard";
+import { hasPlanPremiumAccess } from "@/utils/planStatus";
 
 const SIGNED_URL_KEYWORDS = ["signature=", "expires=", "token=", "policy="];
 const BASE64_INDICATOR = "base64";
@@ -20,8 +23,41 @@ type MobileStrategicProfileSession = {
     role?: string | null;
     isAdmin?: boolean | null;
     isDev?: boolean | null;
+    planStatus?: string | null;
+    instagramConnected?: boolean | null;
+    isInstagramConnected?: boolean | null;
   };
 } | null;
+
+async function resolveNarrativeMapUploadAccess(sessionUser: NonNullable<MobileStrategicProfileSession>["user"]) {
+  const isAdmin =
+    Boolean(sessionUser?.isAdmin || sessionUser?.isDev) ||
+    sessionUser?.role === "admin" ||
+    sessionUser?.role === "dev";
+  let hasPremiumAccess = hasPlanPremiumAccess(sessionUser?.planStatus ?? null);
+
+  if (!hasPremiumAccess && sessionUser?.id) {
+    const planAccess = await ensurePlannerAccess({
+      session: { user: sessionUser } as any,
+      userId: sessionUser.id,
+      email: sessionUser.email ?? undefined,
+      allowAdmin: true,
+      forceReload: true,
+      routePath: "/api/dashboard/mobile-strategic-profile/upload-session",
+    });
+    hasPremiumAccess = Boolean(planAccess.ok && hasPlanPremiumAccess(planAccess.normalizedStatus));
+  }
+
+  return {
+    isAdmin,
+    hasPremiumAccess,
+    hasFullReportAccess: hasPremiumAccess,
+    instagram: {
+      connected: Boolean(sessionUser?.instagramConnected || sessionUser?.isInstagramConnected),
+      needsReconnect: false,
+    },
+  };
+}
 
 export async function GET() {
   return NextResponse.json({ message: "Método não permitido." }, { status: 405 });
@@ -55,6 +91,31 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { message: "Acesso não autorizado: sessão não identificada." },
         { status: 401 }
+      );
+    }
+
+    const access = await resolveNarrativeMapUploadAccess(session.user);
+    const accessDecision = await assertCanStartNarrativeMapReading({
+      userId: session.user.id,
+      access,
+    });
+    if (!accessDecision.ok) {
+      return NextResponse.json(
+        {
+          ok: false,
+          status: "disabled",
+          reason: "reading_quota_unavailable",
+          accessState: accessDecision.state,
+          quota: accessDecision.quota,
+          issues: [
+            {
+              code: "reading_quota_unavailable",
+              message: accessDecision.message,
+              severity: "blocker",
+            },
+          ],
+        },
+        { status: 403 },
       );
     }
 

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -41,6 +41,13 @@ function resolveInstagramNextTarget(
   return null;
 }
 
+function sanitizeReturnTo(value: unknown): string | null {
+  if (typeof value === "string" && value.startsWith("/") && !value.startsWith("//")) {
+    return value;
+  }
+  return null;
+}
+
 export default function BillingSuccessPage() {
   const sp = useSearchParams();
   const sid = sp.get("session_id");
@@ -79,15 +86,22 @@ export default function BillingSuccessPage() {
             if (typeof data?.context === "string") {
               resolvedContext = data.context;
             }
-            const returnTo =
-              typeof data?.returnTo === "string" && data.returnTo.startsWith("/")
-                ? data.returnTo
+            const returnTo = sanitizeReturnTo(data?.returnTo);
+            const postCheckoutIntent =
+              data?.postCheckoutIntent === "connect_instagram" || data?.postCheckoutIntent === "join_community"
+                ? data.postCheckoutIntent
                 : null;
             const source =
               typeof data?.source === "string" && data.source.trim().length > 0
                 ? data.source.trim().toLowerCase()
                 : null;
-            const instagramNextTarget = !instagramConnected
+            if (postCheckoutIntent === "connect_instagram" && !instagramConnected) {
+              redirectHref = "/dashboard/instagram/connect?next=narrative-map";
+              keepPaywallReturnState = true;
+            } else if (postCheckoutIntent === "join_community" && returnTo) {
+              redirectHref = returnTo;
+            }
+            const instagramNextTarget = !redirectHref && !instagramConnected
               ? resolveInstagramNextTarget(resolvedContext, source)
               : null;
             if (instagramNextTarget) {

--- a/src/app/components/PaywallModalProvider.tsx
+++ b/src/app/components/PaywallModalProvider.tsx
@@ -20,6 +20,7 @@ const ALLOWED_CONTEXTS: PaywallContext[] = [
   "reply_email",
   "ai_analysis",
   "calculator",
+  "narrative_map",
   "mentoria",
   "media_kit",
   "publis",
@@ -57,6 +58,10 @@ export default function PaywallModalProvider() {
         typeof detail?.proposalId === "string" && detail.proposalId.trim().length > 0
           ? detail.proposalId.trim()
           : null;
+      const postCheckoutIntent =
+        detail?.postCheckoutIntent === "connect_instagram" || detail?.postCheckoutIntent === "join_community"
+          ? detail.postCheckoutIntent
+          : null;
 
       setContext(normalizedContext);
 
@@ -69,6 +74,7 @@ export default function PaywallModalProvider() {
               source: typeof detail?.source === "string" ? detail.source : null,
               returnTo: sanitizedReturn,
               proposalId,
+              postCheckoutIntent,
               ts: Date.now(),
             })
           );
@@ -83,6 +89,7 @@ export default function PaywallModalProvider() {
               context: normalizedContext,
               source: typeof detail?.source === "string" ? detail.source : null,
               returnTo: sanitizedReturn,
+              postCheckoutIntent,
               ts: Date.now(),
             })
           );

--- a/src/app/dashboard/billing/BillingSubscribeModal.tsx
+++ b/src/app/dashboard/billing/BillingSubscribeModal.tsx
@@ -143,16 +143,33 @@ const PAYWALL_COPY: Record<PaywallContext | "default", PaywallCopy> = {
       "Volte para liberar suas publis",
     ],
   },
-  mentoria: {
-    title: "Mentoria D2C",
-    subtitle:
-      "Participe das reuniões com Arthur Marba, Ronaldo Fonseca e convidados para revisar conteúdo, repertório e posicionamento.",
+  narrative_map: {
+    title: "Desbloqueie seu Perfil vivo",
+    subtitle: "A leitura gratuita mostra o que a D2C percebeu neste vídeo.",
     bullets: [
-      "Agenda semanal com encontros ao vivo",
-      "Acesso ao grupo da comunidade no WhatsApp",
-      "Revisões de conteúdo e roteiros com olhar comercial",
+      "Até 10 leituras estratégicas por mês",
+      "Perfil vivo com padrões e hipóteses",
+      "Conexão com Instagram",
+      "Consultorias em grupo",
     ],
-    ctaLabel: "Ativar Acesso VIP",
+    ctaLabel: "Assinar Pro e conectar Instagram",
+    steps: [
+      "Ative sua assinatura",
+      "Conecte seu Instagram",
+      "Volte para o Perfil",
+    ],
+  },
+  mentoria: {
+    title: "Entre na consultoria da D2C",
+    subtitle:
+      "No Plano Pro, você entra no Grupo VIP e participa das consultorias em grupo, além de liberar o Perfil vivo com 10 leituras por mês e Instagram conectado.",
+    bullets: [
+      "Grupo VIP da D2C",
+      "Consultorias em grupo",
+      "Perfil vivo com 10 leituras por mês",
+      "Instagram conectado",
+    ],
+    ctaLabel: "Assinar Pro e entrar",
     steps: [
       "Ative sua assinatura",
       "Entre no grupo VIP",
@@ -252,9 +269,9 @@ export default function BillingSubscribeModal({
   
   // O modal deve ser uniforme mostrando todo o valor do plano Pro (D2C)
   // mas mantendo os "steps" específicos para guiar o usuário no funil atual.
-  const paywallCopy = PAYWALL_COPY.default;
   const contextCopy = PAYWALL_COPY[effectiveContext] ?? PAYWALL_COPY.default;
-  const bulletItems = FEATURES; 
+  const paywallCopy = contextCopy;
+  const bulletItems = contextCopy.bullets;
   const stepItems = useMemo(() => {
     let items = Array.isArray(contextCopy.steps) ? [...contextCopy.steps] : [];
     if (sessionStatus === "unauthenticated" && items.length > 0) {
@@ -262,7 +279,7 @@ export default function BillingSubscribeModal({
     }
     return items;
   }, [contextCopy.steps, sessionStatus]);
-  const primaryCtaLabel = "Assinar e continuar";
+  const primaryCtaLabel = contextCopy.ctaLabel || "Assinar e continuar";
   const isDefaultContext = effectiveContext === "default";
   const shouldBlockSubscribe =
     !billingStatusError && (hasPremiumAccess || needsPaymentAction);
@@ -372,6 +389,8 @@ export default function BillingSubscribeModal({
             return "planning";
           case "calculator":
             return "calculator";
+          case "narrative_map":
+            return "other";
           case "mentoria":
             return "discover";
           case "whatsapp":

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -7,6 +7,10 @@ import {
   type MobileStrategicProfilePreviewFixtureState,
 } from "./buildMobileStrategicProfilePreviewFixture";
 
+jest.mock("@/utils/paywallModal", () => ({
+  openPaywallModal: jest.fn(),
+}));
+
 const SOURCE_PATH = path.join(__dirname, "MobileStrategicProfilePreview.tsx");
 
 function renderState(state: MobileStrategicProfilePreviewFixtureState) {
@@ -39,15 +43,14 @@ describe("MobileStrategicProfilePreview", () => {
     expect(screen.getByText("Ana Creator")).toBeInTheDocument();
     expect(screen.getAllByText("@ana.creator").length).toBeGreaterThan(0);
     expect(screen.getByText("Diagnóstico vivo do creator")).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/Cada vídeo analisado ajuda a atualizar seu diagnóstico como creator/).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Status do Perfil")).toBeInTheDocument();
   });
 
-  it("renders header plus button as profile update action", () => {
+  it("renders profile status bubble as next action", () => {
     renderState("first_reading_free");
 
-    expect(screen.getByLabelText("Atualizar meu Perfil")).toBeInTheDocument();
+    expect(screen.getByText("Leitura grátis usada")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assinar Pro" })).toBeInTheDocument();
   });
 
   it("renders status pills without forbidden technical language", () => {
@@ -80,8 +83,8 @@ describe("MobileStrategicProfilePreview", () => {
     renderState("account_only");
 
     expect(screen.getAllByText("Perfil em construção").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Analisar primeiro vídeo").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Seu Perfil Estratégico começa aqui").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Analisar meu primeiro vídeo").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Teste sua primeira leitura narrativa").length).toBeGreaterThan(0);
   });
 
   it("construction profile does not show Media Kit available", () => {
@@ -93,18 +96,19 @@ describe("MobileStrategicProfilePreview", () => {
     expect(text).not.toContain("ver como marca");
   });
 
-  it("first reading renders Diagnosis and Atualizar meu Perfil CTA", () => {
+  it("first reading renders Mapa and conversion CTA", () => {
     renderState("first_reading_free");
 
-    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Comercial").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mapa").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Oportunidades").length).toBeGreaterThan(0);
     expect(screen.getByText("O que este vídeo comunica")).toBeInTheDocument();
-    expect(screen.getAllByText("Atualizar meu Perfil").length).toBeGreaterThan(0);
+    expect(screen.getByText("Transforme essa leitura em um Perfil vivo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assinar Pro e conectar Instagram" })).toBeInTheDocument();
   });
 
   it("premium renders Commercial section without brand promise", () => {
     const { container } = renderState("premium_without_instagram");
-    fireEvent.click(screen.getByRole("tab", { name: "Comercial" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
     const text = renderedText(container);
 
     expect(screen.getAllByText("Potencial comercial").length).toBeGreaterThan(0);
@@ -121,20 +125,20 @@ describe("MobileStrategicProfilePreview", () => {
     expect(screen.getByText("Instagram conectado")).toBeInTheDocument();
   });
 
-  it("internal tabs switch between Diagnóstico and Comercial locally", () => {
+  it("internal tabs switch between Mapa and Oportunidades locally", () => {
     renderState("premium_without_instagram");
 
-    expect(screen.getByRole("tab", { name: "Diagnóstico" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Mapa" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Diagnóstico vivo")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Comercial" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Oportunidades" }));
 
-    expect(screen.getByRole("tab", { name: "Comercial" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Oportunidades" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getAllByText("Potencial comercial").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Diagnóstico" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Mapa" }));
 
-    expect(screen.getByRole("tab", { name: "Diagnóstico" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Mapa" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Diagnóstico vivo")).toBeInTheDocument();
   });
 
@@ -164,35 +168,34 @@ describe("MobileStrategicProfilePreview", () => {
     expect(screen.queryByRole("dialog", { name: "Vamos atualizar seu Perfil" })).not.toBeInTheDocument();
   });
 
-  it("opens Analyze flow from header plus button", () => {
-    renderState("first_reading_free");
+  it("opens Analyze flow from status bubble when free reading is available", () => {
+    renderState("account_only");
 
-    fireEvent.click(screen.getByLabelText("Atualizar meu Perfil"));
-
-    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
-  });
-
-  it("opens Analyze flow from bottom nav central plus", () => {
-    renderState("first_reading_free");
-    const nav = screen.getByLabelText("Navegação mobile futura");
-
-    fireEvent.click(within(nav).getByRole("button", { name: "Analisar vídeo pela ação central" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analisar vídeo" }));
 
     expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
   });
 
-  it("opens Analyze flow from Atualizar meu Perfil action", () => {
+  it("does not render central analyze action in bottom nav", () => {
     renderState("first_reading_free");
+    const nav = screen.getByLabelText("Navegação mobile principal");
 
-    clickAnalyzeAction("Atualizar meu Perfil");
+    expect(within(nav).queryByRole("button", { name: "Analisar vídeo pela ação central" })).not.toBeInTheDocument();
+    expect(within(nav).queryByText("+")).not.toBeInTheDocument();
+  });
+
+  it("opens Analyze flow from Analisar meu primeiro vídeo action in account_only", () => {
+    renderState("account_only");
+
+    clickAnalyzeAction("Analisar meu primeiro vídeo");
 
     expect(screen.getByText("Use um vídeo para a D2C entender novos sinais da sua narrativa.")).toBeInTheDocument();
   });
 
-  it("opens Analyze flow from Analisar primeiro vídeo action in account_only", () => {
+  it("opens Analyze flow from empty state CTA in account_only", () => {
     renderState("account_only");
 
-    clickAnalyzeAction("Analisar primeiro vídeo");
+    clickAnalyzeAction("Analisar meu primeiro vídeo");
 
     expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
   });
@@ -206,9 +209,9 @@ describe("MobileStrategicProfilePreview", () => {
   });
 
   it("Analyze flow returns to Profile after short confirmation", () => {
-    renderState("first_reading_free");
+    renderState("account_only");
 
-    clickAnalyzeAction("Atualizar meu Perfil");
+    clickAnalyzeAction("Analisar meu primeiro vídeo");
     advanceAnalyzeFlowToConfirmation();
 
     expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
@@ -216,14 +219,14 @@ describe("MobileStrategicProfilePreview", () => {
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
-    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mapa").length).toBeGreaterThan(0);
     expect(screen.getByText("Seu Perfil foi atualizado com a nova leitura.")).toBeInTheDocument();
   });
 
   it("Analyze flow does not create analyzed videos history or active file input", () => {
-    const { container } = renderState("first_reading_free");
+    const { container } = renderState("account_only");
 
-    clickAnalyzeAction("Atualizar meu Perfil");
+    clickAnalyzeAction("Analisar meu primeiro vídeo");
     advanceAnalyzeFlowToConfirmation();
     fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
 
@@ -239,13 +242,11 @@ describe("MobileStrategicProfilePreview", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("opens Media Kit modal from share_media_kit action", () => {
+  it("does not compete with status action for Media Kit", () => {
     renderState("media_kit_available");
 
-    fireEvent.click(screen.getByRole("button", { name: "Compartilhar Mídia Kit" }));
-
-    expect(screen.getByRole("dialog", { name: "Compartilhar Mídia Kit" })).toBeInTheDocument();
-    expect(screen.getByText("Use o Mídia Kit existente para apresentar seu perfil para marcas.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Compartilhar Mídia Kit" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copiar link" })).toBeInTheDocument();
   });
 
   it("opens Media Kit modal from bridge action", () => {
@@ -271,25 +272,25 @@ describe("MobileStrategicProfilePreview", () => {
     const text = renderedText(container);
 
     expect(screen.getAllByText("Comunidade").length).toBeGreaterThan(0);
-    expect(screen.getByText("Acesse a Comunidade Data2Content, destino existente para continuar aprendendo com outros membros.")).toBeInTheDocument();
+    expect(text).not.toContain("conhecer comunidade");
     expect(text).not.toContain("feed");
     expect(text).not.toContain("chat");
     expect(text).not.toContain("comments");
     expect(text).not.toContain("comentários");
   });
 
-  it("bottom nav renders Perfil, + and Comunidade", () => {
+  it("bottom nav renders only Perfil and Comunidade", () => {
     renderState("first_reading_free");
-    const nav = screen.getByLabelText("Navegação mobile futura");
+    const nav = screen.getByLabelText("Navegação mobile principal");
 
     expect(within(nav).getByText("Perfil")).toBeInTheDocument();
-    expect(within(nav).getByText("+")).toBeInTheDocument();
     expect(within(nav).getByText("Comunidade")).toBeInTheDocument();
+    expect(within(nav).queryByText("+")).not.toBeInTheDocument();
   });
 
   it("bottom nav does not render Mídia Kit, Diagnóstico or Comercial as global tabs", () => {
     renderState("media_kit_available");
-    const nav = screen.getByLabelText("Navegação mobile futura");
+    const nav = screen.getByLabelText("Navegação mobile principal");
 
     expect(within(nav).queryByText("Mídia Kit")).not.toBeInTheDocument();
     expect(within(nav).queryByText("Diagnóstico")).not.toBeInTheDocument();

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -8,6 +8,14 @@ import type {
   MobileStrategicProfileSectionCard,
 } from "../../../videoUpload/mobileStrategicProfileMapping";
 import {
+  getNarrativeMapAccessAction,
+  getNarrativeMapAccessStatusText,
+  normalizeNarrativeMapReadingQuotaSnapshot,
+  type NarrativeMapAccessState,
+  type NarrativeMapReadingQuotaSnapshot,
+} from "../../../videoUpload/narrativeMapAccessState";
+import { openPaywallModal } from "@/utils/paywallModal";
+import {
   MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
   type MobileStrategicProfilePreviewFixtureState,
 } from "./buildMobileStrategicProfilePreviewFixture";
@@ -45,6 +53,8 @@ type MobileStrategicProfilePreviewProps = {
     input: MobileStrategicProfileDirectUploadInput,
   ) => Promise<MobileStrategicProfileDirectUploadResult>;
   enableRealAnalysis?: boolean;
+  accessState?: NarrativeMapAccessState;
+  readingQuota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
   onCleanupTemporaryUpload?: (payload: {
     uploadSessionId: string;
     objectKey?: string;
@@ -73,6 +83,15 @@ function isMediaKitAction(action: MobileStrategicProfileAction): boolean {
 
 function isAnalyzeAction(action: MobileStrategicProfileAction): boolean {
   return action.intent === "analyze_video";
+}
+
+function inferAccessStateFromProfile(profile: MobileStrategicProfile): NarrativeMapAccessState {
+  if (profile.state.subscriptionState === "premium") {
+    return profile.state.instagramState === "connected" ? "pro_instagram_connected" : "pro_needs_instagram";
+  }
+  if (profile.state.profileAvailability === "construction") return "free_unused";
+  if (profile.state.diagnosisState !== "empty") return "free_preview_used";
+  return "free_unused";
 }
 
 function StateSwitcher({ activeState }: { activeState?: MobileStrategicProfilePreviewFixtureState }) {
@@ -166,13 +185,22 @@ function AuthGate({ profile, isRealShell }: { profile: MobileStrategicProfile; i
 function ProfileHeader({
   profile,
   onAction,
-  onAnalyze,
+  accessState,
+  readingQuota,
+  onPrimaryAccessAction,
+  onJoinCommunity,
 }: {
   profile: MobileStrategicProfile;
   onAction: (action: MobileStrategicProfileAction) => void;
-  onAnalyze: () => void;
+  accessState: NarrativeMapAccessState;
+  readingQuota: Partial<NarrativeMapReadingQuotaSnapshot> | null | undefined;
+  onPrimaryAccessAction: () => void;
+  onJoinCommunity: () => void;
 }) {
   const identity = profile.header.identity;
+  const accessAction = getNarrativeMapAccessAction(accessState);
+  const statusText = getNarrativeMapAccessStatusText({ state: accessState, quota: readingQuota });
+  const quota = normalizeNarrativeMapReadingQuotaSnapshot(readingQuota);
   const initials = identity.displayName
     .split(/\s+/)
     .filter(Boolean)
@@ -188,14 +216,7 @@ function ProfileHeader({
           <p className="text-sm font-semibold text-zinc-950">{identity.displayHandle ?? "Perfil Estratégico"}</p>
           <p className="text-xs font-medium text-zinc-500">Diagnóstico vivo do creator</p>
         </div>
-        <button
-          type="button"
-          aria-label="Atualizar meu Perfil"
-          className="grid h-10 w-10 place-items-center rounded-full bg-zinc-950 text-xl font-semibold text-white shadow-lg shadow-zinc-950/20"
-          onClick={onAnalyze}
-        >
-          +
-        </button>
+        <span className="rounded-full bg-zinc-950 px-3 py-1 text-xs font-semibold text-white shadow-sm">D2C</span>
       </div>
 
       <div className="mt-5 rounded-[1.75rem] bg-[#f7f7f4] p-4">
@@ -210,9 +231,24 @@ function ProfileHeader({
           </div>
         </div>
 
-        <p className="mt-4 rounded-2xl bg-white px-3 py-2 text-sm leading-6 text-zinc-700 shadow-sm">
-          Cada vídeo analisado ajuda a atualizar seu diagnóstico como creator. Use o botão + para trazer uma nova leitura.
-        </p>
+        <section className="mt-4 rounded-2xl bg-white px-3 py-3 shadow-sm" aria-label="Status do Perfil">
+          <p className="text-xs font-semibold uppercase text-zinc-500">Próximo passo</p>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-zinc-950">{statusText}</p>
+              {accessState === "pro_instagram_connected" ? (
+                <p className="mt-0.5 text-xs text-zinc-500">{quota.usedThisMonth}/10 leituras usadas este mês · Instagram conectado</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="shrink-0 rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+              onClick={onPrimaryAccessAction}
+            >
+              {accessAction.label}
+            </button>
+          </div>
+        </section>
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">
@@ -223,11 +259,15 @@ function ProfileHeader({
         ))}
       </div>
 
-      <div className="mt-4 grid gap-2">
-        {profile.primaryActions.slice(0, 2).map((action, index) => (
-          <ActionButton key={action.id} action={action} onAction={onAction} fullWidth={index === 0} />
-        ))}
-      </div>
+      {profile.state.subscriptionState === "premium" ? (
+        <button
+          type="button"
+          className="mt-4 rounded-full border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-700"
+          onClick={onJoinCommunity}
+        >
+          Entrar na consultoria
+        </button>
+      ) : null}
     </header>
   );
 }
@@ -342,25 +382,12 @@ function MediaKitBridge({
 
 function BottomNav({
   profile,
-  onAnalyze,
 }: {
   profile: MobileStrategicProfile;
-  onAnalyze: () => void;
 }) {
   return (
-    <nav className="sticky bottom-0 mt-6 grid grid-cols-3 items-center border-t border-zinc-200 bg-white/95 px-4 pb-4 pt-3 backdrop-blur" aria-label="Navegação mobile futura">
-      {profile.navigation.items.map((item) =>
-        item.role === "central_action" ? (
-          <button
-            key={item.id}
-            type="button"
-            aria-label="Analisar vídeo pela ação central"
-            className="mx-auto -mt-7 grid h-14 w-14 place-items-center rounded-full border-4 border-white bg-zinc-950 text-xl font-semibold text-white shadow-xl shadow-zinc-950/25"
-            onClick={onAnalyze}
-          >
-            {item.label}
-          </button>
-        ) : (
+    <nav className="sticky bottom-0 mt-6 grid grid-cols-2 items-center border-t border-zinc-200 bg-white/95 px-4 pb-4 pt-3 backdrop-blur" aria-label="Navegação mobile principal">
+      {profile.navigation.items.map((item) => (
           <a
             key={item.id}
             href={item.href ?? "#"}
@@ -368,9 +395,26 @@ function BottomNav({
           >
             {item.label}
           </a>
-        ),
-      )}
+      ))}
     </nav>
+  );
+}
+
+function FreeConversionCard({ onSubscribe }: { onSubscribe: () => void }) {
+  return (
+    <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+      <h3 className="text-base font-semibold text-zinc-950">Transforme essa leitura em um Perfil vivo</h3>
+      <p className="mt-2 text-sm leading-6 text-zinc-600">
+        No Plano Pro, você libera 10 leituras por mês, conecta seu Instagram e participa das consultorias em grupo.
+      </p>
+      <button
+        type="button"
+        className="mt-3 rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
+        onClick={onSubscribe}
+      >
+        Assinar Pro e conectar Instagram
+      </button>
+    </section>
   );
 }
 
@@ -382,14 +426,71 @@ export function MobileStrategicProfilePreview({
   onCreateUploadSession,
   onUploadToTemporarySignedUrl,
   enableRealAnalysis,
+  accessState: accessStateProp,
+  readingQuota,
   onCleanupTemporaryUpload,
 }: MobileStrategicProfilePreviewProps) {
   const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
   const [analyzeFlowOpen, setAnalyzeFlowOpen] = useState(false);
   const [profileUpdated, setProfileUpdated] = useState(false);
   const [activeTab, setActiveTab] = useState<"diagnosis" | "commercial">("diagnosis");
+  const [accessMessage, setAccessMessage] = useState<string | null>(null);
+  const accessState = accessStateProp ?? inferAccessStateFromProfile(profile);
+  const normalizedQuota = normalizeNarrativeMapReadingQuotaSnapshot(readingQuota);
 
   if (profile.authGate.visible) return <AuthGate profile={profile} isRealShell={isRealShell} />;
+
+  const openProfilePaywall = () => {
+    openPaywallModal({
+      context: "narrative_map",
+      source: "mobile_profile",
+      returnTo: "/dashboard/boards/mobile-strategic-profile",
+      postCheckoutIntent: "connect_instagram",
+    });
+  };
+
+  const joinCommunity = () => {
+    if (typeof window !== "undefined") {
+      window.location.href = "/planning/discover";
+    }
+  };
+
+  const connectInstagram = () => {
+    if (accessState === "free_unused" || accessState === "free_preview_used") {
+      openProfilePaywall();
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.location.href = "/dashboard/instagram/connect?next=narrative-map";
+    }
+  };
+
+  const handleStartAnalysis = () => {
+    setAccessMessage(null);
+    if (accessState === "free_unused" || accessState === "pro_instagram_connected" || accessState === "admin" || accessState === "pro_needs_instagram") {
+      setAnalyzeFlowOpen(true);
+      return;
+    }
+    if (accessState === "free_preview_used") {
+      openProfilePaywall();
+      return;
+    }
+    if (accessState === "payment_pending" || accessState === "payment_action_needed") {
+      openProfilePaywall();
+      return;
+    }
+    if (accessState === "pro_quota_reached") {
+      setAccessMessage("Você usou suas 10 leituras deste mês. Seu Perfil continua disponível.");
+    }
+  };
+
+  const handlePrimaryAccessAction = () => {
+    if (accessState === "pro_needs_instagram") {
+      connectInstagram();
+      return;
+    }
+    handleStartAnalysis();
+  };
 
   const handleAction = (action: MobileStrategicProfileAction) => {
     if (isMediaKitAction(action)) {
@@ -398,7 +499,12 @@ export function MobileStrategicProfilePreview({
     }
 
     if (isAnalyzeAction(action)) {
-      setAnalyzeFlowOpen(true);
+      handleStartAnalysis();
+      return;
+    }
+
+    if (action.intent === "connect_instagram") {
+      connectInstagram();
     }
   };
 
@@ -428,7 +534,14 @@ export function MobileStrategicProfilePreview({
 
         <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
           <div className="relative min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
-            <ProfileHeader profile={profile} onAction={handleAction} onAnalyze={() => setAnalyzeFlowOpen(true)} />
+            <ProfileHeader
+              profile={profile}
+              onAction={handleAction}
+              accessState={accessState}
+              readingQuota={normalizedQuota}
+              onPrimaryAccessAction={handlePrimaryAccessAction}
+              onJoinCommunity={joinCommunity}
+            />
             <Tabs profile={profile} activeTab={activeTab} onChange={setActiveTab} />
 
             <div className="mt-5 grid gap-5 pb-2">
@@ -436,6 +549,12 @@ export function MobileStrategicProfilePreview({
                 <section className="mx-5 rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
                   <p className="text-sm font-semibold text-zinc-950">Diagnóstico atualizado</p>
                   <p className="mt-1 text-sm leading-6 text-zinc-600">Seu Perfil foi atualizado com a nova leitura.</p>
+                </section>
+              ) : null}
+
+              {accessMessage ? (
+                <section className="mx-5 rounded-2xl border border-amber-100 bg-amber-50 p-4">
+                  <p className="text-sm font-semibold text-zinc-950">{accessMessage}</p>
                 </section>
               ) : null}
 
@@ -447,9 +566,9 @@ export function MobileStrategicProfilePreview({
                     <button
                       type="button"
                       className="mt-3 inline-flex rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white"
-                      onClick={() => setAnalyzeFlowOpen(true)}
+                      onClick={handleStartAnalysis}
                     >
-                      {profile.constructionState.recommendedActionLabel}
+                      Analisar meu primeiro vídeo
                     </button>
                   ) : null}
                 </section>
@@ -459,15 +578,10 @@ export function MobileStrategicProfilePreview({
 
               <MediaKitBridge profile={profile} onOpen={() => setMediaKitModalOpen(true)} />
 
-              {profile.communityBridge.visible ? (
-                <section className="mx-5 rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
-                  <h3 className="text-base font-semibold text-zinc-950">{profile.communityBridge.label}</h3>
-                  <p className="mt-1 text-sm leading-6 text-zinc-600">{profile.communityBridge.description}</p>
-                </section>
-              ) : null}
+              {accessState === "free_preview_used" ? <FreeConversionCard onSubscribe={openProfilePaywall} /> : null}
             </div>
 
-            <BottomNav profile={profile} onAnalyze={() => setAnalyzeFlowOpen(true)} />
+            <BottomNav profile={profile} />
             <MobileStrategicProfileAnalyzeFlow
               open={analyzeFlowOpen}
               onClose={() => setAnalyzeFlowOpen(false)}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
@@ -11,6 +11,25 @@ jest.mock("../../../../home/homeSummaryClient", () => ({
   fetchHomeSummaryCached: jest.fn(),
 }));
 
+jest.mock("@/app/hooks/useBillingStatus", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    hasPremiumAccess: false,
+    hasFullReportAccess: false,
+    needsCheckout: false,
+    needsPaymentAction: false,
+    needsBilling: false,
+    needsPaymentUpdate: false,
+    isAdminViewer: false,
+    hasResolvedOnce: true,
+    instagram: { connected: false, needsReconnect: false },
+  })),
+}));
+
+jest.mock("@/utils/paywallModal", () => ({
+  openPaywallModal: jest.fn(),
+}));
+
 jest.mock("./mobileStrategicProfileUploadSessionClient", () => ({
   requestUploadSession: jest.fn(),
 }));
@@ -557,7 +576,7 @@ describe("MobileStrategicProfileRealShellClient", () => {
     globalFetchSpy.mockRestore();
   });
 
-  it("MM85 - renderiza shell real Perfil | Leituras | Oportunidades quando view model narrativo vem do servidor", async () => {
+  it("MM85 - renderiza shell real Mapa | Leituras | Oportunidades quando view model narrativo vem do servidor", async () => {
     (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
     const fixture = buildNarrativeMapReadingPreviewFixture({ state: "narrative_map_three_related_readings" });
 
@@ -570,7 +589,7 @@ describe("MobileStrategicProfileRealShellClient", () => {
       />
     );
 
-    expect(screen.getByRole("tab", { name: "Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Mapa" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Leituras" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Oportunidades" })).toBeInTheDocument();
     expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -7,11 +7,19 @@ import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUp
 import { buildMobileStrategicProfileFromSnapshot } from "../../../videoUpload/mobileStrategicProfileSnapshotMapping";
 import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
 import { NarrativeMapMobileShell } from "./NarrativeMapMobileShell";
+import { MobileStrategicProfileAnalyzeFlow } from "./MobileStrategicProfileAnalyzeFlow";
 import { fetchHomeSummaryCached } from "../../../../home/homeSummaryClient";
+import useBillingStatus from "@/app/hooks/useBillingStatus";
+import { openPaywallModal } from "@/utils/paywallModal";
 import { requestUploadSession } from "./mobileStrategicProfileUploadSessionClient";
 import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectUploadClient";
 import type { CreatorNarrativeMapReadingPresentation } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
 import type { NarrativeMapMobileViewModel } from "../../../videoUpload/narrativeMapMobileViewModel";
+import {
+  normalizeNarrativeMapReadingQuotaSnapshot,
+  resolveNarrativeMapAccessState,
+  type NarrativeMapReadingQuotaSnapshot,
+} from "../../../videoUpload/narrativeMapAccessState";
 import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
 
 interface MobileStrategicProfileRealShellClientProps {
@@ -21,6 +29,7 @@ interface MobileStrategicProfileRealShellClientProps {
   initialNarrativeMapViewModel?: NarrativeMapMobileViewModel | null;
   initialNarrativeMapPresentation?: CreatorNarrativeMapReadingPresentation | null;
   initialSynthesisSnapshotWrite?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
+  initialReadingQuota?: NarrativeMapReadingQuotaSnapshot | null;
   internalSnapshotReview?: boolean;
 }
 
@@ -31,9 +40,27 @@ export function MobileStrategicProfileRealShellClient({
   initialNarrativeMapViewModel,
   initialNarrativeMapPresentation,
   initialSynthesisSnapshotWrite,
+  initialReadingQuota,
   internalSnapshotReview,
 }: MobileStrategicProfileRealShellClientProps) {
   const realAnalysisEnabled = process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED === "1";
+  const billing = useBillingStatus();
+  const quota = normalizeNarrativeMapReadingQuotaSnapshot(initialReadingQuota);
+  const sessionUser = session?.user as any;
+  const accessState = resolveNarrativeMapAccessState({
+    hasPremiumAccess: billing.hasResolvedOnce ? billing.hasPremiumAccess : sessionUser?.planStatus === "active",
+    hasFullReportAccess: billing.hasResolvedOnce ? billing.hasFullReportAccess : sessionUser?.planStatus === "active",
+    needsCheckout: billing.needsCheckout,
+    needsPaymentAction: billing.needsPaymentAction,
+    needsBilling: billing.needsBilling,
+    needsPaymentUpdate: billing.needsPaymentUpdate,
+    isAdmin: billing.isAdminViewer || sessionUser?.role === "admin" || sessionUser?.isAdmin || sessionUser?.isDev,
+    instagram: billing.instagram ?? {
+      connected: Boolean(sessionUser?.instagramConnected || sessionUser?.isInstagramConnected),
+      needsReconnect: false,
+    },
+    readingQuota: quota,
+  });
 
   // 1. Calcular o perfil inicial (Session-only, snapshot ou fixture via stateQuery)
   const [profile, setProfile] = useState<MobileStrategicProfile>(() => {
@@ -60,6 +87,8 @@ export function MobileStrategicProfileRealShellClient({
   });
 
   const [isHydrating, setIsHydrating] = useState(false);
+  const [mapAnalyzeFlowOpen, setMapAnalyzeFlowOpen] = useState(false);
+  const [mapAccessMessage, setMapAccessMessage] = useState<string | null>(null);
 
   useEffect(() => {
     // Se for anônimo, não precisamos hidratar
@@ -236,6 +265,32 @@ export function MobileStrategicProfileRealShellClient({
     }
   }, []);
 
+  const openProfilePaywall = useCallback(() => {
+    openPaywallModal({
+      context: "narrative_map",
+      source: "mobile_profile",
+      returnTo: "/dashboard/boards/mobile-strategic-profile",
+      postCheckoutIntent: "connect_instagram",
+    });
+  }, []);
+
+  const handleMapPrimaryAccessAction = useCallback(() => {
+    setMapAccessMessage(null);
+    if (accessState === "free_unused" || accessState === "pro_instagram_connected" || accessState === "pro_needs_instagram" || accessState === "admin") {
+      if (accessState === "pro_needs_instagram") {
+        window.location.href = "/dashboard/instagram/connect?next=narrative-map";
+        return;
+      }
+      setMapAnalyzeFlowOpen(true);
+      return;
+    }
+    if (accessState === "pro_quota_reached") {
+      setMapAccessMessage("Você usou suas 10 leituras deste mês. Seu Perfil continua disponível.");
+      return;
+    }
+    openProfilePaywall();
+  }, [accessState, openProfilePaywall]);
+
   return (
     <div className="relative">
       {isHydrating && (
@@ -258,6 +313,24 @@ export function MobileStrategicProfileRealShellClient({
               presentation={initialNarrativeMapPresentation}
               snapshotReview={initialSynthesisSnapshotWrite}
               internalReview={internalSnapshotReview}
+              accessState={accessState}
+              readingQuota={quota}
+              onPrimaryAccessAction={handleMapPrimaryAccessAction}
+            />
+            {mapAccessMessage ? (
+              <p className="mx-auto max-w-sm rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm font-semibold text-zinc-950">
+                {mapAccessMessage}
+              </p>
+            ) : null}
+            <MobileStrategicProfileAnalyzeFlow
+              open={mapAnalyzeFlowOpen}
+              onClose={() => setMapAnalyzeFlowOpen(false)}
+              onComplete={() => setMapAnalyzeFlowOpen(false)}
+              onSubmitAnalysis={handleAnalysisSubmit}
+              onCreateUploadSession={requestUploadSession}
+              onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
+              enableRealAnalysis={realAnalysisEnabled}
+              onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
             />
           </div>
         </main>
@@ -270,6 +343,8 @@ export function MobileStrategicProfileRealShellClient({
           onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
           enableRealAnalysis={realAnalysisEnabled}
           onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
+          accessState={accessState}
+          readingQuota={quota}
         />
       )}
     </div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
@@ -12,6 +12,16 @@ function renderShell(state = "narrative_map_three_related_readings", internalRev
       presentation={fixture.presentation}
       snapshotReview={fixture.synthesisSnapshotWrite}
       internalReview={internalReview}
+      accessState="pro_instagram_connected"
+      readingQuota={{
+        userId: "user-test",
+        freeReadingUsed: true,
+        totalCompletedReadings: 4,
+        usedThisMonth: 4,
+        periodStart: "2026-05-01T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
+      }}
+      onPrimaryAccessAction={jest.fn()}
     />,
   );
 }
@@ -21,10 +31,10 @@ function renderedText(container: HTMLElement): string {
 }
 
 describe("NarrativeMapMobileShell", () => {
-  it("renderiza tabs Perfil, Leituras e Oportunidades", () => {
+  it("renderiza tabs Mapa, Leituras e Oportunidades", () => {
     renderShell();
 
-    expect(screen.getByRole("tab", { name: "Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Mapa" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Leituras" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Oportunidades" })).toBeInTheDocument();
   });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
@@ -8,11 +8,17 @@ import { NarrativeMapReadingChapterCard } from "./NarrativeMapReadingChapterCard
 import { NarrativeMapReadingChapterModal } from "./NarrativeMapReadingChapterModal";
 import { NarrativeMapReadingFullDiagnosisModal } from "./NarrativeMapReadingFullDiagnosisModal";
 import { NarrativeMapSnapshotReviewPanel } from "./NarrativeMapSnapshotReviewPanel";
+import {
+  getNarrativeMapAccessAction,
+  getNarrativeMapAccessStatusText,
+  type NarrativeMapAccessState,
+  type NarrativeMapReadingQuotaSnapshot,
+} from "../../../videoUpload/narrativeMapAccessState";
 
 type NarrativeMapReadingPreviewTab = "profile" | "readings" | "opportunities";
 
 const TAB_LABELS: Record<NarrativeMapReadingPreviewTab, string> = {
-  profile: "Perfil",
+  profile: "Mapa",
   readings: "Leituras",
   opportunities: "Oportunidades",
 };
@@ -69,6 +75,9 @@ export function NarrativeMapMobileShell({
   stateNav,
   snapshotReview,
   internalReview,
+  accessState,
+  readingQuota,
+  onPrimaryAccessAction,
 }: {
   viewModel: NarrativeMapMobileViewModel;
   presentation: CreatorNarrativeMapReadingPresentation;
@@ -76,6 +85,9 @@ export function NarrativeMapMobileShell({
   stateNav?: ReactNode;
   snapshotReview?: VideoNarrativeSynthesisSnapshotWriteSummary | null;
   internalReview?: boolean;
+  accessState?: NarrativeMapAccessState;
+  readingQuota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
+  onPrimaryAccessAction?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState<NarrativeMapReadingPreviewTab>(
     (viewModel.tabs.find((tab) => tab.active)?.id ?? "profile") as NarrativeMapReadingPreviewTab,
@@ -87,6 +99,10 @@ export function NarrativeMapMobileShell({
   const readingsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Leituras")?.value ?? "0";
   const patternsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Padrões")?.value ?? "0";
   const opportunitiesCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Oportunidades")?.value ?? "0";
+  const accessAction = accessState ? getNarrativeMapAccessAction(accessState) : null;
+  const accessStatusText = accessState
+    ? getNarrativeMapAccessStatusText({ state: accessState, quota: readingQuota })
+    : null;
 
   return (
     <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
@@ -126,14 +142,20 @@ export function NarrativeMapMobileShell({
             <h2 className="mt-1.5 text-2xl font-semibold tracking-normal text-zinc-950">{viewModel.hero.title}</h2>
             <p className="mt-2 text-base font-semibold leading-6 text-zinc-950">{viewModel.hero.headline}</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.hero.subheadline}</p>
+            {accessAction && accessStatusText ? (
+              <div className="mt-4 rounded-2xl bg-zinc-50 p-3">
+                <p className="text-xs font-semibold text-zinc-500">{accessStatusText}</p>
+                <button
+                  type="button"
+                  data-priority="primary"
+                  className="mt-2 min-h-[40px] w-full rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15"
+                  onClick={onPrimaryAccessAction}
+                >
+                  {accessAction.label}
+                </button>
+              </div>
+            ) : null}
             <div className="mt-4 grid gap-2">
-              <button
-                type="button"
-                data-priority="primary"
-                className="min-h-[44px] rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15"
-              >
-                {viewModel.profile.primaryAction.label}
-              </button>
               {viewModel.profile.secondaryAction ? (
                 <button
                   type="button"

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
@@ -5,6 +5,8 @@ import { isMobileStrategicProfileEnabled } from "../videoUpload/mobileStrategicP
 import { MobileStrategicProfileRealShellClient } from "../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient";
 import { getStrategicProfileSnapshotByUserId } from "../videoUpload/mobileStrategicProfileSnapshotService";
 import { buildNarrativeMapMobileViewModelFromReadings } from "../videoUpload/narrativeMapMobileViewModelServerSelector";
+import { getNarrativeMapReadingQuotaForUser } from "../videoUpload/narrativeMapReadingQuotaService";
+import type { NarrativeMapReadingQuotaSnapshot } from "../videoUpload/narrativeMapAccessState";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +38,7 @@ export default async function MobileStrategicProfilePage({
   let initialSnapshotPayload = null;
   let initialNarrativeMapViewModel = null;
   let initialNarrativeMapPresentation = null;
+  let initialReadingQuota: NarrativeMapReadingQuotaSnapshot | null = null;
   const isSnapshotEnabled = process.env.MOBILE_STRATEGIC_PROFILE_SNAPSHOT_ENABLED !== "0";
 
   if (isSnapshotEnabled && session.user?.id) {
@@ -51,6 +54,9 @@ export default async function MobileStrategicProfilePage({
 
   if (session.user?.id) {
     try {
+      initialReadingQuota = await getNarrativeMapReadingQuotaForUser({
+        userId: session.user.id,
+      });
       const result = await buildNarrativeMapMobileViewModelFromReadings({
         userId: session.user.id,
         displayName: session.user.name ?? "Creator",
@@ -76,6 +82,7 @@ export default async function MobileStrategicProfilePage({
       initialSnapshotPayload={initialSnapshotPayload}
       initialNarrativeMapViewModel={initialNarrativeMapViewModel}
       initialNarrativeMapPresentation={initialNarrativeMapPresentation}
+      initialReadingQuota={initialReadingQuota}
     />
   );
 }

--- a/src/app/dashboard/boards/videoUpload/MM89_PRO_ACCESS_READING_QUOTA_INSTAGRAM_COMMUNITY_UX.md
+++ b/src/app/dashboard/boards/videoUpload/MM89_PRO_ACCESS_READING_QUOTA_INSTAGRAM_COMMUNITY_UX.md
@@ -1,0 +1,111 @@
+# MM89 — Pro Access, Reading Quota, Instagram and Community UX
+
+Status: implementado.
+
+## Produto
+
+- Free tem 1 leitura narrativa gratuita total.
+- Pro tem até 10 leituras por mês.
+- Instagram é recurso Pro.
+- Comunidade continua aberta como marketplace/vitrine de creators da D2C.
+- Consultoria em grupo e Grupo VIP são acesso Pro.
+- Não há novo plano, pacote extra de leituras ou alteração profunda de Stripe.
+
+## Navegação mobile
+
+- A navegação fixa inferior do mobile tem apenas `Perfil` e `Comunidade`.
+- `Nova leitura` não é item de menu global nem botão central.
+- A nova leitura fica dentro do Perfil:
+  - no balão/status de próximo passo;
+  - no estado vazio inicial com `Analisar meu primeiro vídeo`.
+- As abas internas do Perfil usam `Mapa | Leituras | Oportunidades` para evitar duplicidade com o menu principal.
+- O Perfil usa balão/status sobreposto.
+- A Comunidade usa banner compacto inline e não renderiza balão/status sobreposto.
+
+## Estados de acesso
+
+`NarrativeMapAccessState` resolve a próxima ação do Mapa Narrativo:
+
+- `free_unused`: `1 leitura grátis disponível`, CTA `Analisar vídeo`.
+- `free_preview_used`: `Leitura grátis usada`, CTA `Assinar Pro`.
+- `pro_needs_instagram`: `Pro ativo · Instagram pendente`, CTA `Conectar Instagram`.
+- `pro_instagram_connected`: `Pro ativo · X/10 leituras`, CTA `Nova leitura`.
+- `pro_quota_reached`: `10/10 leituras usadas`, CTA `Ver Perfil`.
+- `payment_pending`: `Pagamento pendente`, CTA `Continuar pagamento`.
+- `payment_action_needed`: `Ação de pagamento necessária`, CTA `Atualizar pagamento`.
+- `admin`: acesso interno sem bloquear a shell.
+
+A resolução considera premium/full report access, checkout pendente, ação de pagamento, billing necessário, Instagram conectado ou precisando reconexão, leitura grátis usada e leituras usadas no mês.
+
+## Quota
+
+- Free: 1 leitura total.
+- Pro: 10 leituras por mês.
+- A UI usa sempre `leituras`, não `uploads`.
+- Apenas diagnóstico concluído e leitura documentada salva conta quota.
+- Upload cancelado não conta.
+- Vídeo rejeitado antes da análise não conta.
+- Falha antes de gerar diagnóstico não conta.
+- Falha de processamento não conta.
+- A contagem é calculada por `userId` e mês UTC atual.
+- A API de upload-session bloqueia acesso antes de criar sessão de upload.
+
+## Perfil
+
+Free antes da primeira leitura vê:
+
+- headline `Teste sua primeira leitura narrativa`;
+- texto `Envie um vídeo e veja como a D2C entende sua fala, cena, intenção e próximo ajuste.`;
+- CTA `Analisar meu primeiro vídeo`.
+
+Free depois da primeira leitura mantém a leitura daquele vídeo e vê o card `Transforme essa leitura em um Perfil vivo`, com CTA único `Assinar Pro e conectar Instagram`.
+
+Pro sem Instagram é direcionado para conectar Instagram. Pro com Instagram vê uso mensal, Instagram conectado e CTA principal `Nova leitura`. Pro com quota atingida mantém o Perfil disponível e bloqueia nova leitura até o próximo ciclo.
+
+O Perfil não adiciona CTA secundário `Conhecer Comunidade`, porque Comunidade já está no menu fixo.
+
+## Comunidade
+
+A página Comunidade continua marketplace/lista/grid de creators da D2C. A seção grande de mentoria foi simplificada para um banner compacto inline antes da lista.
+
+Free vê:
+
+- título `Consultoria em grupo da D2C`;
+- texto de Pro com Grupo VIP, consultorias, Perfil vivo, 10 leituras por mês e Instagram;
+- CTA `Assinar Pro e entrar`.
+
+Pro vê:
+
+- título `Seu acesso à consultoria está liberado`;
+- texto direto para entrar no Grupo VIP;
+- CTA `Entrar na consultoria`;
+- subtexto `via WhatsApp`;
+- label de próxima consultoria quando o summary já fornece a informação.
+
+Pagamento pendente vê `Finalize seu Plano Pro` e CTA `Continuar pagamento`.
+
+## Paywall e intent
+
+O fluxo reaproveita `BillingSubscribeModal` e o evento `open-subscribe-modal`.
+
+`postCheckoutIntent` aceita somente:
+
+- `connect_instagram`;
+- `join_community`.
+
+Quando o pagamento vem do Perfil, o intent é `connect_instagram`, com retorno interno ao Perfil e conexão de Instagram como próxima etapa. Quando vem da Comunidade, o intent é `join_community`, com retorno interno à Comunidade e acesso ao Grupo VIP.
+
+`returnTo` é sanitizado: precisa começar com `/` e não pode começar com `//`. Redirect externo não é aceito.
+
+## Guardrails
+
+- Sem novo checkout.
+- Sem novo plano financeiro.
+- Sem pacote extra de leituras.
+- Sem nova aba Instagram.
+- Sem botão central de nova leitura no menu fixo.
+- Sem CTA repetido de nova leitura em múltiplos cards.
+- Sem transformação da Comunidade em landing page de mentoria.
+- Sem remoção de marketplace/lista/filtros de creators.
+- Sem alteração profunda de Stripe, NextAuth, DashboardShell, BoardShell, sidebar ou MediaKitView.
+- Sem persistência de vídeo, thumbnail, signed URL, upload URL, objectKey, localPath, storageProviderPath, raw response ou transcrição longa.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,41 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM89 — Pro Access, Reading Quota, Instagram and Community UX
+
+Status: implementado.
+
+Arquivos principais:
+
+- `MM89_PRO_ACCESS_READING_QUOTA_INSTAGRAM_COMMUNITY_UX.md`
+- `narrativeMapAccessState.ts`
+- `narrativeMapReadingQuotaService.ts`
+- `../components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx`
+- `../components/videoUpload/appPreview/NarrativeMapMobileShell.tsx`
+- `src/app/dashboard/discover/CommunityConversionSection.tsx`
+- `src/app/billing/success/page.tsx`
+
+O que faz:
+
+- cria o estado de acesso do Mapa Narrativo para Free, Pro, pagamento pendente e admin;
+- aplica 1 leitura gratuita total para Free e 10 leituras por mês para Pro;
+- bloqueia nova leitura antes de criar sessão de upload quando o usuário não tem acesso ou quota;
+- mantém Instagram como recurso Pro;
+- deixa o menu fixo mobile com apenas `Perfil` e `Comunidade`;
+- move `Nova leitura` para o Perfil, no balão/status ou no estado vazio inicial;
+- troca as abas internas para `Mapa | Leituras | Oportunidades`;
+- mantém Comunidade como marketplace e troca a seção de mentoria por banner compacto;
+- adiciona `postCheckoutIntent` seguro para `connect_instagram` e `join_community`.
+
+O que não faz:
+
+- não cria novo plano, novo checkout ou pacote extra de leituras;
+- não cria botão central de nova leitura no menu;
+- não transforma Comunidade em landing page de mentoria;
+- não altera profundamente Stripe, NextAuth, DashboardShell, BoardShell, sidebar ou MediaKitView;
+- não salva vídeo, thumbnail, signed URL, upload URL, objectKey, localPath, storageProviderPath, raw response ou transcrição longa.
+
 ### MM86 — Diagnostic Writer Evidence Anchors
 
 Status: concluído.

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.test.ts
@@ -207,7 +207,7 @@ describe("mobileStrategicProfileMapping", () => {
     expect(result.authGate.action).toMatchObject({ label: "Entrar e analisar vídeo" });
   });
 
-  it("construction profile builds header, empty diagnosis section and Analisar primeiro vídeo action", () => {
+  it("construction profile builds header, empty diagnosis section and Analisar meu primeiro vídeo action", () => {
     const result = build({ state: makeState({ diagnosisPresentation: null, instagramConnected: false }) });
 
     expect(result.constructionState.visible).toBe(true);
@@ -217,7 +217,7 @@ describe("mobileStrategicProfileMapping", () => {
       state: "construction",
       title: "Diagnóstico",
     });
-    expect(result.primaryActions[0]).toMatchObject({ label: "Analisar primeiro vídeo", intent: "analyze_video" });
+    expect(result.primaryActions[0]).toMatchObject({ label: "Analisar meu primeiro vídeo", intent: "analyze_video" });
   });
 
   it("construction profile does not show Media Kit Bridge as available", () => {
@@ -339,14 +339,14 @@ describe("mobileStrategicProfileMapping", () => {
     expect(text).not.toContain("mediakitview");
   });
 
-  it("Community appears only as bridge and existing destination, without social surface modeling", () => {
+  it("Community bridge is not duplicated inside Perfil when Community is a fixed destination", () => {
     const presentation = makePresentation("free");
     const state = makeState({ accessLevel: "free", diagnosisPresentation: presentation });
     const result = build({ state, presentation, communityHref: "/community" });
     const text = textOf(result.communityBridge);
 
     expect(result.communityBridge).toMatchObject({
-      visible: true,
+      visible: false,
       label: "Comunidade",
       href: "/community",
       description: "Acesse a Comunidade Data2Content, destino existente para continuar aprendendo com outros membros.",
@@ -356,12 +356,11 @@ describe("mobileStrategicProfileMapping", () => {
     expect(text).not.toContain("creators");
   });
 
-  it("navigation contains profile, central analyze_video and community", () => {
+  it("navigation contains only profile and community destinations", () => {
     const result = build({ state: makeState({ diagnosisPresentation: null }) });
 
     expect(result.navigation.items).toEqual([
       expect.objectContaining({ id: "profile", role: "destination", active: true }),
-      expect.objectContaining({ id: "analyze_video", role: "central_action" }),
       expect.objectContaining({ id: "community", role: "destination" }),
     ]);
   });

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
@@ -247,8 +247,8 @@ function buildTabs(state: MobileStrategicProfileState): MobileStrategicProfileTa
   if (state.profileAvailability === "auth_gate") return [];
 
   return [
-    { id: "diagnosis", label: "Diagnóstico", active: true },
-    { id: "commercial", label: "Comercial", active: false },
+    { id: "diagnosis", label: "Mapa", active: true },
+    { id: "commercial", label: "Oportunidades", active: false },
   ];
 }
 
@@ -284,8 +284,8 @@ function buildDiagnosisSection(input: MobileStrategicProfileInput): MobileStrate
       cards: [
         card({
           id: "diagnosis-empty",
-          title: "Seu Perfil Estratégico começa aqui",
-          body: "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo.",
+          title: "Teste sua primeira leitura narrativa",
+          body: "Envie um vídeo e veja como a D2C entende sua fala, cena, intenção e próximo ajuste.",
           tone: "action",
           source: "state",
         }),
@@ -440,7 +440,7 @@ function buildMediaKitBridge(input: MobileStrategicProfileInput): MobileStrategi
 
 function buildCommunityBridge(input: MobileStrategicProfileInput): MobileStrategicProfileCommunityBridge {
   return {
-    visible: input.state.profileAvailability !== "auth_gate",
+    visible: false,
     label: "Comunidade",
     href: href(input.communityHref) ?? "/dashboard/community",
     description: "Acesse a Comunidade Data2Content, destino existente para continuar aprendendo com outros membros.",
@@ -458,13 +458,6 @@ function buildNavigation(input: MobileStrategicProfileInput): MobileStrategicPro
         active: true,
       },
       {
-        id: "analyze_video",
-        label: "+",
-        href: href(input.analyzeVideoHref),
-        role: "central_action",
-        active: false,
-      },
-      {
         id: "community",
         label: "Comunidade",
         href: href(input.communityHref) ?? "/dashboard/community",
@@ -479,12 +472,12 @@ function buildConstructionState(input: MobileStrategicProfileInput): MobileStrat
   const visible = input.state.profileAvailability === "construction";
   return {
     visible,
-    title: visible ? "Seu Perfil Estratégico começa aqui" : "",
+    title: visible ? "Teste sua primeira leitura narrativa" : "",
     description: visible
-      ? "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo."
+      ? "Envie um vídeo e veja como a D2C entende sua fala, cena, intenção e próximo ajuste."
       : "",
     recommendedActionLabel: visible
-      ? input.state.recommendedActions.find((item) => item.intent === "analyze_video")?.label ?? "Analisar primeiro vídeo"
+      ? input.state.recommendedActions.find((item) => item.intent === "analyze_video")?.label ?? "Analisar meu primeiro vídeo"
       : null,
   };
 }
@@ -492,7 +485,6 @@ function buildConstructionState(input: MobileStrategicProfileInput): MobileStrat
 export function buildMobileStrategicProfile(input: MobileStrategicProfileInput): MobileStrategicProfile {
   const tabs = buildTabs(input.state);
   const primaryActions = input.state.recommendedActions
-    .filter((item) => item.id !== "community-future")
     .map((item) => actionFromState(item, input));
 
   return {

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.test.ts
@@ -92,10 +92,10 @@ describe("mobileStrategicProfileStateContract", () => {
     expect(result.readinessState).toBe("first_diagnosis_pending");
     expect(result.diagnosisState).toBe("empty");
     expect(result.statusPills.map((pill) => pill.label)).toContain("Perfil em construção");
-    expect(result.summary.title).toBe("Seu Perfil Estratégico começa aqui");
+    expect(result.summary.title).toBe("Teste sua primeira leitura narrativa");
   });
 
-  it("authenticated user without diagnosis prioritizes Analisar primeiro vídeo", () => {
+  it("authenticated user without diagnosis prioritizes Analisar meu primeiro vídeo", () => {
     const result = resolveMobileStrategicProfileState({
       isAuthenticated: true,
     });
@@ -103,7 +103,7 @@ describe("mobileStrategicProfileStateContract", () => {
     expect(result.recommendedActions[0]).toMatchObject({
       id: "analyze-first-video",
       intent: "analyze_video",
-      label: "Analisar primeiro vídeo",
+      label: "Analisar meu primeiro vídeo",
       priority: "primary",
     });
   });
@@ -123,7 +123,7 @@ describe("mobileStrategicProfileStateContract", () => {
     expect(result.recommendedActions[0]).toMatchObject({
       id: "analyze-next-video",
       intent: "analyze_video",
-      label: "Atualizar meu Perfil",
+      label: "Nova leitura",
     });
   });
 
@@ -218,7 +218,7 @@ describe("mobileStrategicProfileStateContract", () => {
     expect(allText(result)).not.toContain("mediakitview");
   });
 
-  it("Comunidade is only modeled as a future existing destination without feed or chat", () => {
+  it("Comunidade is not duplicated as a Perfil CTA when it already exists in navigation", () => {
     const result = resolveMobileStrategicProfileState({
       isAuthenticated: true,
       diagnosisPresentation: makePresentation("free"),
@@ -226,11 +226,7 @@ describe("mobileStrategicProfileStateContract", () => {
     });
     const communityAction = result.recommendedActions.find((item) => item.id === "community-future");
 
-    expect(communityAction).toMatchObject({
-      label: "Comunidade",
-      disabled: true,
-    });
-    expect(communityAction?.description).toContain("Destino existente de navegação futura");
+    expect(communityAction).toBeUndefined();
     expect(allText(result)).not.toContain("feed");
     expect(allText(result)).not.toContain("comentários");
   });

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileStateContract.ts
@@ -209,8 +209,8 @@ function buildAuthenticatedSummary(params: {
 }): MobileStrategicProfileStateSummary {
   if (params.diagnosisState === "empty") {
     return {
-      title: "Seu Perfil Estratégico começa aqui",
-      description: "Analise seu primeiro vídeo para a D2C identificar sua narrativa, ponto forte e próximo passo.",
+      title: "Teste sua primeira leitura narrativa",
+      description: "Envie um vídeo e veja como a D2C entende sua fala, cena, intenção e próximo ajuste.",
       helper: "Aqui ficam sua leitura atual, seus próximos passos e seu potencial comercial.",
     };
   }
@@ -300,7 +300,7 @@ function buildRecommendedActions(params: {
     actions.push(action({
       id: "analyze-first-video",
       intent: "analyze_video",
-      label: "Analisar primeiro vídeo",
+      label: "Analisar meu primeiro vídeo",
       description: "Analise seu primeiro vídeo para a D2C entender sua narrativa, ponto forte e próximo passo.",
       priority: "primary",
     }));
@@ -308,8 +308,8 @@ function buildRecommendedActions(params: {
     actions.push(action({
       id: "analyze-next-video",
       intent: "analyze_video",
-      label: "Atualizar meu Perfil",
-      description: "Use um vídeo para atualizar seu Perfil Estratégico.",
+      label: "Nova leitura",
+      description: "Use um vídeo para atualizar seu Perfil vivo.",
       priority: "primary",
     }));
   }
@@ -320,8 +320,8 @@ function buildRecommendedActions(params: {
       intent: "connect_instagram",
       label: "Conectar Instagram",
       description: params.subscriptionState === "premium"
-        ? "Conecte Instagram para comparar sua narrativa com mais contexto."
-        : "Conecte Instagram para ativar o Mídia Kit existente e melhorar a leitura.",
+        ? "Conecte Instagram para cruzar suas leituras com conteúdos que sua audiência respondeu melhor."
+        : "Instagram é um recurso Pro do Perfil vivo.",
       priority: "secondary",
     }));
   }
@@ -353,15 +353,6 @@ function buildRecommendedActions(params: {
       priority: "secondary",
     }));
   }
-
-  actions.push(action({
-    id: "community-future",
-    intent: "continue_diagnosis",
-    label: "Comunidade",
-    description: "Destino existente de navegação futura, sem recriar experiências sociais neste contrato.",
-    priority: "secondary",
-    disabled: true,
-  }));
 
   return actions;
 }

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
@@ -1,0 +1,60 @@
+import {
+  getNarrativeMapAccessAction,
+  resolveNarrativeMapAccessState,
+  sanitizeInternalReturnTo,
+} from "./narrativeMapAccessState";
+
+describe("narrativeMapAccessState", () => {
+  it("Free sem leitura usada retorna free_unused", () => {
+    expect(resolveNarrativeMapAccessState({ readingQuota: { usedTotal: 0 } })).toBe("free_unused");
+    expect(getNarrativeMapAccessAction("free_unused").canStartReading).toBe(true);
+  });
+
+  it("Free com leitura usada retorna free_preview_used", () => {
+    expect(resolveNarrativeMapAccessState({ readingQuota: { usedTotal: 1 } })).toBe("free_preview_used");
+    expect(getNarrativeMapAccessAction("free_preview_used").canStartReading).toBe(false);
+  });
+
+  it("Pro sem Instagram retorna pro_needs_instagram", () => {
+    expect(resolveNarrativeMapAccessState({
+      hasPremiumAccess: true,
+      instagram: { connected: false },
+      readingQuota: { usedThisMonth: 2 },
+    })).toBe("pro_needs_instagram");
+  });
+
+  it("Pro com Instagram retorna pro_instagram_connected", () => {
+    expect(resolveNarrativeMapAccessState({
+      hasPremiumAccess: true,
+      instagram: { connected: true },
+      readingQuota: { usedThisMonth: 2 },
+    })).toBe("pro_instagram_connected");
+  });
+
+  it("Pro com 10/10 leituras retorna pro_quota_reached", () => {
+    expect(resolveNarrativeMapAccessState({
+      hasPremiumAccess: true,
+      instagram: { connected: true },
+      readingQuota: { usedThisMonth: 10 },
+    })).toBe("pro_quota_reached");
+  });
+
+  it("Pagamento pendente e ação necessária têm estados próprios", () => {
+    expect(resolveNarrativeMapAccessState({ needsCheckout: true, readingQuota: { usedTotal: 0 } })).toBe("payment_pending");
+    expect(resolveNarrativeMapAccessState({ needsPaymentAction: true, readingQuota: { usedTotal: 0 } })).toBe("payment_action_needed");
+  });
+
+  it("Admin recebe acesso sem loading indevido", () => {
+    expect(resolveNarrativeMapAccessState({
+      isAdmin: true,
+      needsCheckout: true,
+      readingQuota: { usedTotal: 99, usedThisMonth: 99 },
+    })).toBe("admin");
+  });
+
+  it("sanitiza returnTo interno e rejeita externo", () => {
+    expect(sanitizeInternalReturnTo("/dashboard/boards/mobile-strategic-profile")).toBe("/dashboard/boards/mobile-strategic-profile");
+    expect(sanitizeInternalReturnTo("//evil.example/path", "/fallback")).toBe("/fallback");
+    expect(sanitizeInternalReturnTo("https://evil.example/path", "/fallback")).toBe("/fallback");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
@@ -1,0 +1,196 @@
+export type NarrativeMapAccessState =
+  | "free_unused"
+  | "free_preview_used"
+  | "pro_needs_instagram"
+  | "pro_instagram_connected"
+  | "pro_quota_reached"
+  | "payment_pending"
+  | "payment_action_needed"
+  | "admin";
+
+export type NarrativeMapPostCheckoutIntent = "connect_instagram" | "join_community";
+
+export interface NarrativeMapReadingQuotaSnapshot {
+  userId?: string | null;
+  monthKey: string;
+  usedTotal: number;
+  usedThisMonth: number;
+  freeTotalLimit: 1;
+  proMonthlyLimit: 10;
+}
+
+export interface ResolveNarrativeMapAccessStateInput {
+  hasPremiumAccess?: boolean | null;
+  hasFullReportAccess?: boolean | null;
+  needsCheckout?: boolean | null;
+  needsPaymentAction?: boolean | null;
+  needsBilling?: boolean | null;
+  needsPaymentUpdate?: boolean | null;
+  nextAction?: string | null;
+  isAdmin?: boolean | null;
+  instagram?: {
+    connected?: boolean | null;
+    needsReconnect?: boolean | null;
+  } | null;
+  readingQuota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
+}
+
+export interface NarrativeMapAccessAction {
+  canStartReading: boolean;
+  label: string;
+  reason:
+    | "free_first_reading_available"
+    | "free_reading_used"
+    | "pro_instagram_pending"
+    | "pro_quota_available"
+    | "pro_quota_reached"
+    | "payment_pending"
+    | "payment_action_needed"
+    | "admin";
+}
+
+function normalizeCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+export function getCurrentNarrativeMapMonthKey(now = new Date()): string {
+  return now.toISOString().slice(0, 7);
+}
+
+export function createEmptyNarrativeMapReadingQuotaSnapshot(params: {
+  userId?: string | null;
+  now?: Date;
+} = {}): NarrativeMapReadingQuotaSnapshot {
+  return {
+    userId: params.userId ?? null,
+    monthKey: getCurrentNarrativeMapMonthKey(params.now ?? new Date()),
+    usedTotal: 0,
+    usedThisMonth: 0,
+    freeTotalLimit: 1,
+    proMonthlyLimit: 10,
+  };
+}
+
+export function normalizeNarrativeMapReadingQuotaSnapshot(
+  quota?: Partial<NarrativeMapReadingQuotaSnapshot> | null,
+): NarrativeMapReadingQuotaSnapshot {
+  const empty = createEmptyNarrativeMapReadingQuotaSnapshot({ userId: quota?.userId ?? null });
+  return {
+    ...empty,
+    ...quota,
+    usedTotal: normalizeCount(quota?.usedTotal),
+    usedThisMonth: normalizeCount(quota?.usedThisMonth),
+    freeTotalLimit: 1,
+    proMonthlyLimit: 10,
+  };
+}
+
+export function resolveNarrativeMapAccessState(
+  input: ResolveNarrativeMapAccessStateInput,
+): NarrativeMapAccessState {
+  if (input.isAdmin) return "admin";
+
+  if (input.needsCheckout) return "payment_pending";
+  if (input.needsPaymentAction || input.needsPaymentUpdate || input.needsBilling) {
+    return "payment_action_needed";
+  }
+
+  const quota = normalizeNarrativeMapReadingQuotaSnapshot(input.readingQuota);
+  const hasPro = Boolean(input.hasPremiumAccess || input.hasFullReportAccess);
+
+  if (!hasPro) {
+    return quota.usedTotal >= quota.freeTotalLimit ? "free_preview_used" : "free_unused";
+  }
+
+  if (quota.usedThisMonth >= quota.proMonthlyLimit) return "pro_quota_reached";
+
+  const instagramConnected = Boolean(input.instagram?.connected) && !input.instagram?.needsReconnect;
+  return instagramConnected ? "pro_instagram_connected" : "pro_needs_instagram";
+}
+
+export function getNarrativeMapAccessAction(
+  state: NarrativeMapAccessState,
+): NarrativeMapAccessAction {
+  switch (state) {
+    case "free_unused":
+      return {
+        canStartReading: true,
+        label: "Analisar vídeo",
+        reason: "free_first_reading_available",
+      };
+    case "free_preview_used":
+      return {
+        canStartReading: false,
+        label: "Assinar Pro",
+        reason: "free_reading_used",
+      };
+    case "pro_needs_instagram":
+      return {
+        canStartReading: true,
+        label: "Conectar Instagram",
+        reason: "pro_instagram_pending",
+      };
+    case "pro_instagram_connected":
+      return {
+        canStartReading: true,
+        label: "Nova leitura",
+        reason: "pro_quota_available",
+      };
+    case "pro_quota_reached":
+      return {
+        canStartReading: false,
+        label: "Ver Perfil",
+        reason: "pro_quota_reached",
+      };
+    case "payment_pending":
+      return {
+        canStartReading: false,
+        label: "Continuar pagamento",
+        reason: "payment_pending",
+      };
+    case "payment_action_needed":
+      return {
+        canStartReading: false,
+        label: "Atualizar pagamento",
+        reason: "payment_action_needed",
+      };
+    case "admin":
+      return {
+        canStartReading: true,
+        label: "Nova leitura",
+        reason: "admin",
+      };
+  }
+}
+
+export function getNarrativeMapAccessStatusText(params: {
+  state: NarrativeMapAccessState;
+  quota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
+}): string {
+  const quota = normalizeNarrativeMapReadingQuotaSnapshot(params.quota);
+  switch (params.state) {
+    case "free_unused":
+      return "1 leitura grátis disponível";
+    case "free_preview_used":
+      return "Leitura grátis usada";
+    case "pro_needs_instagram":
+      return "Pro ativo · Instagram pendente";
+    case "pro_instagram_connected":
+      return `Pro ativo · ${quota.usedThisMonth}/10 leituras`;
+    case "pro_quota_reached":
+      return "10/10 leituras usadas";
+    case "payment_pending":
+      return "Pagamento pendente";
+    case "payment_action_needed":
+      return "Ação de pagamento necessária";
+    case "admin":
+      return `Admin · ${quota.usedThisMonth}/10 leituras`;
+  }
+}
+
+export function sanitizeInternalReturnTo(value: string | null | undefined, fallback = "/"): string {
+  if (typeof value === "string" && value.startsWith("/") && !value.startsWith("//")) {
+    return value;
+  }
+  return fallback;
+}

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.test.ts
@@ -7,7 +7,7 @@ function text(value: unknown): string {
 }
 
 describe("narrativeMapMobileViewModel", () => {
-  it("gera view model valido com Perfil, Leituras e Oportunidades", () => {
+  it("gera view model valido com Mapa, Leituras e Oportunidades", () => {
     const viewModel = buildNarrativeMapMobileViewModelFixture();
 
     expect(viewModel.profileHeader.displayName).toBe("Lívia Linhares");
@@ -17,11 +17,11 @@ describe("narrativeMapMobileViewModel", () => {
     expect(viewModel.opportunities.items.length).toBeGreaterThan(0);
   });
 
-  it("tabs sao exatamente Perfil, Leituras e Oportunidades", () => {
+  it("tabs sao exatamente Mapa, Leituras e Oportunidades", () => {
     const viewModel = buildNarrativeMapMobileViewModelFixture("default", { activeTab: "readings" });
 
     expect(viewModel.tabs).toEqual([
-      { id: "profile", label: "Perfil", active: false },
+      { id: "profile", label: "Mapa", active: false },
       { id: "readings", label: "Leituras", active: true },
       { id: "opportunities", label: "Oportunidades", active: false },
     ]);

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
@@ -399,7 +399,7 @@ export function buildNarrativeMapMobileViewModel(
       badgeLabel: input.instagramConnected ? "Cruzado com Instagram" : synthesisLabel ?? input.currentPresentation.statusLabel,
     },
     tabs: [
-      { id: "profile", label: "Perfil", active: activeTab === "profile" },
+      { id: "profile", label: "Mapa", active: activeTab === "profile" },
       { id: "readings", label: "Leituras", active: activeTab === "readings" },
       { id: "opportunities", label: "Oportunidades", active: activeTab === "opportunities" },
     ],

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModelServerSelector.test.ts
@@ -117,7 +117,7 @@ describe("narrativeMapMobileViewModelServerSelector", () => {
     });
     const serialized = JSON.stringify(result.viewModel).toLowerCase();
 
-    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Perfil", "Leituras", "Oportunidades"]);
+    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Mapa", "Leituras", "Oportunidades"]);
     expect(serialized).not.toContain("match real");
   });
 
@@ -180,7 +180,7 @@ describe("narrativeMapMobileViewModelServerSelector", () => {
     });
 
     expect(result.viewModel.hero.badgeLabel).toBe("Cruzado com Instagram");
-    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Perfil", "Leituras", "Oportunidades"]);
+    expect(result.viewModel.tabs.map((tab) => tab.label)).toEqual(["Mapa", "Leituras", "Oportunidades"]);
   });
 
   it("oportunidades não prometem marca real, creator real ou match real", async () => {

--- a/src/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService.test.ts
@@ -1,0 +1,95 @@
+import { Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import {
+  assertCanStartNarrativeMapReading,
+  getNarrativeMapReadingQuotaForUser,
+} from "./narrativeMapReadingQuotaService";
+
+jest.mock("@/app/lib/mongoose", () => ({
+  connectToDatabase: jest.fn(),
+}));
+
+function mockModel(counts: number[]) {
+  return {
+    countDocuments: jest.fn()
+      .mockResolvedValueOnce(counts[0] ?? 0)
+      .mockResolvedValueOnce(counts[1] ?? 0),
+  } as any;
+}
+
+describe("narrativeMapReadingQuotaService", () => {
+  const userId = new Types.ObjectId().toString();
+  const now = new Date("2026-05-21T12:00:00.000Z");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (connectToDatabase as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("calcula quota por userId e mês atual", async () => {
+    const model = mockModel([3, 2]);
+    const quota = await getNarrativeMapReadingQuotaForUser({ userId, now, model });
+
+    expect(quota).toMatchObject({
+      userId,
+      monthKey: "2026-05",
+      usedTotal: 3,
+      usedThisMonth: 2,
+      freeTotalLimit: 1,
+      proMonthlyLimit: 10,
+    });
+    expect(model.countDocuments).toHaveBeenNthCalledWith(1, {
+      userId: new Types.ObjectId(userId),
+      status: "completed",
+    });
+    expect(model.countDocuments).toHaveBeenNthCalledWith(2, {
+      userId: new Types.ObjectId(userId),
+      status: "completed",
+      createdAt: {
+        $gte: new Date("2026-05-01T00:00:00.000Z"),
+        $lt: new Date("2026-06-01T00:00:00.000Z"),
+      },
+    });
+  });
+
+  it("Free pode iniciar primeira leitura e bloqueia segunda", async () => {
+    await expect(assertCanStartNarrativeMapReading({
+      userId,
+      now,
+      model: mockModel([0, 0]),
+      access: {},
+    })).resolves.toMatchObject({ ok: true, state: "free_unused" });
+
+    await expect(assertCanStartNarrativeMapReading({
+      userId,
+      now,
+      model: mockModel([1, 1]),
+      access: {},
+    })).resolves.toMatchObject({ ok: false, state: "free_preview_used" });
+  });
+
+  it("Pro pode iniciar até 10 por mês e bloqueia 11ª", async () => {
+    await expect(assertCanStartNarrativeMapReading({
+      userId,
+      now,
+      model: mockModel([20, 9]),
+      access: { hasPremiumAccess: true, instagram: { connected: true } },
+    })).resolves.toMatchObject({ ok: true, state: "pro_instagram_connected" });
+
+    await expect(assertCanStartNarrativeMapReading({
+      userId,
+      now,
+      model: mockModel([20, 10]),
+      access: { hasPremiumAccess: true, instagram: { connected: true } },
+    })).resolves.toMatchObject({ ok: false, state: "pro_quota_reached" });
+  });
+
+  it("não permite contagem de outro userId", async () => {
+    const model = mockModel([0, 0]);
+    await getNarrativeMapReadingQuotaForUser({ userId, now, model });
+    const serializedQueries = JSON.stringify(model.countDocuments.mock.calls);
+
+    expect(serializedQueries).toContain(userId);
+    expect(serializedQueries).not.toContain(new Types.ObjectId().toString());
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapReadingQuotaService.ts
@@ -1,0 +1,87 @@
+import { Types } from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import CreatorVideoNarrativeDiagnosis from "@/app/models/CreatorVideoNarrativeDiagnosis";
+import {
+  createEmptyNarrativeMapReadingQuotaSnapshot,
+  normalizeNarrativeMapReadingQuotaSnapshot,
+  resolveNarrativeMapAccessState,
+  type NarrativeMapReadingQuotaSnapshot,
+  type ResolveNarrativeMapAccessStateInput,
+} from "./narrativeMapAccessState";
+
+type DiagnosisModelLike = typeof CreatorVideoNarrativeDiagnosis;
+
+function assertValidUserId(userId: string): void {
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    throw new Error("UserId inválido");
+  }
+}
+
+function monthRange(now: Date): { monthKey: string; start: Date; end: Date } {
+  const monthKey = now.toISOString().slice(0, 7);
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const start = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0));
+  return { monthKey, start, end };
+}
+
+export async function getNarrativeMapReadingQuotaForUser(params: {
+  userId: string;
+  now?: Date;
+  model?: DiagnosisModelLike;
+}): Promise<NarrativeMapReadingQuotaSnapshot> {
+  assertValidUserId(params.userId);
+  await connectToDatabase();
+
+  const model = params.model ?? CreatorVideoNarrativeDiagnosis;
+  const now = params.now ?? new Date();
+  const range = monthRange(now);
+  const userId = new Types.ObjectId(params.userId);
+  const completedForUser = { userId, status: "completed" };
+
+  const [usedTotal, usedThisMonth] = await Promise.all([
+    model.countDocuments(completedForUser),
+    model.countDocuments({
+      ...completedForUser,
+      createdAt: { $gte: range.start, $lt: range.end },
+    }),
+  ]);
+
+  return normalizeNarrativeMapReadingQuotaSnapshot({
+    ...createEmptyNarrativeMapReadingQuotaSnapshot({ userId: params.userId, now }),
+    monthKey: range.monthKey,
+    usedTotal,
+    usedThisMonth,
+  });
+}
+
+export async function assertCanStartNarrativeMapReading(params: {
+  userId: string;
+  access: Omit<ResolveNarrativeMapAccessStateInput, "readingQuota">;
+  now?: Date;
+  model?: DiagnosisModelLike;
+}): Promise<{
+  ok: boolean;
+  state: ReturnType<typeof resolveNarrativeMapAccessState>;
+  quota: NarrativeMapReadingQuotaSnapshot;
+  message: string;
+}> {
+  const quota = await getNarrativeMapReadingQuotaForUser({
+    userId: params.userId,
+    now: params.now,
+    model: params.model,
+  });
+  const state = resolveNarrativeMapAccessState({
+    ...params.access,
+    readingQuota: quota,
+  });
+  const ok = state === "free_unused" || state === "pro_instagram_connected" || state === "pro_needs_instagram" || state === "admin";
+
+  return {
+    ok,
+    state,
+    quota,
+    message: ok ? "Leitura disponível." : "Limite de leituras indisponível.",
+  };
+}

--- a/src/app/dashboard/discover/CommunityConversionSection.test.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import useBillingStatus from "@/app/hooks/useBillingStatus";
+import { fetchHomeSummaryCached } from "@/app/dashboard/home/homeSummaryClient";
+import CommunityConversionSection from "./CommunityConversionSection";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock("@/app/hooks/useBillingStatus", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/home/homeSummaryClient", () => ({
+  fetchHomeSummaryCached: jest.fn(),
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    section: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => <section {...props}>{children}</section>,
+  },
+}));
+
+const mockedUseSession = useSession as jest.Mock;
+const mockedUseBillingStatus = useBillingStatus as jest.Mock;
+const mockedFetchHomeSummaryCached = fetchHomeSummaryCached as jest.Mock;
+
+function mockBilling(overrides: Partial<ReturnType<typeof useBillingStatus>> = {}) {
+  mockedUseBillingStatus.mockReturnValue({
+    hasPremiumAccess: false,
+    needsCheckout: false,
+    needsPaymentAction: false,
+    ...overrides,
+  });
+}
+
+describe("CommunityConversionSection", () => {
+  beforeEach(() => {
+    mockedUseSession.mockReturnValue({ status: "authenticated" });
+    mockedFetchHomeSummaryCached.mockResolvedValue({
+      community: {
+        free: { isMember: true, inviteUrl: null },
+        vip: { hasAccess: true, isMember: false, inviteUrl: "https://chat.whatsapp.com/vip", joinedAt: null, needsJoinReminder: true },
+      },
+      mentorship: { nextSessionLabel: "quinta, 19h" },
+    });
+    jest.spyOn(window, "dispatchEvent");
+    jest.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("mostra banner compacto de consultoria para Free e abre paywall de mentoria", async () => {
+    mockBilling();
+
+    render(<CommunityConversionSection />);
+
+    expect(screen.getByText("Consultoria em grupo da D2C")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Assinar Pro e entrar/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Assinar Pro e entrar/i }));
+
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "open-subscribe-modal",
+        detail: expect.objectContaining({
+          context: "mentoria",
+          source: "community_mentoria",
+          postCheckoutIntent: "join_community",
+        }),
+      }),
+    );
+  });
+
+  it("mostra acesso direto para Pro sem pitch longo de assinatura", async () => {
+    mockBilling({ hasPremiumAccess: true });
+
+    render(<CommunityConversionSection />);
+
+    expect(screen.getByText("Seu acesso à consultoria está liberado")).toBeInTheDocument();
+    expect(screen.getByText("via WhatsApp")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Entrar na consultoria/i })).toBeInTheDocument();
+    expect(screen.queryByText("Consultoria em grupo da D2C")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText("Próxima consultoria: quinta, 19h")).toBeInTheDocument());
+  });
+
+  it("mostra acao segura para pagamento pendente", () => {
+    mockBilling({ needsCheckout: true });
+
+    render(<CommunityConversionSection />);
+
+    expect(screen.getByText("Finalize seu Plano Pro")).toBeInTheDocument();
+    expect(screen.getByText("Conclua o pagamento para liberar consultoria, Instagram e 10 leituras por mês.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Continuar pagamento/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/discover/CommunityConversionSection.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArrowRight, Sparkles, Users, FileEdit, Play, Target, CheckCircle2, Crown, Calendar, Instagram } from "lucide-react";
+import { ArrowRight, Calendar, CheckCircle2, Crown } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
 import type { PaywallEventDetail } from "@/types/paywall";
@@ -14,68 +14,6 @@ const COMMUNITY_VIP_URL =
   process.env.NEXT_PUBLIC_COMMUNITY_URL ||
   "https://chat.whatsapp.com/CKTT84ZHEouKyXoDxIJI4c";
 
-const MENTORING_TRACKS = [
-  {
-    eyebrow: "Networking",
-    title: "Comunidade de Criadores",
-    description: "Trocas práticas com creators em momentos parecidos.",
-    icon: Users,
-    color: "text-blue-600",
-    bg: "bg-blue-50/40 border-blue-100/50",
-    glow: "shadow-blue-500/10",
-  },
-  {
-    eyebrow: "Execução",
-    title: "Revisão de Conteúdo",
-    description: "Ajustes objetivos de posts, formato e execução técnica.",
-    icon: Play,
-    color: "text-rose-600",
-    bg: "bg-rose-50/40 border-rose-100/50",
-    glow: "shadow-rose-500/10",
-  },
-  {
-    eyebrow: "Roteiro",
-    title: "Refino de Ideias",
-    description: "Otimização de roteiros e ganchos antes de publicar.",
-    icon: FileEdit,
-    color: "text-amber-600",
-    bg: "bg-amber-50/40 border-amber-100/50",
-    glow: "shadow-amber-500/10",
-  },
-  {
-    eyebrow: "Estratégia",
-    title: "Análise Direcionada",
-    description: "Direção clara para posicionamento e novos movimentos.",
-    icon: Target,
-    color: "text-emerald-600",
-    bg: "bg-emerald-50/40 border-emerald-100/50",
-    glow: "shadow-emerald-500/10",
-  },
-];
-
-const MENTORING_STEPS = [
-  {
-    label: "Conta Ativa",
-    description: "Seu cadastro na Data2Content.",
-    icon: Users,
-  },
-  {
-    label: "Plano Pro",
-    description: "Libere o acesso às mentorias.",
-    icon: Crown,
-  },
-  {
-    label: "Instagram",
-    description: "Conecte sua conta para análise.",
-    icon: Instagram,
-  },
-  {
-    label: "Grupo VIP",
-    description: "Entre no grupo para o link ao vivo.",
-    icon: ArrowRight,
-  },
-];
-
 function openMentoriaPaywall() {
   try {
     const returnTo =
@@ -86,6 +24,7 @@ function openMentoriaPaywall() {
       context: "mentoria",
       source: "community_mentoria",
       returnTo,
+      postCheckoutIntent: "join_community",
     };
     window.dispatchEvent(new CustomEvent("open-subscribe-modal", { detail }));
   } catch {
@@ -93,24 +32,25 @@ function openMentoriaPaywall() {
   }
 }
 
-export default function CommunityConversionSection(props: {
+export default function CommunityConversionSection(_props: {
   teaserMode?: boolean;
   compactView?: boolean;
-}) {
-  const { compactView = false } = props;
+} = {}) {
   const { status: sessionStatus } = useSession();
-  const { hasPremiumAccess } = useBillingStatus();
+  const { hasPremiumAccess, needsCheckout, needsPaymentAction } = useBillingStatus();
   const [communitySummary, setCommunitySummary] = React.useState<HomeSummaryResponse["community"] | null>(null);
   const [mentorshipData, setMentorshipData] = React.useState<MentorshipCardData | null>(null);
   const [resolvingVipAccess, setResolvingVipAccess] = React.useState(false);
   const planActive = Boolean(hasPremiumAccess);
-
-  const communityButtonLabel = planActive
-    ? "Acessar Grupo VIP"
-    : "Participar da Mentoria";
+  const paymentPending = Boolean(needsCheckout || needsPaymentAction);
 
   const vipInviteUrl = communitySummary?.vip?.inviteUrl ?? null;
   const vipHasAccess = Boolean(communitySummary?.vip?.hasAccess);
+  const communityButtonLabel = paymentPending
+    ? "Continuar pagamento"
+    : planActive
+      ? "Entrar na consultoria"
+      : "Assinar Pro e entrar";
 
   React.useEffect(() => {
     if (sessionStatus !== "authenticated") {
@@ -126,10 +66,8 @@ export default function CommunityConversionSection(props: {
       try {
         const payload = await fetchHomeSummaryCached("community");
         if (controller.signal.aborted || cancelled) return;
-        if (!cancelled) {
-          setCommunitySummary(payload?.community ?? null);
-          setMentorshipData(payload?.mentorship ?? null);
-        }
+        setCommunitySummary(payload?.community ?? null);
+        setMentorshipData(payload?.mentorship ?? null);
       } catch (error) {
         if (cancelled || (error as Error)?.name === "AbortError") return;
       }
@@ -144,7 +82,7 @@ export default function CommunityConversionSection(props: {
   }, [sessionStatus]);
 
   const handleCommunityAccess = React.useCallback(async () => {
-    if (!planActive) {
+    if (!planActive || paymentPending) {
       openMentoriaPaywall();
       return;
     }
@@ -183,188 +121,73 @@ export default function CommunityConversionSection(props: {
     } finally {
       setResolvingVipAccess(false);
     }
-  }, [planActive, vipHasAccess, vipInviteUrl]);
-
-  const isCompact = compactView;
-
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: { opacity: 1, transition: { staggerChildren: 0.1 } },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0 },
-  };
+  }, [paymentPending, planActive, vipHasAccess, vipInviteUrl]);
 
   return (
-    <motion.div
-      initial="hidden"
-      animate="visible"
-      variants={containerVariants}
-      className={isCompact ? "space-y-4 pb-6" : "space-y-8 pb-10"}
-    >
+    <motion.div initial="hidden" animate="visible" variants={{ hidden: { opacity: 0 }, visible: { opacity: 1 } }} className="pb-4">
       <motion.section
-        variants={itemVariants}
-        className={`relative overflow-hidden border border-zinc-200/70 bg-white shadow-[0_14px_34px_rgba(15,23,42,0.035)] ${
-          isCompact ? "rounded-[1.35rem] px-5 py-5" : "rounded-[1.8rem] px-7 py-7"
-        }`}
+        variants={{ hidden: { opacity: 0, y: 12 }, visible: { opacity: 1, y: 0 } }}
+        className="relative overflow-hidden rounded-[1.25rem] border border-zinc-200/70 bg-white px-5 py-5 shadow-sm"
       >
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-primary/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-brand-primary ring-1 ring-inset ring-brand-primary/12">
-              <Crown className="h-3 w-3" />
-              Mentoria VIP
-            </span>
-            {planActive ? (
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-[10px] font-bold text-emerald-600 ring-1 ring-inset ring-emerald-500/18">
-                <CheckCircle2 className="h-3 w-3" />
-                Acesso liberado
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-primary/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-brand-primary ring-1 ring-inset ring-brand-primary/12">
+                <Crown className="h-3 w-3" />
+                Grupo VIP
               </span>
-            ) : (
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-50 px-2.5 py-1 text-[10px] font-bold text-zinc-500 ring-1 ring-inset ring-zinc-200/70">
-                Plano Pro
-              </span>
-            )}
-          </div>
-
-          <div className="max-w-[34rem]">
-            <h1 className={`font-black tracking-tight text-zinc-950 ${
-              isCompact ? "text-[1.55rem] leading-[1.05]" : "text-[2.35rem] leading-[1.02]"
-            }`}>
-              Mentoria para criar com mais direção.
-            </h1>
-            <p className={`mt-3 max-w-xl text-zinc-500 ${isCompact ? "text-[13.5px] leading-5" : "text-base leading-7"}`}>
-              Análise de perfil, revisão de ideias e encontros ao vivo para ajustar conteúdo, roteiro e posicionamento.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2 border-t border-zinc-100 pt-3">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-50 px-3 py-1.5 text-[11px] font-semibold text-zinc-600 ring-1 ring-inset ring-zinc-200/70">
-              <Calendar className="h-3.5 w-3.5 text-zinc-400" />
-              Quintas às 19h
-            </span>
-            {planActive && mentorshipData?.nextSessionLabel ? (
-              <span className="inline-flex min-w-0 items-center gap-1.5 rounded-full bg-indigo-50/70 px-3 py-1.5 text-[11px] font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-100">
-                <span className="truncate">Próxima: {mentorshipData.nextSessionLabel}</span>
-              </span>
-            ) : null}
-            {!planActive ? (
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-50 px-3 py-1.5 text-[11px] font-semibold text-zinc-600 ring-1 ring-inset ring-zinc-200/70">
-                R$ 49,90/mês
-              </span>
-            ) : null}
-          </div>
-        </div>
-      </motion.section>
-
-      <section>
-        <div className="flex items-center gap-2 mb-5">
-          <div className="h-px flex-1 bg-zinc-100" />
-          <h2 className="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-400">O que você recebe</h2>
-          <div className="h-px flex-1 bg-zinc-100" />
-        </div>
-
-        <div className={`grid gap-4 ${isCompact ? "grid-cols-1" : "grid-cols-1 md:grid-cols-2"}`}>
-          {MENTORING_TRACKS.map((track) => {
-            const Icon = track.icon;
-            return (
-              <motion.div
-                key={track.title}
-                variants={itemVariants}
-                whileHover={{ y: -4 }}
-                className="group relative overflow-hidden rounded-[2rem] border border-zinc-100 bg-white p-6 shadow-sm transition-all duration-500 hover:shadow-2xl hover:shadow-zinc-200/60"
-              >
-                <div className="flex items-start gap-4">
-                  <div className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl ${track.bg} group-hover:scale-110 transition-transform duration-500`}>
-                    <Icon className={`h-7 w-7 ${track.color}`} />
-                  </div>
-                  <div>
-                    <p className={`text-[10px] font-bold uppercase tracking-widest ${track.color} opacity-80`}>
-                      {track.eyebrow}
-                    </p>
-                    <h3 className="mt-1 text-base font-bold text-zinc-900 tracking-tight">
-                      {track.title}
-                    </h3>
-                    <p className="mt-2 text-sm text-zinc-500 leading-relaxed">
-                      {track.description}
-                    </p>
-                  </div>
-                </div>
-              </motion.div>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="relative">
-        <div className="mb-4 flex items-center gap-2">
-          <div className="h-px flex-1 bg-zinc-100" />
-          <h2 className="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-            Como funciona seu acesso
-          </h2>
-          <div className="h-px flex-1 bg-zinc-100" />
-        </div>
-
-        <div className="overflow-hidden rounded-[1.25rem] border border-zinc-100 bg-white">
-          {MENTORING_STEPS.map((step, index) => {
-            const Icon = step.icon;
-            return (
-              <motion.div
-                key={step.label}
-                variants={itemVariants}
-                className={`flex items-center gap-3 px-4 py-3.5 ${
-                  index > 0 ? "border-t border-zinc-100" : ""
-                }`}
-              >
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-50 text-zinc-500 ring-1 ring-inset ring-zinc-200/70">
-                  <Icon className="h-4 w-4" />
+              {planActive && !paymentPending ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-[10px] font-bold text-emerald-600 ring-1 ring-inset ring-emerald-500/18">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Acesso liberado
                 </span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-[13px] font-bold leading-tight text-zinc-950">
-                    {index + 1}. {step.label}
-                  </p>
-                  <p className="mt-0.5 text-[12px] leading-5 text-zinc-500">
-                    {step.description}
-                  </p>
-                </div>
-              </motion.div>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="mt-12 flex justify-center pb-12">
-        <motion.div 
-          className="pointer-events-auto w-full max-w-md px-4"
-          whileHover={{ y: -4 }} 
-          whileTap={{ scale: 0.97 }}
-        >
+              ) : null}
+            </div>
+            <h2 className="mt-3 text-lg font-black tracking-tight text-zinc-950">
+              {paymentPending
+                ? "Finalize seu Plano Pro"
+                : planActive
+                  ? "Seu acesso à consultoria está liberado"
+                  : "Consultoria em grupo da D2C"}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-500">
+              {paymentPending
+                ? "Conclua o pagamento para liberar consultoria, Instagram e 10 leituras por mês."
+                : planActive
+                  ? "Entre no Grupo VIP para acompanhar a agenda e participar dos encontros."
+                  : "No Plano Pro, você entra no Grupo VIP, participa das consultorias em grupo e libera o Perfil vivo com 10 leituras por mês e Instagram conectado."}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {planActive && !paymentPending ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-50 px-3 py-1.5 text-[11px] font-semibold text-zinc-600 ring-1 ring-inset ring-zinc-200/70">
+                  via WhatsApp
+                </span>
+              ) : null}
+              {mentorshipData?.nextSessionLabel ? (
+                <span className="inline-flex min-w-0 items-center gap-1.5 rounded-full bg-indigo-50/70 px-3 py-1.5 text-[11px] font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-100">
+                  <Calendar className="h-3.5 w-3.5" />
+                  <span className="truncate">Próxima consultoria: {mentorshipData.nextSessionLabel}</span>
+                </span>
+              ) : null}
+            </div>
+          </div>
           <button
             type="button"
             onClick={handleCommunityAccess}
             disabled={resolvingVipAccess}
-            className="group relative flex w-full items-center justify-center gap-3 overflow-hidden rounded-full bg-zinc-950 py-4 text-sm font-bold text-white shadow-[0_20px_40px_rgba(0,0,0,0.3)] transition-all hover:bg-black disabled:opacity-70"
+            className="inline-flex shrink-0 items-center justify-center gap-2 rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition-all hover:bg-black disabled:opacity-70"
           >
-            {/* Shimmer effect */}
-            <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/10 to-transparent transition-transform duration-1000 group-hover:translate-x-full" />
-            
-            {/* Subtle inner border for premium feel */}
-            <div className="absolute inset-0 rounded-full border border-white/10" />
-
             {resolvingVipAccess ? (
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/20 border-t-white" />
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/20 border-t-white" />
             ) : (
               <>
-                <span className="relative z-10 tracking-tight">{communityButtonLabel}</span>
-                <div className="relative z-10 flex h-6 w-6 items-center justify-center rounded-full bg-white/10 text-white transition-all duration-300 group-hover:bg-brand-primary group-hover:translate-x-1">
-                  <ArrowRight className="h-3.5 w-3.5" />
-                </div>
+                <span>{communityButtonLabel}</span>
+                <ArrowRight className="h-3.5 w-3.5" />
               </>
             )}
           </button>
-        </motion.div>
-      </section>
+        </div>
+      </motion.section>
     </motion.div>
   );
 }

--- a/src/app/dashboard/home/README.md
+++ b/src/app/dashboard/home/README.md
@@ -4,6 +4,14 @@ Este diretório implementa a nova Home do dashboard. Cada card tem regras claras
 
 ## Cards da Release 1
 
+### Comunidade / MM89
+
+- A Comunidade permanece marketplace/vitrine de creators da D2C.
+- O acesso à consultoria em grupo e ao Grupo VIP aparece como banner compacto inline na página Comunidade.
+- Free vê CTA `Assinar Pro e entrar`; Pro vê apenas `Entrar na consultoria` / acesso ao Grupo VIP.
+- O banner usa o paywall existente com contexto de mentoria e `postCheckoutIntent: join_community`.
+- O Perfil mobile usa balão/status para próxima ação; Comunidade não renderiza balão sobreposto.
+
 ### 1. `next_post`
 - **Dados esperados**: slot (dia/hora), 1–3 ganchos, lift vs. P50, status de conexão do Instagram.
 - **Fallback**: se `isInstagramConnected === false`, exibe CTA “Conectar Instagram” com copy “Conecte o Instagram para gerar seu primeiro planner personalizado”.
@@ -37,4 +45,3 @@ Este diretório implementa a nova Home do dashboard. Cada card tem regras claras
 - Substituir dados mockados em `HomeClientPage` por chamadas reais (planner, métricas de comunidade, billing etc.).
 - Implementar camada de carregamento (`loading`) e tratamento de erros usando os props já previstos em `CardShell`.
 - Encadear ações dos CTAs às rotas/modais correspondentes (planner, WhatsApp, media kit).
-

--- a/src/app/dashboard/proposals/ProposalsClient.tsx
+++ b/src/app/dashboard/proposals/ProposalsClient.tsx
@@ -637,7 +637,7 @@ export default function ProposalsClient({ compactView = false }: { compactView?:
     (source: string, context: PaywallContext) => {
       const normalizedPlan = billingStatus.normalizedStatus ?? billingStatus.planStatus ?? null;
       const telemetryContext =
-        context === 'default'
+        context === 'default' || context === 'narrative_map'
           ? 'other'
           : context === 'whatsapp'
             ? 'whatsapp_ai'

--- a/src/types/paywall.ts
+++ b/src/types/paywall.ts
@@ -3,6 +3,7 @@ export type PaywallContext =
   | "reply_email"
   | "ai_analysis"
   | "calculator"
+  | "narrative_map"
   | "mentoria"
   | "media_kit"
   | "publis"
@@ -14,6 +15,7 @@ export type PaywallEventDetail = {
   source?: string | null;
   returnTo?: string | null;
   proposalId?: string | null;
+  postCheckoutIntent?: "connect_instagram" | "join_community" | null;
 };
 
 export const PAYWALL_RETURN_STORAGE_KEY = "d2c.paywall.return";

--- a/src/utils/paywallModal.ts
+++ b/src/utils/paywallModal.ts
@@ -7,6 +7,7 @@ export type OpenPaywallModalOptions = {
   source?: string | null;
   returnTo?: string | null;
   proposalId?: string | null;
+  postCheckoutIntent?: "connect_instagram" | "join_community" | null;
 };
 
 export function openPaywallModal(options?: OpenPaywallModalOptions) {
@@ -17,6 +18,7 @@ export function openPaywallModal(options?: OpenPaywallModalOptions) {
     source: options?.source ?? null,
     returnTo: options?.returnTo ?? null,
     proposalId: options?.proposalId ?? null,
+    postCheckoutIntent: options?.postCheckoutIntent ?? null,
   };
 
   try {


### PR DESCRIPTION
## Summary

Adds the Pro access, quota, Instagram, and community UX layer for the mobile Narrative Map experience.

Includes:
- NarrativeMapAccessState for Free/Pro/payment/admin states
- Free: 1 documented reading total
- Pro: 10 readings per month
- pre-upload gating for access/quota
- Instagram as a Pro feature
- Profile-only status balloon with the right next action
- mobile navigation simplified to Perfil | Comunidade
- Profile internal tabs as Mapa | Leituras | Oportunidades
- Community preserved as the D2C creator marketplace/list
- compact consultation access banner in Community
- Pro Community state focused on direct access: Entrar na consultoria / Acessar Grupo VIP
- postCheckoutIntent support for connect_instagram and join_community
- contextual paywall copy for Narrative Map and Community/Mentoria

## Product direction

Free tests the product with one reading. Pro uses the product continuously with 10 readings per month, Instagram precision, and access to group consulting.

UX rules:
- Menu resolves navigation.
- Profile status balloon resolves the next action.
- Community banner resolves consulting access.
- New reading is not a menu item.

## Guardrails

- Does not create a new plan.
- Does not create extra reading packages.
- Does not create real matches, brands, or creators.
- Does not create a new Instagram tab.
- Does not deeply alter Stripe/billing core.
- Does not alter NextAuth, DashboardShell, BoardShell, sidebar, or MediaKitView.
- Keeps Community as marketplace/list, not a mentoring landing page.
- Does not store video, thumbnail, signed/upload URL, objectKey, localPath, storageProviderPath, raw response, raw transcript, or long transcript.

## Validation reported locally

- 240 focused/impacted tests passed.
- npm run typecheck passed.
- npm run build passed with existing unrelated warnings only.
- git diff --check passed.

## Next milestone

MM90 — Closed Beta Activation, Telemetry and Operator Smoke Harness: activation telemetry, quota renewal messaging, post-checkout follow-through, operator smoke checks, and final beta hardening.