### PR TITLE
fix(collabs): surface generation blockers on "Carregar nova rodada"

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCollabsFeed.stack.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCollabsFeed.stack.test.tsx
@@ -508,6 +508,42 @@ describe("DiagnosticoCollabsFeed — deck unificado", () => {
     expect(onOpenWhatsAppCommunity).toHaveBeenCalledTimes(1);
   });
 
+  it("rodada concluída expõe falha de geração e oferece Tentar novamente", () => {
+    const onGenerate = jest.fn();
+    render(
+      <DiagnosticoCollabsFeed
+        {...baseProps}
+        pautas={[pauta("guardada", { status: "saved" as const })]}
+        pautaCollabs={new Map()}
+        collabDecisions={new Map()}
+        ideaGenerationBlocker="failed"
+        onGenerate={onGenerate}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/Não foi possível carregar a nova rodada/i);
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rodada concluída com cota estourada avisa e esconde o botão de gerar", () => {
+    const onGenerate = jest.fn();
+    render(
+      <DiagnosticoCollabsFeed
+        {...baseProps}
+        pautas={[pauta("guardada", { status: "saved" as const })]}
+        pautaCollabs={new Map()}
+        collabDecisions={new Map()}
+        ideaGenerationBlocker="quota_exceeded"
+        ideaQuotaResetAt="2026-08-01T00:00:00.000Z"
+        onGenerate={onGenerate}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/gerações de pautas deste mês/i);
+    expect(screen.queryByRole("button", { name: /Carregar nova rodada/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Tentar novamente/ })).not.toBeInTheDocument();
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
   it("não assinante abre o modal contextual em cada ação do fim da rodada", () => {
     const onUpgrade = jest.fn();
     const onGenerate = jest.fn();

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCollabsFeed.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoCollabsFeed.tsx
@@ -77,6 +77,8 @@ interface Props {
   isGeneratingIdeas: boolean;
   /** "map_incomplete" => sem mapa (estado travado que devolve ao Perfil). */
   ideaGenerationBlocker?: "premium_required" | "quota_exceeded" | "map_incomplete" | "failed" | null;
+  /** ISO da virada da cota mensal (só presente em quota_exceeded). */
+  ideaQuotaResetAt?: string | null;
   /** Criador compatível por pauta (id da pauta → match). Ausente/null = sem collab. */
   pautaCollabs?: Map<string, NarrativeCollabMatch | null>;
   /** True enquanto o match por-pauta está sendo buscado — mostra skeleton da pilha. */
@@ -799,21 +801,77 @@ function GenerateButton({
   );
 }
 
+function RoundBlockerNotice({
+  blocker,
+  quotaResetAt,
+}: {
+  blocker: NonNullable<Props["ideaGenerationBlocker"]>;
+  quotaResetAt?: string | null;
+}) {
+  // Cota estourada trava a rodada até a virada do mês — tom de aviso (âmbar), sem
+  // botão de retry (tentar de novo não destrava). Falha transitória é vermelha; o
+  // próprio "Carregar nova rodada" acima já serve de retry.
+  const isQuota = blocker === "quota_exceeded";
+  const isPremium = blocker === "premium_required";
+  const warningTone = isQuota;
+  const resetLabel = quotaResetAt
+    ? new Date(quotaResetAt).toLocaleDateString("pt-BR", { month: "long", year: "numeric" })
+    : null;
+  const message = isQuota
+    ? resetLabel
+      ? `Você usou todas as suas gerações de pautas deste mês. Novas a partir de ${resetLabel}.`
+      : "Você usou todas as suas gerações de pautas deste mês."
+    : isPremium
+      ? "Gerar novas rodadas de pautas é um recurso Pro."
+      : "Não foi possível carregar a nova rodada agora. Tente novamente.";
+  return (
+    <div
+      role="alert"
+      style={{
+        borderRadius: 14, padding: "10px 12px", textAlign: "left",
+        background: warningTone ? "#fefce8" : "#fff1f2",
+        color: warningTone ? "#854d0e" : "#be123c",
+        fontSize: 12.5, fontWeight: 650, lineHeight: 1.4,
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
 function RoundCompleteActions({
   isPro,
   isGeneratingIdeas,
+  ideaGenerationBlocker,
+  ideaQuotaResetAt,
   onGenerate,
   onUpgrade,
   onOpenWhatsAppCommunity,
-}: Pick<Props, "isPro" | "isGeneratingIdeas" | "onGenerate" | "onUpgrade" | "onOpenWhatsAppCommunity">) {
+}: Pick<Props, "isPro" | "isGeneratingIdeas" | "ideaGenerationBlocker" | "ideaQuotaResetAt" | "onGenerate" | "onUpgrade" | "onOpenWhatsAppCommunity">) {
   const proBadge = !isPro ? (
     <span style={{ borderRadius: 999, padding: "3px 6px", background: "rgba(255,255,255,0.16)", fontSize: 9, fontWeight: 800, letterSpacing: 0.65 }}>
       PRO
     </span>
   ) : null;
 
+  // Blocker de geração que impede a nova rodada (mapa incompleto é tratado antes,
+  // no estado sem pautas). Sem isto, uma falha/cota estourada deixava o toque em
+  // "Carregar nova rodada" sem resposta visível — parecia que nada carregava.
+  const blocker =
+    ideaGenerationBlocker === "quota_exceeded" ||
+    ideaGenerationBlocker === "failed" ||
+    ideaGenerationBlocker === "premium_required"
+      ? ideaGenerationBlocker
+      : null;
+  // Cota estourada / recurso Pro não destravam via retry — some o botão de gerar.
+  const canRetryGenerate = !blocker || blocker === "failed";
+
   return (
     <div role="group" aria-label="Continuar depois da rodada" style={{ display: "grid", gap: 10 }}>
+      {blocker && !isGeneratingIdeas ? (
+        <RoundBlockerNotice blocker={blocker} quotaResetAt={ideaQuotaResetAt} />
+      ) : null}
+      {canRetryGenerate ? (
       <button
         type="button"
         disabled={isGeneratingIdeas}
@@ -825,9 +883,10 @@ function RoundCompleteActions({
           opacity: isGeneratingIdeas ? 0.72 : 1,
         }}
       >
-        <span>{isGeneratingIdeas ? "Criando sua próxima rodada…" : "Carregar nova rodada"}</span>
+        <span>{isGeneratingIdeas ? "Criando sua próxima rodada…" : blocker === "failed" ? "Tentar novamente" : "Carregar nova rodada"}</span>
         {!isGeneratingIdeas ? proBadge : null}
       </button>
+      ) : null}
 
       {onOpenWhatsAppCommunity ? (
         <button
@@ -858,6 +917,7 @@ export function DiagnosticoCollabsFeed({
   whatsappLinked,
   isGeneratingIdeas,
   ideaGenerationBlocker,
+  ideaQuotaResetAt,
   pautaCollabs,
   bootstrapStatus = "ready",
   bootstrapError,
@@ -1070,6 +1130,8 @@ export function DiagnosticoCollabsFeed({
                 <RoundCompleteActions
                   isPro={isPro}
                   isGeneratingIdeas={isGeneratingIdeas}
+                  ideaGenerationBlocker={ideaGenerationBlocker}
+                  ideaQuotaResetAt={ideaQuotaResetAt}
                   onGenerate={onGenerate}
                   onUpgrade={onUpgrade}
                   onOpenWhatsAppCommunity={onOpenWhatsAppCommunity}
@@ -1110,13 +1172,22 @@ export function DiagnosticoCollabsFeed({
           <p style={{ fontSize: 14, color: TEXT_SECONDARY_HEX, lineHeight: 1.5, margin: "8px 0 18px" }}>
             A D2C cria ideias do seu mapa, na sua voz — e indica criadores pra postar junto.
           </p>
-          <GenerateButton
-            isPro={isPro}
-            isGeneratingIdeas={isGeneratingIdeas}
-            onGenerate={onGenerate}
-            onUpgrade={onUpgrade}
-            label="Gerar pautas"
-          />
+          {(ideaGenerationBlocker === "quota_exceeded" ||
+            ideaGenerationBlocker === "failed" ||
+            ideaGenerationBlocker === "premium_required") && !isGeneratingIdeas ? (
+            <div style={{ maxWidth: 340, margin: "0 auto 14px" }}>
+              <RoundBlockerNotice blocker={ideaGenerationBlocker} quotaResetAt={ideaQuotaResetAt} />
+            </div>
+          ) : null}
+          {ideaGenerationBlocker !== "quota_exceeded" ? (
+            <GenerateButton
+              isPro={isPro}
+              isGeneratingIdeas={isGeneratingIdeas}
+              onGenerate={onGenerate}
+              onUpgrade={onUpgrade}
+              label={ideaGenerationBlocker === "failed" ? "Tentar novamente" : "Gerar pautas"}
+            />
+          ) : null}
         </div>
       )}
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
@@ -1782,6 +1782,7 @@ export function DiagnosticoRealShellClient({ data }: Props) {
             whatsappLinked={hydratedData.userInfo.whatsappLinked ?? false}
             isGeneratingIdeas={isGeneratingIdeas}
             ideaGenerationBlocker={ideaGenerationBlocker}
+            ideaQuotaResetAt={ideaQuotaResetAt}
             pautaCollabs={pautaCollabs}
             pautaCollabsLoading={effectiveCollabsBootstrapStatus === "loading"}
             bootstrapStatus={effectiveCollabsBootstrapStatus}


### PR DESCRIPTION
## Problema

Ao concluir uma rodada na aba **Collabs** e tocar em **"Carregar nova rodada"**, a rodada de novos cards não carregava — o botão voltava sozinho e nada acontecia, sem nenhuma explicação.

## Causa

A geração de pautas pode ser bloqueada (cota mensal esgotada, falha transitória, etc.). Nesses casos o shell define `ideaGenerationBlocker`, mas **a aba Collabs só tratava `map_incomplete`** — `quota_exceeded`, `failed` e `premium_required` eram completamente ignorados no estado de rodada concluída. A aba Perfil (`DiagnosticoPage`) já mostrava todos esses blockers; a Collabs não.

Resultado: `isGeneratingIdeas` voltava a `false`, o botão revertia para "Carregar nova rodada" e o usuário não recebia feedback nenhum — parecia que "não carrega".

## Correção

- Novo aviso (`RoundBlockerNotice`) exibido nos estados de rodada concluída e de feed vazio quando há blocker de geração.
- `quota_exceeded`: mostra a mensagem com a data de virada da cota e **esconde o botão de gerar** (tentar de novo não destrava até a virada do mês).
- `failed`: mostra o erro e transforma o CTA em **"Tentar novamente"** (o próprio botão faz o retry).
- `premium_required`: mensagem explicando que é recurso Pro (borda de segurança para Pro).
- Nova prop `ideaQuotaResetAt` encaminhada do shell (`DiagnosticoRealShellClient`) para o feed, espelhando o que a aba Perfil já recebe.

## Arquivos

- `DiagnosticoCollabsFeed.tsx` — aviso de blocker + prop `ideaQuotaResetAt`, integrado a `RoundCompleteActions` e ao estado vazio.
- `DiagnosticoRealShellClient.tsx` — passa `ideaQuotaResetAt` para o feed.
- `DiagnosticoCollabsFeed.stack.test.tsx` — 2 testes novos (falha → "Tentar novamente"; cota → aviso e botão escondido).

## Testes

`npx jest DiagnosticoCollabsFeed.stack.test.tsx` → **25/25 passando** (incluindo os 2 novos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpPL171KEjMufMpcsGMh2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpPL171KEjMufMpcsGMh2T)_