### PR TITLE
MM90 — Mobile UX Simplification Pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ with their followers.
 Posts are considered eligible only if they have at least three shares and a save
 rate of 0.2% (saved divided by reach) or higher.
 
+Mobile community UX note: the creator-facing mobile app uses `/planning/discover`
+as the canonical Community route. Community remains a marketplace/list of D2C
+creators; the Pro consulting/Grupo VIP entry appears as a compact inline banner,
+not as a replacement for the marketplace.
+
 #### Running the community cron manually
 
 Set `LOG_LEVEL=debug` before invoking the cron route to see additional debug

--- a/docs/MM90_MOBILE_UX_SIMPLIFICATION_PASS.md
+++ b/docs/MM90_MOBILE_UX_SIMPLIFICATION_PASS.md
@@ -1,0 +1,76 @@
+# MM90 — Mobile UX Simplification Pass
+
+Issue: #877
+
+## Goal
+
+Optimize the real mobile app experience before telemetry and final beta hardening.
+
+The product should feel like a mobile app for strategic direction, not a dashboard, landing page, preview, or generic video AI.
+
+Core flow:
+
+`Perfil → Nova leitura → Upload de vídeo → Pergunta/objetivo → Contexto rápido → Leitura pronta → Perfil atualizado`
+
+## Product principle
+
+Interface enxuta. Texto suficiente. Diagnóstico profundo.
+
+The user should open the Perfil, understand what D2C has already read, know the next step, generate a new reading, and share the Media Kit without hunting for it.
+
+## Mobile-only scope
+
+This milestone should touch only the real mobile experience for:
+
+- Perfil
+- Mapa Narrativo
+- Status Card
+- New reading flow
+- Media Kit entry inside Oportunidades
+- Mobile Community entry/banner
+
+Out of scope:
+
+- telemetry
+- beta activation
+- billing core
+- Stripe
+- NextAuth
+- desktop DashboardShell/BoardShell/sidebar
+- public MediaKitView
+- AI engine/prompt/parser/schema changes
+- real brand matching
+- campaign CRM
+
+## Implementation order
+
+1. Separate real mobile app surface from internal preview/device frame.
+2. Consolidate the real mobile Perfil experience.
+3. Simplify the mobile Status Card for access/quota/Instagram/payment states.
+4. Rework the new reading flow around video, creator question, quick context, and Perfil update.
+5. Ensure `creatorGoal` and `quickAnswers` come from real user input, not hardcoded values.
+6. Place Media Kit actions at the top of Oportunidades.
+7. Keep Community as marketplace/list with a compact consulting banner.
+8. Update tests and run typecheck, tests, and build.
+
+## Key UX rules
+
+- Global mobile navigation: `Perfil | Comunidade` only.
+- Perfil tabs: `Mapa | Leituras | Oportunidades`.
+- New reading never appears as global navigation.
+- Card equals summary.
+- Modal/bottom sheet/detail equals complete diagnosis.
+- Buttons must be short but specific.
+- Avoid technical language in real UI: mock, preview, upload session, objectKey, signed URL, raw response, raw transcript, storage path.
+
+## Validation
+
+Expected validation before PR is ready:
+
+```bash
+npm run typecheck
+npm test -- --runInBand
+npm run build
+```
+
+See issue #877 for the full implementation brief and acceptance criteria.

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
@@ -21,7 +21,13 @@ function renderFlow(onSubmitAnalysis?: any) {
 }
 
 function continueFlow() {
-  fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+  const button =
+    screen.queryByRole("button", { name: "Continuar" }) ||
+    screen.queryByRole("button", { name: "Começar" }) ||
+    screen.queryByRole("button", { name: "Gerar leitura" }) ||
+    screen.queryByRole("button", { name: "Ver leitura no Perfil" });
+  if (!button) throw new Error("Flow continuation button not found");
+  fireEvent.click(button);
 }
 
 describe("MobileStrategicProfileAnalyzeFlow", () => {
@@ -34,16 +40,16 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
   it("renders intro step", () => {
     renderFlow();
 
-    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
-    expect(screen.getByText("Use um vídeo para a D2C entender novos sinais da sua narrativa.")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Nova leitura estratégica" })).toBeInTheDocument();
+    expect(screen.getByText("Envie um vídeo e diga o que você quer entender. A D2C transforma esse conteúdo em direção para o seu Perfil.")).toBeInTheDocument();
   });
 
-  it("advances to mock upload", () => {
+  it("advances to upload", () => {
     renderFlow();
     continueFlow();
 
-    expect(screen.getByText("Vídeo pronto para análise")).toBeInTheDocument();
-    expect(screen.getByText("Preview local. Nenhum arquivo será enviado neste protótipo.")).toBeInTheDocument();
+    expect(screen.getByText("Vídeo pronto para leitura")).toBeInTheDocument();
+    expect(screen.getByText("Continue para informar sua pergunta e gerar uma leitura estratégica.")).toBeInTheDocument();
   });
 
   it("advances to creator goal and allows selection", () => {
@@ -51,7 +57,8 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     continueFlow();
     continueFlow();
 
-    expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+    expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Ex: por que esse vídeo prendeu atenção?")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ganhar autoridade" })).toBeInTheDocument();
     
     // Click "Preparar publi" to select
@@ -67,29 +74,41 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     continueFlow();
 
     expect(screen.getByText("Só mais um contexto rápido")).toBeInTheDocument();
-    expect(screen.getByText("Essas respostas ajudam a D2C entender o que você queria comunicar.")).toBeInTheDocument();
-    expect(screen.getByText("Esse conteúdo representa sua fase atual?")).toBeInTheDocument();
+    expect(screen.getByText("Isso ajuda a D2C interpretar o vídeo pela sua intenção, não só pela imagem.")).toBeInTheDocument();
+    expect(screen.getByText("Esse vídeo representa sua fase atual?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mais ou menos" })).toBeInTheDocument();
   });
 
-  it("chama onSubmitAnalysis ao entrar em updating_profile e avança para sucesso", async () => {
+  it("chama onSubmitAnalysis com pergunta e contexto reais e avança para sucesso", async () => {
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     renderFlow(onSubmit);
 
-    continueFlow(); // intro -> mock_upload
-    continueFlow(); // mock_upload -> creator_goal
-    continueFlow(); // creator_goal -> quick_questions
-    continueFlow(); // quick_questions -> updating_profile
+    continueFlow(); // intro -> upload
+    continueFlow(); // upload -> creator_goal
+    fireEvent.change(screen.getByPlaceholderText("Ex: por que esse vídeo prendeu atenção?"), {
+      target: { value: "Por que esse vídeo prendeu atenção?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Melhorar retenção" }));
+    continueFlow(); // creator_goal -> context
+    fireEvent.click(screen.getByRole("button", { name: "Mais ou menos" }));
+    fireEvent.click(screen.getByRole("button", { name: "Gerar comentários" }));
+    continueFlow(); // context -> processing
 
-    expect(screen.getByText("Atualizando seu Perfil")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Analisando sua narrativa" })).toBeInTheDocument();
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        selectedGoalOption: "authority",
+        creatorGoal: "Por que esse vídeo prendeu atenção?",
+        selectedGoalOption: "retention",
+        quickAnswers: expect.arrayContaining([
+          { id: "represents_current_phase", value: "Mais ou menos" },
+          { id: "content_intent", value: "Gerar comentários" },
+        ]),
       })
     );
 
     // Wait until it advances to success step
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+      expect(screen.getByRole("dialog", { name: "Leitura pronta" })).toBeInTheDocument();
     });
   });
 
@@ -101,10 +120,10 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
 
     const { onComplete } = renderFlow(onSubmit);
 
-    continueFlow(); // intro -> mock_upload
-    continueFlow(); // mock_upload -> creator_goal
-    continueFlow(); // creator_goal -> quick_questions
-    continueFlow(); // quick_questions -> updating_profile
+    continueFlow(); // intro -> upload
+    continueFlow(); // upload -> creator_goal
+    continueFlow(); // creator_goal -> context
+    continueFlow(); // context -> processing
 
     await waitFor(() => {
       expect(screen.getByText("Erro na atualização")).toBeInTheDocument();
@@ -116,11 +135,11 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     fireEvent.click(retryBtn);
 
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+      expect(screen.getByRole("dialog", { name: "Leitura pronta" })).toBeInTheDocument();
     });
 
     // Clique em concluir
-    const completeBtn = screen.getByRole("button", { name: "Voltar para meu Perfil" });
+    const completeBtn = screen.getByRole("button", { name: "Ver leitura no Perfil" });
     fireEvent.click(completeBtn);
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
@@ -182,7 +201,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
   describe("Fase MM61 - Upload Metadata & Consent Dry Run", () => {
     const fileMock = new File(["dummy content"], "vlog.mp4", { type: "video/mp4" });
 
-    it("preview sem onCreateUploadSession continua mostrando modal local original", () => {
+    it("preview sem onCreateUploadSession continua mostrando caminho sem seletor real", () => {
       render(
         <MobileStrategicProfileAnalyzeFlow
           open
@@ -190,9 +209,9 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
           onComplete={jest.fn()}
         />
       );
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
-      expect(screen.getByText("Vídeo pronto para análise")).toBeInTheDocument();
-      expect(screen.queryByText("Selecionar arquivo de vídeo")).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
+      expect(screen.getByText("Vídeo pronto para leitura")).toBeInTheDocument();
+      expect(screen.queryByText("Selecionar vídeo")).not.toBeInTheDocument();
     });
 
     it("rota real com onCreateUploadSession mostra seletor de arquivo e não mostra thumbnail/player", () => {
@@ -205,13 +224,12 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
           onCreateUploadSession={onCreateSession}
         />
       );
-      // Avança para mock_upload
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
 
-      expect(screen.getByText("Selecionar arquivo de vídeo")).toBeInTheDocument();
+      expect(screen.getByText("Selecionar vídeo")).toBeInTheDocument();
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
       expect(container.querySelector("video")).not.toBeInTheDocument();
-      expect(screen.getByText("Aguardando seleção.")).toBeInTheDocument();
+      expect(screen.getByText("Escolha um arquivo para começar.")).toBeInTheDocument();
     });
 
     it("selecionar arquivo e interagir com consentimento e validação da API", async () => {
@@ -228,8 +246,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      // Avança para mock_upload
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
 
       // Seleciona o arquivo
       const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -266,8 +283,8 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
 
       // Valida que seguiu para objetivo/perguntas (Creator Goal)
       await waitFor(() => {
-        expect(screen.getByText("Vídeo validado para análise")).toBeInTheDocument();
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("Vídeo pronto para leitura")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
     });
 
@@ -286,8 +303,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      // Avança para mock_upload
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
 
       // Seleciona o arquivo
       const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -303,10 +319,10 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
       await waitFor(() => {
         expect(screen.getByText(/O tamanho do vídeo excede o limite/i)).toBeInTheDocument();
       });
-      expect(screen.queryByText("Qual era o objetivo do conteúdo?")).not.toBeInTheDocument();
+      expect(screen.queryByText("O que você quer entender?")).not.toBeInTheDocument();
     });
 
-    it("finaliza a analise mock depois da validacao de upload metadata", async () => {
+    it("finaliza a leitura depois da validacao de upload metadata", async () => {
       const onCreateSession = jest.fn().mockResolvedValue({
         ok: true,
         status: "mock_session_created",
@@ -322,17 +338,17 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Gerar leitura" }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -376,7 +392,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -396,8 +412,8 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
       resolveUpload({ ok: true, status: "uploaded", uploadedAt: "2026-05-19T00:00:00.000Z", bytesSent: fileMock.size });
 
       await waitFor(() => {
-        expect(screen.getByText("Vídeo enviado para análise temporária.")).toBeInTheDocument();
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("Vídeo pronto para leitura")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
     });
 
@@ -417,13 +433,13 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
       expect(onDirectUpload).not.toHaveBeenCalled();
     });
@@ -462,7 +478,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
@@ -470,7 +486,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
       await waitFor(() => {
         expect(screen.getByText("Não foi possível enviar o vídeo agora.")).toBeInTheDocument();
       });
-      expect(screen.queryByText("Qual era o objetivo do conteúdo?")).not.toBeInTheDocument();
+      expect(screen.queryByText("O que você quer entender?")).not.toBeInTheDocument();
     });
 
     it("cleanup failure não quebra análise mock nem envia uploadUrl/objectKey para análise", async () => {
@@ -508,19 +524,19 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Gerar leitura" }));
 
       await waitFor(() => {
-        expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
+        expect(screen.getByRole("dialog", { name: "Leitura pronta" })).toBeInTheDocument();
       });
       expect(onCleanup).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -571,16 +587,16 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
       fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [fileMock] } });
       fireEvent.click(screen.getByRole("checkbox"));
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Qual era o objetivo do conteúdo?")).toBeInTheDocument();
+        expect(screen.getByText("O que você quer entender?")).toBeInTheDocument();
       });
       fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Gerar leitura" }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalled();
@@ -604,7 +620,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
           onCreateUploadSession={jest.fn()}
         />
       );
-      fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+      fireEvent.click(screen.getByRole("button", { name: "Começar" }));
 
       const text = document.body.textContent?.toLowerCase() ?? "";
       expect(text).not.toContain("histórico de vídeos");

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -11,11 +11,11 @@ import type {
 
 const STEPS = [
   "intro",
-  "mock_upload",
+  "upload",
   "creator_goal",
-  "quick_questions",
-  "updating_profile",
-  "updated_confirmation",
+  "context",
+  "processing",
+  "confirmation",
 ] as const;
 
 type AnalyzeFlowStep = (typeof STEPS)[number];
@@ -52,7 +52,7 @@ type MobileStrategicProfileAnalyzeFlowProps = {
 
 function nextStep(current: AnalyzeFlowStep): AnalyzeFlowStep {
   const index = STEPS.indexOf(current);
-  return STEPS[Math.min(index + 1, STEPS.length - 1)] ?? "updated_confirmation";
+  return STEPS[Math.min(index + 1, STEPS.length - 1)] ?? "confirmation";
 }
 
 function stepIndex(step: AnalyzeFlowStep): number {
@@ -92,6 +92,60 @@ function getUploadSessionErrorMessage(response?: UploadSessionResponse) {
   return response?.message || "Não foi possível validar o vídeo agora.";
 }
 
+const goalOptions = [
+  {
+    label: "Melhorar retenção",
+    value: "retention" as const,
+    defaultQuestion: "Como esse vídeo pode prender mais atenção?",
+  },
+  {
+    label: "Entender narrativa",
+    value: "authority" as const,
+    defaultQuestion: "O que esse vídeo revela sobre minha narrativa?",
+  },
+  {
+    label: "Preparar publi",
+    value: "sponsored_content" as const,
+    defaultQuestion: "Como transformar essa direção em um conteúdo útil para marcas?",
+  },
+  {
+    label: "Testar formato",
+    value: "format_test" as const,
+    defaultQuestion: "Esse formato vale repetir no meu Perfil?",
+  },
+  {
+    label: "Ganhar autoridade",
+    value: "authority" as const,
+    defaultQuestion: "Como esse conteúdo fortalece minha autoridade?",
+  },
+];
+
+const contextQuestions = [
+  {
+    id: "represents_current_phase",
+    question: "Esse vídeo representa sua fase atual?",
+    options: ["Sim", "Mais ou menos", "Não"],
+  },
+  {
+    id: "wants_to_repeat_direction",
+    question: "Você quer repetir essa direção?",
+    options: ["Sim", "Talvez", "Não"],
+  },
+  {
+    id: "content_intent",
+    question: "O que você mais queria com esse conteúdo?",
+    options: ["Alcançar mais pessoas", "Gerar comentários", "Atrair marcas", "Fortalecer autoridade"],
+  },
+];
+
+function defaultContextAnswers(): Record<string, string> {
+  return {
+    represents_current_phase: "Sim",
+    wants_to_repeat_direction: "Talvez",
+    content_intent: "Fortalecer autoridade",
+  };
+}
+
 export function MobileStrategicProfileAnalyzeFlow({
   open,
   onClose,
@@ -104,6 +158,8 @@ export function MobileStrategicProfileAnalyzeFlow({
 }: MobileStrategicProfileAnalyzeFlowProps) {
   const [step, setStep] = useState<AnalyzeFlowStep>("intro");
   const [selectedOption, setSelectedOption] = useState<"authority" | "retention" | "format_test" | "sponsored_content">("authority");
+  const [creatorGoal, setCreatorGoal] = useState("");
+  const [quickAnswers, setQuickAnswers] = useState<Record<string, string>>(() => defaultContextAnswers());
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [submitAttempt, setSubmitAttempt] = useState(0);
@@ -137,11 +193,14 @@ export function MobileStrategicProfileAnalyzeFlow({
       setUploadSessionValidated(false);
       setTemporaryUploadForCleanup(null);
       setTemporaryUploadForAnalysis(null);
+      setCreatorGoal("");
+      setSelectedOption("authority");
+      setQuickAnswers(defaultContextAnswers());
     }
   }, [open]);
 
   useEffect(() => {
-    if (step !== "updating_profile") return;
+    if (step !== "processing") return;
 
     let active = true;
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
@@ -152,12 +211,12 @@ export function MobileStrategicProfileAnalyzeFlow({
         setErrorMsg(null);
         try {
           await onSubmitAnalysis({
-            creatorGoal: "Como posso otimizar meu posicionamento de conteúdo?",
+            creatorGoal: creatorGoal.trim() || goalOptions.find((option) => option.value === selectedOption)?.defaultQuestion || "O que este vídeo revela sobre minha narrativa?",
             selectedGoalOption: selectedOption,
-            quickAnswers: [
-              { id: "represents_current_phase", value: "sim" },
-              { id: "wants_to_repeat_direction", value: "sim" }
-            ],
+            quickAnswers: contextQuestions.map((question) => ({
+              id: question.id,
+              value: quickAnswers[question.id] ?? "",
+            })),
             consentTextVersion: "mobile_strategic_profile_temporary_video_v1",
             temporaryUpload: enableRealAnalysis ? temporaryUploadForAnalysis ?? undefined : undefined,
           });
@@ -173,7 +232,7 @@ export function MobileStrategicProfileAnalyzeFlow({
           }
           if (active) {
             setIsSubmitting(false);
-            setStep("updated_confirmation");
+            setStep("confirmation");
           }
         } catch (err: any) {
           if (temporaryUploadForCleanup && onCleanupTemporaryUpload) {
@@ -194,7 +253,7 @@ export function MobileStrategicProfileAnalyzeFlow({
       } else {
         fallbackTimer = setTimeout(() => {
           if (active) {
-            setStep("updated_confirmation");
+            setStep("confirmation");
           }
         }, 1000);
       }
@@ -210,7 +269,9 @@ export function MobileStrategicProfileAnalyzeFlow({
     };
   }, [
     step,
+    creatorGoal,
     selectedOption,
+    quickAnswers,
     onSubmitAnalysis,
     submitAttempt,
     temporaryUploadForCleanup,
@@ -222,7 +283,7 @@ export function MobileStrategicProfileAnalyzeFlow({
   if (!open) return null;
 
   const handleContinue = async () => {
-    if (step === "mock_upload" && onCreateUploadSession) {
+    if (step === "upload" && onCreateUploadSession) {
       if (!selectedFile) {
         setFileValidationError("Selecione um arquivo de vídeo primeiro.");
         return;
@@ -301,6 +362,9 @@ export function MobileStrategicProfileAnalyzeFlow({
     setUploadSessionValidated(false);
     setTemporaryUploadForCleanup(null);
     setTemporaryUploadForAnalysis(null);
+    setCreatorGoal("");
+    setSelectedOption("authority");
+    setQuickAnswers(defaultContextAnswers());
     onClose();
   };
 
@@ -310,24 +374,20 @@ export function MobileStrategicProfileAnalyzeFlow({
     setUploadSessionValidated(false);
     setTemporaryUploadForCleanup(null);
     setTemporaryUploadForAnalysis(null);
+    setCreatorGoal("");
+    setSelectedOption("authority");
+    setQuickAnswers(defaultContextAnswers());
     onComplete();
   };
 
   const currentStepIndex = stepIndex(step);
-
-  const goalOptions = [
-    { label: "Ganhar autoridade", value: "authority" as const },
-    { label: "Melhorar retenção", value: "retention" as const },
-    { label: "Testar formato", value: "format_test" as const },
-    { label: "Preparar publi", value: "sponsored_content" as const },
-  ];
 
   // Regra de disabled para o botão Continuar
   const isContinueDisabled =
     isSubmitting ||
     validationStatus === "validating" ||
     validationStatus === "uploading" ||
-    (step === "mock_upload" &&
+    (step === "upload" &&
       onCreateUploadSession &&
       (validationStatus === "validated" || validationStatus === "uploaded"));
 
@@ -342,10 +402,20 @@ export function MobileStrategicProfileAnalyzeFlow({
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold uppercase text-zinc-500">
-            Etapa {currentStepIndex + 1} de {STEPS.length} · Atualizar Perfil
+            Etapa {currentStepIndex + 1} de {STEPS.length} · Nova leitura
           </p>
           <h2 id="mobile-strategic-profile-analyze-flow-title" className="mt-1 text-xl font-semibold text-zinc-950">
-            {step === "updated_confirmation" ? "Diagnóstico atualizado." : "Vamos atualizar seu Perfil"}
+            {step === "intro"
+              ? "Nova leitura estratégica"
+              : step === "upload"
+                ? "Escolha o vídeo"
+                : step === "creator_goal"
+                  ? "O que você quer entender?"
+                  : step === "context"
+                    ? "Só mais um contexto rápido"
+                    : step === "processing"
+                      ? "Analisando sua narrativa"
+                      : "Leitura pronta"}
           </h2>
         </div>
         <button
@@ -372,25 +442,25 @@ export function MobileStrategicProfileAnalyzeFlow({
         {step === "intro" ? (
           <div>
             <p className="text-sm leading-6 text-zinc-600">
-              Use um vídeo para a D2C entender novos sinais da sua narrativa.
+              Envie um vídeo e diga o que você quer entender. A D2C transforma esse conteúdo em direção para o seu Perfil.
             </p>
             <div className="mt-5 rounded-[1.5rem] border border-zinc-200 bg-[#f7f7f4] p-4">
-              <p className="text-sm font-semibold text-zinc-950">Atualizar Perfil</p>
+              <p className="text-sm font-semibold text-zinc-950">Seu Perfil é a casa da leitura</p>
               <p className="mt-1 text-sm leading-6 text-zinc-600">
-                A análise é temporária e retorna para o Diagnóstico vivo.
+                O vídeo traz sinais, sua pergunta dá intenção e o resultado volta para o Perfil.
               </p>
             </div>
           </div>
         ) : null}
 
-        {step === "mock_upload" ? (
+        {step === "upload" ? (
           onCreateUploadSession ? (
             <div>
               <p className="text-sm leading-6 text-zinc-600 mb-4">
-                Selecione um vídeo para validar se ele está pronto para análise temporária.
+                Use um post recente, um conteúdo que performou bem ou uma ideia que você quer avaliar.
               </p>
               {!selectedFile ? (
-                <p className="mb-3 text-xs font-semibold text-zinc-500">Aguardando seleção.</p>
+                <p className="mb-3 text-xs font-semibold text-zinc-500">Escolha um arquivo para começar.</p>
               ) : null}
 
               <input
@@ -416,13 +486,13 @@ export function MobileStrategicProfileAnalyzeFlow({
                 htmlFor="video-file-picker"
                 className="flex cursor-pointer flex-col items-center justify-center rounded-2xl border-2 border-dashed border-zinc-300 bg-[#f7f7f4] px-4 py-8 text-center transition-colors hover:bg-zinc-50"
               >
-                <span className="text-sm font-semibold text-zinc-950">Selecionar arquivo de vídeo</span>
-                <span className="mt-1 text-xs text-zinc-500">MP4, MOV ou WEBM (max. 100MB)</span>
+                <span className="text-sm font-semibold text-zinc-950">Selecionar vídeo</span>
+                <span className="mt-1 text-xs text-zinc-500">MP4, MOV ou WEBM até 100 MB</span>
               </label>
 
               {selectedFile ? (
                 <div className="mt-4 rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4 text-left">
-                  <p className="text-xs uppercase font-semibold text-zinc-500">Arquivo Selecionado</p>
+                  <p className="text-xs uppercase font-semibold text-zinc-500">Vídeo selecionado</p>
                   <p className="mt-1 truncate text-sm font-semibold text-zinc-950">{sanitizeVisibleFileName(selectedFile.name)}</p>
                   <p className="text-xs text-zinc-600 mt-1">
                     {selectedFile.type || "video/mp4"} · {formatSize(selectedFile.size)}
@@ -445,14 +515,14 @@ export function MobileStrategicProfileAnalyzeFlow({
                     className="mt-1 h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-900"
                   />
                   <label htmlFor="video-consent-checkbox" className="text-xs leading-5 text-zinc-600 cursor-pointer">
-                    Entendo que este vídeo será usado apenas para validar a análise narrativa temporária.
+                    Usar este vídeo apenas para gerar esta leitura.
                   </label>
                 </div>
               ) : null}
 
               {validationStatus === "validating" ? (
                 <p className="mt-3 text-xs font-medium text-sky-600">
-                  Preparando envio...
+                  Preparando vídeo...
                 </p>
               ) : null}
 
@@ -464,13 +534,13 @@ export function MobileStrategicProfileAnalyzeFlow({
 
               {validationStatus === "validated" ? (
                 <p className="mt-3 text-xs font-semibold text-emerald-600">
-                  Vídeo validado para análise
+                  Vídeo pronto para leitura
                 </p>
               ) : null}
 
               {validationStatus === "uploaded" ? (
                 <p className="mt-3 text-xs font-semibold text-emerald-600">
-                  Vídeo enviado para análise temporária.
+                  Vídeo pronto para leitura
                 </p>
               ) : null}
 
@@ -481,11 +551,10 @@ export function MobileStrategicProfileAnalyzeFlow({
               ) : null}
             </div>
           ) : (
-            // Interface Mock de Preview local legada
             <div className="rounded-[1.5rem] border border-dashed border-zinc-300 bg-[#f7f7f4] p-4">
-              <p className="text-sm font-semibold text-zinc-950">Vídeo pronto para análise</p>
+              <p className="text-sm font-semibold text-zinc-950">Vídeo pronto para leitura</p>
               <p className="mt-2 text-sm leading-6 text-zinc-600">
-                Preview local. Nenhum arquivo será enviado neste protótipo.
+                Continue para informar sua pergunta e gerar uma leitura estratégica.
               </p>
             </div>
           )
@@ -495,10 +564,16 @@ export function MobileStrategicProfileAnalyzeFlow({
           <div>
             {uploadSessionValidated ? (
               <p className="mb-3 rounded-2xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700">
-                {validationStatus === "uploaded" ? "Vídeo enviado para análise temporária." : "Vídeo validado para análise"}
+                Vídeo pronto para leitura
               </p>
             ) : null}
-            <p className="text-sm font-semibold text-zinc-950">Qual era o objetivo do conteúdo?</p>
+            <p className="text-sm leading-6 text-zinc-600">Escreva sua dúvida ou escolha um objetivo rápido.</p>
+            <textarea
+              value={creatorGoal}
+              onChange={(event) => setCreatorGoal(event.target.value)}
+              placeholder="Ex: por que esse vídeo prendeu atenção?"
+              className="mt-3 min-h-[92px] w-full resize-none rounded-2xl border border-zinc-200 bg-white px-3 py-3 text-sm text-zinc-950 outline-none transition focus:border-zinc-950"
+            />
             <div className="mt-3 grid grid-cols-2 gap-2">
               {goalOptions.map((opt) => {
                 const isSelected = selectedOption === opt.value;
@@ -511,7 +586,12 @@ export function MobileStrategicProfileAnalyzeFlow({
                         ? "border-zinc-950 bg-zinc-950 text-white shadow-sm"
                         : "border-zinc-200 bg-[#f7f7f4] text-zinc-800 hover:border-zinc-300"
                     }`}
-                    onClick={() => setSelectedOption(opt.value)}
+                    onClick={() => {
+                      setSelectedOption(opt.value);
+                      if (!creatorGoal.trim()) {
+                        setCreatorGoal(opt.defaultQuestion);
+                      }
+                    }}
                   >
                     {opt.label}
                   </button>
@@ -521,26 +601,41 @@ export function MobileStrategicProfileAnalyzeFlow({
           </div>
         ) : null}
 
-        {step === "quick_questions" ? (
+        {step === "context" ? (
           <div>
-            <p className="text-sm font-semibold text-zinc-950">Só mais um contexto rápido</p>
             <p className="mt-1 text-sm leading-6 text-zinc-600">
-              Essas respostas ajudam a D2C entender o que você queria comunicar.
+              Isso ajuda a D2C interpretar o vídeo pela sua intenção, não só pela imagem.
             </p>
             <div className="mt-3 grid gap-3">
-              <div className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4">
-                <p className="text-sm font-semibold text-zinc-800">Esse conteúdo representa sua fase atual?</p>
-                <p className="mt-1 text-xs leading-5 text-zinc-500">Resposta visual nesta preview, sem salvar nada.</p>
-              </div>
-              <div className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4">
-                <p className="text-sm font-semibold text-zinc-800">Você quer repetir essa direção no próximo post?</p>
-                <p className="mt-1 text-xs leading-5 text-zinc-500">A leitura volta para o Perfil Estratégico.</p>
-              </div>
+              {contextQuestions.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-zinc-200 bg-[#f7f7f4] p-4">
+                  <p className="text-sm font-semibold text-zinc-800">{item.question}</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {item.options.map((option) => {
+                      const selected = quickAnswers[item.id] === option;
+                      return (
+                        <button
+                          key={option}
+                          type="button"
+                          className={
+                            selected
+                              ? "rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+                              : "rounded-full border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-700"
+                          }
+                          onClick={() => setQuickAnswers((current) => ({ ...current, [item.id]: option }))}
+                        >
+                          {option}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         ) : null}
 
-        {step === "updating_profile" ? (
+        {step === "processing" ? (
           <div className="rounded-[1.5rem] border border-sky-100 bg-sky-50 p-4 transition-all">
             {errorMsg ? (
               <div>
@@ -555,37 +650,58 @@ export function MobileStrategicProfileAnalyzeFlow({
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
                   <p className="text-sm font-semibold text-zinc-950">
-                    {temporaryUploadForAnalysis ? "Analisando vídeo e atualizando seu Perfil" : "Atualizando seu Perfil"}
+                    Analisando sua narrativa
                   </p>
                 </div>
                 <p className="mt-2 text-sm leading-6 text-zinc-600">
-                  Estamos conectando essa leitura ao seu diagnóstico vivo.
+                  Estamos conectando vídeo, pergunta e contexto ao seu Perfil.
                 </p>
+                <div className="mt-3 grid gap-2 text-xs font-semibold text-sky-700">
+                  <span>Lendo sinais do vídeo</span>
+                  <span>Interpretando sua intenção</span>
+                  <span>Atualizando o Perfil</span>
+                </div>
               </div>
             )}
           </div>
         ) : null}
 
-        {step === "updated_confirmation" ? (
+        {step === "confirmation" ? (
           <div className="rounded-[1.5rem] border border-emerald-100 bg-emerald-50 p-4">
-            <p className="text-sm font-semibold text-zinc-950">Identificamos novos aprendizados sobre sua narrativa.</p>
+            <p className="text-sm font-semibold text-zinc-950">Encontramos novos sinais para o seu Perfil.</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">
-              A confirmação é curta porque o destino final é o seu Perfil.
+              O diagnóstico completo aparece no Perfil, junto das leituras e do mapa.
             </p>
           </div>
         ) : null}
       </div>
 
       <div className="mt-5 flex gap-2">
-        {step === "updated_confirmation" ? (
-          <button
-            type="button"
-            className="w-full rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zinc-800 transition-colors"
-            onClick={complete}
-          >
-            Voltar para meu Perfil
-          </button>
-        ) : step === "updating_profile" && errorMsg ? (
+        {step === "confirmation" ? (
+          <div className="flex w-full gap-2">
+            <button
+              type="button"
+              className="w-2/3 rounded-full bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zinc-800 transition-colors"
+              onClick={complete}
+            >
+              Ver leitura no Perfil
+            </button>
+            <button
+              type="button"
+              className="w-1/3 rounded-full border border-zinc-300 bg-white px-3 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-50 transition-colors"
+              onClick={() => {
+                setStep("upload");
+                setSelectedFile(null);
+                setConsentAccepted(false);
+                setValidationStatus("idle");
+                setFileValidationError(null);
+                setUploadSessionValidated(false);
+              }}
+            >
+              Outro vídeo
+            </button>
+          </div>
+        ) : step === "processing" && errorMsg ? (
           <div className="flex w-full gap-2">
             <button
               type="button"
@@ -600,7 +716,7 @@ export function MobileStrategicProfileAnalyzeFlow({
               onClick={() => {
                 setErrorMsg(null);
                 setSubmitAttempt((prev) => prev + 1);
-                setStep("updating_profile");
+                setStep("processing");
               }}
             >
               Tentar novamente
@@ -613,7 +729,11 @@ export function MobileStrategicProfileAnalyzeFlow({
             onClick={handleContinue}
             disabled={isContinueDisabled}
           >
-            Continuar
+            {step === "intro"
+              ? "Começar"
+              : step === "context"
+                ? "Gerar leitura"
+                : "Continuar"}
           </button>
         )}
       </div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.test.tsx
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MobileStrategicProfilePreview } from "./MobileStrategicProfilePreview";
 import {
   buildMobileStrategicProfilePreviewFixture,
@@ -30,10 +30,13 @@ function clickAnalyzeAction(label: string) {
   fireEvent.click(button);
 }
 
-function advanceAnalyzeFlowToConfirmation() {
-  for (let index = 0; index < 5; index += 1) {
-    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+async function advanceAnalyzeFlowToConfirmation() {
+  for (const label of ["Começar", "Continuar", "Continuar", "Gerar leitura"]) {
+    fireEvent.click(screen.getByRole("button", { name: label }));
   }
+  await waitFor(() => {
+    expect(screen.getByRole("dialog", { name: "Leitura pronta" })).toBeInTheDocument();
+  }, { timeout: 2000 });
 }
 
 describe("MobileStrategicProfilePreview", () => {
@@ -165,15 +168,15 @@ describe("MobileStrategicProfilePreview", () => {
   it("Analyze flow does not appear by default", () => {
     renderState("first_reading_free");
 
-    expect(screen.queryByRole("dialog", { name: "Vamos atualizar seu Perfil" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Nova leitura estratégica" })).not.toBeInTheDocument();
   });
 
   it("opens Analyze flow from status bubble when free reading is available", () => {
     renderState("account_only");
 
-    fireEvent.click(screen.getByRole("button", { name: "Analisar vídeo" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Analisar meu primeiro vídeo" })[0]);
 
-    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Nova leitura estratégica" })).toBeInTheDocument();
   });
 
   it("does not render central analyze action in bottom nav", () => {
@@ -189,7 +192,7 @@ describe("MobileStrategicProfilePreview", () => {
 
     clickAnalyzeAction("Analisar meu primeiro vídeo");
 
-    expect(screen.getByText("Use um vídeo para a D2C entender novos sinais da sua narrativa.")).toBeInTheDocument();
+    expect(screen.getByText("Envie um vídeo e diga o que você quer entender. A D2C transforma esse conteúdo em direção para o seu Perfil.")).toBeInTheDocument();
   });
 
   it("opens Analyze flow from empty state CTA in account_only", () => {
@@ -197,7 +200,7 @@ describe("MobileStrategicProfilePreview", () => {
 
     clickAnalyzeAction("Analisar meu primeiro vídeo");
 
-    expect(screen.getByRole("dialog", { name: "Vamos atualizar seu Perfil" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Nova leitura estratégica" })).toBeInTheDocument();
   });
 
   it("anonymous auth gate does not open real Analyze flow", () => {
@@ -205,30 +208,30 @@ describe("MobileStrategicProfilePreview", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Entrar e analisar vídeo" }));
 
-    expect(screen.queryByRole("dialog", { name: "Vamos atualizar seu Perfil" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Nova leitura estratégica" })).not.toBeInTheDocument();
   });
 
-  it("Analyze flow returns to Profile after short confirmation", () => {
+  it("Analyze flow returns to Profile after short confirmation", async () => {
     renderState("account_only");
 
     clickAnalyzeAction("Analisar meu primeiro vídeo");
-    advanceAnalyzeFlowToConfirmation();
+    await advanceAnalyzeFlowToConfirmation();
 
-    expect(screen.getByRole("dialog", { name: "Diagnóstico atualizado." })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+    expect(screen.getByRole("dialog", { name: "Leitura pronta" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Ver leitura no Perfil" }));
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
     expect(screen.getAllByText("Mapa").length).toBeGreaterThan(0);
-    expect(screen.getByText("Seu Perfil foi atualizado com a nova leitura.")).toBeInTheDocument();
+    expect(screen.getByText("A D2C atualizou seu Perfil com sinais deste vídeo.")).toBeInTheDocument();
   });
 
-  it("Analyze flow does not create analyzed videos history or active file input", () => {
+  it("Analyze flow does not create analyzed videos history or active file input", async () => {
     const { container } = renderState("account_only");
 
     clickAnalyzeAction("Analisar meu primeiro vídeo");
-    advanceAnalyzeFlowToConfirmation();
-    fireEvent.click(screen.getByRole("button", { name: "Voltar para meu Perfil" }));
+    await advanceAnalyzeFlowToConfirmation();
+    fireEvent.click(screen.getByRole("button", { name: "Ver leitura no Perfil" }));
 
     const text = renderedText(container);
     expect(text).not.toContain("histórico de vídeos");

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -8,12 +8,16 @@ import type {
   MobileStrategicProfileSectionCard,
 } from "../../../videoUpload/mobileStrategicProfileMapping";
 import {
-  getNarrativeMapAccessAction,
-  getNarrativeMapAccessStatusText,
+  getNarrativeMapStatusCardContent,
   normalizeNarrativeMapReadingQuotaSnapshot,
   type NarrativeMapAccessState,
   type NarrativeMapReadingQuotaSnapshot,
 } from "../../../videoUpload/narrativeMapAccessState";
+import {
+  MOBILE_COMMUNITY_ROUTE,
+  MOBILE_INSTAGRAM_CONNECT_ROUTE,
+  MOBILE_PROFILE_ROUTE,
+} from "../../../videoUpload/mobileStrategicProfileRoutes";
 import { openPaywallModal } from "@/utils/paywallModal";
 import {
   MOBILE_STRATEGIC_PROFILE_PREVIEW_STATES,
@@ -145,8 +149,8 @@ function AuthGate({ profile, isRealShell }: { profile: MobileStrategicProfile; i
   const gate = profile.authGate;
 
   return (
-    <section className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
-      <div className="mx-auto grid max-w-5xl gap-5">
+    <section className={isRealShell ? "min-h-screen bg-[#f7f7f4] text-zinc-950" : "min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950"}>
+      <div className={isRealShell ? "mx-auto grid w-full max-w-md gap-5" : "mx-auto grid max-w-5xl gap-5"}>
         {!isRealShell ? (
           <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
             <p className="text-xs font-semibold uppercase text-zinc-500">Preview interno — Perfil Estratégico</p>
@@ -157,8 +161,8 @@ function AuthGate({ profile, isRealShell }: { profile: MobileStrategicProfile; i
           </header>
         ) : null}
 
-        <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
-          <div className="min-h-[680px] rounded-[1.5rem] bg-[#f7f7f4] px-5 py-5">
+        <div className={isRealShell ? "mx-auto w-full max-w-md bg-[#f7f7f4]" : "mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl"}>
+          <div className={isRealShell ? "min-h-screen bg-[#f7f7f4] px-5 py-5" : "min-h-[680px] rounded-[1.5rem] bg-[#f7f7f4] px-5 py-5"}>
             <div className="flex items-center justify-between">
               <span className="text-sm font-semibold text-zinc-950">Perfil Estratégico</span>
               <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-zinc-600 shadow-sm">D2C</span>
@@ -198,9 +202,7 @@ function ProfileHeader({
   onJoinCommunity: () => void;
 }) {
   const identity = profile.header.identity;
-  const accessAction = getNarrativeMapAccessAction(accessState);
-  const statusText = getNarrativeMapAccessStatusText({ state: accessState, quota: readingQuota });
-  const quota = normalizeNarrativeMapReadingQuotaSnapshot(readingQuota);
+  const statusCard = getNarrativeMapStatusCardContent({ state: accessState, quota: readingQuota });
   const initials = identity.displayName
     .split(/\s+/)
     .filter(Boolean)
@@ -232,21 +234,33 @@ function ProfileHeader({
         </div>
 
         <section className="mt-4 rounded-2xl bg-white px-3 py-3 shadow-sm" aria-label="Status do Perfil">
-          <p className="text-xs font-semibold uppercase text-zinc-500">Próximo passo</p>
-          <div className="mt-2 flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-zinc-950">{statusText}</p>
-              {accessState === "pro_instagram_connected" ? (
-                <p className="mt-0.5 text-xs text-zinc-500">{quota.usedThisMonth}/10 leituras usadas este mês · Instagram conectado</p>
-              ) : null}
-            </div>
+          <p className="text-sm font-semibold text-zinc-950">{statusCard.title}</p>
+          <p className="mt-1 text-xs leading-5 text-zinc-500">{statusCard.description}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
             <button
               type="button"
-              className="shrink-0 rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+              className="rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
               onClick={onPrimaryAccessAction}
             >
-              {accessAction.label}
+              {statusCard.primaryLabel}
             </button>
+            {statusCard.secondaryLabel ? (
+              <button
+                type="button"
+                className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-800"
+                onClick={() => onAction({
+                  id: "status-secondary-new-reading",
+                  intent: "analyze_video",
+                  label: statusCard.secondaryLabel ?? "Nova leitura",
+                  description: "Iniciar uma nova leitura estratégica.",
+                  href: null,
+                  priority: "secondary",
+                  disabled: false,
+                })}
+              >
+                {statusCard.secondaryLabel}
+              </button>
+            ) : null}
           </div>
         </section>
       </div>
@@ -348,14 +362,16 @@ function MediaKitBridge({
   onOpen: () => void;
 }) {
   const bridge = profile.mediaKitBridge;
-  if (bridge.state === "hidden" || bridge.state === "unavailable" || !bridge.title || !bridge.description) return null;
+  if (bridge.state === "hidden" || !bridge.title || !bridge.description) return null;
 
   return (
     <section className="mx-5 rounded-[1.5rem] border border-zinc-200 bg-white p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-zinc-950">{bridge.title}</h3>
-          <p className="mt-1 text-sm leading-6 text-zinc-600">{bridge.description}</p>
+          <p className="mt-1 text-sm leading-6 text-zinc-600">
+            {bridge.state === "available" ? "Seu perfil pronto para enviar às marcas." : "Conecte o Instagram para liberar seu perfil comercial."}
+          </p>
         </div>
         <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
           {bridge.state === "available" ? "Mídia Kit ativo" : "Instagram"}
@@ -367,13 +383,13 @@ function MediaKitBridge({
             <ActionButton key={action.id} action={action} onAction={onOpen} />
           ))}
         </div>
-      ) : bridge.state === "connect_instagram_required" ? (
+      ) : bridge.state === "connect_instagram_required" || bridge.state === "unavailable" ? (
         <button
           type="button"
           className="mt-4 rounded-full border border-zinc-200 bg-white px-4 py-2.5 text-sm font-semibold text-zinc-800"
           onClick={onOpen}
         >
-          Ativar Mídia Kit
+          Conectar Instagram
         </button>
       ) : null}
     </section>
@@ -444,14 +460,14 @@ export function MobileStrategicProfilePreview({
     openPaywallModal({
       context: "narrative_map",
       source: "mobile_profile",
-      returnTo: "/dashboard/boards/mobile-strategic-profile",
+      returnTo: MOBILE_PROFILE_ROUTE,
       postCheckoutIntent: "connect_instagram",
     });
   };
 
   const joinCommunity = () => {
     if (typeof window !== "undefined") {
-      window.location.href = "/planning/discover";
+      window.location.href = MOBILE_COMMUNITY_ROUTE;
     }
   };
 
@@ -461,7 +477,7 @@ export function MobileStrategicProfilePreview({
       return;
     }
     if (typeof window !== "undefined") {
-      window.location.href = "/dashboard/instagram/connect?next=narrative-map";
+      window.location.href = MOBILE_INSTAGRAM_CONNECT_ROUTE;
     }
   };
 
@@ -517,7 +533,7 @@ export function MobileStrategicProfilePreview({
   const activeSection = profile.sections.find((section) => section.id === activeTab);
 
   return (
-    <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
+    <main className={isRealShell ? "min-h-screen bg-white text-zinc-950" : "min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950"}>
       <div className="mx-auto grid max-w-5xl gap-5">
         {!isRealShell ? (
           <header className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
@@ -532,8 +548,8 @@ export function MobileStrategicProfilePreview({
           </header>
         ) : null}
 
-        <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
-          <div className="relative min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white">
+        <div className={isRealShell ? "mx-auto w-full max-w-md bg-white" : "mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl"}>
+          <div className={isRealShell ? "relative min-h-screen overflow-hidden bg-white" : "relative min-h-[720px] overflow-hidden rounded-[1.5rem] bg-white"}>
             <ProfileHeader
               profile={profile}
               onAction={handleAction}
@@ -547,8 +563,16 @@ export function MobileStrategicProfilePreview({
             <div className="mt-5 grid gap-5 pb-2">
               {profileUpdated ? (
                 <section className="mx-5 rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
-                  <p className="text-sm font-semibold text-zinc-950">Diagnóstico atualizado</p>
-                  <p className="mt-1 text-sm leading-6 text-zinc-600">Seu Perfil foi atualizado com a nova leitura.</p>
+                  <p className="text-sm font-semibold text-zinc-950">Nova leitura adicionada</p>
+                  <p className="mt-1 text-sm leading-6 text-zinc-600">A D2C atualizou seu Perfil com sinais deste vídeo.</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button type="button" className="rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white" onClick={() => setActiveTab("diagnosis")}>
+                      Ver Mapa
+                    </button>
+                    <button type="button" className="rounded-full border border-emerald-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-800">
+                      Ver leitura
+                    </button>
+                  </div>
                 </section>
               ) : null}
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -20,6 +20,11 @@ import {
   resolveNarrativeMapAccessState,
   type NarrativeMapReadingQuotaSnapshot,
 } from "../../../videoUpload/narrativeMapAccessState";
+import {
+  MOBILE_INSTAGRAM_CONNECT_ROUTE,
+  MOBILE_MEDIA_KIT_ROUTE,
+  MOBILE_PROFILE_ROUTE,
+} from "../../../videoUpload/mobileStrategicProfileRoutes";
 import type { VideoNarrativeSynthesisSnapshotWriteSummary } from "../../../videoUpload/videoNarrativeSafeResponseBuilder";
 
 interface MobileStrategicProfileRealShellClientProps {
@@ -89,6 +94,7 @@ export function MobileStrategicProfileRealShellClient({
   const [isHydrating, setIsHydrating] = useState(false);
   const [mapAnalyzeFlowOpen, setMapAnalyzeFlowOpen] = useState(false);
   const [mapAccessMessage, setMapAccessMessage] = useState<string | null>(null);
+  const [mapProfileUpdated, setMapProfileUpdated] = useState(false);
 
   useEffect(() => {
     // Se for anônimo, não precisamos hidratar
@@ -269,18 +275,18 @@ export function MobileStrategicProfileRealShellClient({
     openPaywallModal({
       context: "narrative_map",
       source: "mobile_profile",
-      returnTo: "/dashboard/boards/mobile-strategic-profile",
+      returnTo: MOBILE_PROFILE_ROUTE,
       postCheckoutIntent: "connect_instagram",
     });
   }, []);
 
   const handleMapPrimaryAccessAction = useCallback(() => {
     setMapAccessMessage(null);
-    if (accessState === "free_unused" || accessState === "pro_instagram_connected" || accessState === "pro_needs_instagram" || accessState === "admin") {
-      if (accessState === "pro_needs_instagram") {
-        window.location.href = "/dashboard/instagram/connect?next=narrative-map";
-        return;
-      }
+    if (accessState === "pro_needs_instagram") {
+      window.location.href = MOBILE_INSTAGRAM_CONNECT_ROUTE;
+      return;
+    }
+    if (accessState === "free_unused" || accessState === "pro_instagram_connected" || accessState === "admin") {
       setMapAnalyzeFlowOpen(true);
       return;
     }
@@ -290,6 +296,18 @@ export function MobileStrategicProfileRealShellClient({
     }
     openProfilePaywall();
   }, [accessState, openProfilePaywall]);
+
+  const handleMapSecondaryAccessAction = useCallback(() => {
+    setMapAccessMessage(null);
+    if (accessState === "pro_needs_instagram") {
+      setMapAnalyzeFlowOpen(true);
+    }
+  }, [accessState]);
+
+  const handleMapAnalyzeComplete = useCallback(() => {
+    setMapAnalyzeFlowOpen(false);
+    setMapProfileUpdated(true);
+  }, []);
 
   return (
     <div className="relative">
@@ -306,8 +324,8 @@ export function MobileStrategicProfileRealShellClient({
         </div>
       )}
       {initialNarrativeMapViewModel && initialNarrativeMapPresentation ? (
-        <main className="min-h-screen bg-zinc-100 px-4 py-6 text-zinc-950">
-          <div className="mx-auto grid max-w-5xl gap-5">
+        <main className="min-h-screen bg-[#f7f7f4] text-zinc-950">
+          <div className="mx-auto grid w-full max-w-md gap-5">
             <NarrativeMapMobileShell
               viewModel={initialNarrativeMapViewModel}
               presentation={initialNarrativeMapPresentation}
@@ -316,6 +334,12 @@ export function MobileStrategicProfileRealShellClient({
               accessState={accessState}
               readingQuota={quota}
               onPrimaryAccessAction={handleMapPrimaryAccessAction}
+              onSecondaryAccessAction={handleMapSecondaryAccessAction}
+              onOpenMediaKit={() => {
+                window.location.href = MOBILE_MEDIA_KIT_ROUTE;
+              }}
+              profileUpdateNotice={mapProfileUpdated}
+              frameMode="app"
             />
             {mapAccessMessage ? (
               <p className="mx-auto max-w-sm rounded-2xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm font-semibold text-zinc-950">
@@ -325,7 +349,7 @@ export function MobileStrategicProfileRealShellClient({
             <MobileStrategicProfileAnalyzeFlow
               open={mapAnalyzeFlowOpen}
               onClose={() => setMapAnalyzeFlowOpen(false)}
-              onComplete={() => setMapAnalyzeFlowOpen(false)}
+              onComplete={handleMapAnalyzeComplete}
               onSubmitAnalysis={handleAnalysisSubmit}
               onCreateUploadSession={requestUploadSession}
               onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.test.tsx
@@ -1,10 +1,15 @@
 import fs from "fs";
 import path from "path";
+import type { ComponentProps } from "react";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { NarrativeMapMobileShell } from "./NarrativeMapMobileShell";
 import { buildNarrativeMapReadingPreviewFixture } from "./buildNarrativeMapReadingPreviewFixture";
 
-function renderShell(state = "narrative_map_three_related_readings", internalReview = false) {
+function renderShell(
+  state = "narrative_map_three_related_readings",
+  internalReview = false,
+  overrides: Partial<ComponentProps<typeof NarrativeMapMobileShell>> = {},
+) {
   const fixture = buildNarrativeMapReadingPreviewFixture({ state });
   return render(
     <NarrativeMapMobileShell
@@ -22,6 +27,7 @@ function renderShell(state = "narrative_map_three_related_readings", internalRev
         periodEnd: "2026-06-01T00:00:00.000Z",
       }}
       onPrimaryAccessAction={jest.fn()}
+      {...overrides}
     />,
   );
 }
@@ -85,6 +91,35 @@ describe("NarrativeMapMobileShell", () => {
 
     expect(screen.getByRole("button", { name: "Nova leitura" })).toHaveAttribute("data-priority", "primary");
     expect(screen.getByRole("button", { name: "Ler diagnóstico completo" })).toHaveAttribute("data-priority", "secondary");
+  });
+
+  it("Status Card MM90 mostra pro sem Instagram sem bloquear nova leitura", () => {
+    const onPrimary = jest.fn();
+    const onSecondary = jest.fn();
+    renderShell("narrative_map_three_related_readings", false, {
+      accessState: "pro_needs_instagram",
+      onPrimaryAccessAction: onPrimary,
+      onSecondaryAccessAction: onSecondary,
+    });
+
+    expect(screen.getByText("Pro ativo")).toBeInTheDocument();
+    expect(screen.getByText("Conecte o Instagram para melhorar a precisão do Perfil.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Conectar Instagram" }));
+    fireEvent.click(screen.getByRole("button", { name: "Nova leitura" }));
+
+    expect(onPrimary).toHaveBeenCalledTimes(1);
+    expect(onSecondary).toHaveBeenCalledTimes(1);
+  });
+
+  it("frameMode app remove moldura de preview da superficie real", () => {
+    const { container } = renderShell("narrative_map_three_related_readings", false, {
+      frameMode: "app",
+    });
+
+    expect(container.firstElementChild).toHaveClass("max-w-md");
+    expect(container.firstElementChild).not.toHaveClass("rounded-[2rem]");
+    expect(container.firstElementChild).not.toHaveClass("bg-zinc-950");
   });
 
   it("Ler diagnostico completo abre leitura completa sob demanda", () => {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/NarrativeMapMobileShell.tsx
@@ -9,8 +9,7 @@ import { NarrativeMapReadingChapterModal } from "./NarrativeMapReadingChapterMod
 import { NarrativeMapReadingFullDiagnosisModal } from "./NarrativeMapReadingFullDiagnosisModal";
 import { NarrativeMapSnapshotReviewPanel } from "./NarrativeMapSnapshotReviewPanel";
 import {
-  getNarrativeMapAccessAction,
-  getNarrativeMapAccessStatusText,
+  getNarrativeMapStatusCardContent,
   type NarrativeMapAccessState,
   type NarrativeMapReadingQuotaSnapshot,
 } from "../../../videoUpload/narrativeMapAccessState";
@@ -78,6 +77,10 @@ export function NarrativeMapMobileShell({
   accessState,
   readingQuota,
   onPrimaryAccessAction,
+  onSecondaryAccessAction,
+  onOpenMediaKit,
+  profileUpdateNotice,
+  frameMode = "preview",
 }: {
   viewModel: NarrativeMapMobileViewModel;
   presentation: CreatorNarrativeMapReadingPresentation;
@@ -88,6 +91,10 @@ export function NarrativeMapMobileShell({
   accessState?: NarrativeMapAccessState;
   readingQuota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
   onPrimaryAccessAction?: () => void;
+  onSecondaryAccessAction?: () => void;
+  onOpenMediaKit?: () => void;
+  profileUpdateNotice?: boolean;
+  frameMode?: "app" | "preview";
 }) {
   const [activeTab, setActiveTab] = useState<NarrativeMapReadingPreviewTab>(
     (viewModel.tabs.find((tab) => tab.active)?.id ?? "profile") as NarrativeMapReadingPreviewTab,
@@ -99,14 +106,21 @@ export function NarrativeMapMobileShell({
   const readingsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Leituras")?.value ?? "0";
   const patternsCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Padrões")?.value ?? "0";
   const opportunitiesCount = viewModel.profileHeader.metrics.find((metric) => metric.label === "Oportunidades")?.value ?? "0";
-  const accessAction = accessState ? getNarrativeMapAccessAction(accessState) : null;
-  const accessStatusText = accessState
-    ? getNarrativeMapAccessStatusText({ state: accessState, quota: readingQuota })
-    : null;
+  const statusCard = accessState ? getNarrativeMapStatusCardContent({ state: accessState, quota: readingQuota }) : null;
+  const mediaKitItem = viewModel.opportunities.items.find((item) => item.type === "media_kit_bridge");
+  const opportunityItems = viewModel.opportunities.items.filter((item) => item.type !== "media_kit_bridge");
+  const appFrame = frameMode === "app";
+
+  const handlePrimaryStatusAction = () => {
+    if (accessState === "pro_quota_reached") {
+      setActiveTab("readings");
+    }
+    onPrimaryAccessAction?.();
+  };
 
   return (
-    <div className="mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl">
-      <section className="relative min-h-[760px] overflow-hidden rounded-[1.5rem] bg-[#f7f7f4]">
+    <div className={appFrame ? "mx-auto w-full max-w-md bg-[#f7f7f4]" : "mx-auto w-full max-w-sm rounded-[2rem] border border-zinc-200 bg-zinc-950 p-2 shadow-xl"}>
+      <section className={appFrame ? "relative min-h-screen overflow-hidden bg-[#f7f7f4]" : "relative min-h-[760px] overflow-hidden rounded-[1.5rem] bg-[#f7f7f4]"}>
         <div className="px-5 pt-4" aria-label="Topo compacto do creator">
           <div className="flex items-start justify-between gap-4">
             <div>
@@ -137,24 +151,61 @@ export function NarrativeMapMobileShell({
         </div>
 
         <div className="px-5 pt-4">
+          {statusCard ? (
+            <section className="mb-4 rounded-[1.35rem] border border-zinc-200 bg-white p-4 shadow-sm" aria-label="Status do Perfil">
+              <p className="text-base font-semibold text-zinc-950">{statusCard.title}</p>
+              <p className="mt-1 text-sm leading-6 text-zinc-600">{statusCard.description}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  data-priority="primary"
+                  className="min-h-[40px] rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15"
+                  onClick={handlePrimaryStatusAction}
+                >
+                  {statusCard.primaryLabel}
+                </button>
+                {statusCard.secondaryLabel ? (
+                  <button
+                    type="button"
+                    data-priority="secondary"
+                    className="min-h-[40px] rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-800"
+                    onClick={onSecondaryAccessAction}
+                  >
+                    {statusCard.secondaryLabel}
+                  </button>
+                ) : null}
+              </div>
+            </section>
+          ) : null}
+
+          {profileUpdateNotice ? (
+            <section className="mb-4 rounded-[1.35rem] border border-emerald-100 bg-emerald-50 p-4" aria-label="Nova leitura adicionada">
+              <p className="text-base font-semibold text-zinc-950">Nova leitura adicionada</p>
+              <p className="mt-1 text-sm leading-6 text-zinc-600">A D2C atualizou seu Perfil com sinais deste vídeo.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  className="rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+                  onClick={() => setActiveTab("readings")}
+                >
+                  Ver leitura
+                </button>
+                <button
+                  type="button"
+                  className="rounded-full border border-emerald-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-800"
+                  onClick={() => setActiveTab("profile")}
+                >
+                  Ver Mapa
+                </button>
+              </div>
+            </section>
+          ) : null}
+
           <section className="rounded-[1.5rem] bg-white p-4 shadow-sm">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">{viewModel.hero.badgeLabel}</p>
             <h2 className="mt-1.5 text-2xl font-semibold tracking-normal text-zinc-950">{viewModel.hero.title}</h2>
             <p className="mt-2 text-base font-semibold leading-6 text-zinc-950">{viewModel.hero.headline}</p>
             <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.hero.subheadline}</p>
-            {accessAction && accessStatusText ? (
-              <div className="mt-4 rounded-2xl bg-zinc-50 p-3">
-                <p className="text-xs font-semibold text-zinc-500">{accessStatusText}</p>
-                <button
-                  type="button"
-                  data-priority="primary"
-                  className="mt-2 min-h-[40px] w-full rounded-full bg-zinc-950 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-zinc-950/15"
-                  onClick={onPrimaryAccessAction}
-                >
-                  {accessAction.label}
-                </button>
-              </div>
-            ) : null}
             <div className="mt-4 grid gap-2">
               {viewModel.profile.secondaryAction ? (
                 <button
@@ -233,11 +284,43 @@ export function NarrativeMapMobileShell({
 
           {activeTab === "opportunities" ? (
             <>
+              {mediaKitItem ? (
+                <article className="rounded-[1.35rem] border border-emerald-100 bg-white p-4 shadow-sm" aria-label="Mídia Kit">
+                  <p className="text-xs font-semibold uppercase text-emerald-700">Mídia Kit</p>
+                  <h3 className="mt-2 text-base font-semibold leading-6 text-zinc-950">Mídia Kit</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">Seu perfil pronto para enviar às marcas.</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {["Copiar link", "Ver como marca", "Abrir Mídia Kit"].map((label) => (
+                      <button
+                        key={label}
+                        type="button"
+                        className="rounded-full border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-800"
+                        onClick={onOpenMediaKit}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </article>
+              ) : accessState === "pro_needs_instagram" ? (
+                <article className="rounded-[1.35rem] border border-zinc-200 bg-white p-4 shadow-sm" aria-label="Mídia Kit">
+                  <p className="text-xs font-semibold uppercase text-zinc-500">Mídia Kit</p>
+                  <h3 className="mt-2 text-base font-semibold leading-6 text-zinc-950">Mídia Kit</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-600">Conecte o Instagram para liberar seu perfil comercial.</p>
+                  <button
+                    type="button"
+                    className="mt-3 rounded-full bg-zinc-950 px-3 py-2 text-xs font-semibold text-white"
+                    onClick={onPrimaryAccessAction}
+                  >
+                    Conectar Instagram
+                  </button>
+                </article>
+              ) : null}
               <div className="rounded-[1.35rem] bg-white p-4 shadow-sm">
                 <h3 className="text-base font-semibold text-zinc-950">{viewModel.opportunities.title}</h3>
                 <p className="mt-2 text-sm leading-6 text-zinc-600">{viewModel.opportunities.description}</p>
               </div>
-              {viewModel.opportunities.items.map((item) => (
+              {opportunityItems.map((item) => (
                 <article key={item.id} className="rounded-[1.35rem] bg-white p-4 shadow-sm">
                   <p className="text-xs font-semibold text-zinc-500">
                     {item.type === "brand_territory"

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture.ts
@@ -6,6 +6,7 @@ import {
   buildMobileStrategicProfile,
   type MobileStrategicProfile,
 } from "../../../videoUpload/mobileStrategicProfileMapping";
+import { MOBILE_COMMUNITY_ROUTE } from "../../../videoUpload/mobileStrategicProfileRoutes";
 import type { VideoNarrativeDiagnosisAccessLevel } from "../../../videoUpload/videoNarrativeDiagnosisLearningModel";
 import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
 
@@ -72,7 +73,7 @@ function buildAnonymousFixture(params: {
       loginHref: "/login",
       profileHref: "/dashboard/profile",
       analyzeVideoHref: "/dashboard/boards/mobile-strategic-profile-preview?state=account_only",
-      communityHref: "/dashboard/community",
+      communityHref: MOBILE_COMMUNITY_ROUTE,
       createdAt: "2026-05-19T00:00:00.000Z",
     }),
   };
@@ -117,7 +118,7 @@ function buildAuthenticatedFixture(params: {
       mediaKitPublicUrl: params.hasMediaKit ? "/mediakit/ana-preview" : null,
       profileHref: "/dashboard/profile",
       analyzeVideoHref: "/dashboard/boards/video-narrative-app-preview",
-      communityHref: "/dashboard/community",
+      communityHref: MOBILE_COMMUNITY_ROUTE,
       createdAt: "2026-05-19T00:00:00.000Z",
     }),
   };

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfileRealShellInput.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildMobileStrategicProfileRealShellInput.ts
@@ -1,6 +1,7 @@
 import type { MobileStrategicProfileInput } from "../../../videoUpload/mobileStrategicProfileMapping";
 import { buildMobileStrategicProfilePreviewFixture } from "./buildMobileStrategicProfilePreviewFixture";
 import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUpload/mobileStrategicProfileExistingDataAdapter";
+import { MOBILE_COMMUNITY_ROUTE, MOBILE_PROFILE_ROUTE } from "../../../videoUpload/mobileStrategicProfileRoutes";
 import { buildVideoNarrativeAppPreviewScenario } from "../buildVideoNarrativeAppPreviewScenario";
 
 function resolveOverrideLevel(stateQuery: string): {
@@ -29,9 +30,9 @@ export function buildMobileStrategicProfileRealShellInput(params: {
   if (!isAuthenticated) {
     const res = buildMobileStrategicProfileExistingDataAdapter({
       sessionUser: null,
-      profileHref: "/dashboard/boards/mobile-profile",
-      analyzeVideoHref: "/dashboard/boards/mobile-profile",
-      communityHref: "/dashboard/community",
+      profileHref: MOBILE_PROFILE_ROUTE,
+      analyzeVideoHref: MOBILE_PROFILE_ROUTE,
+      communityHref: MOBILE_COMMUNITY_ROUTE,
     });
     return {
       ...res.profileInput,
@@ -53,9 +54,9 @@ export function buildMobileStrategicProfileRealShellInput(params: {
         planStatus: user.planStatus,
       },
       diagnosisOverrideState: params.stateQuery,
-      profileHref: "/dashboard/boards/mobile-profile",
-      analyzeVideoHref: "/dashboard/boards/mobile-profile",
-      communityHref: "/dashboard/community",
+      profileHref: MOBILE_PROFILE_ROUTE,
+      analyzeVideoHref: MOBILE_PROFILE_ROUTE,
+      communityHref: MOBILE_COMMUNITY_ROUTE,
     });
 
     const override = resolveOverrideLevel(params.stateQuery);
@@ -89,9 +90,9 @@ export function buildMobileStrategicProfileRealShellInput(params: {
       instagramUsername: user.instagramUsername,
       planStatus: user.planStatus,
     },
-    profileHref: "/dashboard/boards/mobile-profile",
-    analyzeVideoHref: "/dashboard/boards/mobile-profile",
-    communityHref: "/dashboard/community",
+    profileHref: MOBILE_PROFILE_ROUTE,
+    analyzeVideoHref: MOBILE_PROFILE_ROUTE,
+    communityHref: MOBILE_COMMUNITY_ROUTE,
   });
 
   return res.profileInput;

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
@@ -43,7 +43,7 @@ describe("MobileStrategicProfilePreviewPage", () => {
 
     expect(screen.getByText("Preview interno — Perfil Estratégico")).toBeInTheDocument();
     expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
-    expect(screen.getAllByText("Diagnóstico").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mapa").length).toBeGreaterThan(0);
   });
 
   it("state query selects fixture", async () => {

--- a/src/app/dashboard/boards/videoUpload/MM90_MOBILE_UX_SIMPLIFICATION_PASS.md
+++ b/src/app/dashboard/boards/videoUpload/MM90_MOBILE_UX_SIMPLIFICATION_PASS.md
@@ -1,0 +1,57 @@
+# MM90 — Mobile UX Simplification Pass
+
+Status: implementado.
+
+## Decisão de produto
+
+A experiência mobile real da Data2Content deve parecer um app de direção estratégica para creators, não um mockup de celular nem uma ferramenta técnica de upload. O Perfil é a casa da leitura; o vídeo é o gatilho; a pergunta do creator define intenção; o contexto rápido ajuda a interpretar; o resultado volta para o Perfil.
+
+## Experiência mobile real
+
+- A rota real usa o `NarrativeMapMobileShell` como referência visual.
+- A superfície real ocupa a tela como app e não usa moldura preta de aparelho.
+- O preview interno pode manter device frame, state switcher e fixtures para QA.
+- A navegação mobile global continua limitada a `Perfil` e `Comunidade`.
+- As abas internas do Perfil continuam `Mapa`, `Leituras` e `Oportunidades`.
+- `Nova leitura` não é item de menu global.
+
+## Status Card do Perfil
+
+O Perfil usa um Status Card compacto, não um balão flutuante. Ele resume estado, consequência e próximo passo:
+
+- Free sem leitura: `Perfil em construção`, CTA `Analisar meu primeiro vídeo`.
+- Free com leitura usada: `Leitura grátis usada`, CTA `Assinar Pro`.
+- Pro sem Instagram: `Pro ativo`, CTA principal `Conectar Instagram`, CTA secundário `Nova leitura`.
+- Pro com Instagram: `Pro ativo`, texto de quota mensal e CTA `Nova leitura`.
+- Pro com limite usado: `Limite mensal usado`, CTA `Ver leituras`.
+- Pagamento pendente ou ação necessária mantém CTA financeiro claro.
+
+Pro sem Instagram não fica bloqueado para nova leitura; conectar Instagram melhora a precisão do Perfil.
+
+## Nova leitura estratégica
+
+O fluxo mobile foi ajustado para:
+
+1. Intro: `Nova leitura estratégica`.
+2. Upload: `Escolha o vídeo`.
+3. Pergunta aberta: `O que você quer entender?`.
+4. Contexto rápido: respostas reais em botões.
+5. Processamento: `Analisando sua narrativa`.
+6. Confirmação: `Leitura pronta`.
+
+A pergunta aberta entra como `creatorGoal`. As sugestões rápidas definem `selectedGoalOption` sem substituir a intenção livre do usuário. O contexto rápido envia `quickAnswers` reais, selecionadas pelo usuário.
+
+## Mídia Kit e Comunidade
+
+- Mídia Kit fica dentro do Perfil, no topo de `Oportunidades`.
+- Quando disponível, mostra ações claras: `Copiar link`, `Ver como marca`, `Abrir Mídia Kit`.
+- Quando falta Instagram, mostra `Conectar Instagram`.
+- Comunidade continua marketplace/lista de creators.
+- O banner de consultoria é compacto: Free vê `Assinar e entrar`; Pro vê `Entrar`.
+- A rota canônica mobile de Comunidade usada por CTAs é `/planning/discover`.
+
+## Segurança
+
+MM90 não altera motor de IA, provider/parser, persistência segura, Stripe, NextAuth, DashboardShell, BoardShell, sidebar ou `MediaKitView` público.
+
+A UI continua sem expor vídeo bruto persistido, thumbnail persistente, `signedUrl`, `uploadUrl`, `objectKey`, `localPath`, `storageProviderPath`, raw response, raw transcript ou transcript longa.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,39 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM90 — Mobile UX Simplification Pass
+
+Status: implementado.
+
+Arquivos principais:
+
+- `MM90_MOBILE_UX_SIMPLIFICATION_PASS.md`
+- `narrativeMapAccessState.ts`
+- `mobileStrategicProfileRoutes.ts`
+- `../components/videoUpload/appPreview/NarrativeMapMobileShell.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx`
+- `src/app/dashboard/discover/CommunityConversionSection.tsx`
+
+O que faz:
+
+- remove a moldura de mockup da experiência mobile real e preserva o frame apenas no preview interno;
+- troca o balão flutuante por Status Card compacto no Perfil;
+- mantém `Perfil | Comunidade` como navegação global mobile e `Mapa | Leituras | Oportunidades` como abas internas;
+- reposiciona `Nova leitura` dentro do Perfil e reformula o fluxo como `Nova leitura estratégica`;
+- envia `creatorGoal` livre e `quickAnswers` reais, selecionadas pelo usuário;
+- coloca Mídia Kit no topo de `Oportunidades`, sem criar aba global;
+- mantém Comunidade como marketplace/lista com banner compacto de consultoria;
+- centraliza CTAs mobile de Comunidade na rota `/planning/discover`.
+
+O que não faz:
+
+- não implementa telemetria ou beta activation;
+- não altera motor de IA, prompts, schema, parser, Stripe, NextAuth, DashboardShell, BoardShell, sidebar ou `MediaKitView`;
+- não cria novo plano, pacote extra de leitura, aba Instagram, página de Mídia Kit ou landing page de Comunidade;
+- não expõe vídeo bruto, thumbnail persistente, signed/upload URL, objectKey, localPath, storageProviderPath, raw response ou transcrição longa.
+
 ### MM89 — Pro Access, Reading Quota, Instagram and Community UX
 
 Status: implementado.

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.test.ts
@@ -196,7 +196,7 @@ describe("buildMobileStrategicProfileExistingDataAdapter", () => {
 
   it("does not create vip feed, chats, comments or complex social layers", () => {
     const res = buildMobileStrategicProfileExistingDataAdapter({});
-    expect(res.profileInput.communityHref).toBe("/dashboard/community");
+    expect(res.profileInput.communityHref).toBe("/planning/discover");
   });
 
   it("always returns no_existing_diagnosis when diagnosis is empty/construction", () => {

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileExistingDataAdapter.ts
@@ -4,6 +4,7 @@ import {
   resolveMobileStrategicProfileState,
   sanitizeMobileStrategicProfileText,
 } from "./mobileStrategicProfileStateContract";
+import { MOBILE_COMMUNITY_ROUTE } from "./mobileStrategicProfileRoutes";
 import type { VideoNarrativeDiagnosisAccessLevel } from "./videoNarrativeDiagnosisLearningModel";
 
 export interface MobileStrategicProfileExistingDataAdapterInput {
@@ -257,7 +258,7 @@ export function buildMobileStrategicProfileExistingDataAdapter(
     mediaKitPublicUrl: resolvedMediaKitShareUrl,
     profileHref: input.profileHref || "/dashboard/boards/mobile-profile",
     analyzeVideoHref: input.analyzeVideoHref || "/dashboard/boards/mobile-profile",
-    communityHref: resolvedCommunityHref || "/dashboard/community",
+    communityHref: resolvedCommunityHref || MOBILE_COMMUNITY_ROUTE,
     createdAt,
   };
 

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileMapping.ts
@@ -11,6 +11,7 @@ import type {
   VideoNarrativeDiagnosisPresentationCard,
   VideoNarrativeDiagnosisPresentationSection,
 } from "./videoNarrativeDiagnosisPresentationModel";
+import { MOBILE_COMMUNITY_ROUTE } from "./mobileStrategicProfileRoutes";
 
 export interface MobileStrategicProfileInput {
   state: MobileStrategicProfileState;
@@ -391,7 +392,7 @@ function buildMediaKitBridge(input: MobileStrategicProfileInput): MobileStrategi
     return {
       state,
       title: "Mídia Kit",
-      description: "Use o Mídia Kit existente para compartilhar seu perfil com marcas.",
+      description: "Seu perfil pronto para enviar às marcas.",
       href: shareHref,
       actions: [
         profileAction({
@@ -429,7 +430,7 @@ function buildMediaKitBridge(input: MobileStrategicProfileInput): MobileStrategi
     return {
       state,
       title: "Mídia Kit",
-      description: "Conectar Instagram é o próximo passo para ativar o Mídia Kit existente.",
+      description: "Conecte o Instagram para liberar seu perfil comercial.",
       href: null,
       actions: [],
     };
@@ -442,7 +443,7 @@ function buildCommunityBridge(input: MobileStrategicProfileInput): MobileStrateg
   return {
     visible: false,
     label: "Comunidade",
-    href: href(input.communityHref) ?? "/dashboard/community",
+    href: href(input.communityHref) ?? MOBILE_COMMUNITY_ROUTE,
     description: "Acesse a Comunidade Data2Content, destino existente para continuar aprendendo com outros membros.",
   };
 }
@@ -460,7 +461,7 @@ function buildNavigation(input: MobileStrategicProfileInput): MobileStrategicPro
       {
         id: "community",
         label: "Comunidade",
-        href: href(input.communityHref) ?? "/dashboard/community",
+        href: href(input.communityHref) ?? MOBILE_COMMUNITY_ROUTE,
         role: "destination",
         active: false,
       },

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes.ts
@@ -1,0 +1,4 @@
+export const MOBILE_PROFILE_ROUTE = "/dashboard/boards/mobile-strategic-profile";
+export const MOBILE_COMMUNITY_ROUTE = "/planning/discover";
+export const MOBILE_INSTAGRAM_CONNECT_ROUTE = "/dashboard/instagram/connect?next=narrative-map";
+export const MOBILE_MEDIA_KIT_ROUTE = "/dashboard/media-kit";

--- a/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileStrategicProfileSnapshotMapping.ts
@@ -2,6 +2,7 @@ import type { VideoNarrativeDiagnosisPresentation } from "./videoNarrativeDiagno
 import type { MobileStrategicProfileSnapshotPayload } from "./mobileStrategicProfileSnapshotTypes";
 import type { MobileStrategicProfileInput } from "./mobileStrategicProfileMapping";
 import { resolveMobileStrategicProfileState } from "./mobileStrategicProfileStateContract";
+import { MOBILE_COMMUNITY_ROUTE } from "./mobileStrategicProfileRoutes";
 
 /**
  * Converte o snapshot estratégico persistido no formato VideoNarrativeDiagnosisPresentation.
@@ -167,7 +168,7 @@ export function buildMobileStrategicProfileFromSnapshot(params: {
       loginHref: params.loginHref || "/login?intent=strategic_profile",
       profileHref: params.profileHref || "/dashboard/boards/mobile-strategic-profile",
       analyzeVideoHref: params.analyzeVideoHref || "/dashboard/boards/mobile-strategic-profile",
-      communityHref: params.communityHref || "/dashboard/community",
+      communityHref: params.communityHref || MOBILE_COMMUNITY_ROUTE,
     };
   }
 
@@ -196,6 +197,6 @@ export function buildMobileStrategicProfileFromSnapshot(params: {
     creatorBio: resolvedBio,
     profileHref: params.profileHref || "/dashboard/boards/mobile-strategic-profile",
     analyzeVideoHref: params.analyzeVideoHref || "/dashboard/boards/mobile-strategic-profile",
-    communityHref: params.communityHref || "/dashboard/community",
+    communityHref: params.communityHref || MOBILE_COMMUNITY_ROUTE,
   };
 }

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
@@ -1,5 +1,6 @@
 import {
   getNarrativeMapAccessAction,
+  getNarrativeMapStatusCardContent,
   resolveNarrativeMapAccessState,
   sanitizeInternalReturnTo,
 } from "./narrativeMapAccessState";
@@ -8,6 +9,7 @@ describe("narrativeMapAccessState", () => {
   it("Free sem leitura usada retorna free_unused", () => {
     expect(resolveNarrativeMapAccessState({ readingQuota: { usedTotal: 0 } })).toBe("free_unused");
     expect(getNarrativeMapAccessAction("free_unused").canStartReading).toBe(true);
+    expect(getNarrativeMapAccessAction("free_unused").label).toBe("Analisar meu primeiro vídeo");
   });
 
   it("Free com leitura usada retorna free_preview_used", () => {
@@ -56,5 +58,35 @@ describe("narrativeMapAccessState", () => {
     expect(sanitizeInternalReturnTo("/dashboard/boards/mobile-strategic-profile")).toBe("/dashboard/boards/mobile-strategic-profile");
     expect(sanitizeInternalReturnTo("//evil.example/path", "/fallback")).toBe("/fallback");
     expect(sanitizeInternalReturnTo("https://evil.example/path", "/fallback")).toBe("/fallback");
+  });
+
+  it("resolve copy compacta do Status Card por estado MM90", () => {
+    expect(getNarrativeMapStatusCardContent({ state: "free_unused" })).toMatchObject({
+      title: "Perfil em construção",
+      primaryLabel: "Analisar meu primeiro vídeo",
+    });
+    expect(getNarrativeMapStatusCardContent({ state: "free_preview_used" })).toMatchObject({
+      title: "Leitura grátis usada",
+      primaryLabel: "Assinar Pro",
+    });
+    expect(getNarrativeMapStatusCardContent({ state: "pro_needs_instagram" })).toMatchObject({
+      title: "Pro ativo",
+      primaryLabel: "Conectar Instagram",
+      secondaryLabel: "Nova leitura",
+    });
+    expect(getNarrativeMapStatusCardContent({
+      state: "pro_instagram_connected",
+      quota: { usedThisMonth: 3 },
+    })).toMatchObject({
+      title: "Pro ativo",
+      description: "Você usou 3 de 10 leituras deste mês.",
+      primaryLabel: "Nova leitura",
+    });
+    expect(getNarrativeMapStatusCardContent({ state: "pro_quota_reached" })).toMatchObject({
+      title: "Limite mensal usado",
+      primaryLabel: "Ver leituras",
+    });
+    expect(getNarrativeMapStatusCardContent({ state: "payment_pending" }).primaryLabel).toBe("Continuar pagamento");
+    expect(getNarrativeMapStatusCardContent({ state: "payment_action_needed" }).primaryLabel).toBe("Atualizar pagamento");
   });
 });

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
@@ -49,6 +49,13 @@ export interface NarrativeMapAccessAction {
     | "admin";
 }
 
+export interface NarrativeMapStatusCardContent {
+  title: string;
+  description: string;
+  primaryLabel: string;
+  secondaryLabel?: string | null;
+}
+
 function normalizeCount(value: number | null | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
@@ -115,7 +122,7 @@ export function getNarrativeMapAccessAction(
     case "free_unused":
       return {
         canStartReading: true,
-        label: "Analisar vídeo",
+        label: "Analisar meu primeiro vídeo",
         reason: "free_first_reading_available",
       };
     case "free_preview_used":
@@ -139,7 +146,7 @@ export function getNarrativeMapAccessAction(
     case "pro_quota_reached":
       return {
         canStartReading: false,
-        label: "Ver Perfil",
+        label: "Ver leituras",
         reason: "pro_quota_reached",
       };
     case "payment_pending":
@@ -185,6 +192,64 @@ export function getNarrativeMapAccessStatusText(params: {
       return "Ação de pagamento necessária";
     case "admin":
       return `Admin · ${quota.usedThisMonth}/10 leituras`;
+  }
+}
+
+export function getNarrativeMapStatusCardContent(params: {
+  state: NarrativeMapAccessState;
+  quota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
+}): NarrativeMapStatusCardContent {
+  const quota = normalizeNarrativeMapReadingQuotaSnapshot(params.quota);
+  switch (params.state) {
+    case "free_unused":
+      return {
+        title: "Perfil em construção",
+        description: "Comece com uma leitura gratuita para a D2C entender sua narrativa.",
+        primaryLabel: "Analisar meu primeiro vídeo",
+      };
+    case "free_preview_used":
+      return {
+        title: "Leitura grátis usada",
+        description: "Assine o Pro para continuar evoluindo seu Perfil.",
+        primaryLabel: "Assinar Pro",
+      };
+    case "pro_needs_instagram":
+      return {
+        title: "Pro ativo",
+        description: "Conecte o Instagram para melhorar a precisão do Perfil.",
+        primaryLabel: "Conectar Instagram",
+        secondaryLabel: "Nova leitura",
+      };
+    case "pro_instagram_connected":
+      return {
+        title: "Pro ativo",
+        description: `Você usou ${quota.usedThisMonth} de 10 leituras deste mês.`,
+        primaryLabel: "Nova leitura",
+      };
+    case "pro_quota_reached":
+      return {
+        title: "Limite mensal usado",
+        description: "Seu Perfil continua disponível. Novas leituras voltam no próximo ciclo.",
+        primaryLabel: "Ver leituras",
+      };
+    case "payment_pending":
+      return {
+        title: "Pagamento pendente",
+        description: "Finalize o pagamento para liberar suas próximas leituras.",
+        primaryLabel: "Continuar pagamento",
+      };
+    case "payment_action_needed":
+      return {
+        title: "Ação de pagamento necessária",
+        description: "Atualize o pagamento para continuar usando o Plano Pro.",
+        primaryLabel: "Atualizar pagamento",
+      };
+    case "admin":
+      return {
+        title: "Acesso interno",
+        description: `Você usou ${quota.usedThisMonth} de 10 leituras deste mês.`,
+        primaryLabel: "Nova leitura",
+      };
   }
 }
 

--- a/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapMobileViewModel.ts
@@ -337,8 +337,8 @@ function buildOpportunities(input: BuildNarrativeMapMobileViewModelInput): Narra
   if (input.mediaKitAvailable) {
     items.push({
       id: "media-kit-bridge",
-      title: "Ponte para Mídia Kit",
-      preview: "Use o Mídia Kit para organizar territórios possíveis quando houver fit narrativo mais claro.",
+      title: "Mídia Kit",
+      preview: "Seu perfil pronto para enviar às marcas.",
       type: "media_kit_bridge",
       badgeLabel: "Apresentação",
       action: action({

--- a/src/app/dashboard/discover/CommunityConversionSection.test.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.test.tsx
@@ -61,10 +61,11 @@ describe("CommunityConversionSection", () => {
 
     render(<CommunityConversionSection />);
 
-    expect(screen.getByText("Consultoria em grupo da D2C")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Assinar Pro e entrar/i })).toBeInTheDocument();
+    expect(screen.getByText("Consultoria em grupo")).toBeInTheDocument();
+    expect(screen.getByText("Assine o Pro para entrar no Grupo VIP da D2C.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Assinar e entrar/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Assinar Pro e entrar/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Assinar e entrar/i }));
 
     expect(window.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -83,10 +84,10 @@ describe("CommunityConversionSection", () => {
 
     render(<CommunityConversionSection />);
 
-    expect(screen.getByText("Seu acesso à consultoria está liberado")).toBeInTheDocument();
+    expect(screen.getByText("Grupo VIP liberado")).toBeInTheDocument();
     expect(screen.getByText("via WhatsApp")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Entrar na consultoria/i })).toBeInTheDocument();
-    expect(screen.queryByText("Consultoria em grupo da D2C")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Entrar" })).toBeInTheDocument();
+    expect(screen.queryByText("Consultoria em grupo")).not.toBeInTheDocument();
 
     await waitFor(() => expect(screen.getByText("Próxima consultoria: quinta, 19h")).toBeInTheDocument());
   });

--- a/src/app/dashboard/discover/CommunityConversionSection.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.tsx
@@ -8,6 +8,7 @@ import type { PaywallEventDetail } from "@/types/paywall";
 import useBillingStatus from "@/app/hooks/useBillingStatus";
 import type { HomeSummaryResponse, MentorshipCardData } from "@/app/dashboard/home/types";
 import { fetchHomeSummaryCached } from "@/app/dashboard/home/homeSummaryClient";
+import { MOBILE_COMMUNITY_ROUTE } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes";
 
 const COMMUNITY_VIP_URL =
   process.env.NEXT_PUBLIC_COMMUNITY_VIP_URL ||
@@ -19,7 +20,7 @@ function openMentoriaPaywall() {
     const returnTo =
       typeof window !== "undefined"
         ? `${window.location.pathname}${window.location.search}${window.location.hash}`
-        : "/dashboard/discover";
+        : MOBILE_COMMUNITY_ROUTE;
     const detail: PaywallEventDetail = {
       context: "mentoria",
       source: "community_mentoria",
@@ -49,8 +50,8 @@ export default function CommunityConversionSection(_props: {
   const communityButtonLabel = paymentPending
     ? "Continuar pagamento"
     : planActive
-      ? "Entrar na consultoria"
-      : "Assinar Pro e entrar";
+      ? "Entrar"
+      : "Assinar e entrar";
 
   React.useEffect(() => {
     if (sessionStatus !== "authenticated") {
@@ -147,15 +148,15 @@ export default function CommunityConversionSection(_props: {
               {paymentPending
                 ? "Finalize seu Plano Pro"
                 : planActive
-                  ? "Seu acesso à consultoria está liberado"
-                  : "Consultoria em grupo da D2C"}
+                  ? "Grupo VIP liberado"
+                  : "Consultoria em grupo"}
             </h2>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-500">
               {paymentPending
                 ? "Conclua o pagamento para liberar consultoria, Instagram e 10 leituras por mês."
                 : planActive
-                  ? "Entre no Grupo VIP para acompanhar a agenda e participar dos encontros."
-                  : "No Plano Pro, você entra no Grupo VIP, participa das consultorias em grupo e libera o Perfil vivo com 10 leituras por mês e Instagram conectado."}
+                  ? "Entre para acompanhar a agenda e participar das consultorias."
+                  : "Assine o Pro para entrar no Grupo VIP da D2C."}
             </p>
             <div className="mt-3 flex flex-wrap items-center gap-2">
               {planActive && !paymentPending ? (


### PR DESCRIPTION
## Summary

Draft milestone PR for MM90.

This starts the Mobile UX Simplification Pass from issue #877 and adds the implementation plan as project documentation.

The implementation should focus on the real mobile app experience:
- Perfil mobile
- Status Card
- new reading flow: video → question → quick context → reading ready
- Media Kit inside Oportunidades
- mobile Community entry/banner

## Product direction

The D2C mobile experience should feel like a strategic app for creators, not a dashboard, landing page, preview, or generic video AI.

Core principle:

> Interface enxuta. Texto suficiente. Diagnóstico profundo.

Core flow:

`Perfil → Nova leitura → Upload de vídeo → Pergunta/objetivo → Contexto rápido → Leitura pronta → Perfil atualizado`

## Scope

Mobile-only.

Do not implement in this PR:
- telemetry
- beta activation
- billing core
- Stripe
- NextAuth
- desktop shell/sidebar changes
- public MediaKitView changes
- AI engine/prompt/parser/schema changes
- real brand matching
- campaign CRM

## Validation target

Before ready for review:

```bash
npm run typecheck
npm test -- --runInBand
npm run build
```

## References

Closes / tracks issue #877.