### PR TITLE
MM91 — Closed Beta Activation, Telemetry and Smoke Harness

### DIFF
--- a/src/app/billing/success/page.test.tsx
+++ b/src/app/billing/success/page.test.tsx
@@ -1,0 +1,107 @@
+import {
+  default as BillingSuccessPage,
+  normalizeBillingSuccessPostCheckoutIntent,
+  sanitizeBillingSuccessReturnTo,
+} from "./page";
+import { act, render } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock("@/lib/track", () => ({
+  track: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry", () => ({
+  trackMobileNarrativeEvent: jest.fn(),
+}));
+
+describe("billing success postCheckoutIntent helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.sessionStorage.clear();
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams("session_id=cs_test"));
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useSession as jest.Mock).mockReturnValue({
+      update: jest.fn().mockResolvedValue({
+        user: { id: "user_1", planInterval: "month", instagramConnected: false },
+      }),
+    });
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, instagram: { connected: false } }),
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it("aceita returnTo interno para connect_instagram e join_community", () => {
+    expect(sanitizeBillingSuccessReturnTo("/dashboard/boards/mobile-strategic-profile")).toBe(
+      "/dashboard/boards/mobile-strategic-profile",
+    );
+    expect(sanitizeBillingSuccessReturnTo("/planning/discover?postCheckoutIntent=join_community")).toBe(
+      "/planning/discover?postCheckoutIntent=join_community",
+    );
+  });
+
+  it("rejeita returnTo externo", () => {
+    expect(sanitizeBillingSuccessReturnTo("https://evil.example")).toBeNull();
+    expect(sanitizeBillingSuccessReturnTo("//evil.example")).toBeNull();
+    expect(sanitizeBillingSuccessReturnTo("dashboard/boards/mobile-strategic-profile")).toBeNull();
+  });
+
+  it("normaliza apenas intents conhecidos", () => {
+    expect(normalizeBillingSuccessPostCheckoutIntent("connect_instagram")).toBe("connect_instagram");
+    expect(normalizeBillingSuccessPostCheckoutIntent("join_community")).toBe("join_community");
+    expect(normalizeBillingSuccessPostCheckoutIntent("external_redirect")).toBeNull();
+  });
+
+  it("registra intent visto/consumido e redireciona sem aceitar rota externa", async () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    window.sessionStorage.setItem(
+      "d2c.paywall.return",
+      JSON.stringify({
+        context: "narrative_map",
+        returnTo: "//evil.example",
+        postCheckoutIntent: "connect_instagram",
+      }),
+    );
+
+    render(<BillingSuccessPage />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(trackMobileNarrativeEvent).toHaveBeenCalledWith(
+      "mobile_post_checkout_intent_seen",
+      expect.objectContaining({
+        postCheckoutIntent: "connect_instagram",
+        paywallContext: "narrative_map",
+      }),
+    );
+    expect(trackMobileNarrativeEvent).toHaveBeenCalledWith(
+      "mobile_post_checkout_intent_consumed",
+      expect.objectContaining({
+        postCheckoutIntent: "connect_instagram",
+        route: "/dashboard/instagram/connect?next=narrative-map",
+      }),
+    );
+    expect(push).toHaveBeenCalledWith("/dashboard/instagram/connect?next=narrative-map");
+    expect(JSON.stringify((trackMobileNarrativeEvent as jest.Mock).mock.calls)).not.toContain("//evil.example");
+  });
+});

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { track } from "@/lib/track";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
 import { PAYWALL_RETURN_STORAGE_KEY } from "@/types/paywall";
 
 async function fetchInstagramConnected(force = false): Promise<boolean | null> {
@@ -41,11 +42,15 @@ function resolveInstagramNextTarget(
   return null;
 }
 
-function sanitizeReturnTo(value: unknown): string | null {
+export function sanitizeBillingSuccessReturnTo(value: unknown): string | null {
   if (typeof value === "string" && value.startsWith("/") && !value.startsWith("//")) {
     return value;
   }
   return null;
+}
+
+export function normalizeBillingSuccessPostCheckoutIntent(value: unknown): "connect_instagram" | "join_community" | null {
+  return value === "connect_instagram" || value === "join_community" ? value : null;
 }
 
 export default function BillingSuccessPage() {
@@ -86,15 +91,20 @@ export default function BillingSuccessPage() {
             if (typeof data?.context === "string") {
               resolvedContext = data.context;
             }
-            const returnTo = sanitizeReturnTo(data?.returnTo);
-            const postCheckoutIntent =
-              data?.postCheckoutIntent === "connect_instagram" || data?.postCheckoutIntent === "join_community"
-                ? data.postCheckoutIntent
-                : null;
+            const returnTo = sanitizeBillingSuccessReturnTo(data?.returnTo);
+            const postCheckoutIntent = normalizeBillingSuccessPostCheckoutIntent(data?.postCheckoutIntent);
             const source =
               typeof data?.source === "string" && data.source.trim().length > 0
                 ? data.source.trim().toLowerCase()
                 : null;
+            if (postCheckoutIntent) {
+              trackMobileNarrativeEvent("mobile_post_checkout_intent_seen", {
+                route: returnTo ?? "/billing/success",
+                paywallContext: resolvedContext ?? undefined,
+                postCheckoutIntent,
+                actionType: "billing_success_seen",
+              });
+            }
             if (postCheckoutIntent === "connect_instagram" && !instagramConnected) {
               redirectHref = "/dashboard/instagram/connect?next=narrative-map";
               keepPaywallReturnState = true;
@@ -111,6 +121,20 @@ export default function BillingSuccessPage() {
               const current = `${window.location.pathname}${window.location.search || ""}`;
               if (current !== returnTo) {
                 redirectHref = returnTo;
+              }
+            }
+            if (postCheckoutIntent) {
+              const consumedKey = sid
+                ? `mobile-post-checkout-intent-consumed:${sid}:${postCheckoutIntent}`
+                : `mobile-post-checkout-intent-consumed:${postCheckoutIntent}`;
+              if (!sessionStorage.getItem(consumedKey)) {
+                sessionStorage.setItem(consumedKey, "1");
+                trackMobileNarrativeEvent("mobile_post_checkout_intent_consumed", {
+                  route: redirectHref ?? returnTo ?? "/billing/success",
+                  paywallContext: resolvedContext ?? undefined,
+                  postCheckoutIntent,
+                  actionType: "billing_success_consumed",
+                });
               }
             }
           } catch {

--- a/src/app/components/PaywallModalProvider.tsx
+++ b/src/app/components/PaywallModalProvider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import BillingSubscribeModal from "@/app/dashboard/billing/BillingSubscribeModal";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
 import { useFeatureFlag } from "@/app/context/FeatureFlagsContext";
 import { startGoogleSignInForPaywall } from "@/app/lib/paywall/startGoogleSignInForPaywall";
 import type { PaywallContext, PaywallEventDetail } from "@/types/paywall";
@@ -64,6 +65,14 @@ export default function PaywallModalProvider() {
           : null;
 
       setContext(normalizedContext);
+      if (normalizedContext === "narrative_map" || normalizedContext === "mentoria") {
+        trackMobileNarrativeEvent("mobile_paywall_opened", {
+          route: sanitizedReturn ?? (typeof window !== "undefined" ? window.location.pathname : undefined),
+          paywallContext: normalizedContext,
+          postCheckoutIntent: postCheckoutIntent ?? undefined,
+          actionType: "open_paywall",
+        });
+      }
 
       if (typeof window !== "undefined") {
         try {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileClosedBetaSmokeHarness.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileClosedBetaSmokeHarness.tsx
@@ -1,0 +1,29 @@
+import { getMobileClosedBetaSmokeScenarios } from "../../../videoUpload/mobileClosedBetaSmokeScenarios";
+
+export function MobileClosedBetaSmokeHarness() {
+  const scenarios = getMobileClosedBetaSmokeScenarios();
+
+  return (
+    <section className="mt-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-4" aria-label="MM91 smoke harness">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase text-zinc-500">MM91 smoke harness</p>
+          <h2 className="text-base font-semibold text-zinc-950">Beta fechado</h2>
+        </div>
+        <p className="text-xs text-zinc-500">Preview interno admin/dev, sem upload real automático.</p>
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {scenarios.map((scenario) => (
+          <a
+            key={scenario.id}
+            href={scenario.href}
+            className="rounded-xl border border-zinc-200 bg-white px-3 py-2 text-left text-xs transition hover:border-zinc-300"
+          >
+            <span className="block font-semibold text-zinc-950">{scenario.label}</span>
+            <span className="mt-1 block text-zinc-500">{scenario.expected}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -579,7 +579,7 @@ export function MobileStrategicProfileAnalyzeFlow({
                 const isSelected = selectedOption === opt.value;
                 return (
                   <button
-                    key={opt.value}
+                    key={`${opt.value}-${opt.label}`}
                     type="button"
                     className={`rounded-2xl border px-3 py-3 text-left text-sm font-semibold transition-all duration-200 ${
                       isSelected

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -24,6 +24,7 @@ import {
   type MobileStrategicProfilePreviewFixtureState,
 } from "./buildMobileStrategicProfilePreviewFixture";
 import { MobileStrategicProfileAnalyzeFlow } from "./MobileStrategicProfileAnalyzeFlow";
+import { MobileClosedBetaSmokeHarness } from "./MobileClosedBetaSmokeHarness";
 import { MobileStrategicProfileMediaKitModal } from "./MobileStrategicProfileMediaKitModal";
 import type {
   UploadSessionPayload,
@@ -57,6 +58,7 @@ type MobileStrategicProfilePreviewProps = {
     input: MobileStrategicProfileDirectUploadInput,
   ) => Promise<MobileStrategicProfileDirectUploadResult>;
   enableRealAnalysis?: boolean;
+  showSmokeHarness?: boolean;
   accessState?: NarrativeMapAccessState;
   readingQuota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
   onCleanupTemporaryUpload?: (payload: {
@@ -442,6 +444,7 @@ export function MobileStrategicProfilePreview({
   onCreateUploadSession,
   onUploadToTemporarySignedUrl,
   enableRealAnalysis,
+  showSmokeHarness = false,
   accessState: accessStateProp,
   readingQuota,
   onCleanupTemporaryUpload,
@@ -545,6 +548,7 @@ export function MobileStrategicProfilePreview({
             <div className="mt-4">
               <StateSwitcher activeState={activeState} />
             </div>
+            {showSmokeHarness ? <MobileClosedBetaSmokeHarness /> : null}
           </header>
         ) : null}
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.test.tsx
@@ -5,6 +5,7 @@ import { fetchHomeSummaryCached } from "../../../../home/homeSummaryClient";
 import { requestUploadSession } from "./mobileStrategicProfileUploadSessionClient";
 import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectUploadClient";
 import { buildNarrativeMapReadingPreviewFixture } from "./buildNarrativeMapReadingPreviewFixture";
+import { trackMobileNarrativeEvent } from "../../../videoUpload/mobileNarrativeTelemetry";
 
 // Mock das dependências
 jest.mock("../../../../home/homeSummaryClient", () => ({
@@ -28,6 +29,11 @@ jest.mock("@/app/hooks/useBillingStatus", () => ({
 
 jest.mock("@/utils/paywallModal", () => ({
   openPaywallModal: jest.fn(),
+}));
+
+jest.mock("../../../videoUpload/mobileNarrativeTelemetry", () => ({
+  ...jest.requireActual("../../../videoUpload/mobileNarrativeTelemetry"),
+  trackMobileNarrativeEvent: jest.fn(),
 }));
 
 jest.mock("./mobileStrategicProfileUploadSessionClient", () => ({
@@ -463,6 +469,47 @@ describe("MobileStrategicProfileRealShellClient", () => {
     expect(body).not.toContain("signedUrl");
     expect(body).not.toContain("base64");
     expect(body).not.toContain("File");
+
+    globalFetchSpy.mockRestore();
+  });
+
+  it("MM91 - telemetria de análise real não envia texto livre nem metadata sensível", async () => {
+    process.env.NEXT_PUBLIC_VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED = "1";
+    (fetchHomeSummaryCached as jest.Mock).mockResolvedValue(null);
+    const globalFetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        e2eBetaAudit: { allowlistGatePassed: true },
+        videoReadingPersistence: { attempted: true, saved: true },
+        synthesisSnapshotWrite: { attempted: true, written: true },
+      }),
+    } as any);
+
+    render(
+      <MobileStrategicProfileRealShellClient
+        session={mockSession}
+        stateQuery={null}
+      />
+    );
+
+    await act(async () => {
+      screen.getByTestId("trigger-real-analysis-submit").click();
+    });
+
+    expect(trackMobileNarrativeEvent).toHaveBeenCalledWith(
+      "mobile_analysis_submitted",
+      expect.objectContaining({
+        selectedGoalOption: "authority",
+        analysisMode: "real_gated",
+      }),
+    );
+    const serializedEvents = JSON.stringify((trackMobileNarrativeEvent as jest.Mock).mock.calls);
+    expect(serializedEvents).not.toContain("creatorGoal");
+    expect(serializedEvents).not.toContain("quickAnswers");
+    expect(serializedEvents).not.toContain("objectKey");
+    expect(serializedEvents).not.toContain("uploadUrl");
+    expect(serializedEvents).not.toContain("temporary/video-narrative");
 
     globalFetchSpy.mockRestore();
   });

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { buildMobileStrategicProfileRealShellInput } from "./buildMobileStrategicProfileRealShellInput";
 import { buildMobileStrategicProfile, type MobileStrategicProfile } from "../../../videoUpload/mobileStrategicProfileMapping";
 import { buildMobileStrategicProfileExistingDataAdapter } from "../../../videoUpload/mobileStrategicProfileExistingDataAdapter";
@@ -16,10 +16,18 @@ import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectU
 import type { CreatorNarrativeMapReadingPresentation } from "../../../videoUpload/creatorNarrativeMapReadingChapters";
 import type { NarrativeMapMobileViewModel } from "../../../videoUpload/narrativeMapMobileViewModel";
 import {
+  getNarrativeMapAccessAction,
+  getNarrativeMapStatusCardContent,
   normalizeNarrativeMapReadingQuotaSnapshot,
   resolveNarrativeMapAccessState,
   type NarrativeMapReadingQuotaSnapshot,
 } from "../../../videoUpload/narrativeMapAccessState";
+import {
+  buildMobileNarrativeTelemetryContext,
+  getSafeMobileNarrativeErrorCode,
+  trackMobileNarrativeEvent,
+  type MobileNarrativeAnalysisMode,
+} from "../../../videoUpload/mobileNarrativeTelemetry";
 import {
   MOBILE_INSTAGRAM_CONNECT_ROUTE,
   MOBILE_MEDIA_KIT_ROUTE,
@@ -52,8 +60,14 @@ export function MobileStrategicProfileRealShellClient({
   const billing = useBillingStatus();
   const quota = normalizeNarrativeMapReadingQuotaSnapshot(initialReadingQuota);
   const sessionUser = session?.user as any;
+  const isPro = billing.hasResolvedOnce ? billing.hasPremiumAccess : sessionUser?.planStatus === "active";
+  const instagramConnected = Boolean(
+    (billing.instagram?.connected && !billing.instagram?.needsReconnect) ||
+    sessionUser?.instagramConnected ||
+    sessionUser?.isInstagramConnected,
+  );
   const accessState = resolveNarrativeMapAccessState({
-    hasPremiumAccess: billing.hasResolvedOnce ? billing.hasPremiumAccess : sessionUser?.planStatus === "active",
+    hasPremiumAccess: isPro,
     hasFullReportAccess: billing.hasResolvedOnce ? billing.hasFullReportAccess : sessionUser?.planStatus === "active",
     needsCheckout: billing.needsCheckout,
     needsPaymentAction: billing.needsPaymentAction,
@@ -66,6 +80,14 @@ export function MobileStrategicProfileRealShellClient({
     },
     readingQuota: quota,
   });
+  const telemetryContext = useMemo(() => buildMobileNarrativeTelemetryContext({
+    route: MOBILE_PROFILE_ROUTE,
+    accessState,
+    isPro,
+    instagramConnected,
+    quotaUsedThisMonth: quota.usedThisMonth,
+    quotaLimit: quota.proMonthlyLimit,
+  }), [accessState, instagramConnected, isPro, quota.proMonthlyLimit, quota.usedThisMonth]);
 
   // 1. Calcular o perfil inicial (Session-only, snapshot ou fixture via stateQuery)
   const [profile, setProfile] = useState<MobileStrategicProfile>(() => {
@@ -95,6 +117,13 @@ export function MobileStrategicProfileRealShellClient({
   const [mapAnalyzeFlowOpen, setMapAnalyzeFlowOpen] = useState(false);
   const [mapAccessMessage, setMapAccessMessage] = useState<string | null>(null);
   const [mapProfileUpdated, setMapProfileUpdated] = useState(false);
+
+  useEffect(() => {
+    trackMobileNarrativeEvent("mobile_profile_viewed", telemetryContext);
+    if (accessState === "pro_quota_reached") {
+      trackMobileNarrativeEvent("mobile_quota_reached_seen", telemetryContext);
+    }
+  }, [accessState, telemetryContext]);
 
   useEffect(() => {
     // Se for anônimo, não precisamos hidratar
@@ -193,6 +222,7 @@ export function MobileStrategicProfileRealShellClient({
     const shouldUseRealAnalysis =
       realAnalysisEnabled &&
       Boolean(payload.temporaryUpload?.uploadSessionId);
+    const analysisMode: MobileNarrativeAnalysisMode = shouldUseRealAnalysis ? "real_gated" : "mock";
     const endpoint = shouldUseRealAnalysis
       ? "/api/dashboard/mobile-strategic-profile/analyze-real"
       : "/api/dashboard/mobile-strategic-profile/analyze";
@@ -217,20 +247,89 @@ export function MobileStrategicProfileRealShellClient({
           mockScenario: payload.mockScenario,
         };
 
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(requestPayload),
+    trackMobileNarrativeEvent("mobile_analysis_submitted", {
+      ...telemetryContext,
+      selectedGoalOption: payload.selectedGoalOption,
+      analysisMode,
     });
 
-    if (!response.ok) {
-      const errData = await response.json().catch(() => ({}));
-      throw new Error(errData.message || "Erro ao conectar com o serviço de análise.");
+    let data: any = null;
+    let failureTracked = false;
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestPayload),
+      });
+
+      data = await response.json().catch(() => ({}));
+      const persistence = data?.videoReadingPersistence;
+      const synthesis = data?.synthesisSnapshotWrite;
+      const allowlistGatePassed = Boolean(data?.e2eBetaAudit?.allowlistGatePassed);
+
+      if (persistence?.attempted) {
+        trackMobileNarrativeEvent("mobile_reading_saved", {
+          ...telemetryContext,
+          analysisMode,
+          allowlistGatePassed,
+          readingSaved: Boolean(persistence.saved),
+          safeErrorCode: persistence.saved ? undefined : persistence.errorCode ?? persistence.skippedReason,
+        });
+      }
+      if (synthesis?.attempted) {
+        trackMobileNarrativeEvent("mobile_synthesis_snapshot_write_attempted", {
+          ...telemetryContext,
+          analysisMode,
+          allowlistGatePassed,
+          synthesisWritten: Boolean(synthesis.written),
+        });
+        trackMobileNarrativeEvent(
+          synthesis.written
+            ? "mobile_synthesis_snapshot_write_succeeded"
+            : "mobile_synthesis_snapshot_write_failed",
+          {
+            ...telemetryContext,
+            analysisMode,
+            allowlistGatePassed,
+            synthesisWritten: Boolean(synthesis.written),
+            safeErrorCode: synthesis.written ? undefined : synthesis.skippedReason,
+          },
+        );
+      }
+
+      if (!response.ok) {
+        failureTracked = true;
+        trackMobileNarrativeEvent("mobile_analysis_failed", {
+          ...telemetryContext,
+          selectedGoalOption: payload.selectedGoalOption,
+          analysisMode,
+          allowlistGatePassed,
+          safeErrorCode: data?.code ?? data?.reason ?? `http_${response.status}`,
+        });
+        throw new Error(data.message || "Erro ao conectar com o serviço de análise.");
+      }
+    } catch (error) {
+      if (!failureTracked) {
+        trackMobileNarrativeEvent("mobile_analysis_failed", {
+          ...telemetryContext,
+          selectedGoalOption: payload.selectedGoalOption,
+          analysisMode,
+          safeErrorCode: getSafeMobileNarrativeErrorCode(error),
+        });
+      }
+      throw error;
     }
 
-    const data = await response.json();
+    trackMobileNarrativeEvent("mobile_analysis_succeeded", {
+      ...telemetryContext,
+      selectedGoalOption: payload.selectedGoalOption,
+      analysisMode,
+      allowlistGatePassed: Boolean(data?.e2eBetaAudit?.allowlistGatePassed),
+      readingSaved: Boolean(data?.videoReadingPersistence?.saved),
+      synthesisWritten: Boolean(data?.synthesisSnapshotWrite?.written),
+    });
     if (data.snapshot) {
       const { buildMobileStrategicProfileFromSnapshot } = await import("../../../videoUpload/mobileStrategicProfileSnapshotMapping");
       const input = buildMobileStrategicProfileFromSnapshot({
@@ -247,7 +346,7 @@ export function MobileStrategicProfileRealShellClient({
       });
       setProfile(buildMobileStrategicProfile(input));
     }
-  }, [session, realAnalysisEnabled]);
+  }, [session, realAnalysisEnabled, telemetryContext]);
 
   const handleCleanupTemporaryUpload = useCallback(async (payload: {
     uploadSessionId: string;
@@ -282,27 +381,127 @@ export function MobileStrategicProfileRealShellClient({
 
   const handleMapPrimaryAccessAction = useCallback(() => {
     setMapAccessMessage(null);
+    const content = getNarrativeMapStatusCardContent({ state: accessState, quota });
+    const accessAction = getNarrativeMapAccessAction(accessState);
+    trackMobileNarrativeEvent("mobile_status_action_clicked", {
+      ...telemetryContext,
+      actionLabel: content.primaryLabel,
+      actionType: accessAction.reason,
+    });
     if (accessState === "pro_needs_instagram") {
+      trackMobileNarrativeEvent("mobile_instagram_connect_clicked", {
+        ...telemetryContext,
+        actionLabel: content.primaryLabel,
+        actionType: "connect_instagram",
+      });
       window.location.href = MOBILE_INSTAGRAM_CONNECT_ROUTE;
       return;
     }
     if (accessState === "free_unused" || accessState === "pro_instagram_connected" || accessState === "admin") {
+      trackMobileNarrativeEvent("mobile_upload_gate_checked", {
+        ...telemetryContext,
+        gateResult: "allowed",
+        actionType: "start_reading",
+      });
+      trackMobileNarrativeEvent("mobile_new_reading_started", {
+        ...telemetryContext,
+        actionType: "start_reading",
+      });
       setMapAnalyzeFlowOpen(true);
       return;
     }
     if (accessState === "pro_quota_reached") {
+      trackMobileNarrativeEvent("mobile_upload_gate_checked", {
+        ...telemetryContext,
+        gateResult: "blocked",
+        actionType: "start_reading",
+        safeErrorCode: "pro_quota_reached",
+      });
+      trackMobileNarrativeEvent("mobile_upload_gate_blocked", {
+        ...telemetryContext,
+        gateResult: "blocked",
+        actionType: "start_reading",
+        safeErrorCode: "pro_quota_reached",
+      });
       setMapAccessMessage("Você usou suas 10 leituras deste mês. Seu Perfil continua disponível.");
       return;
     }
+    trackMobileNarrativeEvent("mobile_upload_gate_checked", {
+      ...telemetryContext,
+      gateResult: "blocked",
+      actionType: "start_reading",
+      safeErrorCode: accessAction.reason,
+    });
+    trackMobileNarrativeEvent("mobile_upload_gate_blocked", {
+      ...telemetryContext,
+      gateResult: "blocked",
+      actionType: "start_reading",
+      safeErrorCode: accessAction.reason,
+    });
     openProfilePaywall();
-  }, [accessState, openProfilePaywall]);
+  }, [accessState, openProfilePaywall, quota, telemetryContext]);
 
   const handleMapSecondaryAccessAction = useCallback(() => {
     setMapAccessMessage(null);
     if (accessState === "pro_needs_instagram") {
+      trackMobileNarrativeEvent("mobile_status_action_clicked", {
+        ...telemetryContext,
+        actionLabel: "Nova leitura",
+        actionType: "start_reading",
+      });
+      trackMobileNarrativeEvent("mobile_upload_gate_checked", {
+        ...telemetryContext,
+        gateResult: "allowed",
+        actionType: "start_reading",
+      });
+      trackMobileNarrativeEvent("mobile_new_reading_started", {
+        ...telemetryContext,
+        actionType: "start_reading",
+      });
       setMapAnalyzeFlowOpen(true);
     }
-  }, [accessState]);
+  }, [accessState, telemetryContext]);
+
+  const handleCreateUploadSession = useCallback(async (...args: Parameters<typeof requestUploadSession>) => {
+    trackMobileNarrativeEvent("mobile_upload_session_requested", {
+      ...telemetryContext,
+      analysisMode: realAnalysisEnabled ? "real_gated" : "mock",
+    });
+    const response = await requestUploadSession(...args);
+    if (response.ok) {
+      trackMobileNarrativeEvent("mobile_upload_session_created", {
+        ...telemetryContext,
+        analysisMode: response.status === "signed_upload_session_created" ? "real_gated" : "mock",
+        allowlistGatePassed: response.status === "signed_upload_session_created",
+      });
+    } else {
+      trackMobileNarrativeEvent("mobile_upload_gate_blocked", {
+        ...telemetryContext,
+        gateResult: "blocked",
+        safeErrorCode: response.issues?.find((issue) => issue.severity === "blocker")?.code ?? response.status,
+        analysisMode: realAnalysisEnabled ? "real_gated" : "mock",
+      });
+    }
+    return response;
+  }, [realAnalysisEnabled, telemetryContext]);
+
+  const handleUploadToTemporarySignedUrl = useCallback(async (...args: Parameters<typeof uploadVideoToTemporarySignedUrl>) => {
+    const response = await uploadVideoToTemporarySignedUrl(...args);
+    if (response.ok) {
+      trackMobileNarrativeEvent("mobile_video_upload_completed", {
+        ...telemetryContext,
+        analysisMode: "real_gated",
+        allowlistGatePassed: true,
+      });
+    } else {
+      trackMobileNarrativeEvent("mobile_analysis_failed", {
+        ...telemetryContext,
+        analysisMode: "real_gated",
+        safeErrorCode: response.status ?? "video_upload_failed",
+      });
+    }
+    return response;
+  }, [telemetryContext]);
 
   const handleMapAnalyzeComplete = useCallback(() => {
     setMapAnalyzeFlowOpen(false);
@@ -336,6 +535,11 @@ export function MobileStrategicProfileRealShellClient({
               onPrimaryAccessAction={handleMapPrimaryAccessAction}
               onSecondaryAccessAction={handleMapSecondaryAccessAction}
               onOpenMediaKit={() => {
+                trackMobileNarrativeEvent("mobile_mediakit_action_clicked", {
+                  ...telemetryContext,
+                  actionLabel: "Abrir Mídia Kit",
+                  actionType: "open_media_kit",
+                });
                 window.location.href = MOBILE_MEDIA_KIT_ROUTE;
               }}
               profileUpdateNotice={mapProfileUpdated}
@@ -351,8 +555,8 @@ export function MobileStrategicProfileRealShellClient({
               onClose={() => setMapAnalyzeFlowOpen(false)}
               onComplete={handleMapAnalyzeComplete}
               onSubmitAnalysis={handleAnalysisSubmit}
-              onCreateUploadSession={requestUploadSession}
-              onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
+              onCreateUploadSession={handleCreateUploadSession}
+              onUploadToTemporarySignedUrl={handleUploadToTemporarySignedUrl}
               enableRealAnalysis={realAnalysisEnabled}
               onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
             />
@@ -363,8 +567,8 @@ export function MobileStrategicProfileRealShellClient({
           profile={profile}
           isRealShell={true}
           onSubmitAnalysis={handleAnalysisSubmit}
-          onCreateUploadSession={requestUploadSession}
-          onUploadToTemporarySignedUrl={uploadVideoToTemporarySignedUrl}
+          onCreateUploadSession={handleCreateUploadSession}
+          onUploadToTemporarySignedUrl={handleUploadToTemporarySignedUrl}
           enableRealAnalysis={realAnalysisEnabled}
           onCleanupTemporaryUpload={handleCleanupTemporaryUpload}
           accessState={accessState}

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
@@ -44,6 +44,9 @@ describe("MobileStrategicProfilePreviewPage", () => {
     expect(screen.getByText("Preview interno — Perfil Estratégico")).toBeInTheDocument();
     expect(screen.getByText("Perfil Estratégico mobile")).toBeInTheDocument();
     expect(screen.getAllByText("Mapa").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("MM91 smoke harness")).toBeInTheDocument();
+    expect(screen.getByText("Free sem leitura")).toBeInTheDocument();
+    expect(screen.getByText("Endpoint real bloqueado")).toBeInTheDocument();
   });
 
   it("state query selects fixture", async () => {

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
@@ -54,5 +54,5 @@ export default async function MobileStrategicProfilePreviewPage({
   }
 
   const fixture = buildMobileStrategicProfilePreviewFixture({ state: searchParams?.state });
-  return <MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} />;
+  return <MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} showSmokeHarness />;
 }

--- a/src/app/dashboard/boards/videoUpload/MM91_CLOSED_BETA_ACTIVATION_TELEMETRY_SMOKE.md
+++ b/src/app/dashboard/boards/videoUpload/MM91_CLOSED_BETA_ACTIVATION_TELEMETRY_SMOKE.md
@@ -1,0 +1,199 @@
+# MM91 — Closed Beta Activation, Telemetry and Operator Smoke Harness
+
+Status: implementado.
+
+## Objetivo
+
+Preparar o beta fechado do mobile real da Data2Content para operação segura: medir o funil sem vazar dados, validar estados antes de chamar integrações reais e manter o acesso restrito por allowlist/admin-dev.
+
+## Como habilitar usuário allowlist/admin-dev
+
+1. Confirme que a rota mobile está protegida pelas flags já usadas no MM88-MM90.
+2. Habilite somente usuários da allowlist ou viewers admin/dev para o fluxo real gated.
+3. Não remova os gates de `upload-session`, `analyze-real`, temporary storage ou usage limits.
+4. Use o preview interno `/dashboard/boards/mobile-strategic-profile-preview` apenas com `NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED=1` e sessão admin/dev.
+
+## Smoke harness interno
+
+O preview interno mostra o painel `MM91 smoke harness` com links para:
+
+- Free sem leitura;
+- Free com leitura usada;
+- Pro sem Instagram;
+- Pro com Instagram;
+- Pro 10/10 leituras;
+- pagamento pendente;
+- ação de pagamento necessária;
+- Comunidade Free;
+- Comunidade Pro;
+- Mídia Kit disponível;
+- Mídia Kit aguardando Instagram;
+- endpoint real bloqueado para usuário comum;
+- endpoint real com allowlist/admin-dev;
+- pós-checkout `connect_instagram`;
+- pós-checkout `join_community`.
+
+O harness não chama Gemini, storage, upload real ou endpoint real automaticamente.
+
+## Testes operacionais
+
+### Free 1 leitura
+
+1. Abra o Perfil com usuário Free e sem diagnóstico salvo.
+2. Confirme Status Card `Perfil em construção`.
+3. Clique `Analisar meu primeiro vídeo`.
+4. Conclua uma leitura.
+5. Reabra o Perfil e confirme `Leitura grátis usada`.
+6. Tente nova leitura e confirme bloqueio antes do upload.
+
+### Pro 10 leituras/mês
+
+1. Abra o Perfil com Plano Pro ativo.
+2. Confirme a mensagem `X/10 leituras`.
+3. Simule uso perto do limite e confirme `Restam X leituras`.
+4. Simule 10 leituras no mês e confirme `10/10 usadas`.
+5. Confirme que o upload não abre em 10/10.
+
+### Pro sem Instagram
+
+1. Abra o Perfil Pro sem Instagram.
+2. Confirme Status Card `Pro ativo`.
+3. Confirme CTA principal `Conectar Instagram`.
+4. Confirme CTA secundário `Nova leitura`.
+5. Gere uma leitura para validar que Pro sem Instagram não fica bloqueado.
+
+### Pro com Instagram
+
+1. Abra o Perfil Pro com Instagram conectado.
+2. Confirme `Nova leitura` como CTA principal.
+3. Confirme que Mídia Kit aparece em `Oportunidades`.
+
+### Paywall Perfil
+
+1. Use Free com leitura usada.
+2. Clique `Assinar Pro`.
+3. Confirme contexto `narrative_map` e `postCheckoutIntent: connect_instagram`.
+4. Após checkout aprovado, confirme redirect para conexão de Instagram ou CTA claro de conexão.
+
+### Paywall Comunidade
+
+1. Abra Comunidade com usuário Free.
+2. Confirme banner compacto `Consultoria em grupo`.
+3. Clique `Assinar e entrar`.
+4. Confirme contexto `mentoria` e `postCheckoutIntent: join_community`.
+5. Após checkout aprovado, confirme retorno para Comunidade e botão `Entrar`.
+
+### Mídia Kit em Oportunidades
+
+1. Abra aba `Oportunidades`.
+2. Com Instagram conectado, confirme ações `Copiar link`, `Ver como marca` e `Abrir Mídia Kit`.
+3. Sem Instagram, confirme CTA `Conectar Instagram`.
+4. Não altere `MediaKitView` público.
+
+### Comunidade marketplace + banner
+
+1. Abra a rota canônica mobile `/planning/discover`.
+2. Confirme que o marketplace/lista/grid de creators continua renderizando.
+3. Confirme banner compacto acima da lista.
+4. Free vê `Assinar e entrar`.
+5. Pro vê `Entrar`, sem pitch longo.
+
+### Endpoint real gated
+
+1. Usuário comum fora da allowlist deve receber bloqueio no fluxo real.
+2. Usuário allowlist/admin-dev pode seguir o fluxo real gated.
+3. Confirme `usageLimitChecked` e `allowlistGatePassed` no response seguro.
+4. Não rode smoke automático chamando Gemini ou storage real.
+
+### Cleanup, leitura salva e snapshot
+
+1. Após análise real concluída, confirme cleanup temporário.
+2. Confirme `videoReadingPersistence.attempted=true`.
+3. Confirme `videoReadingPersistence.saved=true`.
+4. Confirme `synthesisSnapshotWrite.attempted=true`.
+5. Confirme `synthesisSnapshotWrite.written=true` ou `skippedReason` seguro.
+
+## Telemetria segura
+
+Eventos mobile usam `mobileNarrativeTelemetry.ts` com whitelist de payload.
+
+Permitido:
+
+- rota interna;
+- estado de acesso;
+- boolean de Pro;
+- boolean de Instagram conectado;
+- leituras usadas, limite e restantes;
+- opção rápida selecionada;
+- tipo/label de ação;
+- contexto de paywall;
+- `postCheckoutIntent`;
+- resultado de gate;
+- código de erro seguro;
+- modo `mock` ou `real_gated`;
+- flags booleanas de allowlist, leitura salva e snapshot escrito.
+
+Proibido:
+
+- `creatorGoal` livre;
+- `quickAnswers` livres;
+- prompt;
+- raw Gemini/model response;
+- transcript;
+- long transcript;
+- vídeo;
+- filename;
+- headers;
+- token;
+- signed/upload URL;
+- `objectKey`;
+- `localPath`;
+- `storageProviderPath`;
+- diagnóstico completo;
+- snapshot completo;
+- email/nome do creator.
+
+Para conferir, use os testes de `mobileNarrativeTelemetry` e inspecione os eventos `[track]` em ambiente dev. Se houver dúvida sobre um campo, não envie.
+
+## Falhas operacionais
+
+### Análise falhou
+
+1. Confirme se o erro exibido é amigável.
+2. Verifique telemetria `mobile_analysis_failed` com `safeErrorCode`.
+3. Confirme que não houve leitura salva quando o diagnóstico não foi gerado.
+4. Confirme cleanup temporário.
+
+### Pagamento pendente
+
+1. O Perfil deve mostrar `Continuar pagamento` ou `Atualizar pagamento`.
+2. A Comunidade deve mostrar `Continuar pagamento`.
+3. Não abra upload antes de resolver pagamento.
+
+### Limite bloqueou
+
+1. Confirme `10/10 usadas`.
+2. Confirme texto `Novas leituras liberam no próximo ciclo.`
+3. Não ofereça pacote extra ou upgrade de quota.
+
+## Rollback
+
+1. Desligue as flags mobile/real analysis já existentes.
+2. Mantenha allowlist/admin-dev ativa.
+3. O provider de telemetria é noop-safe quando não há `gtag`.
+4. Não reverta billing core, Stripe ou NextAuth.
+
+## Checklist com creators reais da allowlist
+
+Para 2 ou 3 creators reais:
+
+1. Validar Perfil inicial.
+2. Validar Free ou Pro correto.
+3. Validar Instagram conectado/desconectado.
+4. Validar nova leitura com vídeo pequeno.
+5. Validar pergunta aberta e contexto rápido.
+6. Validar leitura salva.
+7. Validar síntese acumulada.
+8. Validar Mídia Kit em Oportunidades.
+9. Validar Comunidade e Grupo VIP.
+10. Conferir telemetria sem dados sensíveis.

--- a/src/app/dashboard/boards/videoUpload/README.md
+++ b/src/app/dashboard/boards/videoUpload/README.md
@@ -6,6 +6,36 @@ O vídeo ainda não é enviado de verdade e ainda não é processado de verdade.
 
 Hoje, vídeo é apenas uma possível origem futura para preencher uma `NarrativeSource`.
 
+### MM91 — Closed Beta Activation, Telemetry and Operator Smoke Harness
+
+Status: implementado.
+
+Arquivos principais:
+
+- `MM91_CLOSED_BETA_ACTIVATION_TELEMETRY_SMOKE.md`
+- `mobileNarrativeTelemetry.ts`
+- `mobileClosedBetaSmokeScenarios.ts`
+- `../components/videoUpload/appPreview/MobileClosedBetaSmokeHarness.tsx`
+- `../components/videoUpload/appPreview/MobileStrategicProfileRealShellClient.tsx`
+- `src/app/billing/success/page.tsx`
+- `src/app/dashboard/discover/CommunityConversionSection.tsx`
+
+O que faz:
+
+- adiciona telemetria segura e tipada para o funil mobile, com provider noop-safe por padrão do `track`;
+- bloqueia campos sensíveis em eventos, incluindo texto livre, URLs, storage metadata, raw response, transcript, diagnóstico e snapshot completos;
+- registra follow-through de `postCheckoutIntent` para `connect_instagram` e `join_community`;
+- simplifica mensagens de leituras perto do limite e em 10/10;
+- adiciona smoke harness interno/admin-dev no preview mobile sem chamar Gemini, storage ou upload real automaticamente.
+
+O que não faz:
+
+- não abre beta para usuários comuns;
+- não altera Stripe core, billing core profundo, NextAuth, DashboardShell, BoardShell, sidebar ou `MediaKitView`;
+- não cria plano, pacote extra, matches, marcas, creators sugeridos ou novas features de marketplace;
+- não altera prompt/schema/parser, Gemini provider ou storage/R2;
+- não salva vídeo, thumbnail, signed/upload URL, objectKey, localPath, storageProviderPath, raw response ou transcrição longa.
+
 ### MM90 — Mobile UX Simplification Pass
 
 Status: implementado.

--- a/src/app/dashboard/boards/videoUpload/mobileClosedBetaSmokeScenarios.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileClosedBetaSmokeScenarios.test.ts
@@ -1,0 +1,37 @@
+import { getMobileClosedBetaSmokeScenarios } from "./mobileClosedBetaSmokeScenarios";
+
+describe("mobileClosedBetaSmokeScenarios", () => {
+  it("lista todos os estados mínimos do smoke interno MM91", () => {
+    const scenarios = getMobileClosedBetaSmokeScenarios();
+    const ids = scenarios.map((scenario) => scenario.id);
+
+    expect(ids).toEqual(expect.arrayContaining([
+      "free_unused",
+      "free_preview_used",
+      "pro_needs_instagram",
+      "pro_instagram_connected",
+      "pro_quota_reached",
+      "payment_pending",
+      "payment_action_needed",
+      "community_free_banner",
+      "community_pro_banner",
+      "mediakit_available",
+      "mediakit_needs_instagram",
+      "real_endpoint_blocked_for_common_user",
+      "real_endpoint_allowlist_success_mocked_or_fixture",
+      "post_checkout_connect_instagram",
+      "post_checkout_join_community",
+    ]));
+  });
+
+  it("usa apenas rotas internas seguras e nao chama endpoint real diretamente", () => {
+    for (const scenario of getMobileClosedBetaSmokeScenarios()) {
+      expect(scenario.href.startsWith("/")).toBe(true);
+      expect(scenario.href.startsWith("//")).toBe(false);
+      expect(scenario.href).not.toContain("/api/dashboard/mobile-strategic-profile/analyze-real");
+      expect(scenario.href).not.toContain("uploadUrl");
+      expect(scenario.href).not.toContain("signedUrl");
+      expect(scenario.href).not.toContain("objectKey");
+    }
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileClosedBetaSmokeScenarios.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileClosedBetaSmokeScenarios.ts
@@ -1,0 +1,137 @@
+export type MobileClosedBetaSmokeScenarioId =
+  | "free_unused"
+  | "free_preview_used"
+  | "pro_needs_instagram"
+  | "pro_instagram_connected"
+  | "pro_quota_reached"
+  | "payment_pending"
+  | "payment_action_needed"
+  | "community_free_banner"
+  | "community_pro_banner"
+  | "mediakit_available"
+  | "mediakit_needs_instagram"
+  | "real_endpoint_blocked_for_common_user"
+  | "real_endpoint_allowlist_success_mocked_or_fixture"
+  | "post_checkout_connect_instagram"
+  | "post_checkout_join_community";
+
+export type MobileClosedBetaSmokeScenario = {
+  id: MobileClosedBetaSmokeScenarioId;
+  label: string;
+  category: "profile" | "community" | "endpoint" | "checkout";
+  href: string;
+  expected: string;
+};
+
+const PREVIEW_ROUTE = "/dashboard/boards/mobile-strategic-profile-preview";
+const COMMUNITY_ROUTE = "/planning/discover";
+
+export function getMobileClosedBetaSmokeScenarios(): MobileClosedBetaSmokeScenario[] {
+  return [
+    {
+      id: "free_unused",
+      label: "Free sem leitura",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=account_only`,
+      expected: "Perfil em construção",
+    },
+    {
+      id: "free_preview_used",
+      label: "Free com leitura usada",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=first_reading_free`,
+      expected: "Leitura grátis usada",
+    },
+    {
+      id: "pro_needs_instagram",
+      label: "Pro sem Instagram",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=premium_without_instagram`,
+      expected: "Conectar Instagram e Nova leitura secundaria",
+    },
+    {
+      id: "pro_instagram_connected",
+      label: "Pro com Instagram",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=instagram_optimized`,
+      expected: "Nova leitura",
+    },
+    {
+      id: "pro_quota_reached",
+      label: "Pro 10/10 leituras",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=instagram_optimized&smoke=pro_quota_reached`,
+      expected: "10/10 usadas",
+    },
+    {
+      id: "payment_pending",
+      label: "Pagamento pendente",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=account_only&smoke=payment_pending`,
+      expected: "Continuar pagamento",
+    },
+    {
+      id: "payment_action_needed",
+      label: "Ação de pagamento",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=account_only&smoke=payment_action_needed`,
+      expected: "Atualizar pagamento",
+    },
+    {
+      id: "community_free_banner",
+      label: "Comunidade Free",
+      category: "community",
+      href: `${COMMUNITY_ROUTE}?smoke=community_free_banner`,
+      expected: "Consultoria em grupo",
+    },
+    {
+      id: "community_pro_banner",
+      label: "Comunidade Pro",
+      category: "community",
+      href: `${COMMUNITY_ROUTE}?smoke=community_pro_banner`,
+      expected: "Grupo VIP liberado",
+    },
+    {
+      id: "mediakit_available",
+      label: "Mídia Kit disponível",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=media_kit_available`,
+      expected: "Copiar link, Ver como marca, Abrir Mídia Kit",
+    },
+    {
+      id: "mediakit_needs_instagram",
+      label: "Mídia Kit pede Instagram",
+      category: "profile",
+      href: `${PREVIEW_ROUTE}?state=premium_without_instagram`,
+      expected: "Conectar Instagram",
+    },
+    {
+      id: "real_endpoint_blocked_for_common_user",
+      label: "Endpoint real bloqueado",
+      category: "endpoint",
+      href: `${PREVIEW_ROUTE}?state=narrative_map_chapters&smoke=real_endpoint_blocked_for_common_user`,
+      expected: "403 para usuário comum fora da allowlist",
+    },
+    {
+      id: "real_endpoint_allowlist_success_mocked_or_fixture",
+      label: "Endpoint real allowlist",
+      category: "endpoint",
+      href: `${PREVIEW_ROUTE}?state=narrative_map_chapters&smoke=real_endpoint_allowlist_success`,
+      expected: "allowlist/admin-dev necessário antes do endpoint real",
+    },
+    {
+      id: "post_checkout_connect_instagram",
+      label: "Pós-checkout Instagram",
+      category: "checkout",
+      href: `${PREVIEW_ROUTE}?state=premium_without_instagram&postCheckoutIntent=connect_instagram`,
+      expected: "Conectar Instagram",
+    },
+    {
+      id: "post_checkout_join_community",
+      label: "Pós-checkout Comunidade",
+      category: "checkout",
+      href: `${COMMUNITY_ROUTE}?postCheckoutIntent=join_community`,
+      expected: "Entrar",
+    },
+  ];
+}

--- a/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.test.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.test.ts
@@ -1,0 +1,118 @@
+import {
+  buildMobileNarrativeTelemetryContext,
+  getSafeMobileNarrativeErrorCode,
+  noopMobileNarrativeTelemetryProvider,
+  sanitizeMobileNarrativeTelemetryPayload,
+  trackMobileNarrativeEvent,
+} from "./mobileNarrativeTelemetry";
+
+describe("mobileNarrativeTelemetry", () => {
+  it("mantem apenas payload seguro para profile_viewed", () => {
+    expect(
+      sanitizeMobileNarrativeTelemetryPayload({
+        eventName: "mobile_profile_viewed",
+        route: "/dashboard/boards/mobile-strategic-profile",
+        accessState: "pro_instagram_connected",
+        isPro: true,
+        instagramConnected: true,
+        quotaUsedThisMonth: 3,
+        quotaLimit: 10,
+        email: "creator@example.com",
+        objectKey: "temporary/video.mp4",
+      }),
+    ).toMatchObject({
+      eventName: "mobile_profile_viewed",
+      route: "/dashboard/boards/mobile-strategic-profile",
+      accessState: "pro_instagram_connected",
+      isPro: true,
+      instagramConnected: true,
+      quotaUsedThisMonth: 3,
+      quotaLimit: 10,
+    });
+  });
+
+  it("remove texto livre, respostas e metadados proibidos", () => {
+    const payload = sanitizeMobileNarrativeTelemetryPayload({
+      creatorGoal: "por que esse vídeo prendeu atenção?",
+      quickAnswers: [{ id: "content_intent", value: "Atrair marcas" }],
+      signedUrl: "https://signed.example.test/upload?token=secret",
+      uploadUrl: "https://signed.example.test/upload",
+      objectKey: "temporary/video.mp4",
+      localPath: "/tmp/video.mp4",
+      storageProviderPath: "r2://bucket/key",
+      rawGeminiResponse: "{ secret: true }",
+      rawTranscript: "fala longa",
+      fullDiagnosis: { summary: "diagnóstico completo" },
+      selectedGoalOption: "retention",
+      gateResult: "blocked",
+      safeErrorCode: "gemini_timeout",
+    } as any);
+
+    expect(payload).toMatchObject({
+      selectedGoalOption: "retention",
+      gateResult: "blocked",
+      safeErrorCode: "provider_timeout",
+    });
+    expect(JSON.stringify(payload)).not.toContain("creatorGoal");
+    expect(JSON.stringify(payload)).not.toContain("quickAnswers");
+    expect(JSON.stringify(payload)).not.toContain("signed");
+    expect(JSON.stringify(payload)).not.toContain("temporary/video");
+    expect(JSON.stringify(payload)).not.toContain("diagnóstico completo");
+  });
+
+  it("rejeita return route externo no contexto seguro", () => {
+    expect(buildMobileNarrativeTelemetryContext({
+      route: "//evil.example",
+      accessState: "free_unused",
+      quotaUsedThisMonth: 1,
+      quotaLimit: 10,
+    })).toMatchObject({
+      accessState: "free_unused",
+      quotaRemaining: 9,
+    });
+    expect(buildMobileNarrativeTelemetryContext({
+      route: "//evil.example",
+      quotaUsedThisMonth: 1,
+      quotaLimit: 10,
+    }).route).toBeUndefined();
+  });
+
+  it("provider noop nao quebra UI", () => {
+    expect(() => {
+      trackMobileNarrativeEvent(
+        "mobile_analysis_submitted",
+        {
+          selectedGoalOption: "authority",
+          creatorGoal: "texto livre proibido",
+        } as any,
+        noopMobileNarrativeTelemetryProvider,
+      );
+    }).not.toThrow();
+  });
+
+  it("emite evento sanitizado para provider injetado", () => {
+    const provider = jest.fn();
+    trackMobileNarrativeEvent(
+      "mobile_analysis_failed",
+      {
+        safeErrorCode: "gemini_failed",
+        rawModelResponse: "{ leak: true }",
+      } as any,
+      provider,
+    );
+
+    expect(provider).toHaveBeenCalledWith(
+      "mobile_analysis_failed",
+      expect.objectContaining({
+        eventName: "mobile_analysis_failed",
+        safeErrorCode: "provider_failed",
+      }),
+    );
+    expect(JSON.stringify(provider.mock.calls[0][1])).not.toContain("rawModelResponse");
+  });
+
+  it("normaliza codigo de erro sem mensagens brutas", () => {
+    expect(getSafeMobileNarrativeErrorCode({ code: "gemini_blocked" })).toBe("provider_blocked");
+    expect(getSafeMobileNarrativeErrorCode(new Error("texto livre"))).toBe("unknown_error");
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.ts
@@ -1,0 +1,224 @@
+import { track } from "@/lib/track";
+import type { NarrativeMapAccessState, NarrativeMapPostCheckoutIntent } from "./narrativeMapAccessState";
+
+export type MobileNarrativeTelemetryEventName =
+  | "mobile_profile_viewed"
+  | "mobile_status_action_clicked"
+  | "mobile_new_reading_started"
+  | "mobile_upload_gate_checked"
+  | "mobile_upload_gate_blocked"
+  | "mobile_upload_session_requested"
+  | "mobile_upload_session_created"
+  | "mobile_video_upload_completed"
+  | "mobile_analysis_submitted"
+  | "mobile_analysis_succeeded"
+  | "mobile_analysis_failed"
+  | "mobile_reading_saved"
+  | "mobile_synthesis_snapshot_write_attempted"
+  | "mobile_synthesis_snapshot_write_succeeded"
+  | "mobile_synthesis_snapshot_write_failed"
+  | "mobile_paywall_opened"
+  | "mobile_post_checkout_intent_seen"
+  | "mobile_post_checkout_intent_consumed"
+  | "mobile_instagram_connect_clicked"
+  | "mobile_mediakit_action_clicked"
+  | "mobile_community_action_clicked"
+  | "mobile_quota_reached_seen";
+
+export type MobileNarrativeAnalysisMode = "mock" | "real_gated";
+export type MobileNarrativeGateResult = "allowed" | "blocked";
+
+export type MobileNarrativeTelemetryPayload = {
+  eventName?: MobileNarrativeTelemetryEventName;
+  timestamp?: string;
+  route?: string;
+  accessState?: NarrativeMapAccessState;
+  isPro?: boolean;
+  instagramConnected?: boolean;
+  quotaUsedThisMonth?: number;
+  quotaLimit?: number;
+  quotaRemaining?: number;
+  selectedGoalOption?: "authority" | "retention" | "format_test" | "sponsored_content";
+  actionLabel?: string;
+  actionType?: string;
+  paywallContext?: string;
+  postCheckoutIntent?: NarrativeMapPostCheckoutIntent;
+  gateResult?: MobileNarrativeGateResult;
+  safeErrorCode?: string;
+  analysisMode?: MobileNarrativeAnalysisMode;
+  allowlistGatePassed?: boolean;
+  readingSaved?: boolean;
+  synthesisWritten?: boolean;
+};
+
+export type MobileNarrativeTelemetryProvider = (
+  eventName: MobileNarrativeTelemetryEventName,
+  payload: MobileNarrativeTelemetryPayload,
+) => void;
+
+const ACCESS_STATES: NarrativeMapAccessState[] = [
+  "free_unused",
+  "free_preview_used",
+  "pro_needs_instagram",
+  "pro_instagram_connected",
+  "pro_quota_reached",
+  "payment_pending",
+  "payment_action_needed",
+  "admin",
+];
+
+const GOAL_OPTIONS: Array<NonNullable<MobileNarrativeTelemetryPayload["selectedGoalOption"]>> = [
+  "authority",
+  "retention",
+  "format_test",
+  "sponsored_content",
+];
+
+const FORBIDDEN_KEY_PATTERN =
+  /(creatorGoal|quickAnswers|prompt|raw|gemini|modelResponse|response|transcript|video|objectKey|signedUrl|uploadUrl|thumbnailUrl|localPath|storageProviderPath|filename|fileName|headers|token|secret|email|creatorName|diagnosis|snapshot)/i;
+
+function safeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.trunc(value));
+}
+
+function safeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function safeShortString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  return normalized.slice(0, 80);
+}
+
+function isSafeRoute(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("/") && !value.startsWith("//") && value.length <= 160;
+}
+
+function safeAccessState(value: unknown): NarrativeMapAccessState | undefined {
+  return ACCESS_STATES.includes(value as NarrativeMapAccessState) ? (value as NarrativeMapAccessState) : undefined;
+}
+
+function safeGoalOption(value: unknown): MobileNarrativeTelemetryPayload["selectedGoalOption"] | undefined {
+  return GOAL_OPTIONS.includes(value as NonNullable<MobileNarrativeTelemetryPayload["selectedGoalOption"]>)
+    ? (value as NonNullable<MobileNarrativeTelemetryPayload["selectedGoalOption"]>)
+    : undefined;
+}
+
+function safePostCheckoutIntent(value: unknown): NarrativeMapPostCheckoutIntent | undefined {
+  return value === "connect_instagram" || value === "join_community" ? value : undefined;
+}
+
+export function sanitizeMobileNarrativeTelemetryPayload(
+  payload: Record<string, unknown> | MobileNarrativeTelemetryPayload | null | undefined,
+): MobileNarrativeTelemetryPayload {
+  const source = payload && typeof payload === "object" ? payload : {};
+  const result: MobileNarrativeTelemetryPayload = {};
+
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_KEY_PATTERN.test(key)) continue;
+  }
+
+  if (isSafeRoute(source.route)) result.route = source.route;
+  const accessState = safeAccessState(source.accessState);
+  if (accessState) result.accessState = accessState;
+
+  const isPro = safeBoolean(source.isPro);
+  if (isPro !== undefined) result.isPro = isPro;
+  const instagramConnected = safeBoolean(source.instagramConnected);
+  if (instagramConnected !== undefined) result.instagramConnected = instagramConnected;
+
+  const quotaUsedThisMonth = safeNumber(source.quotaUsedThisMonth);
+  if (quotaUsedThisMonth !== undefined) result.quotaUsedThisMonth = quotaUsedThisMonth;
+  const quotaLimit = safeNumber(source.quotaLimit);
+  if (quotaLimit !== undefined) result.quotaLimit = quotaLimit;
+  const quotaRemaining = safeNumber(source.quotaRemaining);
+  if (quotaRemaining !== undefined) result.quotaRemaining = quotaRemaining;
+
+  const selectedGoalOption = safeGoalOption(source.selectedGoalOption);
+  if (selectedGoalOption) result.selectedGoalOption = selectedGoalOption;
+
+  const actionLabel = safeShortString(source.actionLabel);
+  if (actionLabel) result.actionLabel = actionLabel;
+  const actionType = safeShortString(source.actionType);
+  if (actionType) result.actionType = actionType;
+  const paywallContext = safeShortString(source.paywallContext);
+  if (paywallContext) result.paywallContext = paywallContext;
+
+  const postCheckoutIntent = safePostCheckoutIntent(source.postCheckoutIntent);
+  if (postCheckoutIntent) result.postCheckoutIntent = postCheckoutIntent;
+
+  if (source.gateResult === "allowed" || source.gateResult === "blocked") {
+    result.gateResult = source.gateResult;
+  }
+  const safeErrorCode = safeShortString(source.safeErrorCode);
+  if (safeErrorCode) result.safeErrorCode = safeErrorCode.replace(/gemini/gi, "provider");
+  if (source.analysisMode === "mock" || source.analysisMode === "real_gated") {
+    result.analysisMode = source.analysisMode;
+  }
+
+  const allowlistGatePassed = safeBoolean(source.allowlistGatePassed);
+  if (allowlistGatePassed !== undefined) result.allowlistGatePassed = allowlistGatePassed;
+  const readingSaved = safeBoolean(source.readingSaved);
+  if (readingSaved !== undefined) result.readingSaved = readingSaved;
+  const synthesisWritten = safeBoolean(source.synthesisWritten);
+  if (synthesisWritten !== undefined) result.synthesisWritten = synthesisWritten;
+
+  return {
+    eventName: safeShortString(source.eventName) as MobileNarrativeTelemetryEventName | undefined,
+    timestamp: typeof source.timestamp === "string" ? source.timestamp : new Date().toISOString(),
+    ...result,
+  };
+}
+
+export function getSafeMobileNarrativeErrorCode(error: unknown, fallback = "unknown_error"): string {
+  if (error && typeof error === "object") {
+    const candidate = (error as { code?: unknown; status?: unknown; safeErrorCode?: unknown }).safeErrorCode
+      ?? (error as { code?: unknown }).code
+      ?? (error as { status?: unknown }).status;
+    const safe = safeShortString(candidate);
+    if (safe) return safe.replace(/gemini/gi, "provider");
+  }
+  return fallback;
+}
+
+export const noopMobileNarrativeTelemetryProvider: MobileNarrativeTelemetryProvider = () => {
+  /* noop */
+};
+
+export function trackMobileNarrativeEvent(
+  eventName: MobileNarrativeTelemetryEventName,
+  payload?: MobileNarrativeTelemetryPayload | Record<string, unknown> | null,
+  provider: MobileNarrativeTelemetryProvider = (name, eventPayload) => {
+    track(name, eventPayload as any);
+  },
+) {
+  const sanitized = sanitizeMobileNarrativeTelemetryPayload({
+    ...(payload ?? {}),
+    eventName,
+  });
+  provider(eventName, sanitized);
+}
+
+export function buildMobileNarrativeTelemetryContext(params: {
+  route?: string;
+  accessState?: NarrativeMapAccessState;
+  isPro?: boolean;
+  instagramConnected?: boolean;
+  quotaUsedThisMonth?: number;
+  quotaLimit?: number;
+}) {
+  const quotaUsedThisMonth = safeNumber(params.quotaUsedThisMonth) ?? 0;
+  const quotaLimit = safeNumber(params.quotaLimit) ?? 0;
+  return sanitizeMobileNarrativeTelemetryPayload({
+    route: params.route,
+    accessState: params.accessState,
+    isPro: params.isPro,
+    instagramConnected: params.instagramConnected,
+    quotaUsedThisMonth,
+    quotaLimit,
+    quotaRemaining: Math.max(0, quotaLimit - quotaUsedThisMonth),
+  });
+}

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.test.ts
@@ -79,11 +79,20 @@ describe("narrativeMapAccessState", () => {
       quota: { usedThisMonth: 3 },
     })).toMatchObject({
       title: "Pro ativo",
-      description: "Você usou 3 de 10 leituras deste mês.",
+      description: "3/10 leituras",
+      primaryLabel: "Nova leitura",
+    });
+    expect(getNarrativeMapStatusCardContent({
+      state: "pro_instagram_connected",
+      quota: { usedThisMonth: 9 },
+    })).toMatchObject({
+      title: "Pro ativo",
+      description: "Restam 1 leituras este mês.",
       primaryLabel: "Nova leitura",
     });
     expect(getNarrativeMapStatusCardContent({ state: "pro_quota_reached" })).toMatchObject({
-      title: "Limite mensal usado",
+      title: "10/10 usadas",
+      description: "Novas leituras liberam no próximo ciclo. Seu Perfil continua disponível.",
       primaryLabel: "Ver leituras",
     });
     expect(getNarrativeMapStatusCardContent({ state: "payment_pending" }).primaryLabel).toBe("Continuar pagamento");

--- a/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeMapAccessState.ts
@@ -200,6 +200,7 @@ export function getNarrativeMapStatusCardContent(params: {
   quota?: Partial<NarrativeMapReadingQuotaSnapshot> | null;
 }): NarrativeMapStatusCardContent {
   const quota = normalizeNarrativeMapReadingQuotaSnapshot(params.quota);
+  const remainingThisMonth = Math.max(0, quota.proMonthlyLimit - quota.usedThisMonth);
   switch (params.state) {
     case "free_unused":
       return {
@@ -223,13 +224,16 @@ export function getNarrativeMapStatusCardContent(params: {
     case "pro_instagram_connected":
       return {
         title: "Pro ativo",
-        description: `Você usou ${quota.usedThisMonth} de 10 leituras deste mês.`,
+        description:
+          remainingThisMonth > 0 && remainingThisMonth <= 2
+            ? `Restam ${remainingThisMonth} leituras este mês.`
+            : `${quota.usedThisMonth}/10 leituras`,
         primaryLabel: "Nova leitura",
       };
     case "pro_quota_reached":
       return {
-        title: "Limite mensal usado",
-        description: "Seu Perfil continua disponível. Novas leituras voltam no próximo ciclo.",
+        title: "10/10 usadas",
+        description: "Novas leituras liberam no próximo ciclo. Seu Perfil continua disponível.",
         primaryLabel: "Ver leituras",
       };
     case "payment_pending":
@@ -247,7 +251,7 @@ export function getNarrativeMapStatusCardContent(params: {
     case "admin":
       return {
         title: "Acesso interno",
-        description: `Você usou ${quota.usedThisMonth} de 10 leituras deste mês.`,
+        description: `${quota.usedThisMonth}/10 leituras`,
         primaryLabel: "Nova leitura",
       };
   }

--- a/src/app/dashboard/discover/CommunityConversionSection.test.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.test.tsx
@@ -3,6 +3,7 @@ import { useSession } from "next-auth/react";
 import useBillingStatus from "@/app/hooks/useBillingStatus";
 import { fetchHomeSummaryCached } from "@/app/dashboard/home/homeSummaryClient";
 import CommunityConversionSection from "./CommunityConversionSection";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),
@@ -15,6 +16,10 @@ jest.mock("@/app/hooks/useBillingStatus", () => ({
 
 jest.mock("@/app/dashboard/home/homeSummaryClient", () => ({
   fetchHomeSummaryCached: jest.fn(),
+}));
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry", () => ({
+  trackMobileNarrativeEvent: jest.fn(),
 }));
 
 jest.mock("framer-motion", () => ({
@@ -75,6 +80,14 @@ describe("CommunityConversionSection", () => {
           source: "community_mentoria",
           postCheckoutIntent: "join_community",
         }),
+      }),
+    );
+    expect(trackMobileNarrativeEvent).toHaveBeenCalledWith(
+      "mobile_community_action_clicked",
+      expect.objectContaining({
+        actionType: "open_paywall",
+        paywallContext: "mentoria",
+        postCheckoutIntent: "join_community",
       }),
     );
   });

--- a/src/app/dashboard/discover/CommunityConversionSection.tsx
+++ b/src/app/dashboard/discover/CommunityConversionSection.tsx
@@ -9,6 +9,7 @@ import useBillingStatus from "@/app/hooks/useBillingStatus";
 import type { HomeSummaryResponse, MentorshipCardData } from "@/app/dashboard/home/types";
 import { fetchHomeSummaryCached } from "@/app/dashboard/home/homeSummaryClient";
 import { MOBILE_COMMUNITY_ROUTE } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
 
 const COMMUNITY_VIP_URL =
   process.env.NEXT_PUBLIC_COMMUNITY_VIP_URL ||
@@ -84,9 +85,25 @@ export default function CommunityConversionSection(_props: {
 
   const handleCommunityAccess = React.useCallback(async () => {
     if (!planActive || paymentPending) {
+      trackMobileNarrativeEvent("mobile_community_action_clicked", {
+        route: MOBILE_COMMUNITY_ROUTE,
+        isPro: planActive,
+        actionLabel: communityButtonLabel,
+        actionType: paymentPending ? "continue_payment" : "open_paywall",
+        paywallContext: "mentoria",
+        postCheckoutIntent: "join_community",
+      });
       openMentoriaPaywall();
       return;
     }
+
+    trackMobileNarrativeEvent("mobile_community_action_clicked", {
+      route: MOBILE_COMMUNITY_ROUTE,
+      isPro: true,
+      actionLabel: communityButtonLabel,
+      actionType: "join_community",
+      postCheckoutIntent: "join_community",
+    });
 
     if (vipHasAccess && vipInviteUrl) {
       window.open(vipInviteUrl, "_blank", "noopener,noreferrer");
@@ -122,7 +139,7 @@ export default function CommunityConversionSection(_props: {
     } finally {
       setResolvingVipAccess(false);
     }
-  }, [paymentPending, planActive, vipHasAccess, vipInviteUrl]);
+  }, [communityButtonLabel, paymentPending, planActive, vipHasAccess, vipInviteUrl]);
 
   return (
     <motion.div initial="hidden" animate="visible" variants={{ hidden: { opacity: 0 }, visible: { opacity: 1 } }} className="pb-4">

--- a/src/app/dashboard/home/README.md
+++ b/src/app/dashboard/home/README.md
@@ -11,6 +11,7 @@ Este diretório implementa a nova Home do dashboard. Cada card tem regras claras
 - Free vê CTA `Assinar Pro e entrar`; Pro vê apenas `Entrar na consultoria` / acesso ao Grupo VIP.
 - O banner usa o paywall existente com contexto de mentoria e `postCheckoutIntent: join_community`.
 - O Perfil mobile usa balão/status para próxima ação; Comunidade não renderiza balão sobreposto.
+- MM91 adiciona telemetria segura para o CTA da Comunidade, sem dados pessoais, URLs de convite ou payload sensível.
 
 ### 1. `next_post`
 - **Dados esperados**: slot (dia/hora), 1–3 ganchos, lift vs. P50, status de conexão do Instagram.


### PR DESCRIPTION
## Summary

Adds the closed beta activation, safe telemetry, post-checkout follow-through, quota messaging, and operator smoke harness layer for the mobile Narrative Map beta.

Includes:
- safe mobile telemetry with whitelist/redaction
- instrumentation for profile, upload, analysis, paywall, checkout, Media Kit, and community actions
- secure postCheckoutIntent follow-through for `connect_instagram` and `join_community`
- clearer reading-limit messaging: `X/10 leituras`, `Restam X leituras`, `10/10 usadas`
- internal admin/dev smoke harness for beta state validation
- runbook `MM91_CLOSED_BETA_ACTIVATION_TELEMETRY_SMOKE.md`

## Product direction

MM91 does not add new product features. It makes the closed beta operable and measurable without opening the real flow to common users.

Principle:

> Medir sem vazar. Operar sem abrir. Validar sem criar feature nova.

## Guardrails

- Does not open beta for common users.
- Does not remove allowlist/admin-dev gates.
- Does not alter Stripe core, NextAuth, DashboardShell, BoardShell, sidebar, public MediaKitView, Gemini provider, prompts/schema/parser, or storage/R2.
- Does not create new plans, extra reading packages, real brand matches, brand suggestions, or creator suggestions.
- Telemetry does not send creatorGoal, quickAnswers, raw response, transcript, full diagnosis, full snapshot, signed/upload URLs, objectKey, localPath, or storageProviderPath.

## Validation reported locally

- npm run typecheck passed.
- npm run build passed with existing unrelated warnings only.
- git diff --check passed.
- Focused MM91/MM90/MM88 tests passed.
- Full `npm test -- --runInBand` still fails outside MM91 scope in older suites such as CalculatorClient and admin routes with next/headers / NEXT_RSC_ERR_CLIENT_IMPORT.

## Next milestone

MM92 — Beta Operator QA, Rollout Flags and Beta Feedback Loop.