### PR TITLE
fix(landing): correções de copy e bugs na página de marketing antiga (não exposta)

### DIFF
--- a/src/app/LandingPageClient.tsx
+++ b/src/app/LandingPageClient.tsx
@@ -17,8 +17,11 @@ import { redirectToGoogleConsentLogin } from "@/lib/auth/googleLogin";
 
 import LandingHeader from "./landing/components/LandingHeader";
 import HeroModern from "./landing/components/HeroModern";
+import MethodSection from "./landing/components/MethodSection";
 import CastingMarketplaceSection from "./landing/components/CastingMarketplaceSection";
 import PlansComparisonSection from "./landing/components/PlansComparisonSection";
+import LandingFaqSection from "./landing/components/LandingFaqSection";
+import ClosingCtaSection from "./landing/components/ClosingCtaSection";
 import MobileStickyCta from "./landing/components/MobileStickyCta";
 import { getLandingPrimaryCtaLabel } from "./landing/copy";
 
@@ -545,8 +548,17 @@ export default function LandingPageClient() {
           categories={categories}
         />
 
+        <MethodSection />
+
         <PlansComparisonSection
           onCreateAccount={handleCreatorCta}
+          isAuthenticated={isAuthenticated}
+        />
+
+        <LandingFaqSection />
+
+        <ClosingCtaSection
+          onPrimaryCta={handleCreatorCta}
           isAuthenticated={isAuthenticated}
         />
       </main>
@@ -611,7 +623,7 @@ export default function LandingPageClient() {
       <MobileStickyCta
         label={getLandingPrimaryCtaLabel(isAuthenticated)}
         onClick={handleCreatorCta}
-        description="Consultoria e direcao estrategica toda semana."
+        description="Consultoria e direção estratégica toda semana."
         scrollOffset={180}
         showAfterTargetId="planos"
         intersectionThreshold={0.15}

--- a/src/app/landing/components/CastingMarketplaceSection.tsx
+++ b/src/app/landing/components/CastingMarketplaceSection.tsx
@@ -451,6 +451,18 @@ export default function CastingMarketplaceSection({
                     </div>
                 ) : (
                     <>
+                        <header className="mx-auto mb-6 mt-2 max-w-3xl text-center md:mb-8">
+                            <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-[10px] font-black uppercase tracking-[0.3em] text-slate-400 shadow-sm">
+                                Banco de Talentos
+                            </span>
+                            <h2 className="mt-5 text-3xl font-black leading-[1.05] tracking-tight text-brand-dark md:text-5xl">
+                                Criadores prontos para a sua{" "}
+                                <span className="bg-gradient-to-r from-brand-primary to-brand-accent bg-clip-text text-transparent">próxima campanha.</span>
+                            </h2>
+                            <p className="mx-auto mt-3 max-w-[52ch] text-[15px] font-medium leading-[1.6] text-slate-500">
+                                Explore por nicho, seguidores e performance real — métricas auditadas direto da API oficial do Instagram.
+                            </p>
+                        </header>
                         <div
                             data-testid="marketplace-filter-bar"
                             className="sticky top-[calc(var(--landing-header-h,4.5rem)+4px)] z-30 mb-5 rounded-[1.25rem] border border-slate-100 bg-white/95 p-2 shadow-[0_18px_40px_rgba(20,33,61,0.08)] backdrop-blur-2xl md:mb-7 md:rounded-[1.75rem] md:p-4"
@@ -830,7 +842,7 @@ function CastingRankCard({
         >
             <div className="relative p-2 sm:p-3">
                 <div className="flex items-center justify-between">
-                    <p className="max-w-full truncate rounded-full bg-slate-100/90 px-2 py-1 text-[8px] font-bold tracking-[-0.01em] text-[#6F7890] sm:bg-transparent sm:px-0 sm:py-0 sm:text-[11px]">@{creator.username || creator.name || "Criador"}</p>
+                    <p className="max-w-full truncate rounded-full bg-slate-100/90 px-2 py-1 text-[8px] font-bold tracking-[-0.01em] text-[#6F7890] sm:bg-transparent sm:px-0 sm:py-0 sm:text-[11px]">@{(creator.username || creator.name || "Criador").replace(/^@+/, "")}</p>
                 </div>
 
                 <div>

--- a/src/app/landing/components/ClosingCtaSection.tsx
+++ b/src/app/landing/components/ClosingCtaSection.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+
+import { LANDING_PRICE_SUPPORT, getLandingPrimaryCtaLabel } from "@/app/landing/copy";
+
+type ClosingCtaSectionProps = {
+  onPrimaryCta: () => void;
+  isAuthenticated?: boolean;
+};
+
+const REASSURANCES = ["Login com Google", "Sem fidelidade", "API oficial do Instagram"];
+
+export default function ClosingCtaSection({
+  onPrimaryCta,
+  isAuthenticated = false,
+}: ClosingCtaSectionProps) {
+  const primaryLabel = getLandingPrimaryCtaLabel(isAuthenticated);
+
+  return (
+    <section
+      id="cta-final"
+      className="relative overflow-hidden bg-[#10182B] py-14 sm:py-20"
+    >
+      <div className="pointer-events-none absolute -top-32 left-1/2 h-80 w-[36rem] -translate-x-1/2 rounded-full bg-brand-primary/15 blur-[120px]" />
+      <div className="pointer-events-none absolute -bottom-32 right-[10%] h-64 w-64 rounded-full bg-brand-accent/15 blur-[100px]" />
+
+      <div className="landing-section__inner relative z-10 mx-auto max-w-3xl text-center">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.6, ease: [0.21, 0.47, 0.32, 0.98] }}
+          className="text-[2rem] font-black leading-[1.05] tracking-tight text-white sm:text-4xl md:text-5xl"
+        >
+          Você cria.{" "}
+          <span className="bg-gradient-to-r from-brand-primary via-[#FF4080] to-brand-accent bg-clip-text text-transparent">
+            A direção é com a gente.
+          </span>
+        </motion.h2>
+
+        <motion.p
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.6, delay: 0.1, ease: [0.21, 0.47, 0.32, 0.98] }}
+          className="mx-auto mt-4 max-w-[38ch] text-[14.5px] font-medium leading-[1.65] text-slate-300 sm:text-base"
+        >
+          Entre hoje, conecte seu Instagram e chegue na próxima mentoria com o seu
+          conteúdo já diagnosticado.
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.6, delay: 0.18, ease: [0.21, 0.47, 0.32, 0.98] }}
+          className="mt-8 flex flex-col items-center gap-4"
+        >
+          <div className="group relative">
+            <div className="absolute -inset-1 rounded-[1.35rem] bg-gradient-to-r from-brand-primary/40 via-brand-accent/40 to-brand-primary/40 opacity-70 blur-md transition duration-700 group-hover:opacity-100" />
+            <button
+              type="button"
+              onClick={onPrimaryCta}
+              className="relative inline-flex min-w-[15rem] items-center justify-center gap-2 rounded-[1.25rem] bg-brand-primary px-8 py-4 text-[1rem] font-black text-white shadow-[0_16px_30px_rgba(245,43,106,0.3)] transition-transform hover:scale-[1.02] active:scale-[0.98] sm:min-w-[18rem] sm:py-5 sm:text-lg"
+            >
+              {primaryLabel}
+              <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+                →
+              </span>
+            </button>
+          </div>
+
+          {!isAuthenticated ? (
+            <p className="text-[11.5px] font-semibold text-slate-400 sm:text-xs">
+              {LANDING_PRICE_SUPPORT}
+            </p>
+          ) : null}
+
+          <ul className="mt-1 flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+            {REASSURANCES.map((item) => (
+              <li
+                key={item}
+                className="flex items-center gap-1.5 text-[10.5px] font-bold uppercase tracking-[0.12em] text-slate-500 sm:text-[11px]"
+              >
+                <span aria-hidden="true" className="text-brand-primary">
+                  ✓
+                </span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/HeroModern.tsx
+++ b/src/app/landing/components/HeroModern.tsx
@@ -37,31 +37,31 @@ const MOBILE_VALUE_PILLARS: MobileValuePillar[] = [
     id: "positioning",
     icon: "✦",
     title: "Reunião de Roteiro",
-    description: "Toda terça, 19h, para revisar se seu roteiro esta no caminho certo.",
+    description: "Toda terça, às 19h, revisamos seu roteiro ao vivo antes de você gravar.",
   },
   {
     id: "direction",
     icon: "↗",
     title: "Reunião de Conteúdo",
-    description: "Toda quinta, 19h, para revisar sua edição, captação e conteúdo.",
+    description: "Toda quinta, às 19h, feedback de edição, captação e narrativa do que você publicou.",
   },
   {
     id: "opportunities",
     icon: "◆",
     title: "Banco de Talentos",
-    description: "Nossos criadores são avalidados para representação comercial pela Destaque;",
+    description: "Criadores da D2C são avaliados para representação comercial pela Agência Destaque.",
   },
   {
     id: "platform",
     icon: "⚡",
     title: "Nossa Plataforma",
-    description: "Diagnósticos de conteúdo por IA, ferramentas para organizar seu planejamento e notificações de revisão de conteúdo/roteiro.",
+    description: "Diagnóstico de conteúdo por IA, planejamento organizado e lembretes de revisão de roteiro.",
   },
   {
     id: "networking",
     icon: "🤝",
     title: "Networking Ativo",
-    description: "Conexão com outros criadores para crescer juntos com collab.",
+    description: "Conexão com outros criadores para crescer junto em collabs.",
   },
 ];
 
@@ -136,7 +136,7 @@ const HeroValuePillarCard: React.FC<{ pillar: MobileValuePillar; index: number }
         {pillar.icon}
       </span>
       <div>
-        <h2 className="text-[0.96rem] font-black leading-[1.1] text-brand-dark md:text-[1.05rem]">{pillar.title}</h2>
+        <h3 className="text-[0.96rem] font-black leading-[1.1] text-brand-dark md:text-[1.05rem]">{pillar.title}</h3>
         <p className="mt-1.5 text-[12px] leading-[1.55] text-slate-600 md:text-[13px] md:leading-[1.65]">{pillar.description}</p>
       </div>
     </div>
@@ -283,13 +283,13 @@ const HeroModern: React.FC<HeroModernProps> = ({ onCreatorCta, isAuthenticated =
                 data-testid="hero-mobile-subtitle"
                 className="mx-auto block max-w-[18.2rem] text-[14px] leading-[1.58] tracking-[-0.012em] text-slate-600 sm:hidden"
               >
-                Estratégia para você focar na criação. Pare de caçar marcas e{" "}
-                <span className="font-bold text-slate-900">comece a ser encontrado pela oportunidade ideal.</span>
+                Mentorias semanais, revisão por IA e um banco de talentos.{" "}
+                <span className="font-bold text-slate-900">Pare de caçar marcas: seja encontrado pela oportunidade certa.</span>
               </span>
               <span className="hidden sm:inline">
-                Focamos na estratégia para você focar em criar. Não se desvalorize indo atrás de marcas.{" "}
+                Cuidamos da estratégia para você focar em criar: mentorias semanais, revisão de conteúdo por IA e um banco de talentos.{" "}
                 <span className="font-bold text-slate-700">
-                  Se posicione para que a oportunidade ideal venha ate a sua narrativa.
+                  Pare de caçar marcas — posicione-se para que a oportunidade certa encontre a sua narrativa.
                 </span>
               </span>
             </motion.p>

--- a/src/app/landing/components/LandingFaqSection.tsx
+++ b/src/app/landing/components/LandingFaqSection.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+
+import { LANDING_FAQ_ITEMS } from "@/app/landing/faqData";
+
+export default function LandingFaqSection() {
+  return (
+    <section
+      id="faq"
+      className="landing-section relative overflow-hidden bg-white py-10 scroll-mt-[calc(var(--landing-header-h,4.5rem)+10px)] sm:py-16 lg:py-20"
+    >
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+      <div className="landing-section__inner relative z-10 mx-auto max-w-3xl">
+        <header className="mb-7 text-center sm:mb-10">
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-[9px] font-black uppercase tracking-[0.26em] text-slate-400 shadow-sm sm:px-4 sm:py-2 sm:text-[10px] sm:tracking-[0.3em]">
+            Dúvidas frequentes
+          </span>
+          <h2 className="mt-4 text-[1.85rem] font-black leading-[1.05] tracking-tight text-brand-dark sm:mt-6 sm:text-4xl">
+            Tudo o que você precisa saber{" "}
+            <span className="bg-gradient-to-r from-brand-primary to-brand-accent bg-clip-text text-transparent">
+              antes de entrar.
+            </span>
+          </h2>
+        </header>
+
+        <div className="space-y-3">
+          {LANDING_FAQ_ITEMS.map((item, index) => (
+            <motion.div
+              key={item.question}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{ duration: 0.45, delay: index * 0.05, ease: [0.21, 0.47, 0.32, 0.98] }}
+            >
+              <details className="group rounded-[1.35rem] border border-slate-200/80 bg-[#FBFBFC] transition-colors duration-300 open:border-brand-primary/20 open:bg-white open:shadow-[0_14px_32px_rgba(20,33,61,0.06)]">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-4 text-left text-[14.5px] font-black leading-[1.3] tracking-[-0.01em] text-brand-dark [&::-webkit-details-marker]:hidden sm:px-6 sm:py-5 sm:text-base">
+                  {item.question}
+                  <span
+                    aria-hidden="true"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-[13px] font-black text-slate-400 transition-all duration-300 group-open:rotate-45 group-open:border-brand-primary/30 group-open:text-brand-primary"
+                  >
+                    +
+                  </span>
+                </summary>
+                <div className="px-4 pb-5 text-[13.5px] font-medium leading-[1.7] text-slate-600 sm:px-6 sm:text-[15px]">
+                  {item.answer}
+                </div>
+              </details>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -18,13 +18,6 @@ interface LandingHeaderProps {
   onCreatorCta?: () => void;
 }
 
-const NAV_LINKS = [
-  { label: 'Comunidade', href: '#galeria' },
-  { label: 'Como funciona', href: '#como-funciona' },
-  { label: 'Planos', href: '#planos' },
-  { label: 'FAQ', href: '#faq' },
-];
-
 export default function LandingHeader({
   showLoginButton = false,
   onCreatorCta,
@@ -165,17 +158,6 @@ export default function LandingHeader({
         </Link>
         <div className="flex items-center gap-3 md:gap-3.5">
           <nav className="hidden items-center gap-2 md:flex">
-            <div className="mr-3 flex items-center gap-1 lg:mr-5 lg:gap-2">
-              {NAV_LINKS.map((item) => (
-                <a
-                  key={item.href}
-                  href={item.href}
-                  className="rounded-full px-2.5 py-1.5 text-[0.88rem] font-semibold text-slate-600 transition-colors hover:bg-slate-50 hover:text-brand-dark lg:px-3"
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
             <div className="flex items-center gap-2">
               {shouldShowLoginAction ? (
                 <ButtonPrimary
@@ -237,19 +219,6 @@ export default function LandingHeader({
       {isMenuOpen && (
         <div className="fixed inset-x-4 top-[calc(var(--landing-header-h,4.5rem)+0.75rem)] z-[60] max-h-[calc(100vh-var(--landing-header-h,4.5rem)-1.5rem)] overflow-y-auto rounded-[1.65rem] border border-[#E7EBF6] bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(250,251,255,0.98))] shadow-[0_18px_38px_rgba(15,23,42,0.12)] md:hidden">
           <nav id="mobile-menu" className="flex flex-col p-2.5">
-            <div className="mb-1 flex flex-col">
-              {NAV_LINKS.map((item) => (
-                <a
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setIsMenuOpen(false)}
-                  className="rounded-[1rem] px-4 py-3 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50"
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
-            <div className="mb-1 h-px bg-slate-100" aria-hidden="true" />
             {shouldShowLoginAction ? (
               <ButtonPrimary
                 onClick={() => {

--- a/src/app/landing/components/LandingHeader.tsx
+++ b/src/app/landing/components/LandingHeader.tsx
@@ -18,6 +18,13 @@ interface LandingHeaderProps {
   onCreatorCta?: () => void;
 }
 
+const NAV_LINKS = [
+  { label: 'Comunidade', href: '#galeria' },
+  { label: 'Como funciona', href: '#como-funciona' },
+  { label: 'Planos', href: '#planos' },
+  { label: 'FAQ', href: '#faq' },
+];
+
 export default function LandingHeader({
   showLoginButton = false,
   onCreatorCta,
@@ -158,6 +165,17 @@ export default function LandingHeader({
         </Link>
         <div className="flex items-center gap-3 md:gap-3.5">
           <nav className="hidden items-center gap-2 md:flex">
+            <div className="mr-3 flex items-center gap-1 lg:mr-5 lg:gap-2">
+              {NAV_LINKS.map((item) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  className="rounded-full px-2.5 py-1.5 text-[0.88rem] font-semibold text-slate-600 transition-colors hover:bg-slate-50 hover:text-brand-dark lg:px-3"
+                >
+                  {item.label}
+                </a>
+              ))}
+            </div>
             <div className="flex items-center gap-2">
               {shouldShowLoginAction ? (
                 <ButtonPrimary
@@ -219,6 +237,19 @@ export default function LandingHeader({
       {isMenuOpen && (
         <div className="fixed inset-x-4 top-[calc(var(--landing-header-h,4.5rem)+0.75rem)] z-[60] max-h-[calc(100vh-var(--landing-header-h,4.5rem)-1.5rem)] overflow-y-auto rounded-[1.65rem] border border-[#E7EBF6] bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(250,251,255,0.98))] shadow-[0_18px_38px_rgba(15,23,42,0.12)] md:hidden">
           <nav id="mobile-menu" className="flex flex-col p-2.5">
+            <div className="mb-1 flex flex-col">
+              {NAV_LINKS.map((item) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className="rounded-[1rem] px-4 py-3 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50"
+                >
+                  {item.label}
+                </a>
+              ))}
+            </div>
+            <div className="mb-1 h-px bg-slate-100" aria-hidden="true" />
             {shouldShowLoginAction ? (
               <ButtonPrimary
                 onClick={() => {

--- a/src/app/landing/components/MethodSection.tsx
+++ b/src/app/landing/components/MethodSection.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+
+type MethodStep = {
+  id: string;
+  step: string;
+  title: string;
+  description: string;
+  highlight: string;
+};
+
+const METHOD_STEPS: MethodStep[] = [
+  {
+    id: "connect",
+    step: "01",
+    title: "Entre e conecte seu Instagram",
+    description:
+      "Login com Google, conexão segura pela API oficial da Meta e diagnóstico do seu conteúdo por IA em minutos.",
+    highlight: "Diagnóstico por IA",
+  },
+  {
+    id: "direction",
+    step: "02",
+    title: "Receba direção toda semana",
+    description:
+      "Mentorias ao vivo de roteiro (terças) e de conteúdo (quintas), com revisões contínuas de posicionamento e narrativa.",
+    highlight: "Mentorias ao vivo",
+  },
+  {
+    id: "opportunities",
+    step: "03",
+    title: "Seja encontrado pelas marcas",
+    description:
+      "Seu mídia kit é auditado em tempo real e você entra no banco de talentos avaliado para representação comercial pela Agência Destaque.",
+    highlight: "Representação comercial",
+  },
+];
+
+export default function MethodSection() {
+  return (
+    <section
+      id="como-funciona"
+      className="landing-section relative overflow-hidden border-y border-slate-100 bg-[#FBFBFC] py-10 scroll-mt-[calc(var(--landing-header-h,4.5rem)+10px)] sm:py-16 lg:py-20"
+    >
+      <div className="pointer-events-none absolute -top-24 right-[8%] h-72 w-72 rounded-full bg-brand-accent/5 blur-[110px]" />
+      <div className="pointer-events-none absolute -bottom-24 left-[6%] h-72 w-72 rounded-full bg-brand-primary/5 blur-[110px]" />
+
+      <div className="landing-section__inner landing-section__inner--wide relative z-10">
+        <header className="mx-auto mb-8 max-w-[22rem] text-center sm:mb-12 sm:max-w-2xl">
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-[9px] font-black uppercase tracking-[0.26em] text-slate-400 shadow-sm sm:px-4 sm:py-2 sm:text-[10px] sm:tracking-[0.3em]">
+            Como funciona
+          </span>
+          <h2 className="mt-4 text-[1.85rem] font-black leading-[1.05] tracking-tight text-brand-dark sm:mt-6 sm:text-4xl md:text-5xl">
+            Da criação à{" "}
+            <span className="bg-gradient-to-r from-brand-primary to-brand-accent bg-clip-text text-transparent">
+              oportunidade certa
+            </span>{" "}
+            em três passos.
+          </h2>
+          <p className="mt-3 text-[14px] font-medium leading-[1.6] text-slate-500 sm:mt-4 sm:text-base">
+            Um método contínuo: você cria, a gente direciona e as marcas encontram você.
+          </p>
+        </header>
+
+        <ol className="relative mx-auto grid max-w-5xl gap-4 md:grid-cols-3 md:gap-6">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-0 right-0 top-[2.4rem] hidden h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent md:block"
+          />
+          {METHOD_STEPS.map((item, index) => (
+            <motion.li
+              key={item.id}
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-80px" }}
+              transition={{ duration: 0.55, delay: index * 0.12, ease: [0.21, 0.47, 0.32, 0.98] }}
+              className="relative flex flex-col gap-3 rounded-[1.6rem] border border-slate-200/80 bg-white p-5 shadow-[0_14px_32px_rgba(20,33,61,0.05)] transition-all duration-300 hover:-translate-y-1 hover:border-brand-primary/20 hover:shadow-[0_20px_40px_rgba(20,33,61,0.08)] sm:p-6"
+            >
+              <div className="flex items-center justify-between">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-[1.05rem] bg-brand-dark text-[0.95rem] font-black tracking-tight text-white shadow-lg shadow-brand-dark/15">
+                  {item.step}
+                </span>
+                <span className="rounded-full border border-brand-primary/15 bg-brand-primary/[0.06] px-2.5 py-1 text-[8.5px] font-black uppercase tracking-[0.14em] text-brand-primary sm:text-[9px]">
+                  {item.highlight}
+                </span>
+              </div>
+              <h3 className="text-[1.08rem] font-black leading-[1.15] tracking-[-0.02em] text-brand-dark sm:text-[1.15rem]">
+                {item.title}
+              </h3>
+              <p className="text-[13px] font-medium leading-[1.65] text-slate-600 sm:text-sm">
+                {item.description}
+              </p>
+            </motion.li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/PlansComparisonSection.tsx
+++ b/src/app/landing/components/PlansComparisonSection.tsx
@@ -125,7 +125,7 @@ const PlanCard = ({
         )}
 
         <div className="mb-8 sm:mb-10" style={{ transform: "translateZ(50px)" }}>
-          <h3 className={`text-[1.65rem] font-black tracking-tight ${isPro ? "text-brand-primary" : "text-brand-dark"} sm:text-2xl`}>
+          <h3 className={`text-[1.65rem] font-black tracking-tight ${isPro ? "pr-28 text-brand-primary sm:pr-32" : "text-brand-dark"} sm:text-2xl`}>
             {title}
           </h3>
           <div className="mt-4 flex items-baseline gap-1 sm:mt-6">
@@ -174,7 +174,7 @@ const PlanCard = ({
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-rose-600"></span>
               </div>
               <span className="text-[10px] font-black uppercase tracking-[0.12em] text-rose-600 sm:text-[10px] sm:tracking-[0.2em]">
-                Só restam 4 vagas p/ mentoria de Terça
+                Turmas de mentoria com vagas limitadas
               </span>
             </div>
           )}
@@ -225,20 +225,29 @@ export default function PlansComparisonSection({
             isPro
             description="Mentorias estratégicas e tecnologia para acelerar sua representação comercial."
             features={[
-              "3 Mentorias Semanais de Conteúdo e Roteiro",
-              "Anotações Inteligentes d2c",
-              "Calculadora de Precificação Comercial",
-              "Radar de Faturamento p/ Representação",
-              "Mídia Kit Auditado em Tempo Real"
+              "Mentorias semanais ao vivo de roteiro e conteúdo",
+              "Diagnóstico de conteúdo por IA",
+              "Anotações inteligentes das mentorias",
+              "Calculadora de precificação de publis",
+              "Radar de faturamento para representação",
+              "Mídia kit auditado em tempo real"
             ]}
             ctaText={primaryCtaLabel}
             onCta={onCreateAccount}
-            note="Valor sofre reajuste nos próximos meses."
+            note="Preço de lançamento · sem fidelidade, cancele quando quiser"
           />
         </div>
 
         <p className="mt-7 text-center text-[13px] font-semibold leading-relaxed text-slate-400 sm:mt-12 sm:text-sm sm:font-bold">
-          Você foca 100% na criação e nós te direcionamos. <button className="text-brand-primary hover:underline underline-offset-4">Fale no WhatsApp se tiver dúvidas →</button>
+          Você foca 100% na criação e nós te direcionamos.{" "}
+          <a
+            href={`https://wa.me/552120380975?text=${encodeURIComponent("Olá! Tenho uma dúvida sobre o plano consultivo da Data2Content.")}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-primary underline-offset-4 hover:underline"
+          >
+            Fale no WhatsApp se tiver dúvidas →
+          </a>
         </p>
       </div>
       <style jsx global>{`

--- a/src/app/landing/copy.ts
+++ b/src/app/landing/copy.ts
@@ -1,7 +1,7 @@
 export const LANDING_JOIN_CTA_LABEL = "Quero entrar na D2C";
 export const LANDING_AUTHENTICATED_CTA_LABEL = "Acessar consultoria";
 export const LANDING_PRICE_SUPPORT =
-  "Plano consultivo por R$ 49,90/mês";
+  "Plano consultivo por R$ 49,90/mês · cancele quando quiser";
 
 export function getLandingPrimaryCtaLabel(isAuthenticated: boolean) {
   return isAuthenticated ? LANDING_AUTHENTICATED_CTA_LABEL : LANDING_JOIN_CTA_LABEL;

--- a/src/app/landing/faqData.ts
+++ b/src/app/landing/faqData.ts
@@ -1,0 +1,37 @@
+export type LandingFaqItem = {
+  question: string;
+  answer: string;
+};
+
+export const LANDING_FAQ_ITEMS: LandingFaqItem[] = [
+  {
+    question: "O que é a Data2Content?",
+    answer:
+      "A Data2Content (D2C) é uma consultoria de direção estratégica para criadores de conteúdo. Você recebe mentorias ao vivo toda semana, revisão de conteúdo e roteiro apoiada por IA, e entra no nosso banco de talentos — onde criadores são avaliados para representação comercial pela Agência Destaque.",
+  },
+  {
+    question: "Como funcionam as mentorias semanais?",
+    answer:
+      "São encontros ao vivo e recorrentes: às terças, às 19h, revisamos roteiros antes de você gravar; às quintas, às 19h, damos feedback de edição, captação e narrativa do que você publicou. Você sai de cada reunião com direcionamento prático para o próximo conteúdo.",
+  },
+  {
+    question: "O que é o Banco de Talentos e a representação comercial?",
+    answer:
+      "Os criadores da comunidade têm o desempenho acompanhado por um mídia kit auditado em tempo real, com dados oficiais do Instagram. Os que mais evoluem são avaliados para representação comercial pela Agência Destaque — ou seja, marcas chegam até você, em vez de você precisar caçar oportunidades.",
+  },
+  {
+    question: "O que está incluído na plataforma?",
+    answer:
+      "Diagnóstico de conteúdo por IA, anotações inteligentes das mentorias, calculadora de precificação de publis, radar de faturamento para representação e mídia kit auditado em tempo real — tudo conectado aos dados reais do seu Instagram.",
+  },
+  {
+    question: "Quanto custa? Posso cancelar quando quiser?",
+    answer:
+      "O plano consultivo custa R$ 49,90 por mês, sem fidelidade — você pode cancelar quando quiser. O valor é de lançamento e pode ser reajustado para novos assinantes.",
+  },
+  {
+    question: "Preciso de conta profissional do Instagram? Meus dados estão seguros?",
+    answer:
+      "Sim, é necessária uma conta profissional (Criador de Conteúdo ou Comercial) para conectarmos suas métricas pela API oficial da Meta. A conexão é segura, em conformidade com a LGPD, e você mantém controle total: seus números só aparecem no seu mídia kit se você quiser.",
+  },
+];

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,6 +1,32 @@
-import { redirect } from "next/navigation";
+import LandingPageClient from "../LandingPageClient";
+import {
+  landingJsonLd,
+  landingProductJsonLd,
+  landingMetadata,
+  landingFaqJsonLd,
+  landingOrganizationJsonLd,
+} from "@/seo/landing";
+
+export const metadata = {
+  ...landingMetadata,
+  alternates: { canonical: "https://data2content.ai/landing" },
+};
 
 export default function LandingPage() {
-  redirect("/");
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([
+            landingJsonLd,
+            landingProductJsonLd,
+            landingFaqJsonLd,
+            landingOrganizationJsonLd,
+          ]),
+        }}
+      />
+      <LandingPageClient />
+    </>
+  );
 }
-

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,32 +1,5 @@
-import LandingPageClient from "../LandingPageClient";
-import {
-  landingJsonLd,
-  landingProductJsonLd,
-  landingMetadata,
-  landingFaqJsonLd,
-  landingOrganizationJsonLd,
-} from "@/seo/landing";
-
-export const metadata = {
-  ...landingMetadata,
-  alternates: { canonical: "https://data2content.ai/landing" },
-};
+import { redirect } from "next/navigation";
 
 export default function LandingPage() {
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify([
-            landingJsonLd,
-            landingProductJsonLd,
-            landingFaqJsonLd,
-            landingOrganizationJsonLd,
-          ]),
-        }}
-      />
-      <LandingPageClient />
-    </>
-  );
+  redirect("/");
 }

--- a/src/seo/landing.ts
+++ b/src/seo/landing.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import faqItems from "@/data/faq";
+import { LANDING_FAQ_ITEMS } from "@/app/landing/faqData";
 
 const SITE_URL = "https://data2content.ai";
 const HOME_SHARE_LOGO_URL = `${SITE_URL}/images/Colorido-Simbolo.png`;
@@ -83,12 +83,12 @@ export const landingOrganizationJsonLd = {
 export const landingFaqJsonLd = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: faqItems.map((item) => ({
+  mainEntity: LANDING_FAQ_ITEMS.map((item) => ({
     "@type": "Question",
-    name: item.q,
+    name: item.question,
     acceptedAnswer: {
       "@type": "Answer",
-      text: item.a,
+      text: item.answer,
     },
   })),
 };


### PR DESCRIPTION
## Status

⚠️ **Aguardando o código da landing oficial.** A landing correta é a `NarrativeLandingPage` (com `CommunityCreatorShowcase` e `communityShowcaseService`), que existe apenas no ambiente local do Codex (Mac mini) e ainda não foi enviada ao GitHub. Assim que esse branch for pushado, o redesign completo será feito sobre ela.

## O que este PR contém hoje

O primeiro commit havia redesenhado a página de marketing antiga (`LandingPageClient`) e a exposto em `/landing` — alvo errado, revertido no segundo commit. Restam apenas melhorias inofensivas no código antigo (que segue não exposto — `/landing` continua redirecionando para `/`):

- Correções de português no hero, pilares e CTA fixo ("esta" → "está", "avalidados" → "avaliados", "ate" → "até", "direcao estrategica" → "direção estratégica")
- Botão "Fale no WhatsApp" nos planos era um `<button>` sem handler → link real `wa.me`
- Remove escassez artificial ("Só restam 4 vagas") e melhora a nota de preço
- Novas seções (Como funciona, FAQ, CTA final) disponíveis caso a página volte a ser usada
- FAQ do JSON-LD emitido na raiz atualizada (`faqData.ts`) — antes usava conteúdo obsoleto (plano gratuito, IA no WhatsApp) com HTML embutido
- Corrige `@@` duplicado nos cards de criador e sobreposição do selo "Recomendado" no mobile

## Validação

- `jest` das suítes de landing + SEO: passando
- `tsc` e `eslint`: limpos nos arquivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4mey1YKLA33Znsh6G72Pn