### PR TITLE
fix(comunidade): atualiza link do grupo de WhatsApp

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCommunityDetailView.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCommunityDetailView.tsx
@@ -5,7 +5,7 @@ import { DiagnosticoCategoryDetailView } from "./DiagnosticoCategoryDetailView";
 import { CreatorDirectorySection } from "./DiagnosticoCollabsDetailView";
 import { CATEGORY_META } from "./DiagnosticoCategoryMeta";
 
-const WHATSAPP_COMMUNITY_URL = "https://chat.whatsapp.com/BAeBQZ8zuhQJOxXXJJaTnH";
+const WHATSAPP_COMMUNITY_URL = "https://chat.whatsapp.com/CKTT84ZHEouKyXoDxIJI4c?mode=gi_t";
 
 const EMPTY_DIRECTORY: DiagnosticoCreatorDirectoryState = {
   status: "idle",


### PR DESCRIPTION
## Summary
- O botão "Acessar comunidade" na tela de Comunidade já redirecionava assinantes (Pro) para o grupo do WhatsApp, mas usava um link de convite desatualizado.
- Atualiza `WHATSAPP_COMMUNITY_URL` em `DiagnosticoCommunityDetailView.tsx` para o novo link: `https://chat.whatsapp.com/CKTT84ZHEouKyXoDxIJI4c?mode=gi_t`.

## Test plan
- [ ] Verificar visualmente que, logado como assinante Pro, o botão "Acessar comunidade" abre o novo link do grupo de WhatsApp em nova aba.
- [ ] Verificar que usuários free continuam vendo o botão "Assinar para participar" (sem link direto).

https://claude.ai/code/session_01FSjQpHChnGrCP1M4JyJDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSjQpHChnGrCP1M4JyJDHu)_