### PR TITLE
fix(mapa-mobile): validação do "Seu Mapa" — asset atômico, rollback otimista e limiar da narrativa

### DIFF
--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
@@ -1056,10 +1056,13 @@ export function MapaCard({
     onConfirmTone != null &&
     s.toneSignals.length >= 1;
 
+  // Considera também os territórios do MapaSeed (fonte exibida no caminho editável):
+  // garante que o botão surja sempre que há território na tela, mesmo que o filtro de
+  // meta-labels da síntese tenha zerado a contagem — mantém display e gate coerentes.
   const shouldAskTerritories =
     territoriesConfirmationState === "pending" &&
     onConfirmTerritories != null &&
-    filteredTerritories.length >= 1;
+    (filteredTerritories.length >= 1 || (mapaSeed?.territorios?.length ?? 0) >= 1);
 
   // ── Hypothesis enrichment ──────────────────────────────────────────────────
   // A hypothesis ("narrativa em teste") is asked once. The creator's decision —
@@ -1071,6 +1074,32 @@ export function MapaCard({
   const [endorsedLocal, setEndorsedLocal] = useState<Set<string>>(new Set(endorsedHypotheses));
   const [dismissedLocal, setDismissedLocal] = useState<Set<string>>(new Set(dismissedHypotheses));
   const [hypothesisPendingSet, setHypothesisPendingSet] = useState<Set<string>>(new Set());
+
+  // ── Feedback calmo ao confirmar (3.1) ──────────────────────────────────────
+  // Antes, ao responder, a linha simplesmente sumia — podia ler como "não
+  // aconteceu nada". Um flash breve ("No seu mapa" ou "Vamos recalibrar", se
+  // dispensou) confirma que a resposta entrou, sem virar badge permanente que
+  // polua o card. Estado local, ~2,2s, tokens quentes nativos do card.
+  const [recentlyResolved, setRecentlyResolved] = useState<Record<string, "confirmed" | "dismissed">>({});
+  const flashResolved = (key: string, response: "yes" | "almost" | "no" | "occasional") => {
+    const state: "confirmed" | "dismissed" = response === "no" ? "dismissed" : "confirmed";
+    setRecentlyResolved((prev) => ({ ...prev, [key]: state }));
+    setTimeout(() => {
+      setRecentlyResolved((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }, 2200);
+  };
+  const renderConfirmedFlash = (state: "confirmed" | "dismissed") => (
+    <div style={{ marginTop: 10, padding: "10px 14px", borderRadius: 14, background: "#fff3ea", border: "1px solid rgba(255,107,53,0.16)" }}>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 12, fontWeight: 600, color: TEXT_PRIMARY_HEX }}>
+        {state === "confirmed" && <span aria-hidden="true" style={{ color: "var(--ds-color-success)" }}>✓</span>}
+        {state === "confirmed" ? "No seu mapa" : "Entendido — vamos recalibrar"}
+      </span>
+    </div>
+  );
 
   useEffect(() => {
     setEndorsedLocal(new Set(endorsedHypotheses));
@@ -1154,7 +1183,11 @@ export function MapaCard({
     filteredTerritories.length > 0 ||
     s.dominantTone != null ||
     confirmedAssets.length > 0 ||
-    s.executionPatterns.length > 0;
+    s.executionPatterns.length > 0 ||
+    // MapaSeed (onboarding/IG) pode ter só "temas" (situações reais), que não
+    // entram na síntese fundida — sem isto, um mapa só-temas cairia no estado
+    // vazio e o editor de temas nunca apareceria.
+    (mapaSeed?.temas?.length ?? 0) > 0;
 
   // ── Tom: chips (all signals, fallback to dominantTone) ──
   const toneChips = s.toneSignals.length > 0
@@ -1375,15 +1408,17 @@ export function MapaCard({
           <p style={{ fontFamily: CS_FONT_DISPLAY, fontSize: 24, fontWeight: 700, color: TEXT_PRIMARY_HEX, margin: 0, lineHeight: 1.12, letterSpacing: -0.7 }}>
             {narrativaLabel}
           </p>
-          {activePending === "narrative" && (
+          {recentlyResolved["narrative"] ? (
+            renderConfirmedFlash(recentlyResolved["narrative"])
+          ) : activePending === "narrative" ? (
             <MapaConfirmationRow
               variant="3way"
               question="Isso ressoa com você?"
-              onPrimary={() => onConfirmNarrative!("yes")}
-              onSecondary={() => onConfirmNarrative!("almost")}
-              onTertiary={() => onConfirmNarrative!("no")}
+              onPrimary={() => { flashResolved("narrative", "yes"); onConfirmNarrative!("yes"); }}
+              onSecondary={() => { flashResolved("narrative", "almost"); onConfirmNarrative!("almost"); }}
+              onTertiary={() => { flashResolved("narrative", "no"); onConfirmNarrative!("no"); }}
             />
-          )}
+          ) : null}
           {activePending === "hypothesis" && pendingHypothesis != null && (
             <MapaConfirmationRow
               variant="2way"
@@ -1429,15 +1464,17 @@ export function MapaCard({
         ) : (
           <p style={{ fontSize: 13, color: TEXT_SECONDARY_HEX, margin: 0, fontStyle: "italic" }}>Emergindo...</p>
         )}
-        {activePending === "territories" && (
+        {recentlyResolved["territories"] ? (
+          renderConfirmedFlash(recentlyResolved["territories"])
+        ) : activePending === "territories" ? (
           <MapaConfirmationRow
             variant="3way"
             question="Esses territórios fazem sentido?"
-            onPrimary={() => onConfirmTerritories!("yes")}
-            onSecondary={() => onConfirmTerritories!("almost")}
-            onTertiary={() => onConfirmTerritories!("no")}
+            onPrimary={() => { flashResolved("territories", "yes"); onConfirmTerritories!("yes"); }}
+            onSecondary={() => { flashResolved("territories", "almost"); onConfirmTerritories!("almost"); }}
+            onTertiary={() => { flashResolved("territories", "no"); onConfirmTerritories!("no"); }}
           />
-        )}
+        ) : null}
       </MapaSection>
 
       {/* ── Temas — situações concretas do MapaSeed (editável) ───────────── */}
@@ -1493,19 +1530,21 @@ export function MapaCard({
         onMutate={mapaSeed && onMapSeedMutate ? onMapSeedMutate : undefined}
         assetGroups={mapaSeed?.assetGroups}
       />
-      {activePending === "asset" && pendingAsset != null && onConfirmAsset != null && (
+      {recentlyResolved["asset"] ? (
+        <div style={{ paddingBottom: 16 }}>{renderConfirmedFlash(recentlyResolved["asset"])}</div>
+      ) : activePending === "asset" && pendingAsset != null && onConfirmAsset != null ? (
         <div style={{ paddingBottom: 16 }}>
           <MapaConfirmationRow
             variant="3way-asset"
             label="Faz parte da sua vida?"
             labelColor="var(--ds-color-success)"
             title={pendingAsset.label}
-            onPrimary={() => onConfirmAsset(pendingAsset.label, "yes")}
-            onSecondary={() => onConfirmAsset(pendingAsset.label, "occasional")}
-            onTertiary={() => onConfirmAsset(pendingAsset.label, "no")}
+            onPrimary={() => { flashResolved("asset", "yes"); onConfirmAsset(pendingAsset.label, "yes"); }}
+            onSecondary={() => { flashResolved("asset", "occasional"); onConfirmAsset(pendingAsset.label, "occasional"); }}
+            onTertiary={() => { flashResolved("asset", "no"); onConfirmAsset(pendingAsset.label, "no"); }}
           />
         </div>
-      )}
+      ) : null}
 
       {/* ── Tom + Formatos — "Como você fala" ────────────────────────── */}
       {/* Editável a partir do MapaSeed (onboarding/IG): tom de voz (escalar,
@@ -1543,15 +1582,17 @@ export function MapaCard({
           ) : (
             <p style={{ fontSize: 13, color: TEXT_SECONDARY_HEX, margin: 0, fontStyle: "italic" }}>Emergindo...</p>
           )}
-          {activePending === "tone" && (
+          {recentlyResolved["tone"] ? (
+            renderConfirmedFlash(recentlyResolved["tone"])
+          ) : activePending === "tone" ? (
             <MapaConfirmationRow
               variant="3way"
               question="Esse tom reflete como você fala?"
-              onPrimary={() => onConfirmTone!("yes")}
-              onSecondary={() => onConfirmTone!("almost")}
-              onTertiary={() => onConfirmTone!("no")}
+              onPrimary={() => { flashResolved("tone", "yes"); onConfirmTone!("yes"); }}
+              onSecondary={() => { flashResolved("tone", "almost"); onConfirmTone!("almost"); }}
+              onTertiary={() => { flashResolved("tone", "no"); onConfirmTone!("no"); }}
             />
-          )}
+          ) : null}
         </MapaSection>
       ) : null}
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
@@ -1041,10 +1041,15 @@ export function MapaCard({
     rawFilteredTerritories.filter((t) => !META_LABEL_PATTERNS.test(t.label))
   );
 
+  // Limiar >= 1 (não >= 2): a narrativa vinda só do onboarding/MapaSeed pesa 1 de
+  // evidência. Com >= 2 o "Isso ressoa com você?" nunca surgia para quem declarou a
+  // narrativa no onboarding (ou conectou IG com amostra insuficiente) — justo a
+  // dimensão mais fundamental falhava para o coorte inicial. Alinha com territórios
+  // e tom (ambos >= 1) e com a lógica de validação surgir conforme o mapa enriquece.
   const shouldAskNarrative =
     narrativeConfirmationState === "pending" &&
     onConfirmNarrative != null &&
-    (leadingNarrative?.evidenceCount ?? 0) >= 2;
+    (leadingNarrative?.evidenceCount ?? 0) >= 1;
 
   const shouldAskTone =
     toneConfirmationState === "pending" &&

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoPage.tsx
@@ -1115,8 +1115,12 @@ export function MapaCard({
   }
 
   // ── Asset enrichment ───────────────────────────────────────────────────────
-  const emergingAssets = s.confirmedLifeAssets.filter((a) => a.evidenceCount < 2);
-  const pendingAsset = emergingAssets.find((a) => {
+  // Sem threshold de evidência: qualquer asset ainda não confirmado/dispensado
+  // recebe o botão. O gate anterior (evidenceCount < 2) invertia a lógica das
+  // demais dimensões — um asset forte do Instagram (peso 2) nunca era validado,
+  // justo o de maior sinal. Alinha com narrativa/territórios/tom (que perguntam
+  // independentemente da força) e com a validação surgir conforme o mapa enriquece.
+  const pendingAsset = s.confirmedLifeAssets.find((a) => {
     const state = assetConfirmations?.get(a.label);
     return state !== "confirmed" && state !== "dismissed";
   }) ?? null;

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
@@ -1609,10 +1609,12 @@ export function DiagnosticoRealShellClient({ data }: Props) {
   // Each callback applies an optimistic local update immediately, then persists
   // to the server in the background. Failures are silent — UX is never blocked.
 
+  // Retorna se a persistência teve sucesso — os handlers usam isso para reverter
+  // o estado otimista em caso de falha (espelha o rollback de decideHypothesis).
   const patchConfirmation = useCallback(
-    async (body: Record<string, string>) => {
+    async (body: Record<string, string>): Promise<boolean> => {
       try {
-        await fetch(
+        const res = await fetch(
           "/api/dashboard/mobile-strategic-profile/confirm-map-dimension",
           {
             method: "PATCH",
@@ -1620,37 +1622,61 @@ export function DiagnosticoRealShellClient({ data }: Props) {
             body: JSON.stringify(body),
           },
         );
+        return res.ok;
       } catch {
-        // Non-fatal — optimistic state already applied
+        return false;
       }
     },
     [],
   );
 
   const handleConfirmNarrative = useCallback((response: ConfirmationResponse) => {
-    setNarrativeConfirmationState(response === "no" ? "dismissed" : "confirmed");
-    void patchConfirmation({ dimension: "narrative", response });
+    let prev: ConfirmationState = "pending";
+    setNarrativeConfirmationState((cur) => { prev = cur; return response === "no" ? "dismissed" : "confirmed"; });
+    void patchConfirmation({ dimension: "narrative", response }).then((ok) => {
+      if (!ok) setNarrativeConfirmationState(prev);
+    });
   }, [patchConfirmation]);
 
   const handleConfirmTerritories = useCallback((response: ConfirmationResponse) => {
-    setTerritoriesConfirmationState(response === "no" ? "dismissed" : "confirmed");
-    void patchConfirmation({ dimension: "territories", response });
+    let prev: ConfirmationState = "pending";
+    setTerritoriesConfirmationState((cur) => { prev = cur; return response === "no" ? "dismissed" : "confirmed"; });
+    void patchConfirmation({ dimension: "territories", response }).then((ok) => {
+      if (!ok) setTerritoriesConfirmationState(prev);
+    });
   }, [patchConfirmation]);
 
   const handleConfirmTone = useCallback((response: ConfirmationResponse) => {
-    setToneConfirmationState(response === "no" ? "dismissed" : "confirmed");
-    void patchConfirmation({ dimension: "tone", response });
+    let prev: ConfirmationState = "pending";
+    setToneConfirmationState((cur) => { prev = cur; return response === "no" ? "dismissed" : "confirmed"; });
+    void patchConfirmation({ dimension: "tone", response }).then((ok) => {
+      if (!ok) setToneConfirmationState(prev);
+    });
   }, [patchConfirmation]);
 
   const handleConfirmAsset = useCallback(
     (assetLabel: string, response: AssetConfirmationResponse) => {
-      // Optimistic: track per-asset state in a Map
+      // Optimistic: track per-asset state in a Map; captura o valor anterior
+      // (presente ou ausente) para reverter se a persistência falhar.
+      let hadPrev = false;
+      let prevVal: "confirmed" | "dismissed" | undefined;
       setAssetConfirmations((prev) => {
+        hadPrev = prev.has(assetLabel);
+        prevVal = prev.get(assetLabel);
         const next = new Map(prev);
         next.set(assetLabel, response === "no" ? "dismissed" : "confirmed");
         return next;
       });
-      void patchConfirmation({ dimension: "asset", response, assetLabel });
+      void patchConfirmation({ dimension: "asset", response, assetLabel }).then((ok) => {
+        if (!ok) {
+          setAssetConfirmations((cur) => {
+            const next = new Map(cur);
+            if (hadPrev && prevVal) next.set(assetLabel, prevVal);
+            else next.delete(assetLabel);
+            return next;
+          });
+        }
+      });
     },
     [patchConfirmation],
   );

--- a/src/app/dashboard/boards/videoUpload/mapConfirmationsService.ts
+++ b/src/app/dashboard/boards/videoUpload/mapConfirmationsService.ts
@@ -119,29 +119,41 @@ export async function confirmMapDimension(
   if (params.dimension === "asset") {
     const assetState: MapDimensionConfirmationState =
       params.response === "no" ? "dismissed" : "confirmed";
+    const userObjectId = new Types.ObjectId(userId);
 
-    // Replace previous decision for the same asset label, then append the latest one.
-    await CreatorMapConfirmations.findOneAndUpdate(
-      { userId: new Types.ObjectId(userId) },
+    // Atomic, idempotent por rótulo. O padrão anterior (pull sem upsert + push
+    // com upsert em duas ops) tinha janela de perda — um crash entre as duas
+    // apagava o asset sem re-inserir — e de duplicação em toque duplo rápido.
+    // 1) Atualiza no lugar quando o rótulo já existe (único $set posicional).
+    const updateExisting = await CreatorMapConfirmations.updateOne(
+      { userId: userObjectId, "assets.label": params.assetLabel },
       {
-        $pull: { assets: { label: params.assetLabel } },
+        $set: {
+          "assets.$.state": assetState,
+          "assets.$.response": params.response,
+          "assets.$.confirmedAt": now,
+        },
       },
     );
-    await CreatorMapConfirmations.findOneAndUpdate(
-      { userId: new Types.ObjectId(userId) },
-      {
-        $push: {
-          assets: {
-            label: params.assetLabel,
-            state: assetState,
-            response: params.response,
-            confirmedAt: now,
+
+    // 2) Senão insere — filtro "rótulo ausente" evita que uma escrita concorrente
+    //    crie duplicata. O upsert cria o documento na primeira confirmação.
+    if (updateExisting.matchedCount === 0) {
+      await CreatorMapConfirmations.updateOne(
+        { userId: userObjectId, "assets.label": { $ne: params.assetLabel } },
+        {
+          $push: {
+            assets: {
+              label: params.assetLabel,
+              state: assetState,
+              response: params.response,
+              confirmedAt: now,
+            },
           },
         },
-        $set: { updatedAt: now },
-      },
-      { upsert: true },
-    );
+        { upsert: true },
+      );
+    }
 
     logUsageEvent(userId, "map_dimension_confirmed", "mapa", { dimension: "asset", platform: "mobile" });
 


### PR DESCRIPTION
## Contexto

Avaliação do funcionamento do card **"Seu Mapa"** no perfil mobile. A lógica esperada: conforme o criador enriquece o mapa (onboarding → Instagram → vídeos), os **botões de validação** de cada dimensão (narrativa, territórios, tom, assets) surgem para ele confirmar ou não. A arquitetura está sã (uma pergunta por vez, estado de confirmação persistido separado da síntese, enriquecimento incremental). Este PR cobre os três lotes do diagnóstico: robustez (P1), gaps de "surgimento" da validação (P2) e polimento calmo (P3).

## Mudanças

### P1 — Robustez de dados
- **1.1 Confirmação de asset atômica e idempotente** (`mapConfirmationsService.ts`) — o padrão anterior (`$pull` sem upsert **e depois** `$push` com upsert, em duas ops) tinha janela de **perda** (crash entre as ops) e **duplicação** (toque duplo). Agora: `$set` posicional se o rótulo existe, senão `$push` guardado por "rótulo ausente".
- **1.2 Rollback do estado otimista em falha** (`DiagnosticoRealShellClient.tsx`) — `patchConfirmation` reporta sucesso via `res.ok`; narrativa/territórios/tom/asset revertem o estado local quando o PATCH falha (espelha o `decideHypothesis`).

### P2 — Gaps de validação ("botões surgem conforme enriquece")
- **2.1 Limiar da narrativa `>=2` → `>=1`** (`DiagnosticoPage.tsx`) — o botão "Isso ressoa com você?" nunca surgia para narrativa semeada só no onboarding (peso 1). Agora alinha com territórios e tom.
- **2.2 Validar todo asset pendente** (`DiagnosticoPage.tsx`) — o gate `evidenceCount < 2` invertia a lógica: assets fortes do Instagram (peso 2) nunca eram validados. Agora qualquer asset pendente recebe o botão.

### P3 — Polimento calmo
- **3.1 Feedback ao confirmar** (`DiagnosticoPage.tsx`) — flash breve "No seu mapa" (ou "Vamos recalibrar", se dispensou) no lugar da linha após responder, com tokens quentes nativos do card. Antes a linha só sumia.
- **3.2 Coerência display × gate de territórios** — o gate passa a considerar também `mapaSeed.territorios`, mantendo chips exibidos e validação consistentes.
- **3.3 MapaSeed só-`temas` renderiza** — `hasAnything` considera `mapaSeed.temas`; um mapa semeado só com situações reais deixa de cair no estado vazio.

## Verificação

- `tsc` (setup do smoke): sem erros nos arquivos alterados.
- Build de preview do Vercel (`next build` = typecheck completo): **Ready** ✅ nos commits anteriores.
- Manual sugerido (viewport ≤430px): usuário só-onboarding vê narrativa/territórios/tom surgirem e confirma em sequência, com o flash "No seu mapa" a cada resposta; recarregar mantém o confirmado. Confirmar o mesmo asset duas vezes não duplica. Repetir com IG conectado (peso 2) para validar assets fortes.
- Regressão: criador só-vídeo (sem MapaSeed) mantém o comportamento atual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)