### PR TITLE
chore(custo-ia): instrumenta uso de tokens do Gemini + modelos por env

### DIFF
--- a/src/app/dashboard/boards/videoUpload/adjacentNarrativesDetectionService.ts
+++ b/src/app/dashboard/boards/videoUpload/adjacentNarrativesDetectionService.ts
@@ -12,6 +12,7 @@
  */
 
 import { GoogleGenAI, createUserContent } from "@google/genai";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -49,7 +50,8 @@ export interface DetectAdjacentNarrativesParams {
 
 // ─── Implementation ───────────────────────────────────────────────────────────
 
-const MODEL = "gemini-2.0-flash";
+// Já no 2.0-flash (barato); configurável por env (GEMINI_ADJACENT_MODEL).
+const MODEL = process.env.GEMINI_ADJACENT_MODEL || "gemini-2.0-flash";
 const MIN_READINGS = 3;
 const MAX_CANDIDATES = 3;
 
@@ -166,6 +168,8 @@ export async function detectAdjacentNarratives(
         temperature: 0.4,
       },
     });
+
+    logGeminiUsage("adjacent", MODEL, response);
 
     const raw = response.text?.trim() ?? "";
     let parsed: { candidates: AdjacentNarrativeCandidate[] };

--- a/src/app/dashboard/boards/videoUpload/contentIdeasGenerationService.ts
+++ b/src/app/dashboard/boards/videoUpload/contentIdeasGenerationService.ts
@@ -21,6 +21,7 @@ import {
   type ContentIdeasMapContext,
 } from "./contentIdeasGeminiPromptBuilder";
 import { cleanIdeaText } from "./contentIdeasTextHygiene";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -60,7 +61,10 @@ export interface GenerateContentIdeasParams {
 
 // ─── Implementation ───────────────────────────────────────────────────────────
 
-const DEFAULT_MODEL = "gemini-2.5-flash";
+// Modelo da geração de pautas. Configurável por env (GEMINI_PAUTAS_MODEL) para
+// permitir A/B de modelo — ex.: gemini-2.5-flash-lite (output ~6× mais barato)
+// nesta extração estruturada — sem deploy. Default idêntico ao histórico.
+const DEFAULT_MODEL = process.env.GEMINI_PAUTAS_MODEL || "gemini-2.5-flash";
 const DEFAULT_COUNT = 3;
 const MAX_COUNT = 6;
 
@@ -281,6 +285,7 @@ export async function generateContentIdeas(
           : {}),
       },
     });
+    logGeminiUsage("pautas", DEFAULT_MODEL, response);
     rawText = response.text ?? null;
   } catch (err) {
     console.error("[contentIdeas] Gemini call failed:", err);

--- a/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
+++ b/src/app/dashboard/boards/videoUpload/geminiVideoNarrativeClientFactory.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { GeminiVideoNarrativeClient } from "./geminiVideoNarrativeProvider";
 import type { VideoNarrativeGeminiClientAdapter } from "./videoNarrativeGeminiProvider";
 import { GEMINI_INLINE_VIDEO_BYTES_LIMIT } from "./videoNarrativeGeminiInlineLimit";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 
 export type GeminiVideoNarrativeClientFactoryOptions = {
   apiKey: string;
@@ -349,6 +350,8 @@ export function createGeminiVideoNarrativeClient(
           config: { systemInstruction },
         });
 
+        logGeminiUsage("video", model, response);
+
         return {
           text: response.text ?? null,
         };
@@ -431,6 +434,8 @@ export function createVideoNarrativeGeminiClientAdapter(
               ...(signal ? { abortSignal: signal } : {}),
             },
           });
+
+          logGeminiUsage("video", model || fallbackModel, response);
 
           return { text: response.text ?? null };
         } finally {

--- a/src/app/dashboard/boards/videoUpload/narrativeCollabMatchingService.ts
+++ b/src/app/dashboard/boards/videoUpload/narrativeCollabMatchingService.ts
@@ -21,8 +21,11 @@ import { Types } from "mongoose";
 import { GoogleGenAI, createUserContent } from "@google/genai";
 import { connectToDatabase } from "@/app/lib/mongoose";
 import { rankByComplementarity, findSharedLabel, findDistinctLabels } from "./collabComplementarity";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 
-const GEMINI_MODEL = "gemini-2.5-flash";
+// Configurável por env (GEMINI_COLLAB_MODEL) para A/B de modelo — candidato a
+// gemini-2.5-flash-lite. Default idêntico ao histórico.
+const GEMINI_MODEL = process.env.GEMINI_COLLAB_MODEL || "gemini-2.5-flash";
 const CANDIDATE_POOL_SIZE = 30; // Pool amplo p/ o matcher por-pauta dedupar por território
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -98,6 +101,7 @@ Responda apenas com a frase, sem pontuação no final.`;
       contents: createUserContent([prompt]),
       config: { maxOutputTokens: 80, temperature: 0.6 },
     });
+    logGeminiUsage("collab", GEMINI_MODEL, response);
     const text = response.text?.trim();
     if (text && text.length > 5) return text;
   } catch {
@@ -327,6 +331,7 @@ Responda apenas com o JSON, sem cercas de código.`;
       contents: createUserContent([prompt]),
       config: { maxOutputTokens: 160, temperature: 0.6, responseMimeType: "application/json" },
     });
+    logGeminiUsage("collab", GEMINI_MODEL, response);
     const text = response.text?.trim();
     if (text) {
       const parsed = JSON.parse(text) as { fitReason?: unknown; recordingIdea?: unknown };
@@ -426,6 +431,7 @@ Responda APENAS com JSON, sem cercas de código:
         thinkingConfig: { thinkingBudget: 0 },
       },
     });
+    logGeminiUsage("collab", GEMINI_MODEL, response);
     const text = response.text?.trim();
     if (!text) return out;
 

--- a/src/app/dashboard/boards/videoUpload/weeklyWhatsAppMessageService.ts
+++ b/src/app/dashboard/boards/videoUpload/weeklyWhatsAppMessageService.ts
@@ -36,6 +36,7 @@ import {
   hasNarrativeMapPremiumAccess,
 } from "./narrativeMapAccessState";
 import { getMapConfirmationsSnapshot } from "./mapConfirmationsService";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 import { buildNarrativeMapMobileViewModelFromReadings } from "./narrativeMapMobileViewModelServerSelector";
 import {
   WHATSAPP_SYSTEM_PROMPT,
@@ -47,7 +48,9 @@ import {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const GEMINI_MODEL = "gemini-2.5-flash";
+// Configurável por env (GEMINI_WHATSAPP_MODEL) para A/B de modelo — candidato a
+// gemini-2.5-flash-lite. Default idêntico ao histórico.
+const GEMINI_MODEL = process.env.GEMINI_WHATSAPP_MODEL || "gemini-2.5-flash";
 
 /** 6 days — same cadence as idea freshness and weekly summary. */
 const MIN_SEND_INTERVAL_MS = 6 * 24 * 60 * 60 * 1000;
@@ -136,6 +139,7 @@ async function callGemini(system: string, user: string): Promise<string | null> 
         temperature: 0.65,
       },
     });
+    logGeminiUsage("whatsapp", GEMINI_MODEL, response);
     const text = response.text?.trim();
     return text || null;
   } catch (err) {

--- a/src/app/lib/llm/geminiProvider.ts
+++ b/src/app/lib/llm/geminiProvider.ts
@@ -8,6 +8,7 @@
 // quando o Gemini de fato roda (nunca em teste, pois o core faz short-circuit).
 
 import { logger } from "@/app/lib/logger";
+import { logGeminiUsage } from "./geminiUsageLog";
 import {
   type LlmGenerateParams,
   type LlmIntensity,
@@ -81,6 +82,8 @@ export const geminiProvider: LlmProvider = {
         ...(params.jsonSchema ? { responseSchema: params.jsonSchema } : {}),
       },
     });
+
+    logGeminiUsage("mapa", model, response);
 
     const text = (response.text ?? "").trim();
     return { text, provider: "gemini" as const, model };

--- a/src/app/lib/llm/geminiUsageLog.ts
+++ b/src/app/lib/llm/geminiUsageLog.ts
@@ -1,0 +1,53 @@
+// src/app/lib/llm/geminiUsageLog.ts
+//
+// Onda 0 do plano de custo do Gemini: atribuição de tokens por call-site.
+//
+// Toda resposta do @google/genai traz `usageMetadata` com as contagens de tokens
+// (prompt/candidates/thoughts/total). Hoje ninguém loga isso — sem esse dado, não
+// dá para saber QUAL dos fluxos (mapa, pautas, collab, IG, whatsapp, vídeo) domina
+// o gasto. Este helper loga uma linha estruturada por chamada, tagueada pelo
+// call-site, para que os custos possam ser agregados a partir dos logs.
+//
+// É puramente observabilidade: nunca lança, nunca altera a resposta.
+
+import { logger } from "@/app/lib/logger";
+
+/** Subconjunto de `GenerateContentResponse` que nos interessa para custo. */
+interface GeminiUsageLike {
+  model?: string;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    thoughtsTokenCount?: number;
+    totalTokenCount?: number;
+    cachedContentTokenCount?: number;
+  };
+}
+
+/**
+ * Loga o uso de tokens de uma chamada Gemini, atribuído a um call-site.
+ *
+ * @param tag    identificador do fluxo (ex.: "mapa", "pautas", "collab", "instagram").
+ * @param model  modelo efetivamente usado na chamada (ex.: "gemini-2.5-flash").
+ * @param response objeto retornado por `generateContent` (qualquer coisa com usageMetadata).
+ */
+export function logGeminiUsage(
+  tag: string,
+  model: string,
+  response: GeminiUsageLike | null | undefined,
+): void {
+  try {
+    const u = response?.usageMetadata;
+    logger.info("[llm][gemini][usage]", {
+      geminiTag: tag,
+      geminiModel: model,
+      promptTokens: u?.promptTokenCount ?? null,
+      outputTokens: u?.candidatesTokenCount ?? null,
+      thoughtsTokens: u?.thoughtsTokenCount ?? null,
+      cachedTokens: u?.cachedContentTokenCount ?? null,
+      totalTokens: u?.totalTokenCount ?? null,
+    });
+  } catch {
+    // Observabilidade nunca pode quebrar o fluxo de geração.
+  }
+}

--- a/src/app/lib/mapaSeed/analyzeInstagramPosts.ts
+++ b/src/app/lib/mapaSeed/analyzeInstagramPosts.ts
@@ -15,6 +15,7 @@
 import { GoogleGenAI, createUserContent, createPartFromBase64, type Part } from "@google/genai";
 import { callClaudeJSON } from "@/app/lib/claudeService";
 import { logger } from "@/app/lib/logger";
+import { logGeminiUsage } from "@/app/lib/llm/geminiUsageLog";
 import type { InstagramMedia } from "@/app/lib/instagram/types";
 
 const TAG = "[mapaSeed][analyzeInstagramPosts]";
@@ -59,7 +60,9 @@ export interface AnalyzeInstagramPostsOptions {
 // representativa. Texto é barato; a leitura visual (cara) segue limitada abaixo.
 const MAX_POSTS = 60;
 const DEFAULT_MAX_VISUAL_POSTS = 12;
-const GEMINI_VISUAL_MODEL = "gemini-2.5-flash";
+// Configurável por env (GEMINI_INSTAGRAM_MODEL) para A/B de modelo — esta é
+// extração estruturada, candidata a gemini-2.5-flash-lite. Default histórico.
+const GEMINI_VISUAL_MODEL = process.env.GEMINI_INSTAGRAM_MODEL || "gemini-2.5-flash";
 /** Acima disso, pula a imagem (thumbnails do IG são pequenas; isso é só guarda). */
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
 const IMAGE_FETCH_TIMEOUT_MS = 8000;
@@ -311,6 +314,8 @@ async function analyzeWithGeminiMultimodal(
       temperature: 0.2,
     },
   });
+
+  logGeminiUsage("instagram", GEMINI_VISUAL_MODEL, response);
 
   const text = response.text;
   if (!text) return null;


### PR DESCRIPTION
## Contexto
Ondas 0 (medir) + A (modelos configuráveis) do plano de redução de custo de IA, com foco nos tools mobile do criador (Seu Mapa, Sua Audiência, pautas, collabs). Hipótese: o maior gasto de Gemini está no `gemini-2.5-flash`. Hoje **nenhum** call-site loga uso de tokens, então a atribuição de custo por fluxo é um chute — esta PR resolve isso primeiro.

## O que muda
**Onda 0 — medição** (`src/app/lib/llm/geminiUsageLog.ts`)
- Helper `logGeminiUsage(tag, model, response)` loga uma linha estruturada `[llm][gemini][usage]` com `geminiTag`, `geminiModel` e tokens (prompt/output/thoughts/cached/total).
- Nunca lança, nunca altera a resposta — pura observabilidade.
- Instrumentado nos 7 call-sites, tagueados: `mapa`, `pautas`, `instagram`, `collab` (3 chamadas), `whatsapp`, `video` (2 variantes do client), `adjacent`.

**Onda A — modelos por env** (defaults idênticos, zero mudança de comportamento)
| Env nova | Fluxo |
|---|---|
| `GEMINI_PAUTAS_MODEL` | pautas |
| `GEMINI_INSTAGRAM_MODEL` | análise do Instagram |
| `GEMINI_COLLAB_MODEL` | match de collabs |
| `GEMINI_WHATSAPP_MODEL` | mensagem semanal |
| `GEMINI_ADJACENT_MODEL` | narrativas adjacentes (já 2.0-flash) |

Mapa (`GEMINI_MAPA_MODEL`) e vídeo (`VIDEO_NARRATIVE_GEMINI_MODEL`) já eram configuráveis.

## Não precisa de env na Vercel
Todas têm fallback = default antigo. Sem setar nada, o comportamento é idêntico ao de hoje. As envs só entram em jogo na **Onda B** (migrar extração para `gemini-2.5-flash-lite`, um fluxo por vez, só por env, sem deploy de código).

## Como medir (após ~1 semana em prod)
Filtrar logs por `message:"[llm][gemini][usage]"`, agrupar por `geminiTag`, somar `outputTokens` (o que pesa a ~\$2,50/M no flash full).

## Verificação
- `tsc` limpo nos arquivos tocados.
- Testes existentes passam: `analyzeInstagramPosts` (9/9), `geminiVideoNarrativeClientFactory` (18/18), `llm/index` (13/13). Os demais serviços não têm teste dedicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)