### PR TITLE
Launch mobile weekly profile experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,8 @@ VIDEO_NARRATIVE_GEMINI_ALLOWED_USER_IDS=
 
 # Diagnóstico V2 UX (Apple Health-style page — replaces old Perfil shell when =1)
 DIAGNOSTICO_V2_ENABLED=0
+# Nova experiência editorial do Perfil mobile. Use 0 para rollback imediato.
+MOBILE_PROFILE_WEEKLY_REPORT_EXPERIENCE_ENABLED=1
 
 # ── PRODUCTION LAUNCH FLAGS (all three must be "1" / "true" in production) ──
 # Enables Gemini as the video analysis provider (vs. mock/stub)

--- a/docs/prototipos/perfil-mobile-v9.html
+++ b/docs/prototipos/perfil-mobile-v9.html
@@ -1,0 +1,1149 @@
+<title>D2C — Protótipo do Perfil no celular</title>
+<style>
+  :root{
+    --cream:#FBF6F0; --paper:#FFFFFF; --ink:#141013; --ink-2:#4A423E; --ink-3:#8A807A;
+    --line:#E4DAD0; --line-2:#F0E7DE;
+    --accent:#E5175A; --up:#12734A; --down:#C31E52;
+    --stage:#EFE7DE; --chip:#F3ECE4; --shadow:0 1px 2px rgba(20,16,19,.05),0 12px 34px rgba(20,16,19,.10);
+  }
+  @media (prefers-color-scheme: dark){
+    :root{
+      --cream:#15110F; --paper:#1C1815; --ink:#F7F0E8; --ink-2:#C3B7AC; --ink-3:#8C817A;
+      --line:#332C27; --line-2:#241F1B;
+      --accent:#FF3E76; --up:#43BE87; --down:#FF5C80;
+      --stage:#0C0A09; --chip:#26201C; --shadow:0 1px 2px rgba(0,0,0,.4),0 16px 40px rgba(0,0,0,.55);
+    }
+  }
+  :root[data-theme="light"]{
+    --cream:#FBF6F0; --paper:#FFFFFF; --ink:#141013; --ink-2:#4A423E; --ink-3:#8A807A;
+    --line:#E4DAD0; --line-2:#F0E7DE;
+    --accent:#E5175A; --up:#12734A; --down:#C31E52;
+    --stage:#EFE7DE; --chip:#F3ECE4; --shadow:0 1px 2px rgba(20,16,19,.05),0 12px 34px rgba(20,16,19,.10);
+  }
+  :root[data-theme="dark"]{
+    --cream:#15110F; --paper:#1C1815; --ink:#F7F0E8; --ink-2:#C3B7AC; --ink-3:#8C817A;
+    --line:#332C27; --line-2:#241F1B;
+    --accent:#FF3E76; --up:#43BE87; --down:#FF5C80;
+    --stage:#0C0A09; --chip:#26201C; --shadow:0 1px 2px rgba(0,0,0,.4),0 16px 40px rgba(0,0,0,.55);
+  }
+
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:var(--stage); color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  .display{font-weight:800; letter-spacing:-.032em; line-height:1.08}
+  .num{font-variant-numeric:tabular-nums; font-weight:800; letter-spacing:-.03em}
+
+  .page{max-width:1180px; margin:0 auto; padding:40px 22px 80px}
+  .intro{max-width:62ch; margin:0 auto 34px; text-align:center}
+  .intro .kicker{font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--accent); font-weight:800}
+  .intro h1{font-size:clamp(30px,5.4vw,50px); margin:12px 0 14px}
+  .intro p{color:var(--ink-2); font-size:16px; line-height:1.6; margin:0 auto}
+  .warn{
+    margin:22px auto 0; max-width:62ch; border:1px solid var(--line); border-radius:12px;
+    background:var(--paper); padding:12px 16px; font-size:13.5px; color:var(--ink-2); line-height:1.55; text-align:left
+  }
+  .warn b{color:var(--ink)}
+
+  .stagegrid{display:flex; gap:44px; align-items:flex-start; justify-content:center; flex-wrap:wrap}
+
+  .phone{
+    width:392px; height:812px; flex:0 0 auto; position:relative;
+    background:var(--cream); border-radius:44px; box-shadow:var(--shadow);
+    border:1px solid var(--line); overflow:hidden; display:flex; flex-direction:column;
+  }
+  .statusbar{
+    height:44px; flex:0 0 auto; display:flex; align-items:center; justify-content:space-between;
+    padding:0 26px; font-size:12px; font-weight:700; color:var(--ink-2)
+  }
+  .viewport{flex:1 1 auto; overflow-y:auto; overflow-x:hidden; position:relative; scroll-behavior:smooth}
+  .viewport::-webkit-scrollbar{width:0}
+  .screen{display:none; padding:0 18px 26px}
+  .screen.active{display:block; animation:slidein .2s ease}
+  @keyframes slidein{from{opacity:0; transform:translateX(10px)} to{opacity:1; transform:none}}
+  @media (prefers-reduced-motion:reduce){ .screen.active{animation:none} .viewport{scroll-behavior:auto} }
+
+  .eyebrow{font-size:10.5px; letter-spacing:.15em; text-transform:uppercase; font-weight:800; color:var(--accent)}
+  .eyebrow.quiet{color:var(--ink-3)}
+  .card{background:var(--paper); border:1px solid var(--line); border-radius:18px; padding:18px; margin-top:14px}
+  .rule{height:1px; background:var(--line-2); margin:15px 0}
+  .body{color:var(--ink-2); font-size:14.5px; line-height:1.55}
+  .body.strong{color:var(--ink); font-weight:600}
+
+  .chip{
+    display:inline-flex; align-items:center; background:var(--chip); color:var(--ink-2);
+    border-radius:999px; padding:3px 9px; font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase
+  }
+  .chip.trend{color:var(--up); background:color-mix(in srgb, var(--up) 12%, transparent)}
+  .chip.week{color:var(--accent); background:color-mix(in srgb, var(--accent) 12%, transparent)}
+
+  .mult{font-size:15px}
+  .mult.up{color:var(--up)} .mult.down{color:var(--down)}
+
+  .btn{
+    -webkit-appearance:none; appearance:none; font:inherit; cursor:pointer;
+    border:1px solid var(--ink); background:var(--ink); color:var(--cream);
+    border-radius:999px; padding:11px 16px; font-size:13.5px; font-weight:700; letter-spacing:-.01em;
+    display:inline-flex; align-items:center; gap:7px; transition:transform .12s ease
+  }
+  .btn:active{transform:scale(.97)}
+  .btn.ghost{background:transparent; color:var(--ink); border-color:var(--line)}
+  .btn.on{background:var(--up); border-color:var(--up); color:#fff}
+  .btn:focus-visible, .row:focus-visible, .tab:focus-visible, .back:focus-visible{outline:2px solid var(--accent); outline-offset:3px}
+  .btnrow{display:flex; gap:8px; flex-wrap:wrap; margin-top:14px}
+
+  /* ---------- ranking ---------- */
+  .rank{margin-top:6px}
+  .ritem{display:flex; gap:12px; padding:12px 0; border-bottom:1px solid var(--line-2)}
+  .ritem:last-child{border-bottom:0}
+  .pos{
+    flex:0 0 24px; height:24px; border-radius:50%; background:var(--chip); color:var(--ink-2);
+    display:flex; align-items:center; justify-content:center; font-size:11.5px; font-weight:800;
+    font-variant-numeric:tabular-nums; margin-top:2px
+  }
+  .ritem.first .pos{background:var(--ink); color:var(--cream)}
+  .rbody{flex:1 1 auto; min-width:0}
+  .rtop{display:flex; align-items:baseline; justify-content:space-between; gap:12px}
+  .rname{font-size:15px; font-weight:600; letter-spacing:-.01em}
+  .rname.quote{font-size:14.5px; line-height:1.4}
+  .rmeta{margin-top:4px; font-size:11.5px; color:var(--ink-3)}
+  .more{font-size:12px; color:var(--ink-3); padding-top:11px}
+  .weekline{margin-top:13px; padding-top:12px; border-top:1px solid var(--line-2); font-size:12.5px; color:var(--ink-2); line-height:1.5}
+  .weekline b{color:var(--accent)}
+
+  .row{
+    display:flex; align-items:center; gap:12px; width:100%; text-align:left; font:inherit; color:inherit;
+    background:none; border:0; border-top:1px solid var(--line-2); padding:15px 0; cursor:pointer
+  }
+  .row:first-of-type{border-top:0}
+  .row .grow{flex:1 1 auto; min-width:0}
+  .row .t{font-size:15.5px; font-weight:700; letter-spacing:-.015em}
+  .row .s{font-size:13px; color:var(--ink-2); margin-top:4px; line-height:1.5}
+  .row .arrow{color:var(--ink-3); font-size:19px; flex:0 0 auto}
+
+  .hero{position:relative; border-radius:18px; overflow:hidden; border:1px solid var(--line); background:#000}
+  .hero img{display:block; width:100%; height:290px; object-fit:cover; opacity:.95}
+  .hero .play{
+    position:absolute; left:12px; top:12px; background:rgba(0,0,0,.62); color:#fff;
+    border-radius:999px; padding:5px 11px; font-size:10.5px; font-weight:800; letter-spacing:.12em
+  }
+
+  /* faixa de números do vídeo */
+  .stats{display:flex; margin-top:14px; border-top:1px solid var(--line-2); border-bottom:1px solid var(--line-2)}
+  .stat{flex:1 1 0; padding:13px 0; display:flex; flex-direction:column; gap:2px}
+  .stat + .stat{border-left:1px solid var(--line-2); padding-left:16px}
+  .stat .v{font-size:29px; line-height:1; color:var(--ink)}
+  .stat .v.up{color:var(--up)}
+  .stat .k{font-size:11.5px; color:var(--ink-3); font-weight:600}
+
+  /* blocos deu certo / não deu certo / na próxima */
+  .blocks{display:flex; flex-direction:column; gap:15px; margin-top:16px}
+  .blk .lbl{
+    display:inline-block; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; font-weight:800;
+    border-radius:999px; padding:4px 10px; margin-bottom:7px
+  }
+  .lbl.ok{color:var(--up); background:color-mix(in srgb, var(--up) 12%, transparent)}
+  .lbl.bad{color:var(--down); background:color-mix(in srgb, var(--down) 12%, transparent)}
+  .lbl.next{color:var(--cream); background:var(--ink)}
+
+  /* valor à direita das linhas de ranking */
+  .rv{flex:0 0 auto; font-size:16px; text-align:right; line-height:1.15}
+  .rv.up{color:var(--up)}
+
+  h2.headline{font-size:22px; margin:12px 0 0; text-wrap:balance}
+  h3.sub{font-size:17px; margin:0 0 6px; text-wrap:balance}
+
+  .note-box{font-size:12.5px; color:var(--ink-2); line-height:1.55; background:var(--chip); border-radius:12px; padding:12px 13px; margin-top:12px}
+  .note-box b{color:var(--ink)}
+
+  /* seu mapa */
+  .mapnarr{font-size:19px; margin:11px 0 0; text-wrap:balance; line-height:1.25}
+  .terr{display:flex; gap:7px; flex-wrap:wrap; margin-top:9px}
+  .terrchip{
+    display:inline-flex; align-items:center; gap:5px; border-radius:999px;
+    padding:6px 12px; font-size:13px; font-weight:600; letter-spacing:-.01em
+  }
+  .terrchip.on{background:color-mix(in srgb, var(--up) 13%, transparent); color:var(--up)}
+  .terrchip.on b{font-weight:800}
+  .terrchip.off{background:var(--chip); color:var(--ink-3)}
+
+  .phead{display:flex; align-items:center; gap:13px; padding:10px 0 2px}
+  .phead img.pic{width:60px; height:60px; border-radius:50%; object-fit:cover; border:1px solid var(--line); flex:0 0 auto}
+  .phead .pic.initials{
+    width:60px; height:60px; border-radius:50%; flex:0 0 auto; display:grid; place-items:center;
+    background:var(--chip); color:var(--ink-3); font-size:19px; font-weight:800; letter-spacing:-.02em
+  }
+  .phead .grow{flex:1 1 auto; min-width:0}
+  .phead .n{font-size:21px; font-weight:800; letter-spacing:-.03em; line-height:1.1}
+  .phead .d{font-size:12.5px; color:var(--ink-3); margin-top:3px}
+  .gear{
+    width:44px; height:44px; border-radius:50%; border:0; background:transparent; cursor:pointer;
+    display:grid; place-items:center; flex:0 0 auto; padding:0
+  }
+  .gear span{
+    width:36px; height:36px; border-radius:50%; background:var(--accent); color:#fff;
+    display:grid; place-items:center; box-shadow:0 8px 22px color-mix(in srgb, var(--accent) 30%, transparent)
+  }
+
+  /* mídia kit + calculadora */
+  .panel{background:var(--paper); border:1px solid var(--line); border-radius:18px; margin-top:14px; overflow:hidden}
+  .prow{
+    display:flex; align-items:center; gap:12px; width:100%; text-align:left; font:inherit; color:inherit;
+    background:none; border:0; border-top:1px solid var(--line-2); padding:14px 16px; cursor:pointer
+  }
+  .prow:first-child{border-top:0}
+  .prow .ico{
+    width:44px; height:44px; border-radius:12px; flex:0 0 auto; display:grid; place-items:center;
+    background:color-mix(in srgb, var(--accent) 12%, transparent); color:var(--accent); font-size:19px
+  }
+  .prow .grow{flex:1 1 auto; min-width:0}
+  .prow .t{font-size:16px; font-weight:700; letter-spacing:-.02em}
+  .prow .s{font-size:12px; color:var(--ink-3); margin-top:2px}
+  .prow .arrow{color:var(--ink-3); font-size:18px; flex:0 0 auto}
+  .prow .val{font-size:16px; font-weight:800; letter-spacing:-.02em; color:var(--ink)}
+
+  .heroLink{display:block; text-decoration:none; color:inherit; margin-top:11px}
+  .watch{display:flex; align-items:center; justify-content:center; gap:7px; margin-top:10px; font-size:13px; font-weight:700; color:var(--accent)}
+
+  .back{background:none; border:0; font:inherit; color:var(--ink-2); font-size:13.5px; font-weight:700; padding:10px 0; cursor:pointer}
+
+  .tabbar{
+    flex:0 0 auto; height:74px; border-top:1px solid var(--line); background:var(--paper);
+    display:flex; align-items:center; justify-content:space-around; padding:0 14px 12px
+  }
+  .tab{background:none; border:0; font:inherit; cursor:pointer; color:var(--ink-3); font-size:11px; font-weight:700;
+    display:flex; flex-direction:column; align-items:center; gap:5px; padding-top:12px}
+  .tab.active{color:var(--ink)}
+  .tab .ic{font-size:17px; line-height:1}
+  .plus{width:48px; height:48px; border-radius:50%; background:var(--accent); color:#fff; border:0; font-size:26px; cursor:pointer;
+    display:flex; align-items:center; justify-content:center; margin-top:6px; box-shadow:0 6px 18px color-mix(in srgb, var(--accent) 40%, transparent)}
+
+  .notes{flex:1 1 330px; max-width:430px; min-width:300px}
+  .notes h2{font-size:20px; margin:0 0 6px; letter-spacing:-.02em}
+  .note{border-top:1px solid var(--line); padding:18px 0}
+  .note:first-of-type{border-top:0}
+  .note h3{font-size:15px; margin:0 0 6px; letter-spacing:-.01em}
+  .note p{margin:0; font-size:14px; line-height:1.6; color:var(--ink-2)}
+  .note .tag{font-size:10.5px; letter-spacing:.14em; text-transform:uppercase; font-weight:800; color:var(--accent); display:block; margin-bottom:7px}
+
+  /* alternador de estado */
+  .switcher{display:flex; gap:6px; background:var(--paper); border:1px solid var(--line); border-radius:999px; padding:5px; margin:0 auto 18px; width:fit-content}
+  .swbtn{
+    border:0; background:none; font:inherit; cursor:pointer; border-radius:999px;
+    padding:9px 16px; font-size:13.5px; font-weight:700; color:var(--ink-3); letter-spacing:-.01em
+  }
+  .swbtn.active{background:var(--ink); color:var(--cream)}
+  .swbtn:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+
+  /* estado zero */
+  .steps{display:flex; flex-direction:column; gap:0; margin-top:14px}
+  .step{display:flex; gap:12px; padding:14px 0; border-top:1px solid var(--line-2)}
+  .step:first-child{border-top:0; padding-top:4px}
+  .stepn{
+    flex:0 0 26px; height:26px; border-radius:50%; display:grid; place-items:center;
+    font-size:12px; font-weight:800; background:var(--accent); color:#fff
+  }
+  .step.later .stepn{background:var(--chip); color:var(--ink-3)}
+  .step .t{font-size:15.5px; font-weight:700; letter-spacing:-.015em}
+  .step .s{font-size:13px; color:var(--ink-2); margin-top:3px; line-height:1.45}
+
+  .lockrow{display:flex; align-items:center; gap:12px; padding:14px 0; border-top:1px solid var(--line-2)}
+  .lockrow:first-child{border-top:0}
+  .lockrow .grow{flex:1 1 auto; min-width:0}
+  .lockrow .t{font-size:15px; font-weight:700; letter-spacing:-.015em; color:var(--ink-2)}
+  .lockrow .s{font-size:12.5px; color:var(--ink-3); margin-top:3px; line-height:1.45}
+  .lockrow .lk{flex:0 0 auto; color:var(--ink-3); font-size:15px}
+
+  .example{background:var(--chip); border:1px solid var(--line-2); border-radius:14px; padding:14px; margin-top:12px}
+  .exrow{display:flex; justify-content:space-between; gap:12px; padding:7px 0; font-size:14px}
+  .exrow + .exrow{border-top:1px solid var(--line)}
+
+  /* avisos do exemplo — parte da rolagem, não faixas fixas */
+  .demoonly{display:none}
+  body.demo .demoonly{display:block}
+  body.demo .terr.demoonly, body.demo .panel.demoonly{display:flex}
+  body.demo .panel.demoonly{display:block}
+  body.demo .hideondemo{display:none}
+
+  .demonote{
+    background:color-mix(in srgb, var(--accent) 8%, var(--paper));
+    border:1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  }
+  .demotag{
+    display:none; margin-left:7px; border-radius:999px; padding:2px 8px;
+    background:color-mix(in srgb, var(--accent) 14%, transparent); color:var(--accent);
+    font-size:9.5px; letter-spacing:.1em
+  }
+  body.demo .demotag{display:inline-block}
+
+  /* capa neutra do vídeo na demonstração */
+  .heroghost{
+    display:none; height:290px; border-radius:18px; border:1px solid var(--line);
+    background:var(--chip); place-items:center; text-align:center; padding:20px
+  }
+  .heroghost span{font-size:13px; color:var(--ink-3); font-weight:600; line-height:1.5}
+  body.demo .heroghost{display:grid}
+  body.demo .heroLink{display:none}
+
+  .toast{
+    position:fixed; left:50%; bottom:26px; transform:translateX(-50%) translateY(20px);
+    background:var(--ink); color:var(--cream); padding:11px 18px; border-radius:999px; font-size:13.5px; font-weight:600;
+    opacity:0; pointer-events:none; transition:opacity .2s, transform .2s; z-index:50
+  }
+  .toast.show{opacity:1; transform:translateX(-50%) translateY(0)}
+</style>
+
+<div class="page">
+  <div class="intro">
+    <div class="kicker">Protótipo · versão 9 · dados reais de 6 de agosto</div>
+    <h1 class="display">O relatório da Débora, dentro do celular dela.</h1>
+    <p>Dois estados: quem já assina e conectou o Instagram, e quem acabou de criar a conta. No estado completo: um vídeo em destaque no topo e, embaixo, os rankings dos últimos 90 dias: dia, horário, cena, assuntos e as frases de abertura. Todos os números são os do relatório desta semana.</p>
+    <div class="warn"><b>É uma maquete.</b> Nada aqui atualiza sozinho e nenhum botão salva de verdade. Serve para você tocar, discordar e a gente ajustar.</div>
+  </div>
+
+  <div class="switcher">
+    <button class="swbtn active" id="sw-full" onclick="setMode('full')">Assinante, Instagram conectado</button>
+    <button class="swbtn" id="sw-zero" onclick="setMode('zero')">Ainda não conectou nem assinou</button>
+  </div>
+
+  <div class="stagegrid">
+    <div class="phone">
+      <div class="statusbar"><span>9:41</span><span>D2C</span></div>
+
+      <div class="viewport" id="vp">
+
+        <!-- ===================== PERFIL ===================== -->
+        <section class="screen active" id="s-perfil">
+          <div class="phead">
+            <img class="pic" id="pavatar" src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QBMRXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAeKADAAQAAAABAAAAeAAAAAD/wAARCAB4AHgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAI/9oADAMBAAIRAxEAPwD96KKKK4zsCiiigAooooAKKKKACiiigAooooAKKKKACiiigD//0P3oooorjOwKKK8B/aK/aT+GP7MngkeMviPf+U105gsLKMF7m8nxnbGgydqjl3PCjryQC0ribPZdf8Q6H4V0qfXPEd9Fp1hbDMk0zBVHt7k9gMk9q+QvEn7bnw5stRTT/DUUl/A2Q95KrxxIR6R7fMYHt0r8evin+3d4X+LGuPqfivWrloUJ+z2kVvILa3U9Ai9z6scsfWvK2/aV+EXT7bc/+Az1vGj3OadbsfrD8Q/20PFF1Z3Fr4Fv0t7iRsxzCFQqKvbDoxJY+v5189+J/wBq/wDaKt3/AOKV8Wz3DKIzmSC3EZbneMNHnHTHQ18Nv+0x8IgOLq6OPS2au+8FfE7wZ41t7rVNFiurq3s5I4ghhKNPPKf3cMefvMepx0HXtSqyUIuTJpUp1JKMXqfY/gb9tT9qLRbqO98cSaPqGjhcv9qt/LkYZPKG3KnPQDPy195/Dn9tD4U+Mre1XxHJJ4XurrAQ3YzbOemVlX7oJ6bwv9a+QPBn7N66np8XiT4uI7zTqGTTLdtsNuh6K7A5d/7x6dhXhn7QHw0tNC1KHVfC/wC70wqsCwMT+7OMAc9Vbp046ivl1nadTlufcQ4YcaPM9X+J+9cE8NzDHc20izQyqHR0IZWVhkFSOCCOhFS1+Gf7J37S/wATPAOrQ/D6O2uPFWiGYCPTsr9ohjkyWa3dyoGzDEoTtOOxOa/cGwvbfUrOG+tSTHMoYZ4Iz2I7EdCK92lU5o3PmK1PklyluiiitDIKKKKAP//R/eiiiiuM7DmPGnjHw58PfCereN/F14tho2iW73V1O/RI0Hb1JOAo6kkAV/Jv+0v8ddf/AGmfiTqHxG19EGn+YbXS7Z9xS0tFyUiQEcucbpGA5c+mK/XX/grL8Uruy8E+GfgXo02yfxVI+pX4B25tLFl8pCfR5SW/7Z46GvxDn0DT7e2PlQnnk7mLY69MnjqelVZqzRhUknoy/wDCz4Y2Hxc8Vab4EkuItIg1Dcj3KQiRlMYLggErnO3HUVh/Ej4QWnw68War4Zub5pDp8gVWdEV5IyMrJtXcAGHbORkVc8A6tdaP8QtEsF4tpfMwEX5i2xgQMc9as/EuS6uvFF7NqELwbcYEgIcrgbWx16V0xfuXvrc8ys2p26WPD73w/DJDI0JaRwGK5AGMflxX65/sc/C7Sn1/QdMnYbfDWnPrMpYZU3143lwbv9xMkD2r80/DGipreqW1jKS32qQoAv3jnjAz0zX6j/s/Sz6z4i8a+B/D90bG9EenYmA+YQQrICB67CwBHXmvmuIcVJU1GP8AXQ+04MwsZ1+ae39M9v0zwx8fdL+IOta1rGsA+F7SKSU4lLpJtGVyhZtrE8fKR7ivmbx9+0He+IIr3w54o0v+zp0Qvbur5Z9p7qVHp2JPtX0V441rV/CfhlNN0XVY7dRgamtq7TyOw+9vimAbn1VmOOlfN/xW8ceF5vh69zPpcR1RIMJcPCUlcNwDhgCCfoDXzUqbU06sd9rH6ZWp8kHGErJa69j54/4Sq/TVb670m6ksrieFzBJCxjdWYKylWHIJ+bkV9J/sMftg+Kfhp8Trfwz8SPEdzqfg/wAUyLbztfyNJ9huTxFOjMSVUnCyDONp3Hlc1+fPh3XJ77w+t+hLy2aSq7evlNx9eDiuS1i41K01S9tLPFvDHK2ZMj5Qe3sfSvrsvbjzRkfkecrWNSB/bOCCMg5Bor4u/YD+MVz8ZP2afD2oaxd/bNc8Ol9G1Bz94yWmPKZvdoGjY/rzX2jXonJF3VwooooGf//S/eiiiiuM7D+bP/gpB4rbXf2r9RtHmDxeHrOGyROpQmBJG468s5NfGWxriISKdyOARxg4NfQH/BQKz1Gz/a++IGoKuFaSB4yRwdtvAfx6V4TZx3QtV3D+Efd7Hvit42sedUepxWnGXTviLotyqbjDvKo3Rvlbjn1rU+ImuN4j1ZNXkhijaaMIfKDKoEfygYJxnI5xWR4psr9fEejXRVhFMWXcOoIVnXkYPaup0bwq/jSPw/4ajPlalNctC5ORiN5cmRs8YCZPXtWUp8q1elyKlLmaa3tb8S98FNJNvfSeO9ZVU0vSmKrIThXmf5do9cKTmvtn9l/XtOS38T/ECwuUe/huXTzGOxWk27mUbsfL8/XpXxn8a9OfTPEdzpemK9p4c8MiK2srRflUybR8z4yXZ3yzEjJJxTfhD8GrTXdYi1Lx5d4trfbI1kGbDEjcDKVOFBP8BwT3ArxswwcasZVKk7H12UYuWHlGnThf8Ne/ofYXxp/aL03S5Y/t+hQXWrsu4PZsJMe5xx+Zr81vin8WvF3xJu/s7KbCwhbd5Sk7mYfxO2BnHp0FfoPrvgvwncL59vCm5hiNEXaiqo7KuOAB9Pevm3XvhXbanvn0qaORZHBZThGIz056CuXL6dKn7/LfzZ6mb43EYhcjnp2RN8JPAaXXwnkvDHzdRTxq3/TRzkZ+uKpaj+zZ+0R4tnOq+HvBF9e6XfhZYZk8vbKjKCr/ADMOK+vPA/gm98D/AAURdRiUxalM72nOd0QJyfb5sgV+lX7Mupf2x8EvCk78yQ272zfWCRo/5AV35fLnrTv6nzuZ07UYHkP/AASx8AfF74XQ+PvDPxH8O3Oh2GoGyvbTz/L2GaPzIpduxmOWUx5z/dFfrtXk/wAPFIv7ojoIgPx3CvWK9SUbOx51H4QoooqTU//T/eiiiiuM7D+fD/gqL4R1zTfjdFrW03Wn67YRTW8CqqkyRRmOQBxySSnTPfjtXx1F4dmkEz2q+VEmwqBkkq4JHf0HNf0I/tifs7aD8dvCWk3+pyTwXPheeSdXttvmPBOmyRCSDwDtf2wfWvyp8eeFPA3gvVpPDsH2yW/tIU3ST5CyISrAggAMQueQPXuOfHzTNlhY6LXcmrg5ezdZ2tex88x/D6WS1gvFjS6WKOYoXUMA+CBlf+BE/QV2fhzSfD3wc8KXfxK8fNbxXMzYsbeOECafGPlRM5+ZucnGQOuAa1dS8b6H4Q8PvqFzYbo182GK3LkPNMW+QZbkKc5JxwoY18s67qeufFHxRDNrc6zXl1IkEbOCtvax9AqIoO1FHXAJPU5NTwzjMRiHPEVVaC2v18/l/Wxx2Tsi1a3158bdS0fwzFI1hq+q3s0t4d3lwvCuHDFwc/Ku4AdyetfVutafpejW1tpthBHHbQvHaRRIMI9xJgbyepEY9c5OM1Q+Gvgrw14E0KW902WPU9VvE/0i92kZAPEcQbBWPv0y3Uiud8cXkg8W+FdPnZkRjLMT0VmxwTjg4FfXU8LBR2unqayrzve+qO11HxXa+HtGUWVsGublgUDfNiPds3Oc8k44BriLzxHdzSRadqSJeIg3To6DBB5AGAccHjgc1wVlrA1W7vfEt6+6whkaG1hJwJTD8qk+oJBwAPWobKe5uJJry9BH2jO9nBIA7fMBjqB6VrZWskZOTbuz6ftVt7j4XW/kTnZpF8sUNuXyBa3Cs/3eufMz7V91fswT2mifCjTdKuJ1WUS3UoVjghHuHx/j+NflJoPiBI2/scyOY4oZpQFySZIiCvy89Nx/CsjSfGPi8a3babZapdl52WGBYZWy7MQERAp7nAA6596+MzPHxweKb5bpo6q+LToRg97n9KfwwIuLK6vQPvFFB7HK7+D34YV6lXkfwJ8B6p8NvhVoHhPXr2TUNVt4TJdzysXdppWLsuTnhMhB2wOK9cr2VNySbVioxsrBRRRTKP/U/eiiiiuM7BrokiNHIoZHBVgeQQeCDXxF8W/hFpFvdtBqWmJqGkXLEwM65MZI5j3DDAjoOeR+Nfb9UdS02x1eyk0/UoRPbyjDK36EehHY15+Y5fHEQ5Xv0O/AY32MtVeL3R/KF+1Dq+ix/G7VvBvhxmXS/DUUaeWzllF3OoaYg/7IAXn35qT4DaW974mn1ptzw6VEAnGR50+VGPou4/lXsv7Zn7CPxh+EvxG8RfFvwrBL4r8B6vJJdSz267rrTt5zsuIRliiE8SqCuOW2nNea/BDSJV8GR68t49kby7Ykr92VIiAFJ5wMr6V7eAoKlRjTgtjx67TqSdrI991B7X7VHoSt5EUKea5cYJPBGMDkg8AelfNPxP15NQ8VrcWEjNbWMbxKWwMttO4juQDx7muk8QeNnvLq9jVHWeaVVQ9FGDjdnvxzgGvMtQFpOJbsy7FTnnnIUHqccfTvXoTn0MrG14Q0oTeHLKKSbasUSsybcszuS2SWwAPSumguhFuRLczbNuDJjA54Ax6mrWlGyTSrWK4kInSOMs0QAwSMDK4yTyMc06b7LPJ/ZmnRTX185CxRKpaSViegVclixwOPbiotYVjN0rQfEviDXTe6FbtctbbvMZW2Y37Qp+b5eoI29x1r9G/2E/2QtZm8aD45/E3TJNPsdLlL6HYTlWMs+CpuGHOEi/5Z56tz0Xn039kn9jvW7TQ4fFnxgtZNKF5J56aPu2ysnGz7QVPyDH/LP73PzY6H9SIYYbaGO3t0WKKJQqIowqqowAAOgAr5mvhfa4l1ai0VrfI9H2VJU421l17ElFFFdxIUUUUAf//V/eiiiiuM7AooooACAQQeQa+cPHv7KPwV8fLPJNoo0W8uM5n0xvsxyxyWMQBiJJ5JKcnnrX0fRVRk1qhNJ7n5I+Lv+CYMs8ss/gzxxGN+diajZncv1lhc7j77BXisX/BJ34s3DyW194+0a3tZAQXhiunkIbr8rKoH/fVfuxRWnt5EeyR+anhD/gm34N0uCOLxX4qutRVNnyWlulsMKPulnaXIPfgGvsT4X/s+/CP4PKZPA2gRW984Ie9nJuLtgeo82TLKPZcD2r2eiplVk92UoJbBRRRWZQUUUUAFFFFAH//W/eiiiiuM7AooooAKKKKACiiigAooooAKKKKACiiigAooooA//9k=" alt="">
+            <div class="grow">
+              <div class="n" id="pname">Débora Broch</div>
+              <div class="d" id="pdate">Semana de 4 a 10 de agosto</div>
+            </div>
+            <button class="gear" aria-label="Configurações" onclick="toast('Abriria as configurações da conta')">
+              <span>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.8"/>
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+            </button>
+          </div>
+
+          <!-- AVISO DO EXEMPLO -->
+          <div class="card demonote demoonly">
+            <div class="eyebrow">Relatório de exemplo</div>
+            <h3 class="sub display" style="margin-top:9px">Os números daqui são de outra criadora.</h3>
+            <p class="body">É um relatório de verdade, com o nome dela trocado. Serve para você ver exatamente o que vai chegar toda segunda quando o seu ficar pronto.</p>
+            <div class="btnrow">
+              <button class="btn" onclick="toast('Abriria os planos')">Assinar e ter o meu</button>
+              <button class="btn ghost" onclick="setMode('zero')">Sair do exemplo</button>
+            </div>
+          </div>
+
+          <!-- MÍDIA KIT + CALCULADORA — assinante -->
+          <div class="panel hideondemo">
+            <button class="prow" onclick="toast('Abriria o seu Mídia Kit')">
+              <span class="ico">▤</span>
+              <span class="grow">
+                <span class="t" style="display:block">Mídia Kit</span>
+                <span class="s" style="display:block">Pronto para marcas</span>
+              </span>
+              <span class="arrow">›</span>
+            </button>
+            <button class="prow" onclick="toast('Abriria a calculadora de publi')">
+              <span class="ico">R$</span>
+              <span class="grow">
+                <span class="t" style="display:block">Quanto vale sua publi</span>
+                <span class="s" style="display:block">Reels · último cálculo</span>
+              </span>
+              <span class="val num">R$ 2.800</span>
+              <span class="arrow">›</span>
+            </button>
+          </div>
+
+          <!-- MÍDIA KIT + CALCULADORA — ainda bloqueados -->
+          <div class="panel demoonly">
+            <button class="prow" onclick="toast('Abriria os planos')">
+              <span class="ico">▤</span>
+              <span class="grow">
+                <span class="t" style="display:block">Mídia Kit</span>
+                <span class="s" style="display:block">Sua página para marcas · incluído no Pro</span>
+              </span>
+              <span class="arrow">🔒</span>
+            </button>
+            <button class="prow" onclick="toast('Abriria os planos')">
+              <span class="ico">R$</span>
+              <span class="grow">
+                <span class="t" style="display:block">Quanto vale sua publi</span>
+                <span class="s" style="display:block">Seu preço justo · incluído no Pro</span>
+              </span>
+              <span class="arrow">🔒</span>
+            </button>
+          </div>
+
+          <!-- SEU MAPA -->
+          <div class="card">
+            <div class="eyebrow">Seu mapa</div>
+            <p class="mapnarr display">“Uma mãe que encontra força e propósito na jornada da maternidade.”</p>
+            <div class="rule"></div>
+            <div class="eyebrow quiet">Seus assuntos</div>
+            <div class="terr hideondemo">
+              <span class="terrchip on">Maternidade <b>✓</b></span>
+              <span class="terrchip on">Bem-estar <b>✓</b></span>
+              <span class="terrchip off">Fé <b>—</b></span>
+            </div>
+            <p class="body hideondemo" style="font-size:13px; margin-top:11px">Maternidade e bem-estar apareceram nos seus vídeos dos últimos 90 dias. Fé você escreveu no seu mapa, mas não apareceu em nenhum vídeo.</p>
+            <div class="terr demoonly">
+              <span class="terrchip off">Maternidade</span>
+              <span class="terrchip off">Fé</span>
+              <span class="terrchip off">Bem-estar</span>
+            </div>
+            <p class="body demoonly" style="font-size:13px; margin-top:11px">Isso é o que <b style="color:var(--ink)">você escreveu</b> quando criou a conta. Nenhum vídeo seu foi lido ainda.</p>
+            <p class="body" style="font-size:12px; color:var(--ink-3); margin-top:10px">Para mudar a sua narrativa e os seus assuntos, vá em Configurações.</p>
+          </div>
+
+          <!-- VÍDEO DA SEMANA — um card só -->
+          <div class="card" style="padding:14px">
+            <div class="eyebrow">O vídeo da semana<span class="demotag eyebrow">exemplo</span></div>
+            <a class="heroLink" href="https://www.instagram.com/deborabroch/" target="_blank" rel="noopener noreferrer">
+              <span class="hero" style="display:block">
+                <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QBMRXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAA4aADAAQAAAABAAABkAAAAAD/4QnKaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA2LjAuMCI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnBob3Rvc2hvcD0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIgcGhvdG9zaG9wOkluc3RydWN0aW9ucz0iRkJNRDIzMDAwOTZlMDEwMDAwYTQ1MTAwMDA0Yzc2MDAwMDAxYTIwMDAwZjY2MDAxMDBlN2FhMDEwMDZjY2QwMTAwMzcyMzAyMDBiYjU1MDIwMGQ2NzIwMjAwIi8+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPD94cGFja2V0IGVuZD0idyI/PgD/7QCmUGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAG4cAVoAAxslRxwCAAACAAIcAigAWkZCTUQyMzAwMDk2ZTAxMDAwMGE0NTEwMDAwNGM3NjAwMDAwMWEyMDAwMGY2NjAwMTAwZTdhYTAxMDA2Y2NkMDEwMDM3MjMwMjAwYmI1NTAyMDBkNjcyMDIwMDhCSU0EJQAAAAAAELdePgkE2NxfYFae96weRNP/wgARCAGQAOEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAwIEAQUABgcICQoL/8QAwxAAAQMDAgQDBAYEBwYECAZzAQIAAxEEEiEFMRMiEAZBUTIUYXEjB4EgkUIVoVIzsSRiMBbBctFDkjSCCOFTQCVjFzXwk3OiUESyg/EmVDZklHTCYNKEoxhw4idFN2WzVXWklcOF8tNGdoDjR1ZmtAkKGRooKSo4OTpISUpXWFlaZ2hpand4eXqGh4iJipCWl5iZmqClpqeoqaqwtba3uLm6wMTFxsfIycrQ1NXW19jZ2uDk5ebn6Onq8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAABAgADBAUGBwgJCgv/xADDEQACAgEDAwMCAwUCBQIEBIcBAAIRAxASIQQgMUETBTAiMlEUQAYzI2FCFXFSNIFQJJGhQ7EWB2I1U/DRJWDBROFy8ReCYzZwJkVUkiei0ggJChgZGigpKjc4OTpGR0hJSlVWV1hZWmRlZmdoaWpzdHV2d3h5eoCDhIWGh4iJipCTlJWWl5iZmqCjpKWmp6ipqrCys7S1tre4ubrAwsPExcbHyMnK0NPU1dbX2Nna4OLj5OXm5+jp6vLz9PX29/j5+v/bAEMAAgICAgICAwICAwUDAwMFBgUFBQUGCAYGBgYGCAoICAgICAgKCgoKCgoKCgwMDAwMDA4ODg4ODw8PDw8PDw8PD//bAEMBAgICBAQEBwQEBxALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEP/aAAwDAQACEQMRAAAB70gW+nT88cn9EcUfq+D5bubZelxxAGo7Ol9b+cvWhyesb589cfxujZvml4oad589j0/VuKRVj6H1tz5Dd3B7C2bOG+aQErezCNy0i1prjnaHmOF9N1jyjPWLyD0Xk71vF6n1zxVPWuS07xHj6A8K7VeX1roOf6zo8Bvz/V+QnR/QVQr6A9zxT7NfS7bhSHx+/R89+qr6HUpopfwbdqtmeIPOWnPRRmWtfQSebdRfr/VVHP0i8VZy/awOTyzobH6PPwPz+r6KpsOf0r1fy2t+I/T/AGfzvvWH6N818c9T1tj+p/hnlpu/819Dy+z4q0e/Dfb+VOOjP8d+z1Vrb4cy262DfEMOE7Xhl9eux8PrfqTwQTkeIg/V+U3t9nVUnadvJ7N6V5ta9f8AGXdcGR2f3jrOd1B+f/p3VclPLc/0vK9ZxBP7B/hX1Dy19U49IrxlQfD/AHzWptaT8z/ePYBc/wA7j4duTyPrB6tpy/esh6Xlm7fXWOot3bbxzjvnl8ez77zPo/U4PoBx5/0Hqfx7eWnNP/D/AGS2suFvX/Z1U/r1R5/xXha/SeZ/aP5j5ZKTfT+v0YfoLpP5P/oz89Hn1z8v+p9qrlKh11qwR6Fz2nuP+d9Q5Ic3Ob0DPlw/Xi5VXHVXDgrQdRVUtr6D1fOe/el8D4sH2Gk8L5Dz76E8a770flvULLhOn6/jeFor2g6/j6T3Kp9P9H95u3de78j9JbcB6DSXT+bfdey+E+P9JbbnugX2Lw/FXjXuG8zzfL8rzj3sB9J55Pf8eZ/YvSn3PfMnp/H/ACgXiPo/g3Rz3d75/wBD6P470hK+O38cd6W+3Z33pHxt9acf9Q9G5oldf1F3UNudvR8o+eO0H5ndSOOagera+u+G+hE329fw8Dx9r5pan7AjTVOfH0vRebeh5+T7j6D5h33m/JeX0dvwG+RH4voHz/n+EJ6Bd+F+S+G8h77YfRfZ/Cn0H13kft/p30+rybofYfruJsPOMPivOvH/AKC8J4+8PWCec/6TdPus4Rx7XuN14fnDOuZN94X07wNxz+X2TgPYa9XsnfcP1nlfC8P5p7T5Wc/pCq8V7v535ToPR/OXGunrL+luP0b7AFVa0mieLu+7829byOurbThtfF5/5e+v/j7wvpOodJZeP9b9Oct0Xq4+UrNZ5eP43GdGv6nwTiy51UoL5uLPxfp30rx72Pz+Add6PxvHz8v5p6TxvZw+XfWPzb33Z0fT77mz+76V7UtGw5CUr+2/D2onXTsPK4vlfxr7c+Ov0fjR6RwTj6Xz/bOy+bQac/1DvmfScK66y8P6fxDvpPHp/WuS5Rw2n0B7p8WfYPm+DeM3tL5bU3H97R9HN5LzvsHM78fQeneNNuvb1zz/AMd4zmb736jkrz+WuntWNM47+Rv80fSPgfuDgSN3/wC4cTYNzX5h1hZOaxo7znPT6+g8atOU62uPoP5y67xumysLr0Y9Hej4r1rZ+Qjoq7DNiO7GDxPKekcTrlyPzl95/Enfw+7++/B3tH5T3/SRPHWXwq+k+Ct9+i/PFcBcfQZ2LRo/7+rYOOPj/HXvU+1hzNu+sPO7LX67TYN9DU8M6GfZf+m1fber5By870XZ80x53rabFuUdWdSH5jivTo6OnwPzv7E+cvn8fP7Orc/M+Y+cPLbV27i6cl+WZ3yGHP7scbxoN4jfRl9p/Ln3r721x5j3fn3udzTsusp+Rq63b8pzdHQcf39L2c/MZv1OiMGYaVd7MbZptx1fDescZ5L/AD86eE+J8koHqdUcWTB7mjNpYONeijxd1ac8zsRpj9T+28a3/RPTdc2/6M6tzXDTFG9dZuLVddccp1ZO0TyS7N65y653rOLvnh5icf0fjnl8/MdAyrfjuDrqxBOZisW1vly2ICBxIdXbm6Oa9X8x7P6k/b+p2/3PqUna+f8ASvq75KxqEIup4n0Pl1bt+Qt+rybuje0O3ocpb1vR5a810PPPrPwmiYsvznxummldDJ0ZpOeXVAcWHJpyp783Q9Vu1znw/sOa9X9bX3RQ2/13uUlw9z5zxfWvxNX1dxYPa893/n3dxsqEa8NbroKCxXIHm3VtstvBXnScv+feIRabPKo0WPU8+fH9jQ9e6VSEntzZrsU8++iWfof3Pp9vSXlJ9L2UVfz7Hj5O3Nwlq2HX8M845er1SqqmxVsq4YA1hLekOL2xp2a6W3mXrdfxYeLH9If+PyeZU/ohOZuW6fnX3z4eOae35RQ6/wB6L9k8o+i/SPS9Jpayu6TzNpQXPL2dJyt/ymvJm3RgTLjjdReo1Ne1FhCubLaalu4p+k58+UdOF82PM8/2nGfM8/ScZ0DrzGqnHOdbZOOP7Dm2cGstpn7PZcz0/wCjfRWQitn9JpBlDrYjsQhq5jZ1y8Tuz5Renn8Z7HxZce+5pnmTk5MnltP4vj+8sOKpeJe4puec+fj0jNVr5tz/AEwKvmksk2XVi+1Zmz9ot2Jf076xzhkPWhwpB1EA6J2jJ7XqALKewbN3ze5l4k3J888B7785fF+R3N1zHU+LkQtkzRaa0cOeeu65sDhc4ml96uL3U+J9ib1Lv9K9++tKe5361BS5foG30xY19nVISPq+xshM31bc76GVbnyV/wA1/Ufhvg8DDpwvPkOayYjeO91FQ5zyuaFnZaLFf0tdrrx27XaNzftPg30n9J0O64F77vpFrj0J1tnbV4+1Yws2ZmztkyXmvqJshM3BWzzLl5jnuz4XyeXn73mx/M4L7nguiyq231ah69rQXJRnZGJknV6i2uvM+y8B2X0/Y8umrT6LsZtFD58+r3PWvT2JR0DE4clTsHfOlPStOI8vk9Mu/BRcqem0FPe/N4Icq2yvLWsMFcsCWSs+d013otP03Pg5dO+3G5G5f0jxj1b1W9AGgf2HZAHLUnDQIN1PK1zVMgWWBhcbwt/T/O8l2dN7zHiOhf0POJxGua37qouexlWfL3ui2bC+c8+9DR9cJ+LmcXYb/wD/2gAIAQEAAQUCV0qWtOO7C4vL9W0SLdxOv3aSBaDF4hs9vtv0ym6uuYZmm7t9vtjk6YpBUpqrVQqJ50W45tnetBQJvfoLS0tt1sb1ROhNGa9jqS1ByaPJhNWsFLvNthuFKt79ct2bG0usM13W0/xueGC1VFClal2i4jc7luk9xt98m6iB0op3kybeJcVzuEkdumyV7yuS6vjLe30e1odrD7vGSl6s6stTXoJT2QghyKS5KBG9bwuzUu8klE4CZY76SO4luFKkk3BC17VMLmyVawqVFEhCVaOa8jgXuwRcWO32abSCRSlGPaUTBVhGpaUxwPmVFauoL0ZIZLUXKXVlUrnuEwv3+K5kvbFMl1u8cabaeNRTaiFyZKXzBaPbrxcws5I5IoLO5uXcbZuEabjV3UiZAjmqj94mSxd3lyNqt5ufud0VMmaVUM/KthdxpRBf2lwVUanIqjlVR5hweLIlKvb0zuwEUUV7vUKI57xd0q9RIEpgNIibQ391bXT2Xb/f5/D+ywlEu42Vqm2ukXkW/wCxxblHbbOu4WjaY4kqtYYlwISFokCRd2hlkVaT2yoprkyXEiLpaNqjWrrSFqcq6C6vKK/SEjFjLG7Pb55Y5pETvGJTWIp5ZbdUlvZ7Vebtd2vgaxiim8PbbEm22CK0kj2vcI444lSz26EW8FxMI4veRIUau8iSqEmh95q0zJL3NU6VWKUxwqtkLSjnxtayWrgoZGUKTJ7tI57hEQ3XfriSXacLeCEjdZJzHto94uLx7FaRbRbIkzcqY1Jmt5YmLlJs9jKRHe7wlDubuX3YLoba8FFyBaJOPBZVCTuSzdRxwycmOVCwtVGvcIkyKlSEmaVbUpUCOeXue+i4jsxbzWdzbBTkhlWfdCiPYwgFStbWRWSpzLKbgYwQkIO2zRmSKOzhnmQbTzrRpnWlKi4AnKS5jlurtEcTFxLOm0mzRvEsikxyyAWU4MFlg7yLkH3axclmqmarddjdmS9klvLK4FxcXKtok+jTLkmGfkrlnMhrpBcIzvNwMUIm/SCE2F0ErQuNfZSXt+yfpaC48G3sCLwTwptI0hAyiReykzqt1kIPIQmxkuYs5rWT9Iwuxvouau2hWtaI7MVMqlBedhezQQQXVAmSrQrFc00aU2EqVJVt8m4Sw2cVvHcWa0hQDntElnQoCpl7ZYe7Wfuz37YPf4bqz5TNzJCqxliMi5o5XJtV07KK75S9uvNwvv6OwuKyVDHHJ03NJJCZIZSmWZovbKKNV9aIFuLgou9xltlE39xFZzXMBgWIxGur8r0BExd/ZTYbHssVhEhAeIa00e8bRabtBdbdc2m539rYXcFtPZWUEW5qDtNzMr/SUkQ/1ucVhd2iTLJayyKt+ZJRbClRtYrLs2wybpJJZ2u12mz7HFKNyijRNYAKuwsu1uUhidJF+oGVHVJb0Ko1MLYW5DUKL8XbZazr2qaGES8kS2URWiNAEduiS8PJS03dxdJvFW6EwWSZFXCZIJtvsVTLudsh94sLaOxspofeZLrC3tbq4sguKe154U8miZSGpVXGaLtFdaFaBbErVLouR+Orrl2QhmuTbxLju7m5RKqBBVLYyI93rcvZBNAZ9usrZm0Qp3q1u23eGCLZJRe7gJarsUgPeLpFJbpClqjXjBOJA9WIlFykW7t9/Uvf416ZPNqk0XPVXjG7F1uEF7BZbebtalW0OQghkMttZI9+5rTd28I3GbOJN+ty3QC7vcwuDwmmk4XQoVSDcYxNKu3FsJJUO22ncr4w7XugjTZzJdxdx2ivEdncKjWgA+H/ABChbElXk5VaXd2i3HiK0FzboBUmBMmVsJUw290pVxHfQz7h/SmN8xVYc7pd0ExtEHMKwuJHhq5C7qU0kjXW1vZLkKuOZXZ4YL3cd33qPakzbjyVyUKrnZor93Xh+0v4brwFt0iZ/Bu42+4WtwbZPvt3SOaaR3prcXi0psl45ot5prXZaW5VY+/W1rYzRz/oncmiZIa7yxguLrc03E1gvaBHul+m4n2OU2+5TA+9Wv8Ai99MBJPayqOz7Vtats3/AGK4vorWJN/bJSklKAwkNYo5AFD9BItdznuUolhjTGm426O9PiHYl/o1FzNSSae0h263K5JNvE0Vjte47Ree+xuOLmi4jCQpJDiQitvbW5KECJKsZUW6kqRdLEYu5Co7ff7rtyLDxbIJPEG47XcbR4YTydljkYU5C1Kd31IuIqSAlUe6brdW722a8jt03OU4VKpH6OnI8PquVbdBimPMuBcoijEalIiMiryAItoZpYincVyPwndG921CsXJDFK/0fCgzwYu6i1uodPD0vN2hBYkapKtSnKThxaEmnL03/crtSl26S4Jprd2viO8QqPxLbqNtvG2LR+kLVyX8EZkXbogtblNu7m8mupFIVIIrWp8EFQnjyhuJYYr6JaFhylQdwUl3MaCPCW4iMpkfMZkebKszDGkvkJBVHQ7vtUW5211GuCSKELCoqEQSlHKWl4Lc1rKxYrkabNKFG3gs5I/cQ1rgku9lUm13JcfVGrlG6UHNHk7mCrnioygpO3eJ9EX9rIJ94sLcW/itG4bpC4VAEKSXOBQvxDYR/pMRQoVQwEJq4gu3VUPcJYlRbWoSo3cciJC1+7oQlTEc1KzRIsL1O4WaeFzqzwWCTcWxUP0VNMYtujC7qFIVfhNu9tufcL6BQKUlpWQ1S5NSn4gK13kYuipUZryhRdijPkyM7dtlIUxzS7vZyi2jt5RcGzRlY+HbZFtvcezwy+Ht7FhOhaVpUirKWInyWqHpTFib5IC932srsVpqPCW+JXGlbC3zHuG4otIpbtcivZKahddAhahVlVxA576zF1f74bgx3coliWqSXaeeu/u9kutyu4fCOzWyILKXbFWtl7zbr2y/iY0NGpOhQ9xhWs3kXJsLi3kgXDGoPb/EN5ClPiW3Lm8RLUFrXcr+jfLS0RZNceMglq8Hfb1fXzJXI7a0S1oTj4f8Pq3m5t9ssdtt0zJC5p5EXKKKdjDLDCmbFqFrO17XbKa9smatpu1OOxtrJ7kpUqb3ZILuCPwsrlrSQknEAgsqATEhMojiOQQAqTmxySLkJznfusTsYBHIaSI27abu/Xte3Q7FYTLKR74hahbXN1PYbeiEzpjDjXrCm1ma/o2pMjULllL5HWUUYxSfENobfc5qhwkpMcoLtgHIiipI1yNKeQShEZ/i7XaBCo5JUuUBSPA21RwbWu1tS73byte2eEba0nnyytUxzswIlCEKQ02kRlQuVS457hTwlU5FRxPPRfCbne8+JgeWoLSwmSqoYY1LzjRZqlU7meVLulJljVuCZkctbliWk4Ky2jabrcb6wQbe1uZShMN/F7/bTe8RzC1TIpUyhHcXVEzqVFNPChAaI1438pjCOlRUADdGWNY6N+jjO25x3BljTEgRYiFcKHzOrOsYQoOa0iB/ibkVRqIJ8MWFlZ7ckxKRe4oaNthXdLkUiLbkkQTw5kWsT8piAY4o4mqR3KDWOC5DnoLaNF8qG5kCU7ytJtUkxACDlxIlUlUMcUi5oC+grSs4c5anzpGU26XYWM+4XO1bfHtlrf212JrK+TeuKFOfuyC5ZwCNWkaqolKKrXNmYxcTRlc8a1mZKHcyqMdtXlXK4xGLtN5dGkYxn5okkSbUolXPCqJUdVSi6XEJdEZOdHLi8IKVHuscpW5MZUbRbJtVQJDvbxMQ5k6hgsrskpzvLhCQlRDVwXRwwcublkuNCEK0Kd23Cea5VCIxzbWWJdwjNAiyQJIV3BBRjWI286UKinWr3dzgqPh295W985JHOEYuLpYcdyTb8tJNx9IwrWNQTCuQrupJl5cwl3EmJQTJInhFEoy3Eyba1NrGpd2lCHbHmIScgkpqOZlbKkJVClSlxzB+9FUnvKHeyqmPhCyhudzur5MC4Voukzg+82nQmYLCVLi5FgmNUN3LhGi1C4U3ybZ2l4vG6vFKdnEpKADjkHv91IYU3MQUY1IVgtUYKlCGFDXCuFdnckTpXMpMdbqQFVeY5lRxq8LoIkubT3qC0xDXGhbAwaCsq5cRVLITPcXKruWJPRe2yLW8klUZo40Zc4JalgxJSEA2yHuW0chrWUOFUcokVHMIJZQbZEN/Pcg+9WU5khzMSpIQE/o1LxuirwlYTwtasnNPDas3cUcsl8krRudkiebdYBLNQJtL22t5Fb1CiCa+UpE0nLXCQh3E6wpF6iSVc0aJwuMpnOBvthUpduOjErGX0KOehZGQs7VaDLarjUEmyj96L2+xFsnaV1nUHcFKXNJbiRVxaSHDGznjwhintoriiLhmbbhcQER2lxPbSy2qTAmFMUh5ogWk7ci6IRJcLNn7xZ3YivufbP8A1pWq8kt5bncr23kuYECNS51JZuFEfRIk5MDCnbXHus/vAKJZkJTOi1M1rEiJJyS7me+gcs/NTPa3fu60bjZuZM1kYBIqL3iTP3q4zUuaeeQTohtcrxYlu5bUInhm3JEwRAZFNFoLkptZUSbhOlS0rHLkhRy0JPMzLjCiYYniohYWlK0Sc22jVEJJ5XcIupo5/ebsTGdTgt0bhPNbY3M65IGUGRCLVVjAhc6ZhEsQKvLta0GSG1K5JLncdLe4PIVHdcozblKEySQ5bdbi5tZNxRaxFFzIrkOKBEQQBWjLLoyGUsro5nt6SF7hcpthe3dzGvb8baxEouCR0gKrUhjlqQq4t4TdrjuhBbJ93sokUXDzY0WiUSXyoFIoJgn3pAzifMVW3SUpLPejIak1a49I+aiScc9c0fvCkigSGoabhu0qbiK9cM0UruLWBUy7UojtboAWUiLJ8xBMS0JgiQLhpK7Z/pH3pPNaLfEjpFe1KujPYterp1464shpaxp4hsTHOuWhszbl297MXFNJnHEqJUN3OZIpTktCFNFpPHIgqXJP0S8lpU8x3SKBR7FlniB1KDoyGlDXond4BdbbHDjLHEDBZfvrqEqnnGSLGCguYYoZZtE30q84ubcKjQI4PfC0KyQhVSktAq1FgV7KZDPFPE9pDi0KqJvZmiVyJQ7SEyRo5MQt7vmT8q3naAqMRQquZbma2iHus0syrVYkuojAusLtpguMe1EkreQSPaZYOpamatLDLuPZTwvCvk20hXHvVlLFewWa4nUBxW67ee5tZsI1rqVyolmTKiWDmZ38vLdmhN7F+iVvw9dLrElShURJqpakpwEsmLjqQ5GXWjSoPNNLiULEa3OnOGCflL38TY2V45JIQvmKmVDdrwlRypJ1xe8yciJckMwSoKnj2xAs0++xO1uI7e7SfoyqrhTRM8mIKsnEnFDVQtQZ4y1UkdTWalIBZoI1RJx3GeIpwa5SmQRiFSJUXjmPLhl43Kqi1C5HbCElJkTLgpxbVDcSLNBEnJSl4uVVSg1aCFJLIdKu5kwCieVJepiEm4CE228QSpVdojRc33OUsc9ikbuhHHNHF7yILJEaZIeeq3tZ0SyQ8xSLeWOz5Vt73PKkXWdg9molBVUoAQJC1Fg0KJSkolC1YJAkNBLzBJc9FsE9F6JBKqZV2mPnIZpMLVSCbmkU8tBHIRbJl+jiKYLmRH0jht1yqjTHZycpOEUKVo50btpl8zaVzqt8izVmj800DSo5LvkoRNuRkCZqquUqmTLN7q1TrkuLO0RMIrMSMC3QtUNtHHMnnSI5VqgFDMeSbExhcESMI9uuJnuMfOtrbCCBRuIpv05dvnlB2ubOLJ6qZZ0Z4ZCISSILOoRJJSa9iSd1Jluk4qO2S4mWZSZ7y2lC0285XIhUi8TICvlCO6gMJm91NkspkFwSq4gBgvFoSi4ESE/63P8A/9oACAEDEQE/AQ9P8zjjiEdr0OOGT7n47oYDdOMnrhvEcOXh6/4DN0+MZJNPxvxvvk2aDHpRg4ErCfgjOPuH1ckdprt6bpJ5SRjDh+GyY5x/URq3qYxhUYOEniMH5Hp8mSoHy5+ozfwpSsPS9Du/G/GdPHFjMjLgvW45SG3GUYc2TJ7O56f4AAn3S5+jmJGhxoA+xP8AJxfCdPhnfT1Z/q9R0AzZBmzS8cPyXx+Ld/J5k/NfvNg+NIOQ/d+Q8v7uf7i38Z1/Xex1AML/ADcH7t9HKc8gyXHy9RsjKRh+F+a/e/qerntwZNsP6PQ/vl8j0OYbsm8f1ei/3EjHgz+7tNH19H4v5OHX4zlnX+Zw/L9HCBxi3qJAzJi/C9PEy9yfgO+H+8B6Ho/YAnku2OafGN+b+Tx9H0+bqsv4ojw4Pluq+R66RnyZF+X/ANwk+L6g4uiGXZ1ey6/3m/7h7klk+Ml0/XfZPjyPyf3l6PHD4Xqp9LHxE8uOcsUuHqOo92i/uJ0P6mWXFkj9lf5n4Pp8HT9H7WGFAOboB7wx42fwEftEZc+rDpo4xHphzb+j/oXN81jMKIejFZ/cD+9Xxs+t6XLg/tSHCemz9F1HuQ4lE/7F/wBw3/enp8Wfq/mvlM15wPtB9bf3Z/eTqv7oPy/y1cyO0f0f3h/3HXIMJwdN0u6BB3c0Cj5eOWf3CnFjs0H91em/SdFHEfPkvT9bGX2UwxieUZXJihMDZ5eqhPDIZoHh/wBuTJ/jf7Bz/G+3D3B+J+K9zPMxlw5Oly4MhPo/vP8Au90PWS92cfv/AKf75ej/AHM6SE9+x/3E394M2IYuiiftq6fjOshkg9X0/wDqiUY/m/uL8JhjD3TyQlwhxYQYCT0/TxycQHIeu6YnFWV/u0Mennx+YfjekGHLcpcvy2eAwEycp5SKD/uJfxMsgh1UR44LCO02HB009wlT+6vxxw9IAfJY4XpOlt6IxlLbb7wh4Z9L72MzMvD+uH5Ps3/Eep6UiInjL1vVyljPuM2Yflc3+yYxslzfuvhlk3jh+D/doQlDII/67GZhG4v964oxEp8f7F/er9/Tg6Ux6PyfV/3Cfrp5+gMMhsxl/v166Rxjh6PrhPFsHDsxOfJkyYvcg4OvyQ+2Xh6n+dzJyx5pp6r4/PDL70eX4n4n3sm8iv6OXpTDhgE9Jj6fcY+Dy9d0vTyw7JwsH0f3Z6PHgh7OKNOXHGf2mVJzSwylAF3f0cnV4thjhPlzy6eXT+Puemw5xQi/IdORlNs+n44Zwegnsk5Z7vLtpnijX3MunxyT0s4TvGWePNd2ynkj5D+pl+T0WfHPLYjw/K5vb6j7PDi6wA2XqutGbISHFJzRt2lHUEDljmtyFGPl6iQEeUZA557zcnaPzYdXLGdwLL5kzlc+X9fvP4Xp+kBlvLnkMfljOMvCYuTHYcB9EZQB9yerxDm3ruuOSXHhwk+jLKD5d0WGOzc3Htug9D0u3kvA5etyCf2uQGPLDrsg9WXWZcn2uLHsHL1eQ0g2+yAwjTQaiyLiAuw4skofcSwmd3Lt3c25ADzJjjxy5pjiFfa5IylRepO6DtZAvuU4535fbGntmIBiEnf59Hb6u4vqxii3LilLwXLMxd6ZW5IuJ3IPIcOLncWXB2saBc5ThnOXLtrhMmUuLKJ35ZlL+II2thwY7mGo7XMYyqR9HHkiUxsvV5Jgfa4Qa+7y5skwfDmiTGkwMTRTF2sY0XHKMuC+3H83Bjr7iyPHD+o9CGNx+4I6yVEAPvmuQx6k14TlmTwjqpfk5pX6O1ATAJAfZ/qwBlw4+myQl/R/T+tPUYsnojHlpOLLHgv6fOPupjHKn3E7mYLGP5psl2BtwhxjSony5+kH+y+HJ02WvNl/W55YI9PkqouQs83NBnYZi/Lk8UiYAZn8newjTjbdzbMuQu5zRqTORb45QfVNHll/VqLHI45okiSZJLkKS5v8ZyR/Jq6tlUvCAAeW9z7IejlwxKcrAs5pyM8nCSmXD7hAd5L4sNX5dtNuIAeETptx5eGWe3f6s8qZ/kyfV8mmMalTMFhA1w/ppOLyhtvS2dOHEJDlyYtnlxz9XJzHc4qkbLkiKIRkIPD+pk//2gAIAQIRAT8BeNNnq7eeyQb7b1mKdxYyNoaa9UG20yQdeExQkMMJPh+V6fNDBKWL8Xo9b+8fyeHHDHHDUjxZ9T/QPxkM0sMI5zc/V+O/d7B08P5kLP8AV6j92+j6vGdsNsv6Mv3MzxiaIv8AJz4zGREhyHbxpIvCZID0PSnPljhHq5cYjwGP5Py/TdTDqsefHj3CN/7F+Ey9RP57pR1c/Xx6f4HLjjMUXpcOwl/ffqPb2ThKpPU9TPLPfPygu98u0tpfg+rGDqseWXgF+f6M4MxI/CfBYZaRkIg5fiIZc8Oo/DMVz/gei/eWE6jk4RPjc/vv8h8/1PyuTL0Uf5Q4F16f7zfj82eeEHqMeyX5Nopr8n7/AM2kRTw4/wB4smLH7J+6P5FyZyTb0IsWWSJ8Mvns0sAwW2nlyxoscdvIdz4cc3JPhj90nyXpp7eGOZ3uLLzpKVOc3JiKRy7dBFy/hLhYSfkPkZY6hAWSw/eDqA9Hm6vqBGQFBh02UEUywzj+II+56qH3MRWm4p8MZlOOxyx4Luc/RZhk92PL8X8aMuTfL/WccQBQ06acYYDJmcQwixw/L4Ix2zjxem59wJk8IEr4epuM2GVhJ6aQE2MnJlERb+8v+4gdVh63Z0U/6f0f+Bl/OdPcpTB/wh/dn98/71x7sv4x5Z9TEMDE+rtx/wCMg8s5c8IyvX/cdyYcsJUjI4usPh+UyTyYJwj5pzkxyX+T1Py8cuEwlHl/3DszHXceKL7iZl95gZejDcPxvzcM2THs6fLteiw+3gjCUif8LHCZeGeOUfKC450XLF/ej90PdyHP0/n1DH91OrlKtj8D8QOixmvxHywyStGQFoM+ujEfaGc/cKBXlEXpsYjHcXg8MujhL0cfRQibTiBfmem2Y90EhMOGMtvllJ9wfm5Oo/J+H6Xcd5DLooz9GcIiH2eH9RADaXHgkBUDwWGCceCWeX7tgZZBHy/I9OTinygGuUyos8lOPqoy+0h9iDDmVPRwjGAgTTnMofbH1RA1t9EdLj80xTKmcIeS/qIQo7bfl+sgMe31TKNOfmNhlK3qcRr7C/zfzejjWaJLulu8cMfu/wAzlEnpIfcQ5s8YOLKJxsPtAikUA9XkOSZMi+3w5dvgMondyjGAX7XpQPdBL78/cr0LihOJI9HqsBn4LDMMY204OlxTleRyH7v5YqLHKLp6qBnAxD1fSyxyrI7QRYKZEU5ZHzF9k5Iv6CX+M/HfF1WTIy8JMz4RkNOQESt94lBKDH+1Hl3vV9PDLxNj8RjB5L1HRY9k+fDlmR4YyzyraeGpfm4pEtsckrLOz4ZzI5LI39zDIT4efVJclXy/MYzv3RRkryzy7RYYEeadzGvTsmLcIgZfeOHJ0uMSM8fFuPBtvl6j5LHAkMvk7PAc/U7jy/hJ3OKYB3llkEhudyBWgCY9hflcG3J/hd5F0iz/ADGfTEneC3I5eY/4WEjKNB2MclhDaToEtvzEbiJPszFsoXj2Hy54y2gRYCwIoxE+j+lk/B5N2OvyQWU6RpbKTuetyAYzaI7h5cmOJPJYxIhy4pCQZTlGuX3ZPwMNuPd+aDTMsZ8O5OR6rqZRFhHXyrl6rqxMkzYzBjwnCD58uOJJdwDlwHyHcX4fqv5mxBTpLImdB6vq7kYsc+6Qrw9X0PuDaHBhGPEB6hxyj6sZOWtrH8L7Jf/aAAgBAQAGPwLTV1xqWbe4XTlioA4D5tUlOny+LghXUCINEta5/qf0tZJBwSnSr0Ryo1eTxQoIHqXGi4V9IrQD1eTr3rV1lUEBnlTBSk+jqOoBpmuqRB4QzBR9ODol6cX1ffIDooPn6Zj9fzfQkIT+0TX8GiBdTpqfj8WsI9nTEljWmbjWtFauqq1r+povYz7zy+CTpR5IJgPkgMAiklOoEebq8iysiuIrozPKfa4BpMftcX9GKBqGOXL6R6MZp+k+DxkUV/N9Ip/MlS1VV6MHKhYhh1kOrKrxGp4UDTChZ8iCDw+DrOpUqmlUmiUa6+jPKqATx82hSdaaFiX844OidOwRJU1ciAaVYkV1183gj7XHNXChq8kHAeYDrSnxPaoP8xoKPKdqTAiv8o/1NK1jR/RilOA+LjpoUCjUZTql/R+ydA/pYsT5UZMcmCPNhWVXWJBV8XUwkj4avAdEjx5nsB4oVQ/Hg8ABUemrxTJgkaUGjWuValYilCa0aoUjoTxaFQ5JofItKVHI+bK19CR5l4xyVL0+7/GLcgHzCnkpSeSv0fMXLoB0/wB1/RL5hf01Usejr5FpM2sZ0+IaI4eplC1cpCRU0eUmsEWg/lPBOtPIPmpFKGjMsQxuE8D6/Atck9UVPDzeKYwfnqyeSEq+D6QKejoEgOTL2VcHWNJ5dePwdEori0RHRCdafFpmTQF0Vx7VLolOVH7IdJY6fNm2kVhGnUMoXJRMVRpxqHEVA4+ZeRqUp4UZMSB0nX4MW9sNfP0AY97UbmTjqaD8A8DapA+FWZbCTRfSYlH+AsRqmGI9H7vGcj5liJHk1SH8rrXqVqexNNQ9GkfmLxk0+L5SfPh8WpZPtMK9lQ831KqA9e2Pq1ISBRL4JeayA/ovoyPMHyct5coJEnmeLV7srlJ+PFlMvtflp5sot4VFBfK4yq1Urty1cVPIjT4NSknglyzKOpL5cHUpy1VXtRbPoWWlX7JdK6hpQDjy+DjOZ6e6olaUeSldLrajP4tSpE5knV+y08lPUf1OKE4mXiXy89KcGUW/SEq4j1DM1ysqX8eLM6Femnz7BIOjUvLFCODSvyOhaozwLKY5egsr4rPm1Rj2/aPfGvaq+D+iFaHR89Sur0YmCekeTT5MRIOPnVqKjl6sok4eT5eSY/noGbbIKB1r5H5P2mSE8OLTLDopLz/bTQ/MORKV0BNfxZ5i6kDzciaUpTVgvMasJSKBxx+mpfLSolXq45SoJCuJL5YVllwI9WrOJQy01ZCxT7khkk5SAQBQVq1e5XAWPT2VPkXaFcxJ1q1RrNEngWBArhx+LCqZVHBn4vGvUWiFFEBfmXjdqryun5B+yplCyVJPGvmzhwPB1r1eT45KLzIw8mY1HoB1DofZPZK/Rq5ZqVOSVGuPS4Y1nGCIdXxUfR8u2HKHw/uvMHJ0U8otD6OhYjQKktEFNR/D25kaQZk8PiPRqhu0mCSLyL5YVkDwZM6qU9WY7YZn4MSqHV6P93gocMnnMimXH007JuU9QPp5POHq9fJnmLofR0ArVg+VeD5csXU0oi6j8HzIOoF4YBSvN5yDlpV5Di/d4COs+fq0pr3IHZNxGmuRCfx4MLWMpjxP9z7nLnT1D2VeYa4p00MS9fk84gAr1DEcYKljiaNc4RWnk+bPplwDCTQR1+3spKE8yEvpScCfN0VpkxRPsspHBgq1dI9ED21ejMVsPt9Wq/vBWvsgs4H+4xqOmp7UU9D2AYSfvJu5NCRjX5Oe2l0BOhLMiZapS5J/y0aEp/Iyhfsp4v2/1sItzUebMPGRhZ/BkFPSeDqoD7WnAa8NPVx2semjw8gxH5APVOf2tJhixrpx9e/SXUsMfetwk6qk/qeUKOpqRIgcK0fu9qrFJ9H7uZKNR26bFf54/N8P1OSKgTzPNXk0yw6qrrXWr+jVisOkh9kuiYVJIZKhTzZZkUylZo8UDL5PI0i+f9x0r1ef3M1nQOCZXTbCsY+3z+7QNNvlpbin+UWiQ/vDwckv5l6OTHiA0E1yLjjlm92x6svi/wB7B/t/a0plAzkDPBBTSjShft/tNIX+1Ul4QpyS5ZT5h69qKV9nEvjy/wBX8Oron8WJrRB0/NwDPvUYChwoa1fUmjxnqB604BoukqpAKAg/mJ838GixvFUkA6VH83+j9zp9sv37++Re18Ul0rWnAPGmnmyqEZa+TSZo+VQcS4pMMxHqQr4P/Fh+LqEPM8EPhxeYTlRmPDR8qmOnavwZ4Rj4cX1nT1LhtKVyPUfgNXHbW8QKqaDyAcAWmomUE/KoaRTRTxmRVDTDc5YpNdDRn3eWSJX+EGDOQbUD20/wUfJRKV4/tauvI/W6yUHwDLmz4FLyRpV5w9ZV5OWTivhi0zAYSoHAtSaZrVwx14v/ABc/qYRNCFD9dHWFJwPEh0P7ocHzY1gKHGpZRb+w4pF8Bx+1mvAvA+TKIRkv4f3WVSl2txaRpEqRXPzy/NVomthlLHpQeaS/cL1KoZ4qVSdFDHgoPAfl4/coWZ0fuT1U+Po+V5+by81dRaZJDy/4S5fcFZKGpSeOI40aU0CseGjQYdAdS0zmVMevmWbeaoB80mjE8aefD8ONHwV/gtR1fRop/B9ZxD6eplX5U+jhmRqlaA6KdEAIT8HROrItpKIVrQiofL3OgB/OBwcqppklaEkwqSrqy8qU1dupRJXKM1E8SVfdPwap8SvLhRoNKEoH4swQRKMx8wNfsfM3LQjJSq+SfiyY+kKL4ZIOj/dGr5O4JUFI0qrzD6Q/ZZAScPgXKcCCkaVZB4uhFCPN1SaOlxIaOWBX/AZXT/ZU9H1PPizg/R1doR5IA/DT7pfB4kaP2i17eqH3dHnXUq+30emjTyz7L60JV+p43EZA8/N4ifj5F/vA1W17WOQ+XEfqa1c06cNdSytceVeHqyVaDyDqQBR1c8X5Fo/WCyR+R8+PolHFlJ+4rbZDTWsf9Y+7j9wxqH0ifYV6FmM6EaFjV1Rq8qvUVfB+8zEk/F87iCWlZqB5uuQljVrq8jigHzDxtvY/hdunIUVVNPm8n83k6vg+DCk6EebEW4jh+cf1h5ImSftdZLhP2Gp/U0WFrHSM1qpXE0HkO2vavZcn7dFMUQQ+lIoWRXi1CuQL9h/Sg8zyaIvI/wBTXiMvl8WY5FY+fB1KqOqBRPq0XEcnWgghx3SfzDUeh8+1O/svXpS8eIDxPAPUceBcF2r8q9fkeLBGoP3StPCgDqVdPoxroxR82Ppfm1Sp1x19WpVseWUFqUmcZHi1W03tD9borQuNe5zdCxUAf3Wn9En4KTqX7vL+4k4/A+rC0HJJ8w6/dLp+0zQfu9eydrujSVH7s/tD0+f3Co6r/KPV1nPtMfsv1BZrTR5U07G5uehJPsUYnnHLwHAcS6QpxT8XzfzOsitGnkRrn0PQxawRCJdepfkE/GjxWVySeaq0avdJOZD/AKWWiYLpmK0pwZJAkT/JdDofuR8rVYWn+FyqIqopIA+LAWHlwUXhdfTJHn+Z/u1h0t4/tUzJLJVT4VfXqPNlSNQliTWroH5v6denoHVCSt8xepH2NKkjoV5vFCqQI9tfp/ovkWaOUgcf2lfMuqU4pOjVGr1/U6hjI8e30iQX0HF9CgX+UPJZykeCfaXoPgwhY6k8CzJlrTRNHwpQ0YChQsR/a/T4OqdKKYmk6q+TGBx5heNQqn2uiA/ZfSdQytAoCKl0VwDTbW3Vl+r4tNnH1qOqj6qdTxZKDV82NJUk+bBk1V8XkVcH9LGUh0QvqeL6S/adVGpZWrVR/UOwSeJagn2ZaL/Fgnz9XUR5E8CzGv2mUrH2BpEIrRhJoFNaZU41adK9uaK6vhoxgKFTjulxjOYGp8+Oj6kB0hXQfFru5z7wpZrQ+yPsZxT+7GgfNUfY46aPLH5VajL7Q4OSTXz1ePMrQP2g+tToNVP4tJ8mCg1+HkHbTL0UQUvOQaK4VYREmiWg6D9bXInrrwIZkFQo/qelcuL5+Jq0wqTr69khCquvq/dUpoOJPoHHbRCiYxQPqL5cgq88aPLDLI0J8n9BQIH2OVfMVSP4cWlZFahqGJr6PAIrMr04AfF8AljBfnQtNB7Xm1LLoNNeB9GrHRRcaqhRiX5ukp6hwaQpWqdWFy0oWQCykHqU8TSvkzzOD9nTi/bV+DyTSpOr6Whc8pXJcgKV/cdIjoPRlJVx9Wm40QSn8fsZtoK0A6j6tCfaR8X0LwT50aQOCXRLCQytI1V2OKjqa0+LxyGP62rLgA0XSk8dPjRxftLNHDAOszqr+DKlD2jT8GeZpwxHq6igR8WolWTBoErpp8X9Lx+Hk6qBI4M10o/Jkq0aYIQKyq0cdtGDOtH5i/eoE4nzoWtChUjQl6p4PXg+Wh6nsSWVllKDiryLxu04/wAoey8Umrx4n0YjSKmT+BnKqcBQAutyBywNT6NUgHSkUQPgGla/bV5NYHtJaQlftDrr8Goni0Ipn6NHNRjR5HqTXyfMjNcn7Dqvio6OKOvGv2aM49KQyIzrTycyyNFFlRNdXgDqX9GMf5RYkC6r+Po1yRewf4Xh+YsDHTsatXpqR9rVT8zTXiOHZdqs0jQrpD5kCwVej+mR1VqavTQK0+LUhfFWn2NONCEcHzCjqefLwqxIrWMH7GmqCn+t+wWBIqpDto6UBOP4soSDQfg9Ho04efF5r1U8QaFohHE6UYOOPwfNPCtA+XwVx0dD20NAOy5Fepo5Jj+QMT3UlSp8yM50aTKMkyEj5Pqj6UmjyJ4ebRIhbooZZejKAaJ9WlB9j0dOXRMftfF/u2rDTzJ/uOOaRRPu/V9vk8cagCpecfss60Sh/tFTJRqyVn6SvAnVplCaV9XT1dC1wZGabyFPL0apJhRFNC6x+tPk+rz7aMQRJqCeosCVGg/UXXRSePzeUaQlI1+TPM0TIyUcBqQWJIRlH5jzDkMMeKf62VSnBI+DVEklSkgqqdODpTHR+0GvzUeDkX6J1+Ho6npUU8GRFXgKv4h14vPy9HWRIPzDxBokDyfu8SuZ8v63Rxzo1pXQ+jlhAAjPl8fN4p8tXTydUK0LKU+fb3m3jCk+YdNKHyDwVXTy9WoK/vf4s1GSWnTCntfFq6AEI9hmNY+1yJyxJ008w0COpUri/ZLCYuo+TkNzoDQ0dBwfWDwJ0STQDiTRrCqitdSCEnHjQ8PNhJNAfixbBXVWnl7Xpxr+qjTbkEqVSlKV1NP9ujqFALS1DGiianGjEo0rUUPw0ZmuABpo1CUYSZEFKuNQyuQ0KmJbeikj+FphriE+Xx+bx8j5+VQAT/CHlUUeR9hpn27rC/yD4Cun2BhelP1tVxSgyCctOJqR8fJqXpx8moI9lYySQQdPs4fawEmulCfizWhqKD5sVxK1enBnOipT5v8Ael5S6yfwNSfUdkyrTklB6h6oV0q/UWuCCYH3eARQSzIqMsspFkUNCrhWnk7pFouOEmYU5kVUqjwAIQMVU66nH4u3iggTzuWgLyrzBKFaqBw1088+GjIjiSuY87LKtVZfuykhB4eXUKOKG6jQv6WXnlUWfRyxjrQ6V9HbXcp5MybTrpGEhU2Z09hQHT5hPwd17rHHibjJAWlQQqLAVSBgrTKumjCJlIjuMYtVp5gAFc0+yrXh83dTRRolVJcSq+kCqSRlPSNEKPHy011cRmiCpDJb5lUef0YCuZ5FxrlgCVIRcp/d4hNSOTWifIVpoaO5VyI0zLXa40RmClNeaoZIFPjoK+TKxCkpTPelNYqjBSPovLhXg45yeUpFsjKiKBcuWo9hQBx8wn4VdwtKQLc87k9NEpUfZNKGnn+XRqnWhCYgfyAlBPJIrTEHVXHRxLl5cF57qpAlVF0JlEmlQE0rh50LN8YAu199twoiPELxiVzMR+zlrR261pjkijP0hirVac60PQjyrSjT7kIVJC5aGOtcD7KVdCB8hrRqWpNFE8HRB4nRoy0OVCXlUK+JfsR9kqpUPIsrJ0DKsqZ+rxj6mAlOSj8aDQVJJ9AGmfPNHJE6gkpIAMuHpU6fbV++AJ5MhKc0KyFUitD9npo5pScZIzAlMSSCr6ZVKKHloXjMQmpWM066x+0l4zhKST1dYqg/y/2fm1GI8vGHnpNRhIMgniRX18mYhD1pUhJ6umsnsUV55f8AD0cS46kSpnKkLokRchQSan4efFotkxVnkxxGQxUFCoIV6PnlCCjl83okCiUA0JA86Hj+qrtwDSG4mTDzI1BWKjrT50+bSTHUmFU9chqiOuR+enBxQlAMsxCRGFArqoVGQ8v6vNoOlFdSVJVklWOh1+DJgBPLrRJOmvF8v2Vq1PzZFvVSfP4NIjNNB+LQceYPzHzeSeqvBmCQkVPDto6q4ugLKSKh9SNPXi8qUUwQkVFeOoIIoQfsZiogRmIQ0SD7OfM8ydavGfEIzMlBXiU4+ZNB8A1UKErWYlqWEnImA1SeNPL0fvUoAUc6gZcV8faJ+ylGm8JHNjVzNEnrV/KFafhTXV/SlKkGHlUVkenLPiVZV+NWs6K52BKeoJ+jFE0xUDw+OrSFKBjiRKmih7QmVkoHWvHg47xNEyR44inSEpFAOPx9Wm25gom3VbcPyLVkTx4uNdUDlTInAoqmSE4+atB8BR+79CqRSW+ZBy5cvHzp5+jiuqJE8Skq5gByUUigy1p89NXGCExoRVKEoBAGZ14kl0h1HBbyi1P9x4xJAB1NWVynIuSiTHCrzP8AU0w2KM1DTIsXFzIkrrwD4h0en36Fgjz0fSnFLC/2nWNBKZxWjhFwRUJqf7jWmeSoUNK+Su+pAeNRV6r4MRhQxOrWsKr6/BqkyzQHhlihJ4U9kseaVebSiGvT0tMaTir1eMgONfPyp36uP8xVgk1YUrXHyYVIfZ00eNe67eHooaElj3qtWeXI6AKUV8Kavo8jq1Qr0SoUU+gZBlKfzBqRTmr9PRqTnizcAClfZI83IVoxqfwfF1Jr/M0++bhPCT+Fj8zKhVCj5B4xjFKfNlMw0WHJLxKWuGtUnyYp5NZH0ZAr8Wrl8Rq5Y5dQvU/BpHksU/1FMPMaj5h0kLJB6g+odGPBoppQNSiqhT+tqUhGsvmfR0rqvyccMhJI/gaCmuocgUmiwK5OskgL8nXzev3Kn+Yr2o5Y/wCSWMwz/I9n4/BpkVqn9YcvL6hT8zoRh9r5Hkr2aejEkya8nRhJ1PoGEgaUrX4MQI6Urpq+jrSOPaoNXXtR0H8zq9HVPEMKVxahGKRS9QP8LQscAHy5AAT5uQLpjKBQvmRJopHt/L1YFa5f7ejNsVe2Kl4Kxov0ZA48NfNoQmgT+b4P3iE8Kh8GqE+zTpY04v499GFHz+9XtRqfLA4uGRHCrkQRUGg+TJXriNPixXgTRmGb2PI/1FpkrTFnXj5uJWPSsa1ZWCK+rxkpkeNWocEg8Pm/aP4OOVHsp0p8GF9ge4B+7RPqwhPAOg8uxBeSNHFGlRUUGpPk1kEDLViRIz0aZJjw8vi+VMrAD2QxVPsHWv7JaFo4Aa/Y806gU/Dzfu0n7unH+Sym3WCEflUdfsakBJr5B8P1tAi9n1YT3PavfR6cXGgfm1fLhOR8y06Vq+o4V9XzJV9DHM6EHgl4UxT5NGYyoaH5OqPUFqzAOTAlVU8KtYlXULGKq/wtcEfT8T5DzaYoyFJUCK8HyApKlpoK/wAlrEXken4tApklVNfT4P8Adh0Vx7176PDupR1yLSPg9Rq8hqAyiJNAgMCtHzFrqxkogeTUonpx/W0hOpUGUx6mg1aMPPU1ZjhJfMSqv5D/AGkvU4oHn/cfLSSpChoSwqM0NeNdGuRA1TxA9X7Cf8JkpNOniPVhd2rKT4d9XXtkHVfFkITQOihoGAn9l1W81J6A1ckay6uTNBqnTTg/4x0hPAP3uI5hdAP63ykmiTrq0pk1Ssn5unFOP21YNeniHc3A0qBT4M8lWSDQ8KNSgvqH5POnwaZIl0VEcSloT/fOJqGJbJX0n5z5F/4sj8HzECvwaUV6kfe6uPo85Nfk6ojf7sMRlWvnTyaEAUR+t8iuH2V1YSkVLCgRqfVjFIkkVxUpoofZ1p5VZUlOLTytcBjRoIdEK6lHV4ISVZ8fSjp+2rX4AJ/usCUGGTI0V8PJmVX7yupHBQfvEKurSqWDNHWorV+2X//EADMQAQADAAICAgICAwEBAAACCwERACExQVFhcYGRobHB8NEQ4fEgMEBQYHCAkKCwwNDg/9oACAEBAAE/IYCLO2aHq904I2iHqgliOQXFYaOzx3eZXkhmB5uhpwA+zrKQU2Xsy/FxyZDyT6oeCEBMnsKHoJ+ayO9fwCLtXKMKoFR2tYItlFtdLI67ogl/b9d385VPw0sONgxzWYnVImzpLgyKUTXL/mZoTzc5I8eZsx4YlOnBWGWIg/BYgeHbt7e6k1khAmeY80E0xSBvzckROZKY0xlBlyJYB5qmyRdh3HunBCOg/M81yZ6AxzHV3gBvIHNjsGdS9Z/R1eZ8Kf6sLG2EFlHYCOMc/ujmYozr7G6o/eY9VH8nuvndCDiw6/4VN7JZlPFAdRAyyz6vlpRE9PRNUU87D7qkzCh9HxXAQQPu7BmZBPQigWn9IVA5GT481cDDHDj8UQO+fdkUWKy/Izo93Fb+YmK2MhHo2PEr34rU5p7LrTfIpsB0/wDRrsAfdiGYdtdI3HN6VgNpIrdc/wCeHg/F2cgYk4LknMf8E1a0+YJlsqlhEO1cg/mU81EOJq2LiPWSP5vm57CpaH4LeYBO3O4fT81KxGzkfRtiIYFETx807zAR77vwFhQ/Z7syRbtSdhT0Xuxr4BITZaWt0uCmATycUWkvtNlZ5PssFvh4bA0srYuiW++w107UfNInFwKoR57ocvFByfKsnTgIiPc05s6ZeLAEp7O64zo+srH7CgawLMRpSmNEEv1QSn2h/qzxHg46y5cFAoOePP8AgPVDIUI/lToY82vdBJFTL3qsZsDT6sSV1hx83yUONCoLW5nzS/gS/wA+rBKziJNoD41wkLLZl9tCev8AnQa9BmOeq/8AciHM/NHx8HJYyWn2F3EMGBJ90fDiTq9z/V9oEc8hpRMJLS+v7Gy5ftj9zcDzzoF59fh/N60OJXP0+AKDkH7Pm76AWzjkn2NYK4uxVmwlMljGvgy8P9UfLBMcBp5tQTRWHCFKAZMujyuuVgzz+F7b8i/4xYX87d/FgE0f1mcWeknsHv3XyMxOTriw3IAOo92f1Qc7SzjyVK9T4KIkcp5cM9WUxO1MWcYtD9U3mOXwXtQyeqh0lA/dWQxsM0NgpkLikofks7H9lQYmqHdoVCuQni5hmxvVSuffqvyHl1Tnfk8CtwU9b7/5aaNBs4XFinDVl7rLFGCXj6oarHW0gbWklh91JCB8DWqq80PxX9wi5sBMrp3YGpXJ2LBCae5vj9JVG5x8ExfCyFcHFZayQB5XCo82jpjJsBDO+FMA5wYuIMdWODGUo+rCEdmm+SLakoeFwTShq+kr/NNadF8Cvw5lZIexebSLBPCQrzhQelg5Ew4XabrMleEhCJ6b6gR5a7Lv0KZoQv1pYGjyCj6JbjwSmyOiIzzVqIyYskWYYrG2fBMaHfZ6qA62R+B0qiQ5HEHV3qX0NBRea5rRXyNL0waQ4oA0pFfmJnZW6FkY8weP+Y/v5EtQRXgPJd/spRyVkFs78XNQjBZoAcN+Zu89g0xlNTRDeijT4Kk0lD5o9JVpLpj2juxOdsdfnk1SlVBFJ7pz/CGpjISpOfAG18oEvy5s45uOn9Pcf4s0QGAj/wC15EOu762wqV6A1RPJMvhVr6pKLO3k6e3/AA86/oES321ZMc/xPukTwclmyg6lDu/1XqYCYQE/NyAPB2hz0AeL4a5yKbRTyDHC6Uwc+Xt+/wDlgdXEUaqzekDmcUAA/wAfr0pOap1/zuSG5mv+vJU3fhhmT1F9GieX3FGCeEZakpuj9XgdhQ8UkwJucF3f+PHUk7D2VAC2HKoM/LYeBxPmmcptQTJ6LPjvvC8WMjBEtVQLviM+bBKxS2JDD0XzOLu95FWdDOUz/E1Hgkn6sYH/AOCMO6Hyh9irDqeIX4wN36sDJbI9JcqThFGtj6X26MMBqv8A5tOWm5IR+VEt2Go470z9U6wjpIfKkCczHa8rfOYCzTkaysic8f2FhG1lJiHv/vWcJqtSVsyob98fVzV6pZq9lgsk/gX+6F2Oji8YdXh5qBvMli2XBiZ5KHrf2IzJ5L7tw9Met9o7qL2NPZNc4jPMf/aqHLB92DWpOxaFMTx/zuzzrr6onYbCAGYn/wBsa/wS/qji9pOX8P7prQfCffw3e6ScolwYas+Ks0InB5v7D6s4p/yi/wCPjj0J+V/osPMMCgLh1PBRepkTXrXFWhIIvIOxNn/96RoFrrNIzyL5fV4KU9Iiu+djSXO5ePxfjs1zFGFmz1/NX9zlKfzFnKhHgb9p/AKJjP2WnVHHu/LjZy/iGR59VRclPBGFEhO//l1kgW6CHriGlA7U6HwRkMhf8NAY353XUBrgLD5uS/wY3VPYVfEfa8h8HkxYjLMIUL0z0IJ8vN/wn+qsiD66s2eJO/ux3IbDZbyIrIAt+CwiBOCk56KYc8cXcpET/ZdzCu3/AHSDHO+MEo+iogXhnzq88RpkkR/V5SSk+EJr8fr2H3pZxxicwIL4WBKfgQ/mrJwvN6k0f1YZzqxn907geTlcP+0/5mNUwI+7xSPSxDVI9oO69HxDytNdsA4hoCp/9r/arlDs/ZTIJcgigwZ+mvux9hmD5xuXBw9xTA5j4YoBeRYbNkVonGo4+f6FlZJ/nNIQkRjqC96XngoxPUJ8U4IuU3a88clJp0+F4BYVlVoUjXhFvo/osZmQV89XwtyeB6rJIeDKrRznOtPks0TmHTPlukVw6nr4rwOMRiz4LDKVjTsQ85fV/wDrrEMJwIU/iwaXZNa9q4PnWyXc8uVoBB0jKNWMP1WPzfdQeSO1/BsYFl8yRJvO8WYHBQvsHVzOFe+auTyfm7DohdDV9RfLTS53ahce1dyQkFfz4ucTIegcUsDOU66/3s/kwnPdC8xY0SnJ0tw3CXy3QZngWye1D6ffVJDEPN/xNj654FP7o4myOkPt2bGzCYd2bNFBz/QTZ2FFl7M+kaPBzZfldJ/4ocRHq6JKgYaaDPtf/Kw1yxrM0SFiPMfVNyCs1pXgddQenp9LGuxfK3JJJNmuPHFHoO0dqEHGhIS//Wo6wz0J8Uwo5RaA5Lxc/akxE4dUxFUZi2QRMWAwYff/AKrCOVSTxSg9Ad+n+qfgbPD1eU76qFsf4pny/wD0Pu4bfl/xZ2GHFVBK7nFJg0p2CZ7PB8PdIKSh4SuTek4omLf1fFT2b/ymiQgm9ee+4+bO8WEcnsuqh1CServjHU4vGxMS8e1iKAwIZOfuhLysMnpWR5UVGgmNXeNTNvkGIlIazgOZ/wAOqFFPofzWgsdfoJVgXmUSR0fd4z/yAjGbAD/iBJgwHEuP8UQ951YFf6uLAGj5lOOY/wCaF7AjoqF3r8eTTna0AT9rkfmAyn7osBGpZ6wRnMIssnkoUQ/FPD81erQk4w0Jq5oqJ53QyWAv9mtQw6p3hvsr8CJ/G/Rr/wAAR8jYbqjUG0AmhIJLvZv92NMHMq/I+N2Mnq7QpdJ5/wCSXvU38LBWQg4n1SxzDES/NCPCcZBUSnmy49QnDpMP+lnlOZX2S/iLKTT28X+1CGGRJEoKusovVg8lIoVxy2cOTB8zWyVHD92ALC1ML/iHXko/8fnU6mPav9Xiu1L5oG7XLV+dbHSE/djnKy91OM1ChnBf8JCELzaskpsHs0MjLluTiCMpvfMFeSp4Qz8nXunyE9t6DLPW28LPp4/i74zk7On4rwG4ecexoYNDps3/AIIloKFkBskJPxX9vaaLzeeJyy70kR0FLB0lkPnv7oRMj4T+biDPZ/RXYI+f18UyZ3pzWOU9LxWGJyfFcPhh8RcfZ4s/P5Xh2HAwVPlWpt4888cHzVkDobpUk7zF+B7dUEMUs32cjYsue7fmzdQflXpDcBuUeJvnXBc9lCVftSTB/i8S/bQI3m7+vFCY8f07fosjH5ia4+SU1PhawdJB4uNx47PNLTYftVnk9OSgTlxUJ0Fp4YoNJQR4B4LnV9DEU6Lzn/BuST+f6s4yA6zxZhXgbr23Hh5eCurOw83LVT1HABZ+rCpQTIPrzSB144FLED0Kinl4yTHxQWIOnH8XJTMVGwWP4VpopeCJ/BfAqbIlihbBB67fsbls0miD8PmnInpmWJn88NASSOWw2Q8USVcfNVcnd92f8l3+8bPD40ilnGIpNKiGj+CKZIHyY02J+fGpGWGU37fd4LCAog91WYPVpP8AnVJPRw/kllRORjvzSuH2aIcz82HcHnz80iO5OKFlo/BWOZ4L0PPmh/wNqkeDrODubPvoLcRvoPrkJ/VkIxzzPM2JszwOKuTuLfRYU5eamChJPTRQIG9o2PaeOq32n5qmGnPin+d25SPpDyzRwj92B/wsvGhJvfrzcgtpD6p7VyFL8cXPIoAZf54rUsqZL4E0FTBTsoUnCQnu/fg3BeZUIBgc0IXDCefdXOlS0hUBcBs5Go5QoDwHi+anwb8iKyzeUObZAKQB6eqM+HMHP4qKXMx4finXQMcPzZzfkdt53UkUUMv1FivgVRA9FSimP5u1Cg66zsFBwSiMRVpVNvKInlHJ6WGknpY++qCGCHv75bMk0rwu3Ml47AEovOE3ysSv8fFjythwzEb8m7LsS8Gx1Op+qRWS44TknnGkwgIT121Spf69vzRCsueSVHmY+RLmqtOqtk6/FjxyJhqf65VAmhfku6VjOYsGbbJvpuD2mY6KcJEXR7+KeXI4/wAeCyqGHK49XdzziJsokevv/NpslLknL0cL0xT1SwWdFfDk5d644Jh+KwF4br57PuiJrnOKM6j4Wf04fXaxjgO8juLOKW+R1XAr+Gn93dCiG4up/uuQvm2zAj1AdKTwIkwT6KQp9Vxj1ZrycvWFxkqPCPVG9PMebDyrsskBUfJCQ8Kb9hXv7q54BNRJnCPqiIBKLmRRQ/kv0UXrsVkubw6gPSOUsRvRFNmYvZVhoS5/JwPas1vtsNPRAQPAXTPDRYxnR6XzYMmSy2bCTyHgp4sc6cuLUGquv2qvOI82iFz5Dn9VgSIcypFB/APZoY+cGYs7si0afxT0HJfSKIeXFz5e6wZ26D0e+PiqTMcNhp96DeCDe+S/Pw9Oz8XEDHLqoaAsGUGAkg8tBZMd3AGtmQdd0FI3kHwrgwKnz1+6wZqzOTdLwm8NUchB7HH5obfbciXOszBMZShEM8MxYwuCVz7as/gAz9XIZMXmSdtk4Ewu/YvsXIaeBxXXhhIH3d1VOQp0P80c8r6bH4sl8uRXgPKaRMow90hCTVBhlIx4LLJShGx5svKHH5q8hXdoekPEcZ4wUKvkMfg/9qCcqfWXd85KaJeCkFamA6M4Gn8n559h6u58A9VMaHLXKLyx3BH7rgon+nsDHsIEiMcX0L6GIk0tAJkij/IBZH7sP/SqmYT19UruyYxDNI5vwzjhqxydHA9xWN5+e6E5qsmasqMa9ILZN5ElEtDkjy9fl6pAfERQDkRJPDr4vI9COir3wxPnusNyy3/m0po7l2oPm6CHX69nq8Xj+os6Tn5LnVDgprGOITbyNMkMQ91iiFIcyd0ZWnC/ua6o9cXHg/4DD/1L+V6yl8d8vNHOSlJg4DASStR6RGQAJuoQMNGU2BQT6LqwdscTj9vJkzlyAuPoLCi77OLEF8ayF5nqjeRhhPeqC6YbsBebKCEZUj8+KKVF8vRPdB5zI6zMKfioCxOWMr7Mgk+UUIejgH2aVocRCZIANnjqh6v3BJIqkhI2eKCbNZCdGpQgSi+5zNe1eWBFE8hbEe7EI8HtHdYFMnxqNkvByDG8VIAQDyOtiyEefJsKU/gs2g1jsfF/+NZzDc+PhRT/APjQmS8EEBsBGO9vsLLLnjK5nlEv5WT8hTiRPeEMHiLlGDphKaheQDKFUXzDMXYUwcmM8zdEQgJZTTS6rn1REYRHFp2feRhJstIKcMQPy0k5kcoiBC9FBhRemCJKgABxjBw0uTIVAhdHMCXyExtGeWSenQg8hNKUsxrF+cIA5mZvKgHJmgQYfiOvVeQLjmsboB0MQE2WkNEFOdgcMpMxXqrQmwZNVGIu8NwEg5jmb8mQxUOzezNXBloTfG1aUB0wdYyRQYMLxZnhBEuQkgeRa2Grygp+7x34XZHJRWcTkwNHEKx0s3/4T/ulNHnRHzNeDR7s5ru5qRKRBmIriCTye6D2HAjYYYAVaHNbARkcXxzydWEWAh01A+Uy6TNQRlQUQgagiHF2k8zQzHPIaCcSPS0DEgRkwviN2SDizlABz/cmRxw4MxE2PE5JwzGHDhgCjDT6k5np0mpMRTydoBuOSB+yEulnZch7ZUURPIKAG8kYPEBxZu2AWEoQdSdEXHyfW2mrL6K1xyiiKEEQp0TsSSyaeka8ThPcV8WIhyNBITw1D5sV2SLz5WOxxh+xZKfvhzNlCtFkRv8AyH7ZoyFNcSCyJD7q9CiCEvhvGm4jh+Sr46oMpGZinugljZiG3MXJVm5+hA99jjHgDqrCIoiDJc8TAmwpOG65SDPSAlr6B54j56HlB8imko4mjuML8FnAeYAQ+AMMryomQbGC5QwYRPNMkgSpXH1BJ2SvN5IX+f5AeOvVxXYGlCQgg8In7ooBGQWRJBwqHXVP4gkYOLYnQVBkBGMFaSod4AFHdjIu17+rEzAc8x2s/YyKBPPujgUTPP4vxy4M+aYjhXOkYw+f+QTKfdRTFNEN4zdaBWqCakkvRU6k0qszYtyr9lXzNVqSvHq+W1n7h/FKIjEQBoqhHi77thXN8g1oldtrmP7Ff+Da/ilQuZQSVGXUgY00alpfsdiWdwQVGsNvA+7zioQ4m6FfaSv+EWWBt84NqqlqbQmxs1KuIYivIZ4MygPRwTJ+KyYIhwyqciHlmyF1Uk0LzEniphId+bsuIMOTz9WWctd3uw2XAHNKDcwHk9XNePnqLzE5v6okgarp1F0w+z4qsEGeg7o09a/8XMQeOL3Lp3/hJYH/AAzR/wABOmNQihNjdDUGjcfHe+gDiogK5MzzVdAf6TcuP3KcILk3Yyy+B3FW4lZHxNJxl4Jby6zbr5vmZ0Qsrjtkc58WHg/Fe6RT/mo90KC0x/2ci7H/AB1FjKZGoDh+OjNxdLDH3jyLtCeoebG57vnDp8j5ubD6eF82Icov6p1HIPXts5uWEnflZnmHjmyhRBMEe7K0TJkx/wAOLy027dYvMeD/ALym6sFU/wDAJK0z63S82BI81ItmP8WUi4RUqfIPTukIs2g2jglhHIsjgdXQ1TqDX4CbHGy15oUMDvNB/lo6W7e5tvl1Y71Mejzf8NuR53LKJavnFYV1ef5LjC7Juq8oG+bOasosIe1YQVmnlRptwcb9JFjwpClYR780Y9xfdAHll/ndDwP9FuUwuBddKN2AKcr1/wC0PAYXkxUQcT6lZdhteIf3VqeBPjhPd9eztlyHx/wmI3tcKhD218crHrKeK4KXmlEE+KhI4XA9NKBO0fBilkjyuGWUcnEoBP5Ht+qWjsj2jFvKSNnieU+K8pCp5wz2DeYwceh5rOhxHhqhBP5MwqWzZPE6rbpKEzF42BA3lsf8xBF9FKmcads+Wijy0cua82tyasdtaRZuKeNTFg5NbOzyNLFioxb0gbJEI7cisjD7LqiNhb9lKDw+7EUSIfKtHL0HdkE2Pfw2E7MFBP8AiK0gBfx2WChBiUe1ZgEOqeV3XaF0deb/AJxcAg7Lw2NOCiYklPJZg91peqX7U5QmViin082fnv8AVdyM38GX/Mw+LNk2+eqLE6ox+6uFHxq1ZR5l/dfnpMp8UDnbfMuGgg49HKElPPqaDkXFn42nggf6D4bClJgTCijaJ6xxEx4qicSdhOx7i7mQZI6ck2CbjmI7T4/5fEwyY+7lm2Y91J9rtLcQ7uh3pRbGkfmg0WbEE+EuJyY/m8/b1QIEATuKdj8JtCPEanJND4M3Mz1QWYMI3ciuQDBHjo3yDvt3/VmCUI9UQOBJX7+a6HKkezmaQ6W/hf2Xs6h9FmKazRM5G5M+FPXy2VnyjSUq/wDNYYZh0SphWUERxZACxctPOyM+roZ2m7vVgjw4qhG7a1kgPkP5sdHi6Sbfdj0OK+qztrh0s6/sqnmvKdJRPCn3WGuQfTCKE68n1V2kvD46oCD9QE1ohZIryaL92Od5FkX4NQ88ggj/AHREACsiE0k02VP0eP8AhCN0N8J92bsBMkc1jZS8IS+C5QGtPxJWta4FVgPuWlgQPkigUJwNfatEDepHmK2qIc5Gi0DeeEOKGd0EoX1dF8h8CTBVXyQdDqrw5fUc3S0D2b21VRK693nNXDh8fFkn2V/BRqVBQ9sfyuQeF7asSzEuP9Bo+YIdj1YCSIf92bP/2gAMAwEAAhEDEQAAEKEgHgZeDjKYMELQiC6fsPK9XV60JKz3C681Hr4VDT/qSzETHqYGgOCtND9dvXr/AMaPozD1Db4zcPR+icMh6VhQ3uwTNzjijaj7lqoD3BcP0wsfki5ABB3EYfJ1uhqxpd9kJkj9g+K9hvMJ2p6+6C70ymZdN4K89aRj3IsHCCgsI9QDKAekuvF94B8bETdYe6gsMBrWh+MEDXJC476Ex29BZDUy8PrqrSMGa86Q8hGyYZh83w9dghzG5Iu6pUixz0OTW5TiANSlkPPoH2U4Xg8vq7SddhsxsQV6arF7hwv1YI1Y680wdro2wUnCMBwWp/rUmMSHs3lcCcPscTGECOHVRGcMYFFh5il8jsoukLxjqTbelf8AbDjl+ty//8QAMxEBAQEAAwABAgUFAQEAAQEJAQARITEQQVFhIHHwkYGhsdHB4fEwQFBgcICQoLDA0OD/2gAIAQMRAT8QcQSIflCPM3WPIV39H3g+RF35XOD6H82caPec5+cYtdgdv+p9UB3xIWzt+UKl3L58OvNsiG583FYGg9v8TKc45JQrl6Pv9rmXj5ZusB6+LavAshiRPvPcZ3cOftfSocOrdPHznxJK8F97Fsg4PPPy7kgquG/T++xf2TlP+Tv08hb/AKB/KQNDw4gH878/FhTl4bwfdYB2Bc36ShhLg837r3tsx9Hn/XsYS07McF+PrD8DBFcZ9dsKCL99g/wXiwN/Bxt9r+i5NN4B0fe4wCjofP8ALIYin6NzgPzYBdnA75cAPp8ExXofIub8OvjhHLeN+WnJ8DZ+i9Nyoav2C3He0ZYkuhnap23A365sa5iw1+VXv7s5Lv5f6zyI2t0Xj7c7b/4S/AvGfJcsOZn8xq4X+ZOQ375n8xzYxH5A/wCm4CF9hhOD7YGHAM51LEADOBn000+bI2AOAiOAKHPX1JI8t/M/eYh1epu7uB+rz/yC1g/pIQAJq4F55zS4FDeXN2/VE3CvDDsft+cHLpvR9cs66en6THK+1Zv5On+8MAU+vM6zK5uNXDj7Y/vaJefpB8A/3TIusL8fc/XEJnG+HX0t0IG8vceMAfh/a+2yj6D56gHPftz8E3W71n1t03IW/AL9g3R/KXRxhpTyf3vqGj9ttTmWa1wLdh43u4ljlnY59b7X9fxOH1h2cMYvO8fr+cGjPgM4j9LQssAV4es+8qN2vB1pPH45Xp/BKg3Pj6yCXX0OD8mm3ANx7+N+Q+v023VAC88IdvtrclC95+c9bXOl98/f/t9G3D+cpiI+ssrbvQdH0sF9MVUvBc+uPxDshu/Rr9IwxcON0IRXz33lyvLocqu/rqTHK7n3eHWQQIM2HknT9H8rH0R8lw03+YUOlufn94VOfX7QM+XH94XUTpg08gPSbsbIcEcyWguUd5frvPVmqzXVr/yoHOYUpZPF8mXHbbiQ0WzjXRkRPAYws55C8uRv3h8feS8T9CK1cROvfNFn1FioJq4DonvKPzxcqKSeXLacjbvsuIFwjT731F+cRy/acFc2VzOkYBq8yaydtW+9fEQodTTo/O1ztCTwZLYanU5mA0MmA+IMA6szurQzYBnK+4XzciD+Z/SziOFv8wN068/1gzNnnlamkgRjwEQm9wt6s2bOMHebVuUIl5+CYA43qIhkwgBwIVK8so4Hablz4mdwyAC+eAjkfMqTnp/Pd0fxLvAPhvL9IuXobg3BkY+fIAfWWxrsA8PldELt7y+ezBkXuAghUzpvcy3oc+kXu7vybY2xAt2M/ixOAX1gpSfJDeGEgB3fUL9ZAPif2/iHowfDl9fu7DJn0w2z2PduJcC5oQILhmHLUfns+WS/o0Q5fz/KD6QlMW5IjpsMIbJPcAarEXWWTtsBk3nLKUnMLp83UGeKkCvCLoz706EqWJLJ8eWhtmXJB8WqMGQuCTcOLnWxgOr71phepnggOLU1sJNt8efMGbh2HcGO35nfBKWJx53IAlrsPa2cX1rntIFWBDvUhqhXUvjep5J9uS7vujhPGXGdGNho3NWTbOUNPVwIt4GMCCPh/9oACAECEQE/EI+VwvNtOUAmPnO4WVo/EeO4N8H0mByjvUs7LrhtTdJy0N92bm7J6kd1mfh+cou4eH1hIYwmv1A6/ngjLIAjjWN5P2jf2OpyIPnh/TpIgxd7cp9bKpwJdGQQbj5Z4Jh24vFh/n+kk/HxYz67DFQG5z8v4sM2FyuN6+5flfIDE3iBZS/Dzid/vOH1dtw7ayN8b9klLmJ5H5PD/e54ecOsecj2/Mpc13i4tpWPlQn2+Mmwa+vxH2cdwJ1scNOC8o8tZM3S6E/MTstnFsQt8ActOCHwson0DSZDjfpb0HLjsjOB8/KfBO+4gxiUviycNuXtDtkmbo2GBGGA8WEyBeQwDWFLVcGtuQTZeyCMy+ZCV+CUovH/AJfXwm8Cfb5jY8w5/Q5uTnqy2fJPwlTk8m6SK4SJvmOhYLqwNz64/EfBAdV9YEHHjrfnmZeYbwcrYccOn4l4vo8hxyUmPb5gqH5uXHw0Sdw5MU3DmBrpS/46soAvQOfl9J24OMfH2T7P9IjI/jF9pEhgNixRy4E7FmyOHw5lyxIPzxz+tvZyvn6lmu+Eq562/pn9ZD3OdWzPec+RBc/H5Q1T6D8fnOqp2rVkMrGDwwCHNgIguegX6l1A+6mW2N7X+vyuHbgPDppCTsPHtOnE4aRHi5/N9KWEHMajMTfOP82l0s5uoJR5cPCyZ8JF4nX82x3wV+wdsHcH3RnW/wASfH2ff5l8DJwOfrAB2YDexv7QQQhCERfa8A8HmxPQ/Pm3FdCP5P8Am2chw+/Jv7dxvqWAgWM7m6hiB/ezzh/2Zm+9khjxNgO+Lk+T5t+vA840lcH5k+269v2lcDh9bsW4933CCdU7kg7jgtAmvH5fBYwPBEcPcTXHJ/3r9bPqlc5jv7QJfPVbI1f52FDCznSfP1kGmpwfCguL8WmgQMD/AH97uvJI3iyM/wAo7AfEws7/AL2UhGVxPnyOkc/T/N8p2XL/AA7virhDmQZfSdWHOJ8nH7wjoisN/uSr6P7WCSo4/X9IfjufE0iA832XgKywWcQb6IYW0K4+s4j5tO+BHXabteT4k4cjIc7mRjx/ux9J9B4Wwjk22j/UWlKCJu5+U23LYSa5Pl/UmEXPVgLn9PmfrxzEj09WvtF0m+e+SJ8RjG6dcrmupfxzfy5b19pI6gdfH2ywDhfmjBJ6RwtvBdZyWO/HH73cPD1KT4v1xI2c623jgOPzsY4X3Lfbuv6SLhdAt5JcG1J4MVu2HhzGeFOvrfNmPMyz4hO3XyN/koBt8kczc7bk5jfL97boBtuuXkgxfA/ayD1akCSHHl9wieZD+7Ow8cMG2FY/gD+99FJy/eD4D5lPzwbcBuBvWR2Tm0g6c8//2gAIAQEAAT8QfYRD5/iaiBQhkHzLxQUwEDHUw56RrC4CtClkOOPNX3cDER7eKZ2FJpDk9fDSsWWeU1BEOy+aQLK8IJiWAw8MXieY4w8QkdOu4r7MnKqDsD28Fhi4mOiezweqnYjR0mm4AbPNBBEOl5zBCPL6sTuTCM44mbORAAw+P9VArZGH4L17sw+wGWZYBElPVJRdsmE+BbxcwWNY8eqZ6IS+7wUDs39FZUR3AkNKYOfFPEBUiGf+JOuaeQrv5DbDMiUB6omabIyCEDYGiDxmUIZKSHlFM8T90JcwIQMqIAPHHilGiFljA6Zj2U2DwQEeW4K1lbGOGAHyO3XulyX7Ut14ssbJbl7PpeQ0L6dxRL3nimylGJgpcJ4hohr52tcCXgvX1ZawFaIf3UzhZGQniJMDulA6zn19PVDrrBALxny0cQhZUHfNlNhOySS64EQncXfs0SY8HnPdZicb0+1mFbL0YfVhoPB268p7sOBXzVgkgpygy+6jqNgTgfVBMEzrPQSs+WxeETNnwCO0iigEwsE7U6rMBGBk46oAelYyWDjUOccVwqmQ6TmXPmzbjLQrujXg7phtHFGEBAvFHtEUiXEhhlObNopjAvlTQscxOV7atjsk8dU1icGRGBRxvmqP3jyNAvY+KuMgHSCQPusm/ChOQ+Y6s4EsAzxh4N7vn0hh9x6fNjYwJEv3SK8Q5FRgJiDJPF6xPfVndfXd0gg80kVtQCkvpf8AGVyCEuXh1VgqaKUyJTSajg3VJePgOmhlGhEAZMEvHA/NCrDGEKJAMg2jmM0YFth452wzZGcrxHmlSXB4FJV5C5lDSGhghnZ4c6sMJ0AN7n0Xk9gpZkYka0+FyMdSgrCijAUeR/ApTOwIIEcQZnyXOMEeI40fdTgnCkZ6N11QRDJmSHK9zdgGAl4IlJ7ilcPHZnF5Y+6WN0QYfEynmqQwnnIiuPOV8xMgVLqKQMVBAngfPgq8U5c/QMTVqSNmkGfNxjjzRagJvsWC8IJAWJCGHqt3SAJQHqvMFZhFHgBvA98PFnEcEAnwceMsfBMgQLoHz5q2WkG4vAx4r5XI9Qz2Ng4ahsuvhohbIQiwVNkuGJWYEAChq99URojKEOq+BO+XKSA8KQDqTCqYmJZhNxr+HAiHtdzwmr1Xu8uIjA3DSFfq6he0PvShjaGZf2lRAkFJwZez4pQY5jE/PxVxCiyFAVGqdFPr8mjTsnmjHCwUF8Trfqq+DGdu17hhVzk7JyuCRkzZoPzjJwh3YfyFJaByvVB1GBDo/wCDzfgkhLh8+boXpInKCJge624EacEjsloMmQhJFkzxNgGAgjwT0mhZWDcFkRCRMqFcPCJ59gPy8G0iAgrsiEDHyfBSUoQR/Qn+bxm0IJI6BUD2kmqjTJLjv0FVTkzmLlsBba9pyvmqBInuDCxZJL5SfwUVPdJYjBOcpFlEidUCI5BEyhK/EWOM5wo9TwStoow55RPMcPipLQB2g03lmhb1iaT0nZUDSICOtSUaej+1aAMhDq+bLdccczx6i/8A0KGsKYAKEgHZ+KPMGIlROHkexsuOUIE2c7L4rFWAsueDD6pByhyF5Tx8tEkImU5YfATXxgTPZB5Q4eWWnJq8NBgzppC6mwaKcT7I4pAHckqnb3YjCNAgp59rZ1zEGhfHlrRgyGSZcUs6FDBvvpsGSBJxUGOmLGPgXw4/qxpA4n6V1FNpsCCIYygOG5BJ3PdmXBN6XuLLbFOeUEzcmacfdCoiZvD5ogAAmCOfcUOu0TTGE9R/zp/6RErSEPL7pIIEQqSBzIVbIfsAz0oTDRF0h08R5qA4cGWwnR9UzQwnG9nTA0yDNpJ1Sk8Dl+iwTCIJTwAZLUrmiEA4RPhsqmXIk8OPVK9JBAPSGNixxHLL48WRqPyAB+7sliU9ZXNDEDxN2PdcA1UgHy5ZLIITAaPh5qgSoFjPPzVypOQI74ihK4dXM1hQQm2DhFTpLCZXMlag8kDqq8UdYM5GJX1zTjNfz/K2Zb6lNQmYIgl+vdg6xAJGTXWj8G8siZD4se67CkIkjHu7cdkCHIQfqwueD8WieJJshASvvu81s1gRh+64MWQsqdvmoBGWLjs/gKRMHwB1B6qs5JatEASq+AloQxSJZkkATE5OGa9jRrAby6kK2edEDHc0WOUyDukSpGdBEIphwJ1ebAh4cEiPylUqnMUvKe7PsKkghwq3Uyo+D1YV4RkF4mKZI5RYeKtrQjIPTYJbGLPA+NsGaAOpoBem/wCQVLBzIZEJJ010cFkJvXjK+wWQkZE+b2g+z6C16KEXzSDe5oNj0UA9CTJ87WCfi9Ce/hu5CPD03UEwOYHa/OJSEX5++qNRhjSZKH5KhA4BxjeBCeAPE5SD6GAcIltPl+IKmsOjM1mfgQf7oOx6/wADw1Kp8I4iUeBh5K5xWTouInVP3VtImycM0oXcyD2nhzugeVJ56Y6PSSPVb0ZAQp6ilBkggc8805iAGKXzFLBCR65vVlIEYnlGDMNZqll9RfZ8X3ftp0mYIWHmuDkkXqcncN5euwvjPJ90UkEBiPZNIROSGOOds6WU5E9TmT3Nl9IEYE+GnZSXE5R30aR6sJcaUL92H7JOh8q7HxFAcmaIgQH80Nwnrnufa2mTZmqxQiSpom1GC5AlEj2sfinsOqTJNm4H7sHCjQihrpuaRgfZ7fZn3QTz5gBhNyoJ6un0kzp58LJnUl95/ulGTg0OT9U8km1SXB83foH5gDpNn0/NOE1WL0hSFKkWhghPk4ShEripJL5acC6D06pUa4gUfVTjjeR6JqvrmwrY+V6DY5v4ebyLPQePNfyTwA8h5HqsLsolwccEufAXGxOO1h46fdkErofFUI6cLVkcPDNMCWmKZSUJ+DmiZaA6ShH6SSkbgFKDbIbt9bFlN0EdkS8j3CnwUH5yMDhE9PDSPpCykf8AP5LwahutVUBYr5CvM91FCaics5Kcf80OTx44yM4aqMogWV59WeUAcX8qvFAFGDiFws7UHJjLiS5PCRYgAG6PKoVPiCmLId7QjtfLVywoPHdDSjoMw90JPQEv0bn+NM405WUNQHMWc14pDRqwnZexoL5U2xNgyROvaPibqTSMzUCWlENAmYWBwgi8z31Is2gyObHmfJRAl5IE/TahxpMEKIY36pGRQ2BHgfdGOQshOYY1gni/4b/VXJYux8EaRzja5yNG5RK+Xo4p4RZQNc/GsirhEjGL3PcXR/7AmarPHe2So7FMeR2ZTM8H1YgyGJ4MWD6EWfBShWkAz1wgqVqTBLP5fufmqVbHZPCYH2rxjwkaeJ5P3WJ0ogcqCVCaOBBdQA5Vr8X1kBmrz8AfNNw8lgLI4qIrSkOKHYfwhhffAE+ml0dh1TJ+C9+KFxJMBUHQruPOVb6iGZTpml5010EDGPYt/wDn0N1hGN8SYyljqjmHEHMeImuHICLK8PmbJHjJk4jjaY4YdYSNGkVJ2Ih97N/aAG7SkWGRHgTVlGIIWYgIHyifBRLjwGT7CR0P1ZjbwJfYl4r16RIQci4Hk2ocHSMfgfiz9VKK+zZTaOsEFGpJEBTxU9PDeIxCCGie47qUSFHocn8NA/HIByDgR3w905BFaYk68Vig3we2uJAw8ojfM5HpfVTzJlUm8xVYXRMAqzgogafEdcUWDmAXiPLR8HLQGwGxb/8ALXzkdy15JmLF2xWUh5ea7OKNIkjhqe8k6alBzDI+781BHGOrGzP5qMcAPvbCJTB2kIryGRDKnpMs+Q/Hdg5zF076X8RU+d6JhBxMBO7QYC5HEGBvDk9SthPlW9wSZQR7pQCBR6R9IP2e6750UjngKMPZMVZEZe9IgqAuUJVahT4UIptpP7ROyLsswnZygsTHpipA+3KVrxoIPIJMUoCnEy+1/io9mRRnK1SIvLCfuvTmkHUVYZhcRmH91NEYZyS8d7legBFATsXj7oGwNdVOpkkb4/4Mixuoh7gMLHux6AE0vh1PNI3hL4C+NSnT3Vkka8ldTPFh5vjxWqkoNIxrHgZurYT0ef2UJAF078/u6ulLt8TDH5PVeaWUnCPK4/T6Lt/7hElNRLD68FGQ1AlJUQStN4Wl3pCoCUIGOQmRx0crxBlkYPtNpAhi4kTd7gpVToiSI2ZRDJklNzzJk9ZdnZi4PAHxzenlcyBIDxH7oFUpi9CTqKGaRQViZE4GHkENivNzQr+UNSxQUxIQ/kvMX5zRJJLM0uDRM5cOO/DQlJKgHNK7PJf8t/qwmnEpjypS0EEJiZyBHD7uwZ5I82QeJ5I9USHXiFPopr2lk4lGOYqQxTvKiZ9ibexUkTzCE/JYyo4IZeXk+vyUEcyYCF5jt8qr7oN3ywZEAaQJhB7r5wQlN86V5NPCcENjqQPhAOKJ6SbNt8jtCsRa8FZQ4NEbRUzTpyYUZ9c3f7jVY8DBQqiQ4gBXuSlifpSJiiPlcdUMd4KIRoIDT6rD5EdBjk8ZcD6AcmcUOZwOU9QZZNQGR5ItUYz4o0Mwvhf84pxhpyjFZNRVGg3yUyV906az5HurG0CSh6CM930Hw8x5LFoGSAXxBFn8GBsK/wAJtaSYWgb9UgmXCSwL5JrCkXztQGD4qkuZ8UfsjG783ehn+6h8zFhdilo7ZxHKzWxlOQhyuBrla066PkpE4DnnwTU+OMxmYEJJMYe3qkpH8hYFIQIAmZhu0MOwR3mTQ3bgB7ERlHNm0l4Eb/8ACf7s0eoBC/24Z7ohhDEQzOd6KNjl6BB+jRauAGB0e6inhfkU7aCx3EYfNZskeQHHoFNJJhQSp/8AGh7BGCR+T2srJ9dNJH8Wpo5ew2jSRfOfovE4BI6H76KMgtscimnmbNlYposu2ElcxRn7q0+BoNxWODyfrH3yVCLoEqoT6Sgll1S4tWMZbE0ZicQ92SEhzA/i+zWXqRpWH83a6nZwDy49WRdrn5ASmI3Qg/ZGRdLGMT+QvPisxyW/k0YfNOI+gSdMoyDihLzy915eG0cfdejJXNADqbRIXyDkpJEKwIB1QSImiNdpLCI+DR98vBTsHJLfsQl7V3I3xIoBCnoZEHDOUr4K2D5aScCU0BSgQR6saaIoiCPJ9svuzsQgh/KpsK7BVVE5isnE0qGNMkeYv+BpPFl4OlTGS631Q7PXH3MF1DLAoHQ6ORo0OnyZodj4sFSQPFnELRYp5KLTFvKnsIfNh9Z5My/HD1FkQiTAP80eSpY9XC+Cx+WHKLC+UZR0jueT1UIYZU5VUSSThG80iOzjMUcPsqW+9/8A0iijABkBInpKYha6XQ55UCatAxYCSv3Cvl8Tyz1WZbeQyfirFAIMIaTjZeV5jzfZ+VErKEkSNjOBPip3WGhrlDCe+S6lyRuOkxSWx5gx2PdUwAgcOPdGPrs4B8J0H3UXYlsRpvDyDPdwS2ZVxh6yPI3qgngIU7ExLKkrSwKMOmpYAK+ALkhpYRfm8FfsQkbgP6c1mGB0juGLr0ccPhr8PoRpsCHG4EP4rAojyRL+B4dti1kVpCZAPupoYxTAasQlQKI9RSA4Edp8FPykWW+38qduv4UwAZLljmmJxV4HAjy1YwAEhThitGsJKYTVZbEefVQYWW6wcwIarBReqYABKJCFgC/yDM4lneyKB4GfbUCXnBL5S5fGu5qRdDIUN0GVjnNVciyj+ZHpakwoiifTSpVBXlEU7RPKLKPMvjm93WKmiX7ZsgSHHqsd8BrJETjdo4xA6IeTJ9U+6/8AGSCZ4mH8UU2aHQHrD91rOFGSHtwDoK0k7COHzNSCsgGEeaqqoC6cBr4h8vQ34ys8qI6B7/5BMDPIJfDz+6+QMAOu5bCN0fYUvFPC6EUOQbHWpkkvBuIfA5cozDByg3kD+ugoyXQgTnaoYKcS4jJDSA88By/FCGki+vT75rZZFAlzvT883trJEg+mb6E6VX9lltDtb94WccGvV6HA/wAaFayGENqj0Sr5g7sedCMDB58tmAxeWZiREPmhSdvITxx6Ta7ouJwI5Xsyzk+GKCEDVY8I2LrAwkgJkeKHF4HALos2AhvnAgAu95et7KzUwJ6QM5AvuVVinYZJHSumy0GvgjYcE1wdCAQb2vdhWTgwTx4Q7fo2rujnFgiB0cHgKIXKs9eqmW16K5L2eOWnAuz6qWVKAQmqA8Hl74KIvkFgfmcsVwSHXEUPbwGtLjy2h+VWpyx82Rd96xSzyWKBqf7oTjiHjxPnugowde4oUEAeYJsCk0cQvX3Pu5Wi4GwcMdVsKSwkTp00N03MY8Yc0/A4YODzHTFVkkyLCbESCWc8kJePcEbVNQi4X/lXEkyEEcub8X4U+AniCj8zNUWSxQMe+6wJYoRllEEBCoS+CY9zVcMsZH2VNIu8w9Rr8XN3hXc5uXuXxQ0m7An5hxOQHBFHZWEjDSUZSNO1ECOsjnoEb+4sUo0+JYF4c48RFceCNwR7O1RInWM780jTJMISDBAtnYe38XLRkWQPP+ctEEQDh5sKnJF8wsO0MBEZMpGRmOZsAzqujAEZGsVsVABz0AUyUniTukeDxVyCVWk+fiu+sdCUdPqhjMJhQcA8+bBaUWjJvrxYs1Jsj2HgsFDgUnhN/wAr/qzsjLYl4Zp+BYmv2slDJLPDKyWYDzULS48MEvbmsVIhKcDY5XUeAlgdlgizBkAEMKP6vPRSUnTKSvqK5dz8pmUQYIiEE0uLwhoB0CwzPcQzSS5A0TTaNEOHTlw63doIXviYBBJ43+jzRWQGJL5/ybrcjwE5HR8/zTTpbjd08zdlX1oOJUAy4RlJYm4VyTAogmoDNFTqKZ9xlm31Uz1MYVL4jDwSTnzc6jUX1EFls5nieY4TYFsrLCeDXkABJx8ktICkgMc+aO4okb5IPP8Aw2Qasy9iUiayo8LxYu4fCEKWNGk6zNR+YOEDBOSloAcqX37jbks/NOKYQa2X5KxKJIsIIDBE6RLhlVaQwMAZSBPo6psEEEkhdGJyJRg4sqUAK8yyzHM9zebxyl9tZcyFlpYHB6dHVRM3arRcHEAcFJincDOcjkAgzp7u5COcpvfmNosEhKPAABIKoeNrplt4IU+YKJN/J3c4cEjfVXhPmhgYOyO6eyD2WUSXguM5CCmJx8vDQPIGMlJnOqKcLykcN90Jg0hLT3STA4NVwfukocx8Dpv/ANO6+YqRbv69UvD5qHyoDAEtkthGCVlhwDxyx3XL6E4QdQgzk4qE7wAQ5E/1k1AC9zIMDwsa7KS7CUUvrx6sIZzz+PVGAOSS1+rDLIUwWgmeIsjUoJ8FizgEB6FXNNiDqfF4C/CPdHk75AfPE+qMDoGXeJeD7pZQCGSTWc5h5qLTECQB+Rs/QNYg6d8djM53XaZh0nHtyPdVyC0CeAzwuYsSMDsHlSfVObtGOgAfdhIODxHiSP3d6BHyk5hxvVTPDlOCQ46ryYQjS4+RTnQJC5evN/8Aq1iUguS9J5o1A+bIiHzTL/CxVHwLQRKeeGtMNTrwxfiZ81hm/ezkn3Qo8QHP0GtzIuoT/g81ZzYVFgBJiTwVICc5VVda51Pd3FWA53uK1QYJY59+KtSmuQiAjonsoOAmAiWXOoM6rsACNAyMShQnYzEiJ/uyXFBPzTVYmBPyeT+ur1igv148WMyHEqaIXY9eKRkOVQc6PFILQeWoPtSYxgR5o+LMPksxPl0TYNjgnbxUdmhCOeY6R81nBS6gOd69Tf8A5h/uwXwJyL2qXXB2lVE75q9BQJH5f0qggvFxOAg5F3Hlpd6DwE/yKhi2TZJ8UgckBCBOTOKxHMUslMoMxKIPdJ6LMQk4MyuDIgz2e7HvkQHK/wCE0uijRnxHpo9kmpG1uzORfFEkzKwiZXox9UjUkuOp+0WKh0YydAZU8WVmcYIB5KHhYXAmTzH6VbzTUI8kLqVCfP2AA86XAq8knPL80u7g5TDs8hQ9BkiE41kNSPJE+DDi8YeiV3hnr1f/ALhQrjpBDx4UeiBJRkKtEyvHBWw5KicghHhLpFcKWZR+wbIyaCKiRBxpO9V1kiPgDgH6qKHW3Hhv6qRAijECXaB77LJzSiHJDXElAAwBsbixJ18DG/ujzjvRZAnBOZVp0kVIBlYhVATYXcFxChJcYscE2S+UPJPn3VToZaKUEZiGx01YyToPLu+KEZIh9Q79LDCYdTSV+/FWraQ5eP8Ay50McQ6CeKfKBBDGW/HFFIuVIk6T31RqgBJHF4I80/cBRgeoDubPo6wCwQ0mQu1VDDv+nv8A4oZYepQdY5aogGZwYL2rOeKy4unskDuHTxXA+Vi5gnl+/wB0nHBng882aYPJRyqdogPJ/ugPckwHynJQwPFoFGY8ZlkhuECb5DB/ai3Kk9kQ1QaRCETLdGTqvitj2AQLMp5GcoSUE1pB8DxNBIIYYj5aYnH2+fdQOk0QLzB1X0DGEdEemeqSaXeefB35nXxQQhybk8E5Vm0o6B5O4rlIGCgM5ln2+oJCEF4bK8YNQSYHZkFA1nnwJRyfNiowEpkOU9lDMCetjhL29xWnMPNPUe7/APUbDB8CkF5iTmsQQomUHk6JeKU5S54P/ixBTbPM9nIAG8DSCim0izHIERzkY2seS4mV5Y6K2om1YJeSYlBHIRKsCQeKcEWgI5m1QyHJbMPXuy0gtlTh4gGUhCxXAeWV/Ao4iUj01QzCQWGwQlRh3T3xtM+GURmpIiKPKIBIDnKebz7dHXgwOQ+bE208wEXA8MEfxWtX4xlBCESiSEogwO2J7PEzE1eiOkTHzOQll5xMHTmIouRk4U9sEEjkSTxD82CjIxAiGyXghEIUK+OIIVjScPgqT3G4nYVSoAggKFLaSx2Ms9bzUyasA7giD6pnASJMHCrMR3RZGDxLxD0f8TEakoD4MfluexMfbik4lbYRGVFm2TQNYFbMBxS5Gk4iYEQV6Yh+ImhepUyAI+mD2gjA9wpYKW2AHCKpSshUEKphfFCd8JcSIbhuZL5VBCNQymDCLMUQjoqQ0UggAHcgTzJoJcpZppQNv8cvmjJAolTa+OtTBgeEgWOc5myWok4xuRV1wRao9Ik2ehWQJCVNQ93FzMwsw5HiL0xBxjPxRwiQSc9wIu2cTMCDEkb8jueMkCB6jkoDRqA9wBnKZMTTjBuIBCIU4CRnCsDOMMmNeQopxICjxoWiIFBYCpEL0CmApAOKNKji+USeHkpJ9+BULHg7s0Qp24jJ7/4AFzkefiqtIkHIxSpm6DgPFjoqUDj4OaQVCYu4CCB9n3WxmnnNSn5o61xlGwNEBwgFQuTuWJNgS4RZOiGuKr+nvAk5hocUV4Jp9pSOkdoYlDgjp/pdnEgUsZqId7rFMLhstIpVckA0oApGFcsCSx3AiqFBRrkDOFh/NlEFUySnArJWZRDaDByfCgiASlxIKJ82BEMmilf1bfFStscSGLnNMip4MEANEhOLz9tT28CBgUjkKxXYic+IQAYgk0PhxSxsGlXIC93plRoBJPXyUnIMp8qj/amSfcuSFutCfnAADs8j1RnRjkH6eqhs0DKCKf8ALgWO+vmjIE49HxdW+Lprw/EwlUMHB5ENEodMVYcR4PKcX3zXSBswj0WmmAmIiUpAUwPAuAiCFUVms/WjNbBy5CVwJZOeqosqAkY6EpNSvZRICQzMOMIYpzZGmKBJtk3dQrjsANjK1JCnAZGIabYSDRT3oDks8iY8Dx7IAZSNjNJVey9TUtMFKNKuCaASlmhDiChRjlc1qrUoDqa7QAkBZSO1h0dTqrIDJSZ4Gs5z0ioc4VEKEE5gs8YXLEAApIJBPhShKUCYQT4BfikHUmA+Rynql2gDIS9Dm7wKjxeE7H6syhw98SXU7fSQYrBKTt/zF3KHK5aa5w2AAylDNBY7sVo2ogAfmy7EPkrQGOTXShAOFOSO/LV3kMkggCeCK9zmSxIwH4bB/TMnVPv+qy5BOMFWi6hgOXCqaNzC7hwYL3Ed1MSFGwKHWbMvJ5ErIyFAYsLGEJBvvaBpj5CaiOEbIlnIBjZ6uIY4ZUljvuK7ZAEoP2QoQzgiAPU1oI1BRJIg690ETuC3kfNDzqLFwkk6ycX5b5aT7yhBCso6PFIdqp4s06oyoaxSWHO1BYq7a2E59l0DhRSvqDs8184S0P2ywWCqicuqkseCfyp6VIC7K1QaRh4P5pxNHBwHHPVcG7gS7waiKyBi95v+FhiREMcgosRViCMuxAw2aicj0Mx4ns7mwYAjLWJkHxxeS5ECFYS/PzQGccnZ0D58VGAyQJcl0tOIBg8umHYYv+MUTNwgQH+7Gfk8FVJyaxWgPNh4RYMxSlTiiViDwO3ZDgpLPHNglQCKZu9WAnHig9cQtHi/JpQhw4um0MDjshLJ0KDQwCSyz9DxNxXpke66n83YaJIILBJ3HJdZSiB50PLRtDw8PQ/dEzjUkkAdItzEYFIrCieY8WY+KfEDTxYsEoA4I67f+fAac8zV55H3VO804vkPhREF1Yq29m8k7LS9lgQOqJOLL0LWkVWux7rgcwOUTP2SfdnAMEmB+2z6YEf7hlBT6tMCteId92HTuRz/ABPumAGkZH1ln0HNb23hSxG2ZQYxHe14KQEyyD8uK3CrFAeEV4hOaM8pwAhFwj480cBadHXC32/k1ZOCRrybfdUMssvkpBxkZVbxdFhxH/BgrxZBjivM80TaAzzRUZkZRDjAYrMIMn3dWaxEy6MqTskoxD34bF4bciLU8z1TBoug+u6cd+OM65qomBLy3H56sAlIVgY0e7GMUZBFEq/GU8oRYA6lqVKAknBifqtowjKk7QPAeLInYQ4escl/wn/SwPFgqTmtQYXS+E3L4KSeAb7opvI6vBQAwAsp8LyNAT4oC+eFMMk3jNSeKDqBJlNo4NaR4OR4mGyeQhz+fmgXgSOS8POP6ax/6jF9D15rtAGDl0L1U8DgOJjvWrGQtFXMQ8KPPrbAmwuiYQ8SVfuuxihPVGihaDRBpMHqo3OcaHEeCMr7RMM4yfSK+07J2WD2/wCYiUAjkzNZMClzYvCXgKFTYXg/ujeQa0V1pRAkj65o1ZOZiqhZIRXYfmqJR2mqj+QqIMEB8+bw5KPLD2nP1VPJBy3/ANpVhGMiTA+SqFUCQpyuvin+wiGp+TNQLYK8T+QivHpg9yjgNKqjLCLB3XvmgKFZFKASFGAgSAwEPZy1+51MMvFOZKb2GAeAHxlV4ocjtjxw/wDGxg4BxkQmd0IkSQ+TKDywcTSqIJPiqzc4fVKDlr8qdfvbILBYk4KsIcVQeFhFgPgJaz9AJ80gwy55e2jYPZVIqUMtZrCHAO2XiwUyhvGJ5iLCkGRzBKR76r8JMdlOAHE1ZTQPej5TixASSHF2U5WzrFAgDAw7E3kf8wHCY74T8V9CHJIUATxMixS5IZETkpOzgjaynM8Lwg1Nitujolyei+pflegZKSS8eKfHwA9BBe2EJ6oZydB1V1zqoYo0xEhK3DaVDFCQY8IiaEIcH0e0sJ+14DkPqtzIoGB68vmuUekZQ916IkOyGM4NbY0BTHgA5sDpS7YcmGS/qgu4BRK4SkcID8K+z+LN+CoYbhPjuvhazNPAj1Hms4OIeY4eRlH0r4fs9MCVsH2cckr09eSplBgDcC5lUJAlgCOXSX3QjgYaNGFM+ZbKZ2yQwBFlf/sNR0lUMxqaR6Fg93zFN/1VTsw4pPiU4XNTfqgnVChe88UWQpy0gwgHjiszwR5kcfVgElO8w1ifustsjjwMH6s+ognLYHxWUrmTG8J92EGBCgOJrIuqyZREvFHgVeSgBPvniyUjyStMT9VlQTKMBK+sTZwiIZIP4px8kgh3B+Vn6AFZBGSePF5OODxh+EM+alHHmqzE3KerHF7iA/BGrMzCXGUionJEAZgmepKzB2rmgvSbJxf/AIOvdFhosnHudoJIAgFE5y+7MjzSkCr+KvaXxFBGz06rFpbX1VzKOVHeoOVDq5wQeQsgT1RjPDPTXZJhnzyo8D0DtaKgaSGPMH3RpAViBrY4pFN5wHErEv1ZpoEEhVIodhWPdf2ZJyZGebu4iYUEE+jbNuC38izrnOGzWrABmKJHIo1wmQodnoq58WjACAJ633UNTj2RB17S8hVnnSZzQv8ARjFmCVBEtDHsQ1IsEHEAAxgO60OLYrkL8Og/4RtsKXaZjmLPVgdEJYPmwSA3xd066sYCpPkqOgkrl15m/b0UhQ3Cj9equSpLNY+Ji8FGkHhVyMYYPS6seDoKOghoPQ7FjGlleEx8VD+8EEpTMBFRO6RiIRGMUKO0QMQ0Y9deburTKEIUGUmEQwXw58WIkTwnSM6My1AQIBrZRfcRtaEVp6k4eh4qSyzxkuIcTLUYAjvGnvCmS/SOziYk/wDaQTpig8odoPhoCTc2DCgOw2jaIVJ+uQ3/AOy/7v8A/9k=" alt="Reel do cabelo maluco">
+                <span class="play">▶ REEL</span>
+              </span>
+              <span class="watch">Assistir no Instagram ↗</span>
+            </a>
+            <div class="heroghost"><span>O vídeo fica aqui.<br>No exemplo ele não aparece, para preservar quem foi filmado.</span></div>
+
+            <div class="stats">
+              <div class="stat"><span class="v num">1.288</span><span class="k">salvamentos</span></div>
+              <div class="stat"><span class="v num up">161×</span><span class="k">o seu normal</span></div>
+            </div>
+
+            <h2 class="headline display">Você repetiu o cabelo maluco um mês depois e rendeu mais ainda.</h2>
+
+            <div class="blocks">
+              <div class="blk">
+                <span class="lbl ok">Deu certo</span>
+                <p class="body">Você apareceu com a sua filha, dentro da sua casa. É uma ideia fácil de copiar. Sua audiência salva o que ela quer fazer depois.</p>
+              </div>
+              <div class="blk">
+                <span class="lbl bad">Não deu certo</span>
+                <p class="body">No mesmo dia você postou dois vídeos de humor. Cada um teve 4 interações, nenhum salvamento e nenhum compartilhamento. Nesses dois não aparecia nada da sua casa nem das suas filhas.</p>
+              </div>
+              <div class="blk">
+                <span class="lbl next">Na próxima</span>
+                <p class="body strong">Antes de gravar, pergunte: alguém consegue copiar isso hoje, em casa?</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- RANKINGS -->
+          <div class="card">
+            <div class="eyebrow">Seus rankings<span class="demotag eyebrow">exemplo</span></div>
+            <h3 class="sub display" style="margin-top:9px">Quem está em 1º lugar</h3>
+            <p class="body" style="font-size:13px">Nos últimos 90 dias. Toque para ver a lista inteira.</p>
+
+            <div style="margin-top:10px">
+              <button class="row" onclick="go('quando')">
+                <div class="grow">
+                  <div class="t">Dia e horário</div>
+                  <div class="s">quinta-feira · das 4h às 8h</div>
+                </div>
+                <span class="rv num up">2,5×<br><span style="font-size:12px">3,2×</span></span>
+                <span class="arrow">›</span>
+              </button>
+              <button class="row" onclick="go('cena')">
+                <div class="grow">
+                  <div class="t">Cena, tom e câmera</div>
+                  <div class="s">sala · humor · plano médio</div>
+                </div>
+                <span class="rv num up">2,5×</span>
+                <span class="arrow">›</span>
+              </button>
+              <button class="row" onclick="go('assuntos')">
+                <div class="grow">
+                  <div class="t">Assuntos</div>
+                  <div class="s">sinais de pré-adolescência</div>
+                </div>
+                <span class="rv num up">132,4×</span>
+                <span class="arrow">›</span>
+              </button>
+              <button class="row" onclick="go('aberturas')">
+                <div class="grow">
+                  <div class="t">Frases de abertura</div>
+                  <div class="s">“4 sinais que a criança está deixando de ser criança…”</div>
+                </div>
+                <span class="rv num up">132,4×</span>
+                <span class="arrow">›</span>
+              </button>
+            </div>
+
+            <div class="note-box">
+              <b>Como ler os números.</b> 1,0× é o seu normal. 2,5× quer dizer que rendeu duas vezes e meia mais que o seu normal. A conta compara você com você mesma nos últimos 90 dias, nunca com o grupo. São 99 posts.
+            </div>
+          </div>
+
+          <!-- MARCA -->
+          <div class="card">
+            <div class="eyebrow">Marca que combina com você<span class="demotag eyebrow">exemplo</span></div>
+            <h3 class="sub display" style="margin-top:9px">doTERRA</h3>
+            <p class="body">Você acabou de visitar a empresa. É uma marca de bem-estar, que é um dos seus assuntos.</p>
+          </div>
+
+          <!-- COMUNIDADE -->
+          <div class="card">
+            <div class="eyebrow">Reunião da comunidade</div>
+            <h3 class="sub display" style="margin-top:9px">Quinta-feira, 19h</h3>
+            <p class="body">O seu vídeo da semana vai estar na apresentação. O assunto desta semana: o horário que você sempre usa pode ser o pior deles.</p>
+            <div class="btnrow hideondemo"><button class="btn ghost" onclick="toast('Abriria o link da reunião')">Entrar na reunião</button></div>
+            <div class="btnrow demoonly"><button class="btn ghost" onclick="toast('Abriria os planos')">Participar das reuniões</button></div>
+          </div>
+
+          <div class="card demonote demoonly">
+            <div class="eyebrow">Fim do exemplo</div>
+            <h3 class="sub display" style="margin-top:9px">O seu fica pronto assim que você conectar.</h3>
+            <p class="body">Ele é feito com os seus últimos 90 dias, que já estão publicados. Depois disso, se atualiza toda segunda.</p>
+            <div class="btnrow">
+              <button class="btn" onclick="toast('Abriria os planos')">Assinar</button>
+              <button class="btn ghost" onclick="setMode('zero')">Voltar</button>
+            </div>
+          </div>
+
+          <p class="body hideondemo" style="text-align:center; margin:22px 0 0; font-size:12px; color:var(--ink-3)">Semana de 4 a 10 de agosto · atualiza toda segunda-feira</p>
+        </section>
+
+        <!-- ===================== ESTADO ZERO — PERFIL ===================== -->
+        <section class="screen" id="s-zero">
+          <div class="phead">
+            <img class="pic" src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QBMRXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAeKADAAQAAAABAAAAeAAAAAD/wAARCAB4AHgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAI/9oADAMBAAIRAxEAPwD96KKKK4zsCiiigAooooAKKKKACiiigAooooAKKKKACiiigD//0P3oooorjOwKKK8B/aK/aT+GP7MngkeMviPf+U105gsLKMF7m8nxnbGgydqjl3PCjryQC0ribPZdf8Q6H4V0qfXPEd9Fp1hbDMk0zBVHt7k9gMk9q+QvEn7bnw5stRTT/DUUl/A2Q95KrxxIR6R7fMYHt0r8evin+3d4X+LGuPqfivWrloUJ+z2kVvILa3U9Ai9z6scsfWvK2/aV+EXT7bc/+Az1vGj3OadbsfrD8Q/20PFF1Z3Fr4Fv0t7iRsxzCFQqKvbDoxJY+v5189+J/wBq/wDaKt3/AOKV8Wz3DKIzmSC3EZbneMNHnHTHQ18Nv+0x8IgOLq6OPS2au+8FfE7wZ41t7rVNFiurq3s5I4ghhKNPPKf3cMefvMepx0HXtSqyUIuTJpUp1JKMXqfY/gb9tT9qLRbqO98cSaPqGjhcv9qt/LkYZPKG3KnPQDPy195/Dn9tD4U+Mre1XxHJJ4XurrAQ3YzbOemVlX7oJ6bwv9a+QPBn7N66np8XiT4uI7zTqGTTLdtsNuh6K7A5d/7x6dhXhn7QHw0tNC1KHVfC/wC70wqsCwMT+7OMAc9Vbp046ivl1nadTlufcQ4YcaPM9X+J+9cE8NzDHc20izQyqHR0IZWVhkFSOCCOhFS1+Gf7J37S/wATPAOrQ/D6O2uPFWiGYCPTsr9ohjkyWa3dyoGzDEoTtOOxOa/cGwvbfUrOG+tSTHMoYZ4Iz2I7EdCK92lU5o3PmK1PklyluiiitDIKKKKAP//R/eiiiiuM7DmPGnjHw58PfCereN/F14tho2iW73V1O/RI0Hb1JOAo6kkAV/Jv+0v8ddf/AGmfiTqHxG19EGn+YbXS7Z9xS0tFyUiQEcucbpGA5c+mK/XX/grL8Uruy8E+GfgXo02yfxVI+pX4B25tLFl8pCfR5SW/7Z46GvxDn0DT7e2PlQnnk7mLY69MnjqelVZqzRhUknoy/wDCz4Y2Hxc8Vab4EkuItIg1Dcj3KQiRlMYLggErnO3HUVh/Ej4QWnw68War4Zub5pDp8gVWdEV5IyMrJtXcAGHbORkVc8A6tdaP8QtEsF4tpfMwEX5i2xgQMc9as/EuS6uvFF7NqELwbcYEgIcrgbWx16V0xfuXvrc8ys2p26WPD73w/DJDI0JaRwGK5AGMflxX65/sc/C7Sn1/QdMnYbfDWnPrMpYZU3143lwbv9xMkD2r80/DGipreqW1jKS32qQoAv3jnjAz0zX6j/s/Sz6z4i8a+B/D90bG9EenYmA+YQQrICB67CwBHXmvmuIcVJU1GP8AXQ+04MwsZ1+ae39M9v0zwx8fdL+IOta1rGsA+F7SKSU4lLpJtGVyhZtrE8fKR7ivmbx9+0He+IIr3w54o0v+zp0Qvbur5Z9p7qVHp2JPtX0V441rV/CfhlNN0XVY7dRgamtq7TyOw+9vimAbn1VmOOlfN/xW8ceF5vh69zPpcR1RIMJcPCUlcNwDhgCCfoDXzUqbU06sd9rH6ZWp8kHGErJa69j54/4Sq/TVb670m6ksrieFzBJCxjdWYKylWHIJ+bkV9J/sMftg+Kfhp8Trfwz8SPEdzqfg/wAUyLbztfyNJ9huTxFOjMSVUnCyDONp3Hlc1+fPh3XJ77w+t+hLy2aSq7evlNx9eDiuS1i41K01S9tLPFvDHK2ZMj5Qe3sfSvrsvbjzRkfkecrWNSB/bOCCMg5Bor4u/YD+MVz8ZP2afD2oaxd/bNc8Ol9G1Bz94yWmPKZvdoGjY/rzX2jXonJF3VwooooGf//S/eiiiiuM7D+bP/gpB4rbXf2r9RtHmDxeHrOGyROpQmBJG468s5NfGWxriISKdyOARxg4NfQH/BQKz1Gz/a++IGoKuFaSB4yRwdtvAfx6V4TZx3QtV3D+Efd7Hvit42sedUepxWnGXTviLotyqbjDvKo3Rvlbjn1rU+ImuN4j1ZNXkhijaaMIfKDKoEfygYJxnI5xWR4psr9fEejXRVhFMWXcOoIVnXkYPaup0bwq/jSPw/4ajPlalNctC5ORiN5cmRs8YCZPXtWUp8q1elyKlLmaa3tb8S98FNJNvfSeO9ZVU0vSmKrIThXmf5do9cKTmvtn9l/XtOS38T/ECwuUe/huXTzGOxWk27mUbsfL8/XpXxn8a9OfTPEdzpemK9p4c8MiK2srRflUybR8z4yXZ3yzEjJJxTfhD8GrTXdYi1Lx5d4trfbI1kGbDEjcDKVOFBP8BwT3ArxswwcasZVKk7H12UYuWHlGnThf8Ne/ofYXxp/aL03S5Y/t+hQXWrsu4PZsJMe5xx+Zr81vin8WvF3xJu/s7KbCwhbd5Sk7mYfxO2BnHp0FfoPrvgvwncL59vCm5hiNEXaiqo7KuOAB9Pevm3XvhXbanvn0qaORZHBZThGIz056CuXL6dKn7/LfzZ6mb43EYhcjnp2RN8JPAaXXwnkvDHzdRTxq3/TRzkZ+uKpaj+zZ+0R4tnOq+HvBF9e6XfhZYZk8vbKjKCr/ADMOK+vPA/gm98D/AAURdRiUxalM72nOd0QJyfb5sgV+lX7Mupf2x8EvCk78yQ272zfWCRo/5AV35fLnrTv6nzuZ07UYHkP/AASx8AfF74XQ+PvDPxH8O3Oh2GoGyvbTz/L2GaPzIpduxmOWUx5z/dFfrtXk/wAPFIv7ojoIgPx3CvWK9SUbOx51H4QoooqTU//T/eiiiiuM7D+fD/gqL4R1zTfjdFrW03Wn67YRTW8CqqkyRRmOQBxySSnTPfjtXx1F4dmkEz2q+VEmwqBkkq4JHf0HNf0I/tifs7aD8dvCWk3+pyTwXPheeSdXttvmPBOmyRCSDwDtf2wfWvyp8eeFPA3gvVpPDsH2yW/tIU3ST5CyISrAggAMQueQPXuOfHzTNlhY6LXcmrg5ezdZ2tex88x/D6WS1gvFjS6WKOYoXUMA+CBlf+BE/QV2fhzSfD3wc8KXfxK8fNbxXMzYsbeOECafGPlRM5+ZucnGQOuAa1dS8b6H4Q8PvqFzYbo182GK3LkPNMW+QZbkKc5JxwoY18s67qeufFHxRDNrc6zXl1IkEbOCtvax9AqIoO1FHXAJPU5NTwzjMRiHPEVVaC2v18/l/Wxx2Tsi1a3158bdS0fwzFI1hq+q3s0t4d3lwvCuHDFwc/Ku4AdyetfVutafpejW1tpthBHHbQvHaRRIMI9xJgbyepEY9c5OM1Q+Gvgrw14E0KW902WPU9VvE/0i92kZAPEcQbBWPv0y3Uiud8cXkg8W+FdPnZkRjLMT0VmxwTjg4FfXU8LBR2unqayrzve+qO11HxXa+HtGUWVsGublgUDfNiPds3Oc8k44BriLzxHdzSRadqSJeIg3To6DBB5AGAccHjgc1wVlrA1W7vfEt6+6whkaG1hJwJTD8qk+oJBwAPWobKe5uJJry9BH2jO9nBIA7fMBjqB6VrZWskZOTbuz6ftVt7j4XW/kTnZpF8sUNuXyBa3Cs/3eufMz7V91fswT2mifCjTdKuJ1WUS3UoVjghHuHx/j+NflJoPiBI2/scyOY4oZpQFySZIiCvy89Nx/CsjSfGPi8a3babZapdl52WGBYZWy7MQERAp7nAA6596+MzPHxweKb5bpo6q+LToRg97n9KfwwIuLK6vQPvFFB7HK7+D34YV6lXkfwJ8B6p8NvhVoHhPXr2TUNVt4TJdzysXdppWLsuTnhMhB2wOK9cr2VNySbVioxsrBRRRTKP/U/eiiiiuM7BrokiNHIoZHBVgeQQeCDXxF8W/hFpFvdtBqWmJqGkXLEwM65MZI5j3DDAjoOeR+Nfb9UdS02x1eyk0/UoRPbyjDK36EehHY15+Y5fHEQ5Xv0O/AY32MtVeL3R/KF+1Dq+ix/G7VvBvhxmXS/DUUaeWzllF3OoaYg/7IAXn35qT4DaW974mn1ptzw6VEAnGR50+VGPou4/lXsv7Zn7CPxh+EvxG8RfFvwrBL4r8B6vJJdSz267rrTt5zsuIRliiE8SqCuOW2nNea/BDSJV8GR68t49kby7Ykr92VIiAFJ5wMr6V7eAoKlRjTgtjx67TqSdrI991B7X7VHoSt5EUKea5cYJPBGMDkg8AelfNPxP15NQ8VrcWEjNbWMbxKWwMttO4juQDx7muk8QeNnvLq9jVHWeaVVQ9FGDjdnvxzgGvMtQFpOJbsy7FTnnnIUHqccfTvXoTn0MrG14Q0oTeHLKKSbasUSsybcszuS2SWwAPSumguhFuRLczbNuDJjA54Ax6mrWlGyTSrWK4kInSOMs0QAwSMDK4yTyMc06b7LPJ/ZmnRTX185CxRKpaSViegVclixwOPbiotYVjN0rQfEviDXTe6FbtctbbvMZW2Y37Qp+b5eoI29x1r9G/2E/2QtZm8aD45/E3TJNPsdLlL6HYTlWMs+CpuGHOEi/5Z56tz0Xn039kn9jvW7TQ4fFnxgtZNKF5J56aPu2ysnGz7QVPyDH/LP73PzY6H9SIYYbaGO3t0WKKJQqIowqqowAAOgAr5mvhfa4l1ai0VrfI9H2VJU421l17ElFFFdxIUUUUAf//V/eiiiiuM7AooooACAQQeQa+cPHv7KPwV8fLPJNoo0W8uM5n0xvsxyxyWMQBiJJ5JKcnnrX0fRVRk1qhNJ7n5I+Lv+CYMs8ss/gzxxGN+diajZncv1lhc7j77BXisX/BJ34s3DyW194+0a3tZAQXhiunkIbr8rKoH/fVfuxRWnt5EeyR+anhD/gm34N0uCOLxX4qutRVNnyWlulsMKPulnaXIPfgGvsT4X/s+/CP4PKZPA2gRW984Ie9nJuLtgeo82TLKPZcD2r2eiplVk92UoJbBRRRWZQUUUUAFFFFAH//W/eiiiiuM7AooooAKKKKACiiigAooooAKKKKACiiigAooooA//9k=" alt="">
+            <div class="grow">
+              <div class="n">Débora Broch</div>
+              <div class="d">Conta criada em 6 de agosto</div>
+            </div>
+            <button class="gear" aria-label="Configurações" onclick="toast('Abriria as configurações da conta')">
+              <span>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.8"/>
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+            </button>
+          </div>
+
+          <!-- PRÓXIMOS PASSOS -->
+          <div class="card">
+            <div class="eyebrow">Faltam 2 passos</div>
+            <h2 class="headline display" style="margin-top:9px">Você já contou quem você é. Agora falta a D2C ver os seus vídeos.</h2>
+            <p class="body" style="margin-top:9px">Sem ler o seu Instagram, não dá pra saber o seu melhor dia, o seu melhor horário, nem quais assuntos rendem pra você. Esses números saem dos seus próprios posts.</p>
+
+            <div class="steps">
+              <div class="step">
+                <span class="stepn">1</span>
+                <div class="grow">
+                  <div class="t">Assinar o Pro</div>
+                  <div class="s">R$ 97 por mês. É o que libera o relatório toda semana, o Mídia Kit, o valor da sua publi, as collabs e a reunião.</div>
+                  <div class="btnrow"><button class="btn" onclick="toast('Abriria os planos')">Assinar</button></div>
+                </div>
+              </div>
+              <div class="step later">
+                <span class="stepn">2</span>
+                <div class="grow">
+                  <div class="t">Conectar o seu Instagram</div>
+                  <div class="s">Depois de assinar, você autoriza pelo próprio Instagram. Leva um minuto e dá pra desconectar quando quiser.</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="note-box">
+              <b>Não tem espera.</b> O relatório é feito com os seus últimos 90 dias, que já estão publicados. Assim que você conectar, ele aparece. Depois disso, ele se atualiza toda segunda-feira com a semana que acabou.
+            </div>
+          </div>
+
+          <!-- MÍDIA KIT + CALCULADORA (bloqueados) -->
+          <div class="panel">
+            <button class="prow" onclick="toast('Abriria os planos')">
+              <span class="ico">▤</span>
+              <span class="grow">
+                <span class="t" style="display:block">Mídia Kit</span>
+                <span class="s" style="display:block">Sua página para marcas · incluído no Pro</span>
+              </span>
+              <span class="arrow">🔒</span>
+            </button>
+            <button class="prow" onclick="toast('Abriria os planos')">
+              <span class="ico">R$</span>
+              <span class="grow">
+                <span class="t" style="display:block">Quanto vale sua publi</span>
+                <span class="s" style="display:block">Seu preço justo · incluído no Pro</span>
+              </span>
+              <span class="arrow">🔒</span>
+            </button>
+          </div>
+
+          <!-- SEU MAPA -->
+          <div class="card">
+            <div class="eyebrow">Seu mapa</div>
+            <p class="mapnarr display">“Uma mãe que encontra força e propósito na jornada da maternidade.”</p>
+            <div class="rule"></div>
+            <div class="eyebrow quiet">Seus assuntos</div>
+            <div class="terr">
+              <span class="terrchip off">Maternidade</span>
+              <span class="terrchip off">Fé</span>
+              <span class="terrchip off">Bem-estar</span>
+            </div>
+            <p class="body" style="font-size:13px; margin-top:11px">Isso é o que <b style="color:var(--ink)">você escreveu</b> quando criou a conta. Nenhum vídeo seu foi lido ainda, então a D2C ainda não sabe se é isso mesmo que você anda fazendo.</p>
+            <p class="body" style="font-size:12px; color:var(--ink-3); margin-top:10px">Para mudar, vá em Configurações.</p>
+          </div>
+
+          <!-- O QUE VOCÊ VAI RECEBER -->
+          <div class="card">
+            <div class="eyebrow">O que chega toda quinta</div>
+            <h3 class="sub display" style="margin-top:9px">Depois dos dois passos</h3>
+            <div style="margin-top:8px">
+              <div class="lockrow">
+                <div class="grow">
+                  <div class="t">O vídeo da semana</div>
+                  <div class="s">Qual dos seus vídeos rendeu mais e o motivo</div>
+                </div><span class="lk">🔒</span>
+              </div>
+              <div class="lockrow">
+                <div class="grow">
+                  <div class="t">Dia e horário</div>
+                  <div class="s">O melhor dia e a melhor hora para você postar</div>
+                </div><span class="lk">🔒</span>
+              </div>
+              <div class="lockrow">
+                <div class="grow">
+                  <div class="t">Cena, tom e câmera</div>
+                  <div class="s">Onde gravar, como falar e como se enquadrar</div>
+                </div><span class="lk">🔒</span>
+              </div>
+              <div class="lockrow">
+                <div class="grow">
+                  <div class="t">Assuntos e frases de abertura</div>
+                  <div class="s">Os temas e as primeiras frases que mais rendem</div>
+                </div><span class="lk">🔒</span>
+              </div>
+              <div class="lockrow">
+                <div class="grow">
+                  <div class="t">Mídia Kit e valor da publi</div>
+                  <div class="s">A sua página para marcas e o seu preço justo</div>
+                </div><span class="lk">🔒</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- DEMONSTRAÇÃO -->
+          <div class="card">
+            <div class="eyebrow">Veja por dentro</div>
+            <h2 class="headline display" style="margin-top:9px">Veja um relatório inteiro antes de assinar.</h2>
+            <p class="body" style="margin-top:9px">São os números reais de uma criadora da comunidade, com o nome dela trocado. Você navega por tudo: os rankings, o vídeo da semana e as frases de abertura.</p>
+            <div class="btnrow"><button class="btn" onclick="setMode('demo')">Ver um relatório de exemplo</button></div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Reunião da comunidade</div>
+            <h3 class="sub display" style="margin-top:9px">Toda quinta, 19h</h3>
+            <p class="body">Os criadores abrem o relatório uns dos outros e dizem o que fariam diferente. É onde você descobre o que ninguém percebe sozinho.</p>
+            <div class="btnrow"><button class="btn ghost" onclick="toast('Abriria os planos')">Participar das reuniões</button></div>
+          </div>
+
+          <p class="body" style="text-align:center; margin:22px 0 0; font-size:12px; color:var(--ink-3)">Segunda o relatório chega. Quinta a gente conversa sobre ele.</p>
+        </section>
+
+        <!-- ===================== ESTADO ZERO — COLLABS ===================== -->
+        <section class="screen" id="s-collabszero">
+          <div class="phead" style="padding-bottom:10px">
+            <div>
+              <div class="n">Collabs</div>
+              <div class="d">Criadores que combinam com você</div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Ainda não dá</div>
+            <h2 class="headline display" style="margin-top:9px">Para achar quem combina com você, a D2C precisa ver os seus vídeos.</h2>
+            <p class="body" style="margin-top:9px">A combinação não é por número de seguidores. É por assunto e por jeito de gravar — e isso só aparece depois que os seus posts são lidos.</p>
+            <div class="btnrow"><button class="btn" onclick="toast('Abriria os planos')">Assinar</button></div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Veja por dentro</div>
+            <h3 class="sub display" style="margin-top:9px">O exemplo também tem as collabs</h3>
+            <p class="body">Você vê uma sugestão inteira: quem combina com quem, por quê, e o passo a passo para gravar cada uma na sua casa.</p>
+            <div class="btnrow"><button class="btn" onclick="setMode('demo'); go('collabs')">Ver um relatório de exemplo</button></div>
+          </div>
+        </section>
+
+        <!-- ===================== DIA E HORÁRIO ===================== -->
+        <section class="screen" id="s-quando">
+          <button class="back" onclick="go('perfil')">‹ Voltar</button>
+          <h2 class="display" style="font-size:27px; margin:4px 0 8px">Dia e horário</h2>
+          <p class="body">Comparado com o seu normal dos últimos 90 dias.</p>
+          <div class="note-box">
+            <b>Quanto dá pra confiar.</b> Embaixo de cada item está o número de posts. <b>Indício</b> é 1 ou 2 posts — pode ser sorte. <b>Sinal</b> é de 3 a 7. <b>Tendência</b> é 8 ou mais — aí já se repetiu bastante.
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Ranking dos dias</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Quinta</span><span class="mult up num">2,5×</span></div>
+                <div class="rmeta">14 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Segunda</span><span class="mult up num">1,5×</span></div>
+                <div class="rmeta">15 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Domingo</span><span class="mult down num">0,4×</span></div>
+                <div class="rmeta">11 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname">Quarta</span><span class="mult down num">0,3×</span></div>
+                <div class="rmeta">14 posts · tendência</div></div></div>
+              <div class="more">Mais 3 dias com menos posts.</div>
+            </div>
+            <div class="weekline">Nesta semana você postou <b>2 vezes na quarta</b>, que é o seu pior dia. E <b>nenhuma vez na quinta</b>, que é o melhor.</div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Ranking dos horários</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Das 4h às 8h</span><span class="mult up num">3,2×</span></div>
+                <div class="rmeta">7 posts · sinal</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Das 20h às 24h</span><span class="mult up num">1,5×</span></div>
+                <div class="rmeta">8 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Das 8h às 12h</span><span class="mult down num">0,8×</span></div>
+                <div class="rmeta">31 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname">Das 12h às 16h</span><span class="mult down num">0,6×</span></div>
+                <div class="rmeta">15 posts · tendência</div></div></div>
+              <div class="more">Mais 1 faixa de horário com menos posts.</div>
+            </div>
+            <div class="weekline">Nesta semana você postou <b>4 vezes entre 4h e 8h</b>, que é o seu melhor horário.</div>
+            <div class="rule"></div>
+            <p class="body">Entre 4h e 8h você alcança as mães que acordam cedo. É o público que mais salva os seus vídeos.</p>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Melhor combinação</div>
+            <h3 class="sub display" style="margin-top:9px">Quinta-feira, às 6h da manhã.</h3>
+            <p class="body">Poste aí o vídeo que você mais quer que alcance gente nova.</p>
+          </div>
+        </section>
+
+        <!-- ===================== CENA ===================== -->
+        <section class="screen" id="s-cena">
+          <button class="back" onclick="go('perfil')">‹ Voltar</button>
+          <h2 class="display" style="font-size:27px; margin:4px 0 8px">Cena, tom e câmera</h2>
+          <p class="body">Cinco rankings: onde você grava, quem aparece, o objeto na cena, o seu jeito de falar e como a câmera te mostra.</p>
+
+          <div class="card">
+            <div class="eyebrow">Onde você grava</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Natureza</span><span class="mult up num">71,5×</span></div>
+                <div class="rmeta">1 post · indício</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Sala</span><span class="mult up num">2,5×</span></div>
+                <div class="rmeta">7 posts · sinal</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Carro</span><span class="mult up num">1,7×</span></div>
+                <div class="rmeta">6 posts · sinal</div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname">Loja ou restaurante</span><span class="mult down num">0,1×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+              <div class="more">Mais 6 lugares com menos posts.</div>
+            </div>
+            <div class="weekline">Nesta semana você gravou <b>1 vez na sala</b>.</div>
+            <div class="rule"></div>
+            <p class="body">Natureza só apareceu uma vez. Um post só não é prova. Sala é o lugar em que dá pra confiar hoje.</p>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Quem e o que aparece</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Você arrumada</span><span class="mult up num">1,7×</span></div>
+                <div class="rmeta">16 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">A casa</span><span class="mult down num">0,5×</span></div>
+                <div class="rmeta">24 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Produto aparecendo</span><span class="mult down num">0,4×</span></div>
+                <div class="rmeta">7 posts · sinal</div></div></div>
+              <div class="more">Mais 3 itens com menos posts.</div>
+            </div>
+            <div class="rule"></div>
+            <p class="body strong">Produto sozinho na cena rende menos da metade do seu normal.</p>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Objeto na cena</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Cachorro</span><span class="mult up num">2,9×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Shampoo</span><span class="mult down num">0,8×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Celular</span><span class="mult down num">0,4×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname">Caneca</span><span class="mult down num">0,3×</span></div>
+                <div class="rmeta">3 posts · sinal</div></div></div>
+              <div class="more">Mais 2 objetos com menos posts.</div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Seu jeito de falar</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Humor</span><span class="mult up num">2,0×</span></div>
+                <div class="rmeta">28 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Direto</span><span class="mult up num">1,1×</span></div>
+                <div class="rmeta">12 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Reflexivo</span><span class="mult down num">0,8×</span></div>
+                <div class="rmeta">13 posts · tendência</div></div></div>
+            </div>
+            <div class="rule"></div>
+            <p class="body">Humor é o seu 1º lugar, com 28 posts. Mas os dois vídeos de humor desta semana não tinham a sua casa nem as suas filhas, e não renderam nada.</p>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Como a câmera te mostra</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Plano médio (da cintura pra cima)</span><span class="mult up num">1,6×</span></div>
+                <div class="rmeta">16 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Celular parado num apoio</span><span class="mult down num">0,8×</span></div>
+                <div class="rmeta">26 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname">Selfie com o braço esticado</span><span class="mult down num">0,6×</span></div>
+                <div class="rmeta">10 posts · tendência</div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname">Celular na mão, andando</span><span class="mult down num">0,4×</span></div>
+                <div class="rmeta">5 posts · sinal</div></div></div>
+              <div class="more">Mais 3 formas com menos posts.</div>
+            </div>
+            <div class="weekline">Nesta semana: <b>1 post</b> em plano médio, <b>1</b> com o celular parado e <b>1</b> com o celular na mão.</div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Resumo</div>
+            <h3 class="sub display" style="margin-top:9px">Sala, humor, plano médio — e você em cena.</h3>
+          </div>
+        </section>
+
+        <!-- ===================== ASSUNTOS ===================== -->
+        <section class="screen" id="s-assuntos">
+          <button class="back" onclick="go('perfil')">‹ Voltar</button>
+          <h2 class="display" style="font-size:27px; margin:4px 0 8px">Assuntos</h2>
+          <p class="body">Do que o vídeo falava de verdade — não o tema geral.</p>
+
+          <div class="card">
+            <div class="eyebrow">Os 5 que mais renderam</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Sinais de que a criança está virando pré-adolescente</span><span class="mult up num">132,4×</span></div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Sinais de que você está ficando mais velha</span><span class="mult up num">71,5×</span></div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Assistir jogo em casa e comemorar o gol</span><span class="mult up num">35,1×</span></div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">A dúvida de ter o terceiro filho</span><span class="mult up num">13,8×</span></div></div></div>
+              <div class="ritem"><div class="pos">5</div><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Parar de trabalhar para ficar com os filhos</span><span class="mult up num">11,4×</span></div></div></div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Os 5 que menos renderam</div>
+            <p class="body" style="font-size:12.5px; color:var(--ink-3); margin-top:6px">Do pior para o menos pior.</p>
+            <div class="rank">
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Tentar engravidar de novo e não conseguir</span><span class="mult down num">0,0×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Compras para a casa e organização do quarto</span><span class="mult down num">0,0×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Rotina da manhã e apresentação de dança das filhas</span><span class="mult down num">0,1×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Compras de roupas infantis</span><span class="mult down num">0,1×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname" style="font-size:14px">Desafios que só mulher consegue fazer</span><span class="mult down num">0,1×</span></div></div></div>
+            </div>
+            <div class="rule"></div>
+            <p class="body strong">Os que mais renderam falam de algo que a mãe já sente. Os que menos renderam mostram o que você comprou ou o que você fez no dia.</p>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Temas que você repetiu</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname">Dificuldades da maternidade</span><span class="mult up num">1,7×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname">Conciliar trabalho e filhos</span><span class="mult down num">0,3×</span></div>
+                <div class="rmeta">2 posts · indício</div></div></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ===================== ABERTURAS ===================== -->
+        <section class="screen" id="s-aberturas">
+          <button class="back" onclick="go('perfil')">‹ Voltar</button>
+          <h2 class="display" style="font-size:27px; margin:4px 0 8px">Frases de abertura</h2>
+          <p class="body">A primeira frase de cada vídeo, do jeito exato que você falou.</p>
+
+          <div class="card">
+            <div class="eyebrow">As 5 que mais renderam</div>
+            <div class="rank">
+              <div class="ritem first"><div class="pos">1</div><div class="rbody">
+                <div class="rtop"><span class="rname quote">“4 sinais que a criança está deixando de ser criança e se tornando um pré-adolescente.”</span></div>
+                <div class="rmeta"><span class="mult up num" style="font-size:14px">132,4×</span></div></div></div>
+              <div class="ritem"><div class="pos">2</div><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Alguns sinais que você está se tornando uma pré-velha.”</span></div>
+                <div class="rmeta"><span class="mult up num" style="font-size:14px">71,5×</span></div></div></div>
+              <div class="ritem"><div class="pos">3</div><div class="rbody">
+                <div class="rtop"><span class="rname quote">“O dilema da mãe que pensa em ter o terceiro filho…”</span></div>
+                <div class="rmeta"><span class="mult up num" style="font-size:14px">13,8×</span></div></div></div>
+              <div class="ritem"><div class="pos">4</div><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Quando você vê uma mãe falando que parou de trabalhar para ficar com os filhos em casa, é lindo, né?”</span></div>
+                <div class="rmeta"><span class="mult up num" style="font-size:14px">11,4×</span></div></div></div>
+              <div class="ritem"><div class="pos">5</div><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Vamos falar hoje sobre a diferença desses shampoos da Verdi Natural.”</span></div>
+                <div class="rmeta"><span class="mult up num" style="font-size:14px">5,2×</span> <span class="chip">publi</span></div></div></div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">As 5 que menos renderam</div>
+            <p class="body" style="font-size:12.5px; color:var(--ink-3); margin-top:6px">Da pior para a menos pior.</p>
+            <div class="rank">
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Eu acho que isso é uma coisa que eu nunca vi ninguém falando por aqui.”</span></div>
+                <div class="rmeta"><span class="mult down num" style="font-size:14px">0,0×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Um vídeo da Shein totalmente diferente.”</span></div>
+                <div class="rmeta"><span class="mult down num" style="font-size:14px">0,0×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Vlog de um dia especial.”</span></div>
+                <div class="rmeta"><span class="mult down num" style="font-size:14px">0,1×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Eu vou gravar rapidinho e já vou descer aí, tá bom?”</span></div>
+                <div class="rmeta"><span class="mult down num" style="font-size:14px">0,1×</span></div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rtop"><span class="rname quote">“Vem, me falaram que só as mulheres conseguem fazer essas coisas aqui.”</span></div>
+                <div class="rmeta"><span class="mult down num" style="font-size:14px">0,1×</span></div></div></div>
+            </div>
+            <div class="rule"></div>
+            <p class="body strong">As que mais renderam já entregam uma informação na primeira frase. As que menos renderam só avisam que o vídeo vai começar.</p>
+          </div>
+        </section>
+
+        <!-- ===================== COLLABS ===================== -->
+        <section class="screen" id="s-collabs">
+          <div class="phead" style="padding-bottom:10px">
+            <div>
+              <div class="n">Collabs</div>
+              <div class="d">Quem combina com você nesta semana</div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Maternidade com humor</div>
+            <h2 class="headline display" style="font-size:21px; margin-top:11px">Você e a Marina contam qual post repetiriam e quanto tempo esperariam</h2>
+            <div class="rule"></div>
+            <div style="display:flex; gap:14px">
+              <div style="flex:1">
+                <div style="font-weight:800; font-size:14.5px">Você</div>
+                <p class="body" style="font-size:13px; margin-top:4px">repetiu um tema um mês depois e teve <b class="mult up num">161×</b> mais salvamento</p>
+              </div>
+              <div style="flex:1">
+                <div style="font-weight:800; font-size:14.5px">Marina Dutra</div>
+                <p class="body" style="font-size:13px; margin-top:4px">fez humor na cozinha e teve <b class="mult up num">4,2×</b>; repetiu em 3 dias e caiu</p>
+              </div>
+            </div>
+            <div class="rule"></div>
+            <div class="eyebrow quiet">Por que combina</div>
+            <p class="body" style="margin-top:6px">Ela aprende com você quanto tempo esperar para repetir um tema. Você aprende com ela o humor na cozinha, que ainda não fez com as suas filhas.</p>
+            <div class="rule"></div>
+            <div class="eyebrow">Como gravar cada uma na sua casa</div>
+            <ol class="body" style="margin:9px 0 0; padding-left:18px; line-height:1.75">
+              <li>Cada uma grava falando do post que mais funcionou e quando repetiria.</li>
+              <li>Monta em tela dividida: você no cabelo maluco, ela no vídeo dos ingredientes.</li>
+              <li>Fecha com a regra que vocês combinarem sobre quanto tempo esperar.</li>
+            </ol>
+            <div class="btnrow">
+              <button class="btn" onclick="toast('Abriria a conversa no WhatsApp')">Chamar a Marina</button>
+              <button class="btn ghost" data-save>Guardar</button>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="eyebrow">Quem fala de quê na comunidade</div>
+            <div class="rank" style="margin-top:10px">
+              <div class="ritem"><div class="rbody">
+                <div class="rname">Maternidade</div>
+                <div class="rmeta">Você · Marina Dutra · Giselle Candido · Cris Valente · Amanda Mol · Simone Magnus</div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rname">Saúde e bem-estar</div>
+                <div class="rmeta">Você · Marina Dutra · Carla Tosta · Fabi Calvo</div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rname">Fé</div>
+                <div class="rmeta">Você · Giselle Candido · Simone Magnus</div></div></div>
+              <div class="ritem"><div class="rbody">
+                <div class="rname">Crescimento pessoal</div>
+                <div class="rmeta">Só você</div></div></div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+
+      <nav class="tabbar">
+        <button class="tab active" id="tab-perfil" onclick="tabPerfil()"><span class="ic">◍</span>Perfil</button>
+        <button class="plus" onclick="tapPlus()" aria-label="Analisar conteúdo">+</button>
+        <button class="tab" id="tab-collabs" onclick="tabCollabs()"><span class="ic">⇄</span>Collabs</button>
+      </nav>
+    </div>
+
+    <div class="notes">
+      <h2 class="display">Pente fino</h2>
+      <div class="note">
+        <span class="tag">Corrigido</span>
+        <h3>As listas de piores tinham 1º, 2º, 3º.</h3>
+        <p>Bolinha numerada em lista de pior é armadilha: parece pódio. Tirei os números dessas listas e escrevi em cima: "do pior para o menos pior".</p>
+      </div>
+      <div class="note">
+        <span class="tag">Corrigido</span>
+        <h3>Indício, sinal e tendência não eram explicados.</h3>
+        <p>As três palavras apareciam em toda linha e em lugar nenhum diziam o que significam. Agora tem uma frase no alto da primeira tela de ranking: indício é 1 ou 2 posts, sinal é de 3 a 7, tendência é 8 ou mais.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Corrigido</span>
+        <h3>Faltava uma frase de abertura.</h3>
+        <p>A lista das piores tinha 4 e o relatório tem 5. A quinta entrou.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Corrigido</span>
+        <h3>A tela de cena não avisava o tamanho.</h3>
+        <p>São cinco rankings seguidos e a pessoa entrava sem saber. Agora o texto de cima diz quais são.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Corrigido</span>
+        <h3>A reunião não dizia o assunto.</h3>
+        <p>Era só data e hora. Agora diz o tema da semana, que é o que faz alguém querer entrar.</p>
+      </div>
+
+      <h2 class="display" style="margin-top:26px">O que mudou nas versões anteriores</h2>
+      <div class="note">
+        <span class="tag">Ajuste 0</span>
+        <h3>O Seu Mapa voltou, só para ler.</h3>
+        <p>A narrativa e os assuntos ficam no Perfil. Escrever e mudar é no onboarding e nas Configurações. E o mapa passou a mostrar o que o relatório confirmou: maternidade e bem-estar apareceram nos vídeos; fé foi escrita por ela e não apareceu em nenhum.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ajuste 1</span>
+        <h3>Cabeçalho igual ao do app.</h3>
+        <p>Foto grande à esquerda, nome, e a engrenagem no círculo rosa à direita — o mesmo padrão que já está no celular hoje.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ajuste 2</span>
+        <h3>Mídia Kit e Calculadora voltaram.</h3>
+        <p>Logo abaixo do cabeçalho, no mesmo formato de duas linhas que existe hoje: Mídia Kit em cima, valor da publi embaixo.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ajuste 3</span>
+        <h3>O vídeo abre o Instagram.</h3>
+        <p>A capa inteira virou link, com "Assistir no Instagram" embaixo. Aqui ele vai para o perfil dela, porque o endereço do post não estava no relatório — no app de verdade vai direto para o vídeo.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ajuste 4</span>
+        <h3>Rankings mais limpos.</h3>
+        <p>Cada linha agora tem só três coisas: posição, nome e número. Embaixo, em cinza pequeno, quantos posts sustentam. Tirei as barras coloridas e as etiquetas. O que você fez nesta semana saiu de dentro das linhas e virou uma frase só, no pé do ranking.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ajuste 5</span>
+        <h3>Botões de ação removidos.</h3>
+        <p>Saíram o lembrete de quinta, o lembrete da melhor combinação, o "usar na próxima gravação" e o "montar proposta". Tirei também o "usar esse começo", nas frases de abertura, porque era do mesmo tipo — se quiser esse de volta, é só falar.</p>
+      </div>
+      <div class="note">
+        <span class="tag">Ainda em aberto</span>
+        <h3>Duas decisões suas.</h3>
+        <p>Se a leitura muda toda quinta ou a cada vídeo analisado. E se as palavras indício, sinal e tendência ficam ou viram algo mais simples, como "poucos posts" e "muitos posts".</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+  const screens = ['perfil','quando','cena','assuntos','aberturas','collabs','zero','collabszero'];
+  let mode = 'full';
+
+  function go(id){
+    screens.forEach(s => document.getElementById('s-'+s).classList.toggle('active', s===id));
+    document.getElementById('vp').scrollTop = 0;
+    const isCollabs = id === 'collabs' || id === 'collabszero';
+    document.getElementById('tab-perfil').classList.toggle('active', !isCollabs);
+    document.getElementById('tab-collabs').classList.toggle('active', isCollabs);
+  }
+
+  function setMode(m){
+    mode = m;
+    document.getElementById('sw-full').classList.toggle('active', m === 'full');
+    document.getElementById('sw-zero').classList.toggle('active', m === 'zero' || m === 'demo');
+    document.body.classList.toggle('demo', m === 'demo');
+
+    // O nome e a foto são sempre da própria criadora — só o relatório é de exemplo.
+    document.getElementById('pdate').textContent = m === 'demo'
+      ? 'Relatório de exemplo'
+      : 'Semana de 4 a 10 de agosto';
+
+    go(m === 'zero' ? 'zero' : 'perfil');
+  }
+
+  function tabPerfil(){ go(mode === 'zero' ? 'zero' : 'perfil'); }
+  function tabCollabs(){ go(mode === 'zero' ? 'collabszero' : 'collabs'); }
+  function tapPlus(){
+    if (mode === 'zero') return toast('Pediria para assinar antes');
+    if (mode === 'demo') return toast('No exemplo este botão não funciona');
+    toast('Abriria a análise de um vídeo novo');
+  }
+
+  let toastTimer;
+  function toast(msg){
+    const t = document.getElementById('toast');
+    t.textContent = msg;
+    t.classList.add('show');
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => t.classList.remove('show'), 2200);
+  }
+
+  document.querySelectorAll('[data-save]').forEach(b => {
+    const original = b.textContent;
+    b.addEventListener('click', () => {
+      const on = b.classList.toggle('on');
+      b.textContent = on ? '✓ Guardado' : original;
+      if (on) toast('Guardado');
+    });
+  });
+
+  document.querySelectorAll('[data-remind]').forEach(b => {
+    const original = b.textContent;
+    b.addEventListener('click', () => {
+      const on = b.classList.toggle('on');
+      b.textContent = on ? '✓ Lembrete criado' : original;
+      if (on) toast('Você receberia um aviso na quinta de manhã');
+    });
+  });
+</script>

--- a/src/app/api/billing/subscribe/route.test.ts
+++ b/src/app/api/billing/subscribe/route.test.ts
@@ -35,6 +35,7 @@ jest.mock("@/app/lib/affiliate", () => ({
 jest.mock("@/app/lib/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
+jest.mock("@/app/lib/billing/syncTaxIdToStripe", () => ({ syncTaxIdToStripe: jest.fn() }));
 jest.mock("@/server/db/models/AffiliateIndexes", () => ({
   AffiliateBuyerCommissionIndex: { exists: jest.fn().mockResolvedValue(false) },
 }));
@@ -49,6 +50,7 @@ const {
   isStripeResourceMissingError,
   persistStaleStripeBillingPatch,
 } = require("@/utils/stripeHelpers");
+const { syncTaxIdToStripe } = require("@/app/lib/billing/syncTaxIdToStripe");
 const { POST } = require("./route");
 
 const mockGetServerSession = getServerSession as jest.Mock;
@@ -60,6 +62,7 @@ const mockCheckRateLimit = checkRateLimit as jest.Mock;
 const mockGetCustomerId = getOrCreateStripeCustomerId as jest.Mock;
 const mockIsStripeResourceMissingError = isStripeResourceMissingError as jest.Mock;
 const mockPersistStaleStripeBillingPatch = persistStaleStripeBillingPatch as jest.Mock;
+const mockSyncTaxIdToStripe = syncTaxIdToStripe as jest.Mock;
 
 const createRequest = (body: any) =>
   new NextRequest("http://localhost/api/billing/subscribe", {
@@ -76,6 +79,7 @@ beforeEach(() => {
   mockIsStripeResourceMissingError.mockReturnValue(false);
   mockPersistStaleStripeBillingPatch.mockResolvedValue(undefined);
   (stripe as any).invoices.list.mockResolvedValue({ data: [] });
+  mockSyncTaxIdToStripe.mockResolvedValue(true);
   delete process.env.D2C_VIP_MAX_REDEMPTIONS;
   delete process.env.D2C_VIP_EXPIRES_AT;
   process.env.STRIPE_PRICE_MONTHLY_BRL = "price_monthly_brl";
@@ -146,6 +150,7 @@ describe("POST /api/billing/subscribe", () => {
         mode: "subscription",
         customer: "cus_123",
         line_items: [{ price: "price_monthly_brl", quantity: 1 }],
+        success_url: "http://localhost/billing/success?session_id={CHECKOUT_SESSION_ID}",
         payment_method_collection: "always",
         discounts: [{ promotion_code: "promo_d2cvip" }],
         subscription_data: {
@@ -393,6 +398,80 @@ describe("POST /api/billing/subscribe", () => {
 
     expect(res.status).toBe(422);
     expect((await res.json()).message).toContain("expirou");
+  });
+
+  it("saves the tax id sent at checkout and mirrors it to Stripe", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u-tax", email: "u-tax@test.com" } });
+    const save = jest.fn();
+    const buyer = { _id: "u-tax", planStatus: "inactive", stripeCustomerId: "cus_123", save };
+    mockFindById.mockResolvedValue(buyer);
+    mockStripeList.mockResolvedValue({ data: [] });
+    stripe.promotionCodes.list.mockResolvedValue({
+      data: [{ id: "promo_d2cvip", code: "d2cVIP", active: true, restrictions: {} }],
+    });
+    stripe.checkout.sessions.create.mockResolvedValue({ id: "cs_tax", url: "https://checkout.stripe.com/tax" });
+
+    const res = await POST(createRequest({
+      plan: "monthly",
+      currency: "BRL",
+      promotionCode: "d2cVIP",
+      taxId: "529.982.247-25",
+    }));
+
+    expect(res.status).toBe(200);
+    expect((buyer as any).taxId).toBe("52998224725");
+    expect((buyer as any).taxIdType).toBe("cpf");
+    expect(mockSyncTaxIdToStripe).toHaveBeenCalledWith("cus_123", { value: "52998224725", type: "cpf" });
+  });
+
+  it("refuses an invalid tax id before touching Stripe", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u-bad", email: "u-bad@test.com" } });
+    mockFindById.mockResolvedValue({ _id: "u-bad", planStatus: "inactive", stripeCustomerId: "cus_123", save: jest.fn() });
+
+    const res = await POST(createRequest({ plan: "monthly", currency: "BRL", taxId: "111.111.111-11" }));
+
+    expect(res.status).toBe(422);
+    expect((await res.json()).code).toBe("INVALID_TAX_ID");
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
+    expect(mockStripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("asks for the document at the hosted checkout only when we do not have it", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u-known", email: "u-known@test.com" } });
+    mockFindById.mockResolvedValue({
+      _id: "u-known",
+      planStatus: "inactive",
+      stripeCustomerId: "cus_123",
+      taxId: "52998224725",
+      taxIdType: "cpf",
+      save: jest.fn(),
+    });
+    mockStripeList.mockResolvedValue({ data: [] });
+    stripe.promotionCodes.list.mockResolvedValue({
+      data: [{ id: "promo_d2cvip", code: "d2cVIP", active: true, restrictions: {} }],
+    });
+    stripe.checkout.sessions.create.mockResolvedValue({ id: "cs_known", url: "https://checkout.stripe.com/known" });
+
+    await POST(createRequest({ plan: "monthly", currency: "BRL", promotionCode: "d2cVIP" }));
+
+    const params = stripe.checkout.sessions.create.mock.calls[0][0];
+    expect(params.tax_id_collection).toBeUndefined();
+  });
+
+  it("turns on tax id collection at the hosted checkout for someone without a document", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u-new", email: "u-new@test.com" } });
+    mockFindById.mockResolvedValue({ _id: "u-new", planStatus: "inactive", stripeCustomerId: "cus_123", save: jest.fn() });
+    mockStripeList.mockResolvedValue({ data: [] });
+    stripe.promotionCodes.list.mockResolvedValue({
+      data: [{ id: "promo_d2cvip", code: "d2cVIP", active: true, restrictions: {} }],
+    });
+    stripe.checkout.sessions.create.mockResolvedValue({ id: "cs_new", url: "https://checkout.stripe.com/new" });
+
+    await POST(createRequest({ plan: "monthly", currency: "BRL", promotionCode: "d2cVIP" }));
+
+    const params = stripe.checkout.sessions.create.mock.calls[0][0];
+    expect(params.tax_id_collection).toEqual({ enabled: true, required: "if_supported" });
+    expect(params.customer_update).toEqual({ name: "auto", address: "auto" });
   });
 
   it("blocks when DB says active", async () => {

--- a/src/app/api/billing/subscribe/route.ts
+++ b/src/app/api/billing/subscribe/route.ts
@@ -24,6 +24,8 @@ import {
   checkVipCampaignWindow,
   vipCampaignMessage,
 } from "@/app/lib/billing/d2cVipCampaign";
+import { TAX_ID_INVALID_MESSAGE, parseTaxId } from "@/app/lib/billing/taxId";
+import { syncTaxIdToStripe } from "@/app/lib/billing/syncTaxIdToStripe";
 
 export const runtime = "nodejs";
 
@@ -73,6 +75,24 @@ function resolveCheckoutRedirectUrl(
   }
 }
 
+function resolveHostedCheckoutSuccessUrl(
+  rawValue: unknown,
+  options: { appBaseUrl: string }
+) {
+  const resolved = resolveCheckoutRedirectUrl(rawValue, {
+    appBaseUrl: options.appBaseUrl,
+    fallbackPath: "/billing/success?session_id={CHECKOUT_SESSION_ID}",
+  });
+  const url = new URL(resolved);
+  if (!url.searchParams.has("session_id")) {
+    url.searchParams.set("session_id", "{CHECKOUT_SESSION_ID}");
+  }
+  // URLSearchParams codifica as chaves; a Stripe exige este placeholder literal.
+  return url
+    .toString()
+    .replace("%7BCHECKOUT_SESSION_ID%7D", "{CHECKOUT_SESSION_ID}");
+}
+
 function buildIdempotencyKey(params: {
   scope: "sub_create" | "checkout_session";
   userId: string;
@@ -99,6 +119,16 @@ function buildIdempotencyKey(params: {
 function getStripeRequestId(obj: unknown): string | null {
   return (obj as any)?.lastResponse?.requestId ?? null;
 }
+
+/**
+ * Coleta de CPF/CNPJ no Checkout hospedado. O `customer_update` é exigido pelo
+ * Stripe para gravar o que foi coletado num customer que já existe — sem ele a
+ * criação da sessão falha.
+ */
+const HOSTED_CHECKOUT_TAX_ID_COLLECTION = {
+  tax_id_collection: { enabled: true, required: "if_supported" },
+  customer_update: { name: "auto", address: "auto" },
+} as const satisfies Partial<Stripe.Checkout.SessionCreateParams>;
 
 /** Erro do Stripe ao recusar um cupom por restrição (elegibilidade, validade, produto). */
 function isPromotionRestrictionError(error: unknown): boolean {
@@ -300,6 +330,24 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
     }
     const userId = String(user._id);
+
+    // CPF/CNPJ: sem documento não há nota fiscal, e o único momento em que dá
+    // para pedir com a pessoa presente é agora. Aceita o que já está salvo,
+    // para quem volta a assinar não precisar digitar de novo.
+    const incomingTaxId = parseTaxId(body.taxId);
+    if (body.taxId !== undefined && !incomingTaxId) {
+      return NextResponse.json(
+        { code: "INVALID_TAX_ID", message: TAX_ID_INVALID_MESSAGE },
+        { status: 422 },
+      );
+    }
+    if (incomingTaxId && (user as any).taxId !== incomingTaxId.value) {
+      (user as any).taxId = incomingTaxId.value;
+      (user as any).taxIdType = incomingTaxId.type;
+      (user as any).taxIdUpdatedAt = new Date();
+      await user.save();
+    }
+
     const dbStatusRaw = (user as any).planStatus ?? null;
     const dbStatus = typeof dbStatusRaw === "string" ? dbStatusRaw.toLowerCase() : "";
     const dbCancelAtPeriodEnd = Boolean((user as any).cancelAtPeriodEnd);
@@ -491,6 +539,13 @@ export async function POST(req: NextRequest) {
     const priceId = getPriceId(plan, currency);
 
     let customerId = await getOrCreateStripeCustomerId(user);
+
+    // Documento no cliente do Stripe: aparece na fatura e no recibo dele.
+    const storedTaxId = parseTaxId((user as any).taxId);
+    if (storedTaxId) {
+      await syncTaxIdToStripe(customerId, storedTaxId);
+    }
+
     let subsList: Stripe.ApiList<Stripe.Subscription>;
     try {
       subsList = await stripe.subscriptions.list({
@@ -735,10 +790,7 @@ export async function POST(req: NextRequest) {
     // garantindo a cobrança automática do segundo mês em diante.
     if (isD2cVipPromotionCode(promotionCode)) {
       const appBaseUrl = process.env.NEXTAUTH_URL || new URL(req.url).origin;
-      const successUrl = resolveCheckoutRedirectUrl(body.successUrl, {
-        appBaseUrl,
-        fallbackPath: "/billing/success?session_id={CHECKOUT_SESSION_ID}",
-      });
+      const successUrl = resolveHostedCheckoutSuccessUrl(body.successUrl, { appBaseUrl });
       const cancelUrl = resolveCheckoutRedirectUrl(body.cancelUrl, {
         appBaseUrl,
         fallbackPath: "/dashboard/billing",
@@ -753,6 +805,8 @@ export async function POST(req: NextRequest) {
           payment_method_collection: "always",
           discounts: discounts as Stripe.Checkout.SessionCreateParams.Discount[],
           subscription_data: { metadata },
+          // Só pede se ainda não temos: quem já informou não digita de novo.
+          ...(storedTaxId ? {} : HOSTED_CHECKOUT_TAX_ID_COLLECTION),
           success_url: successUrl,
           cancel_url: cancelUrl,
           client_reference_id: String(user._id),
@@ -901,10 +955,7 @@ export async function POST(req: NextRequest) {
       } catch { /* noop */ }
 
       const appBaseUrl = process.env.NEXTAUTH_URL || new URL(req.url).origin;
-      const successUrl = resolveCheckoutRedirectUrl(body.successUrl, {
-        appBaseUrl,
-        fallbackPath: "/billing/success?session_id={CHECKOUT_SESSION_ID}",
-      });
+      const successUrl = resolveHostedCheckoutSuccessUrl(body.successUrl, { appBaseUrl });
       const cancelUrl = resolveCheckoutRedirectUrl(body.cancelUrl, {
         appBaseUrl,
         fallbackPath: "/dashboard/billing",
@@ -918,6 +969,7 @@ export async function POST(req: NextRequest) {
           ? { discounts: discounts as Stripe.Checkout.SessionCreateParams.Discount[] }
           : {}
         ),
+        ...(storedTaxId ? {} : HOSTED_CHECKOUT_TAX_ID_COLLECTION),
         subscription_data: {
           metadata: {
             userId: String(user._id),

--- a/src/app/api/billing/tax-id/route.test.ts
+++ b/src/app/api/billing/tax-id/route.test.ts
@@ -1,0 +1,113 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth/next", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }), { virtual: true });
+jest.mock("@/app/lib/mongoose", () => ({ connectToDatabase: jest.fn() }));
+jest.mock("@/app/models/User", () => ({ findById: jest.fn() }));
+jest.mock("@/app/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/utils/rateLimit", () => ({ checkRateLimit: jest.fn() }));
+jest.mock("@/app/lib/billing/syncTaxIdToStripe", () => ({ syncTaxIdToStripe: jest.fn() }));
+
+const { getServerSession } = require("next-auth/next");
+const User = require("@/app/models/User");
+const { checkRateLimit } = require("@/utils/rateLimit");
+const { syncTaxIdToStripe } = require("@/app/lib/billing/syncTaxIdToStripe");
+const { POST, GET } = require("./route");
+
+const CPF = "52998224725";
+
+const createRequest = (body: unknown) =>
+  new NextRequest("http://localhost/api/billing/tax-id", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true });
+  (syncTaxIdToStripe as jest.Mock).mockResolvedValue(true);
+  (getServerSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+});
+
+describe("POST /api/billing/tax-id", () => {
+  it("saves a valid CPF stripped of formatting and mirrors it to Stripe", async () => {
+    const save = jest.fn();
+    const user = { _id: "u1", stripeCustomerId: "cus_1", save };
+    (User.findById as jest.Mock).mockResolvedValue(user);
+
+    const res = await POST(createRequest({ taxId: "529.982.247-25" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, taxIdType: "cpf" });
+    expect((user as any).taxId).toBe(CPF);
+    expect((user as any).taxIdType).toBe("cpf");
+    expect(save).toHaveBeenCalled();
+    expect(syncTaxIdToStripe).toHaveBeenCalledWith("cus_1", { value: CPF, type: "cpf" });
+  });
+
+  it("refuses a document whose check digits do not close", async () => {
+    (User.findById as jest.Mock).mockResolvedValue({ _id: "u1", save: jest.fn() });
+
+    const res = await POST(createRequest({ taxId: "123.456.789-00" }));
+
+    expect(res.status).toBe(422);
+    expect((await res.json()).code).toBe("INVALID_TAX_ID");
+    expect(User.findById).not.toHaveBeenCalled();
+  });
+
+  it("still saves when Stripe sync fails — the invoice data is ours", async () => {
+    const save = jest.fn();
+    const user = { _id: "u1", stripeCustomerId: "cus_1", save };
+    (User.findById as jest.Mock).mockResolvedValue(user);
+    (syncTaxIdToStripe as jest.Mock).mockResolvedValue(false);
+
+    const res = await POST(createRequest({ taxId: CPF }));
+
+    expect(res.status).toBe(200);
+    expect((user as any).taxId).toBe(CPF);
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+    const res = await POST(createRequest({ taxId: CPF }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rate limits repeated attempts", async () => {
+    (checkRateLimit as jest.Mock).mockResolvedValue({ allowed: false });
+    const res = await POST(createRequest({ taxId: CPF }));
+    expect(res.status).toBe(429);
+  });
+});
+
+describe("GET /api/billing/tax-id", () => {
+  it("reports the stored document without exposing it raw", async () => {
+    (User.findById as jest.Mock).mockReturnValue({
+      select: () => ({ lean: async () => ({ taxId: CPF, taxIdType: "cpf" }) }),
+    });
+
+    const res = await GET();
+
+    expect(await res.json()).toEqual({
+      hasTaxId: true,
+      taxIdType: "cpf",
+      taxIdMasked: "529.982.247-25",
+    });
+  });
+
+  it("reports nothing stored for a user who never informed it", async () => {
+    (User.findById as jest.Mock).mockReturnValue({
+      select: () => ({ lean: async () => ({}) }),
+    });
+
+    expect(await (await GET()).json()).toEqual({
+      hasTaxId: false,
+      taxIdType: null,
+      taxIdMasked: null,
+    });
+  });
+});

--- a/src/app/api/billing/tax-id/route.ts
+++ b/src/app/api/billing/tax-id/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import { logger } from "@/app/lib/logger";
+import { checkRateLimit } from "@/utils/rateLimit";
+import {
+  TAX_ID_INVALID_MESSAGE,
+  formatTaxId,
+  parseTaxId,
+} from "@/app/lib/billing/taxId";
+import { syncTaxIdToStripe } from "@/app/lib/billing/syncTaxIdToStripe";
+
+export const runtime = "nodejs";
+
+const noStoreHeaders = { "Cache-Control": "no-store, max-age=0" } as const;
+
+async function loadAuthOptions() {
+  if (process.env.NODE_ENV === "test") {
+    return {} as any;
+  }
+  const mod = await import("@/app/api/auth/[...nextauth]/route");
+  return mod.authOptions as any;
+}
+
+/** Diz se já temos o documento — usado para decidir se o campo aparece. */
+export async function GET() {
+  const authOptions = await loadAuthOptions();
+  const session = (await getServerSession(authOptions as any)) as any;
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Não autenticado" }, { status: 401, headers: noStoreHeaders });
+  }
+
+  await connectToDatabase();
+  const user = await User.findById(session.user.id).select("taxId taxIdType").lean();
+
+  const taxId = (user as any)?.taxId ?? null;
+  return NextResponse.json(
+    {
+      hasTaxId: Boolean(taxId),
+      taxIdType: (user as any)?.taxIdType ?? null,
+      // Só o formatado volta: serve para confirmar visualmente, não para
+      // reidratar formulário.
+      taxIdMasked: taxId ? formatTaxId(taxId) : null,
+    },
+    { headers: noStoreHeaders },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const authOptions = await loadAuthOptions();
+    const session = (await getServerSession(authOptions as any)) as any;
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Não autenticado" }, { status: 401, headers: noStoreHeaders });
+    }
+
+    const { allowed } = await checkRateLimit(`tax_id:${session.user.id}`, 10, 60);
+    if (!allowed) {
+      return NextResponse.json(
+        { code: "RATE_LIMITED", message: "Muitas tentativas. Aguarde um instante." },
+        { status: 429, headers: noStoreHeaders },
+      );
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const parsed = parseTaxId((body as any)?.taxId);
+    if (!parsed) {
+      return NextResponse.json(
+        { code: "INVALID_TAX_ID", message: TAX_ID_INVALID_MESSAGE },
+        { status: 422, headers: noStoreHeaders },
+      );
+    }
+
+    await connectToDatabase();
+    const user = await User.findById(session.user.id);
+    if (!user) {
+      return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404, headers: noStoreHeaders });
+    }
+
+    (user as any).taxId = parsed.value;
+    (user as any).taxIdType = parsed.type;
+    (user as any).taxIdUpdatedAt = new Date();
+    await user.save();
+
+    // Best-effort: o dado que a nota precisa já está salvo acima.
+    const synced = await syncTaxIdToStripe((user as any).stripeCustomerId, parsed);
+
+    logger.info("billing_tax_id_saved", {
+      endpoint: "POST /api/billing/tax-id",
+      userId: String(user._id),
+      taxIdType: parsed.type,
+      stripeSynced: synced,
+    });
+
+    return NextResponse.json(
+      { ok: true, taxIdType: parsed.type, taxIdMasked: formatTaxId(parsed.value) },
+      { headers: noStoreHeaders },
+    );
+  } catch (error: any) {
+    logger.error("[billing/tax-id] error", error);
+    return NextResponse.json(
+      { code: "TAX_ID_SAVE_FAILED", message: "Não foi possível salvar o documento." },
+      { status: 500, headers: noStoreHeaders },
+    );
+  }
+}

--- a/src/app/api/cron/creator-weekly-reports/route.test.ts
+++ b/src/app/api/cron/creator-weekly-reports/route.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+
+const publishJSON = jest.fn();
+const verify = jest.fn();
+
+jest.mock("@upstash/qstash", () => ({
+  Client: jest.fn(() => ({ publishJSON })),
+  Receiver: jest.fn(() => ({ verify })),
+}));
+jest.mock("@/app/lib/mongoose", () => ({ connectToDatabase: jest.fn() }));
+jest.mock("@/app/models/User", () => ({ find: jest.fn() }));
+jest.mock("@/app/lib/creatorWeeklyReport/service", () => ({
+  generateCreatorWeeklyReport: jest.fn(),
+}));
+jest.mock("@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag", () => ({
+  isCreatorWeeklyProfileExperienceEnabled: jest.fn(() => true),
+}));
+
+process.env.QSTASH_TOKEN = "qstash-test-token";
+process.env.QSTASH_CURRENT_SIGNING_KEY = "current-test-key";
+process.env.QSTASH_NEXT_SIGNING_KEY = "next-test-key";
+process.env.CRON_SECRET = "creator-weekly-test-secret";
+process.env.APP_BASE_URL = "https://data2content.ai";
+
+const User = require("@/app/models/User");
+const { POST } = require("./route");
+
+function request(authorized = true) {
+  return new NextRequest("https://data2content.ai/api/cron/creator-weekly-reports", {
+    method: "POST",
+    headers: authorized ? { "x-cron-key": "creator-weekly-test-secret" } : {},
+    body: "[CREATOR_WEEKLY_REPORT] test",
+  });
+}
+
+describe("creator weekly reports cron", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    publishJSON.mockResolvedValue({ messageId: "msg_test" });
+    verify.mockResolvedValue(false);
+    User.find.mockReturnValue({
+      select: jest.fn(() => ({
+        lean: jest.fn().mockResolvedValue([
+          { _id: { toString: () => "507f1f77bcf86cd799439011" } },
+          { _id: { toString: () => "507f1f77bcf86cd799439012" } },
+        ]),
+      })),
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.QSTASH_TOKEN;
+    delete process.env.QSTASH_CURRENT_SIGNING_KEY;
+    delete process.env.QSTASH_NEXT_SIGNING_KEY;
+    delete process.env.CRON_SECRET;
+    delete process.env.APP_BASE_URL;
+  });
+
+  it("rejects unsigned direct calls", async () => {
+    const response = await POST(request(false));
+
+    expect(response.status).toBe(401);
+    expect(publishJSON).not.toHaveBeenCalled();
+  });
+
+  it("fans out one signed worker job for every eligible creator", async () => {
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(User.find).toHaveBeenCalledWith({
+      isInstagramConnected: true,
+      planStatus: { $in: ["active", "non_renewing"] },
+    });
+    expect(publishJSON).toHaveBeenNthCalledWith(1, {
+      url: "https://data2content.ai/api/worker/generate-creator-weekly-report",
+      body: { userId: "507f1f77bcf86cd799439011" },
+      retries: 2,
+    });
+    expect(publishJSON).toHaveBeenNthCalledWith(2, {
+      url: "https://data2content.ai/api/worker/generate-creator-weekly-report",
+      body: { userId: "507f1f77bcf86cd799439012" },
+      retries: 2,
+    });
+    expect(body).toEqual({
+      ok: true,
+      mode: "queue",
+      eligible: 2,
+      queued: 2,
+      failed: 0,
+    });
+  });
+});

--- a/src/app/api/cron/creator-weekly-reports/route.ts
+++ b/src/app/api/cron/creator-weekly-reports/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Client as QStashClient, Receiver } from "@upstash/qstash";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import User from "@/app/models/User";
+import { generateCreatorWeeklyReport } from "@/app/lib/creatorWeeklyReport/service";
+import { isCreatorWeeklyProfileExperienceEnabled } from "@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const receiver = process.env.QSTASH_CURRENT_SIGNING_KEY && process.env.QSTASH_NEXT_SIGNING_KEY
+  ? new Receiver({
+      currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY,
+      nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY,
+    })
+  : null;
+
+const qstash = process.env.QSTASH_TOKEN
+  ? new QStashClient({ token: process.env.QSTASH_TOKEN })
+  : null;
+const workerUrl = `${
+  process.env.APP_BASE_URL || process.env.NEXT_PUBLIC_APP_URL
+}/api/worker/generate-creator-weekly-report`;
+
+async function authorized(request: NextRequest): Promise<boolean> {
+  if (process.env.NODE_ENV === "development") return true;
+  if (process.env.CRON_SECRET && request.headers.get("x-cron-key") === process.env.CRON_SECRET) return true;
+  if (!receiver) return false;
+  const signature = request.headers.get("upstash-signature") ?? "";
+  const body = await request.clone().text();
+  return receiver.verify({ signature, body }).catch(() => false);
+}
+
+export async function POST(request: NextRequest) {
+  if (!isCreatorWeeklyProfileExperienceEnabled()) {
+    return NextResponse.json({ message: "Recurso não habilitado." }, { status: 404 });
+  }
+  if (!(await authorized(request))) {
+    return NextResponse.json({ message: "Não autorizado." }, { status: 401 });
+  }
+
+  await connectToDatabase();
+  const users = await User.find({
+    isInstagramConnected: true,
+    planStatus: { $in: ["active", "non_renewing"] },
+  })
+    .select("_id")
+    .lean<Array<{ _id: { toString(): string } }>>();
+
+  if (!qstash || !workerUrl.startsWith("http")) {
+    if (process.env.NODE_ENV !== "development") {
+      return NextResponse.json({ message: "Fila semanal não configurada." }, { status: 500 });
+    }
+
+    let generated = 0;
+    let failed = 0;
+    for (const user of users) {
+      try {
+        await generateCreatorWeeklyReport({ userId: user._id.toString(), force: true });
+        generated += 1;
+      } catch (error) {
+        failed += 1;
+        console.error("[creator-weekly-reports] Falha local ao gerar relatório:", error);
+      }
+    }
+    return NextResponse.json({ ok: true, mode: "local", eligible: users.length, generated, failed });
+  }
+
+  let queued = 0;
+  let failed = 0;
+  for (const user of users) {
+    try {
+      await qstash.publishJSON({
+        url: workerUrl,
+        body: { userId: user._id.toString() },
+        retries: 2,
+      });
+      queued += 1;
+    } catch (error) {
+      failed += 1;
+      console.error("[creator-weekly-reports] Falha ao enfileirar relatório:", error);
+    }
+  }
+
+  return NextResponse.json({ ok: true, mode: "queue", eligible: users.length, queued, failed });
+}
+
+export async function GET(request: NextRequest) {
+  if (process.env.NODE_ENV !== "development") {
+    return NextResponse.json({ message: "Método não permitido." }, { status: 405 });
+  }
+  return POST(request);
+}

--- a/src/app/api/dashboard/mobile-strategic-profile/weekly-report/route.test.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/weekly-report/route.test.ts
@@ -1,0 +1,79 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { getServerSession } from "next-auth/next";
+import {
+  generateCreatorWeeklyReport,
+  getOrGenerateCreatorWeeklyReport,
+} from "@/app/lib/creatorWeeklyReport/service";
+import { isCreatorWeeklyProfileExperienceEnabled } from "@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag";
+
+jest.mock("next-auth/next", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/app/api/auth/resolveAuthOptions", () => ({
+  resolveAuthOptions: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("@/app/lib/creatorWeeklyReport/service", () => ({
+  generateCreatorWeeklyReport: jest.fn(),
+  getOrGenerateCreatorWeeklyReport: jest.fn(),
+}));
+jest.mock("@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag", () => ({
+  isCreatorWeeklyProfileExperienceEnabled: jest.fn(),
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockGetReport = getOrGenerateCreatorWeeklyReport as jest.Mock;
+const mockGenerateReport = generateCreatorWeeklyReport as jest.Mock;
+const mockFeatureEnabled = isCreatorWeeklyProfileExperienceEnabled as jest.Mock;
+const USER_ID = "507f1f77bcf86cd799439011";
+
+function postRequest(body: object) {
+  return new NextRequest("http://localhost/api/dashboard/mobile-strategic-profile/weekly-report", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("creator weekly report route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFeatureEnabled.mockReturnValue(true);
+    mockGetServerSession.mockResolvedValue({ user: { id: USER_ID } });
+    mockGetReport.mockResolvedValue({ report: { status: "ready", weekKey: "2026-W32" } });
+    mockGenerateReport.mockResolvedValue({ report: { status: "partial", weekKey: "2026-W32" } });
+  });
+
+  it("never loads another creator and rejects an anonymous request", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(mockGetReport).not.toHaveBeenCalled();
+  });
+
+  it("returns only the report for the authenticated session", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetReport).toHaveBeenCalledWith(USER_ID);
+    expect(body.report).toEqual({ status: "ready", weekKey: "2026-W32" });
+  });
+
+  it("regenerates on demand only when force is explicitly true", async () => {
+    const response = await POST(postRequest({ force: true }));
+
+    expect(response.status).toBe(200);
+    expect(mockGenerateReport).toHaveBeenCalledWith({ userId: USER_ID, force: true });
+  });
+
+  it("returns 404 while the rollout flag is disabled", async () => {
+    mockFeatureEnabled.mockReturnValue(false);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/dashboard/mobile-strategic-profile/weekly-report/route.ts
+++ b/src/app/api/dashboard/mobile-strategic-profile/weekly-report/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { resolveAuthOptions } from "@/app/api/auth/resolveAuthOptions";
+import {
+  generateCreatorWeeklyReport,
+  getOrGenerateCreatorWeeklyReport,
+} from "@/app/lib/creatorWeeklyReport/service";
+import { isCreatorWeeklyProfileExperienceEnabled } from "@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+async function authenticatedUserId(): Promise<string | null> {
+  const session = await getServerSession(await resolveAuthOptions()) as {
+    user?: { id?: string };
+  } | null;
+  return session?.user?.id ?? null;
+}
+
+export async function GET() {
+  if (!isCreatorWeeklyProfileExperienceEnabled()) {
+    return NextResponse.json({ message: "Recurso não habilitado." }, { status: 404 });
+  }
+  const userId = await authenticatedUserId();
+  if (!userId) return NextResponse.json({ message: "Não autorizado." }, { status: 401 });
+
+  try {
+    const snapshot = await getOrGenerateCreatorWeeklyReport(userId);
+    return NextResponse.json({ ok: true, report: snapshot.report });
+  } catch (error) {
+    console.error("[weekly-report] Falha ao carregar relatório:", error);
+    return NextResponse.json(
+      { ok: false, safeErrorCode: "weekly_report_unavailable" },
+      { status: 503 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!isCreatorWeeklyProfileExperienceEnabled()) {
+    return NextResponse.json({ message: "Recurso não habilitado." }, { status: 404 });
+  }
+  const userId = await authenticatedUserId();
+  if (!userId) return NextResponse.json({ message: "Não autorizado." }, { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  try {
+    const snapshot = await generateCreatorWeeklyReport({
+      userId,
+      force: body?.force === true,
+    });
+    return NextResponse.json({ ok: true, report: snapshot.report });
+  } catch (error) {
+    console.error("[weekly-report] Falha ao gerar relatório:", error);
+    return NextResponse.json(
+      { ok: false, safeErrorCode: "weekly_report_generation_failed" },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/worker/generate-creator-weekly-report/route.test.ts
+++ b/src/app/api/worker/generate-creator-weekly-report/route.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { generateCreatorWeeklyReport } from "@/app/lib/creatorWeeklyReport/service";
+import { isCreatorWeeklyProfileExperienceEnabled } from "@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag";
+
+jest.mock("@/app/lib/creatorWeeklyReport/service", () => ({
+  generateCreatorWeeklyReport: jest.fn(),
+}));
+jest.mock("@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag", () => ({
+  isCreatorWeeklyProfileExperienceEnabled: jest.fn(),
+}));
+
+const mockGenerate = generateCreatorWeeklyReport as jest.Mock;
+const mockFeatureEnabled = isCreatorWeeklyProfileExperienceEnabled as jest.Mock;
+const USER_ID = "507f1f77bcf86cd799439011";
+
+function request(body: object, authorized = true) {
+  return new NextRequest("http://localhost/api/worker/generate-creator-weekly-report", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(authorized ? { "x-cron-key": "weekly-report-test-secret" } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("generate creator weekly report worker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CRON_SECRET = "weekly-report-test-secret";
+    mockFeatureEnabled.mockReturnValue(true);
+    mockGenerate.mockResolvedValue({ report: { weekKey: "2026-W32", status: "ready" } });
+  });
+
+  afterAll(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("rejects unsigned direct calls", async () => {
+    const response = await POST(request({ userId: USER_ID }, false));
+
+    expect(response.status).toBe(401);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it("requires the scoped user id", async () => {
+    const response = await POST(request({}));
+
+    expect(response.status).toBe(400);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it("materializes one report per queued job", async () => {
+    const response = await POST(request({ userId: USER_ID }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGenerate).toHaveBeenCalledWith({ userId: USER_ID, force: true });
+    expect(body).toEqual({ ok: true, weekKey: "2026-W32", status: "ready" });
+  });
+});

--- a/src/app/api/worker/generate-creator-weekly-report/route.ts
+++ b/src/app/api/worker/generate-creator-weekly-report/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Receiver } from "@upstash/qstash";
+import { generateCreatorWeeklyReport } from "@/app/lib/creatorWeeklyReport/service";
+import { isCreatorWeeklyProfileExperienceEnabled } from "@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const receiver = process.env.QSTASH_CURRENT_SIGNING_KEY && process.env.QSTASH_NEXT_SIGNING_KEY
+  ? new Receiver({
+      currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY,
+      nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY,
+    })
+  : null;
+
+async function authorized(request: NextRequest): Promise<boolean> {
+  if (process.env.NODE_ENV === "development") return true;
+  if (process.env.CRON_SECRET && request.headers.get("x-cron-key") === process.env.CRON_SECRET) return true;
+  if (!receiver) return false;
+  const signature = request.headers.get("upstash-signature") ?? "";
+  const body = await request.clone().text();
+  return receiver.verify({ signature, body }).catch(() => false);
+}
+
+export async function POST(request: NextRequest) {
+  if (!isCreatorWeeklyProfileExperienceEnabled()) {
+    return NextResponse.json({ message: "Recurso não habilitado." }, { status: 404 });
+  }
+  if (!(await authorized(request))) {
+    return NextResponse.json({ message: "Não autorizado." }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const userId = typeof body?.userId === "string" ? body.userId : null;
+  if (!userId) {
+    return NextResponse.json({ message: "userId obrigatório." }, { status: 400 });
+  }
+
+  try {
+    const snapshot = await generateCreatorWeeklyReport({ userId, force: true });
+    return NextResponse.json({
+      ok: true,
+      weekKey: snapshot.report.weekKey,
+      status: snapshot.report.status,
+    });
+  } catch (error) {
+    console.error("[generate-creator-weekly-report] Falha ao gerar relatório:", error);
+    return NextResponse.json(
+      { ok: false, safeErrorCode: "weekly_report_generation_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/worker/refresh-instagram-user/route.ts
+++ b/src/app/api/worker/refresh-instagram-user/route.ts
@@ -7,6 +7,8 @@ import { triggerDataRefresh } from '@/app/lib/instagram';
 import mongoose from 'mongoose'; // Para validar ObjectId
 import { invalidateDashboardHomeSummaryCache } from '@/app/lib/cache/dashboardCache';
 import { enrichMapaSeedWithInstagram } from '@/app/lib/mapaSeed/enrichMapaSeedForUser';
+import { generateCreatorWeeklyReport } from '@/app/lib/creatorWeeklyReport/service';
+import { isCreatorWeeklyProfileExperienceEnabled } from '@/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic'; // Garante execução dinâmica
@@ -108,6 +110,15 @@ export async function POST(request: NextRequest) {
         // Enriquece o MapaSeed com os posts recentes do Instagram.
         // Non-fatal: nunca bloqueia a resposta do worker.
         await enrichMapaSeedWithInstagram(userId);
+
+        // O relatório individual é materializado depois do sync, usando as
+        // métricas que acabaram de chegar. Falha aqui não invalida a conexão:
+        // a rota do Perfil e a cron de segunda também conseguem regenerá-lo.
+        if (isCreatorWeeklyProfileExperienceEnabled()) {
+          await generateCreatorWeeklyReport({ userId }).catch((error) => {
+            logger.error(`${TAG} Falha não fatal ao materializar relatório semanal para User ${userId}:`, error);
+          });
+        }
 
         return NextResponse.json({ success: true, message: refreshResult.message, details: refreshResult.details }, { status: 200 });
     } else {

--- a/src/app/billing/success/page.test.tsx
+++ b/src/app/billing/success/page.test.tsx
@@ -1,6 +1,7 @@
 import {
   default as BillingSuccessPage,
   normalizeBillingSuccessPostCheckoutIntent,
+  resolveBillingSuccessAttemptId,
   sanitizeBillingSuccessReturnTo,
 } from "./page";
 import { act, render } from "@testing-library/react";
@@ -66,6 +67,15 @@ describe("billing success postCheckoutIntent helpers", () => {
     expect(normalizeBillingSuccessPostCheckoutIntent("connect_instagram")).toBe("connect_instagram");
     expect(normalizeBillingSuccessPostCheckoutIntent("join_community")).toBe("join_community");
     expect(normalizeBillingSuccessPostCheckoutIntent("external_redirect")).toBeNull();
+  });
+
+  it("identifica tanto o Checkout hospedado quanto a assinatura do Payment Element", () => {
+    expect(resolveBillingSuccessAttemptId(new URLSearchParams("session_id=cs_live_123"))).toBe(
+      "cs_live_123",
+    );
+    expect(resolveBillingSuccessAttemptId(new URLSearchParams("sid=sub_live_123"))).toBe(
+      "sub_live_123",
+    );
   });
 
   it("registra intent visto/consumido e redireciona sem aceitar rota externa", async () => {

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -71,9 +71,15 @@ export function normalizeBillingSuccessPostCheckoutIntent(value: unknown): "conn
   return value === "connect_instagram" || value === "join_community" ? value : null;
 }
 
+export function resolveBillingSuccessAttemptId(
+  params: Pick<URLSearchParams, "get">,
+): string | null {
+  return params.get("session_id") ?? params.get("sid");
+}
+
 export default function BillingSuccessPage() {
   const sp = useSearchParams();
-  const sid = sp.get("session_id");
+  const sid = resolveBillingSuccessAttemptId(sp);
   const { update } = useSession();
   const router = useRouter();
 

--- a/src/app/dashboard/billing/BillingSubscribeModal.tsx
+++ b/src/app/dashboard/billing/BillingSubscribeModal.tsx
@@ -569,7 +569,7 @@ export default function BillingSubscribeModal({
         plan: period,              // "monthly" | "annual"
         currency,                  // "brl" | "usd"
         mode: "subscription",
-        successUrl: `${window.location.origin}/billing/success`,
+        successUrl: `${window.location.origin}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
         cancelUrl: resolveCheckoutCancelUrl(),
         source: "modal",
         ...(couponApplied || isD2cVipPromotionCode(searchParams?.get(PAYWALL_COUPON_PARAM))

--- a/src/app/dashboard/billing/CheckoutForm.tsx
+++ b/src/app/dashboard/billing/CheckoutForm.tsx
@@ -27,7 +27,9 @@ export default function CheckoutForm({ subscriptionId, onBack }: Props) {
       setSubmitting(true);
       setErr(null);
 
-      const returnUrl = `${window.location.origin}/billing/success`;
+      const returnUrl = `${window.location.origin}/billing/success${
+        subscriptionId ? `?sid=${encodeURIComponent(subscriptionId)}` : ""
+      }`;
 
       const { error, paymentIntent } = await stripe.confirmPayment({
         elements,

--- a/src/app/dashboard/billing/CheckoutPage.tsx
+++ b/src/app/dashboard/billing/CheckoutPage.tsx
@@ -11,6 +11,7 @@ import { useDebounce } from "use-debounce";
 import useBillingStatus from "@/app/hooks/useBillingStatus";
 import { mapSubscribeError } from "@/app/lib/billing/errors";
 import { isD2cVipPromotionCode } from "@/app/lib/billing/d2cVipPromotion";
+import { TAX_ID_INVALID_MESSAGE, maskTaxIdInput, parseTaxId } from "@/app/lib/billing/taxId";
 
 // --- Tipos e Constantes ---
 type Plan = "monthly" | "annual";
@@ -92,6 +93,10 @@ export default function CheckoutPage({ affiliateCode: initialAffiliateCode }: Ch
   const [loading, setLoading] = useState(false);
   const [resumeLoading, setResumeLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // CPF/CNPJ é requisito da nota fiscal, então é obrigatório para assinar.
+  const [taxId, setTaxId] = useState("");
+  const [taxIdError, setTaxIdError] = useState<string | null>(null);
+  const [hasStoredTaxId, setHasStoredTaxId] = useState<boolean | null>(null);
   const [errorAction, setErrorAction] = useState<{ label: string; href: string } | null>(null);
 
   // <<< ALTERAÇÃO 4: Remover o useEffect que lia a URL, pois isso agora é feito no Server Component pai >>>
@@ -305,12 +310,39 @@ export default function CheckoutPage({ affiliateCode: initialAffiliateCode }: Ch
     }
   }, [affiliateCode, plan, currency, fetchPreview]);
 
+  // Quem já informou o documento antes não vê o campo de novo.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/billing/tax-id", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setHasStoredTaxId(Boolean(data?.hasTaxId));
+      } catch {
+        // Indisponibilidade aqui não pode travar o checkout: o campo aparece e
+        // o backend valida de novo.
+        if (!cancelled) setHasStoredTaxId(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   // --- Iniciar pagamento ---
   async function startCheckout() {
     try {
       setLoading(true);
       setErr(null);
       setErrorAction(null);
+      setTaxIdError(null);
+
+      const needsTaxId = hasStoredTaxId === false;
+      const parsedTaxId = parseTaxId(taxId);
+      if (needsTaxId && !parsedTaxId) {
+        setTaxIdError(TAX_ID_INVALID_MESSAGE);
+        setLoading(false);
+        return;
+      }
       const res = await fetch("/api/billing/subscribe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -320,11 +352,16 @@ export default function CheckoutPage({ affiliateCode: initialAffiliateCode }: Ch
           ...(isD2cVipPromotionCode(affiliateCode)
             ? { promotionCode: affiliateCode.trim() }
             : { affiliateCode: affiliateCode.trim().toUpperCase() || undefined }),
+          ...(parsedTaxId ? { taxId: parsedTaxId.value } : {}),
         }),
       });
       const data = await res.json();
 
       if (!res.ok) {
+        if (data?.code === "INVALID_TAX_ID") {
+          setTaxIdError(data?.message || TAX_ID_INVALID_MESSAGE);
+          return;
+        }
         if (data?.code === "SELF_REFERRAL") {
           setAffiliateError("Você não pode usar seu próprio código.");
           return;
@@ -442,6 +479,42 @@ export default function CheckoutPage({ affiliateCode: initialAffiliateCode }: Ch
                   </button>
                 </div>
               </div>
+
+              {/* CPF/CNPJ — obrigatório para a nota fiscal */}
+              {hasStoredTaxId === false && (
+                <div>
+                  <label htmlFor="tax-id" className="block text-sm font-medium mb-2">
+                    CPF ou CNPJ
+                  </label>
+                  <input
+                    id="tax-id"
+                    value={taxId}
+                    onChange={(e) => {
+                      setTaxId(maskTaxIdInput(e.target.value));
+                      setTaxIdError(null);
+                    }}
+                    inputMode="numeric"
+                    autoComplete="off"
+                    placeholder="000.000.000-00"
+                    aria-invalid={!!taxIdError}
+                    aria-describedby={taxIdError ? "tax-id-error" : "tax-id-hint"}
+                    className={`w-full px-3 py-2 border rounded-md text-sm outline-none ${
+                      taxIdError ? "border-red-500" : "border-gray-300 focus:border-gray-900"
+                    }`}
+                  />
+                  <div role="status" aria-live="polite" className="min-h-[1.25rem]">
+                    {taxIdError ? (
+                      <p id="tax-id-error" className="mt-1 text-xs text-red-600">
+                        {taxIdError}
+                      </p>
+                    ) : (
+                      <p id="tax-id-hint" className="mt-1 text-xs text-gray-500">
+                        Usamos para emitir sua nota fiscal.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
 
               {/* Código de Afiliado */}
               <div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CreatorWeeklyCollabsGate } from "./CreatorWeeklyCollabsGate";
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry", () => ({
+  trackMobileNarrativeEvent: jest.fn(),
+}));
+
+describe("CreatorWeeklyCollabsGate", () => {
+  it("asks a Pro creator to connect Instagram before personalized collabs", () => {
+    const onConnectInstagram = jest.fn();
+    render(
+      <CreatorWeeklyCollabsGate
+        accessState="pro_needs_instagram"
+        isDemo={false}
+        onUpgrade={jest.fn()}
+        onConnectInstagram={onConnectInstagram}
+        onDemoChange={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Conectar Instagram" }));
+    expect(onConnectInstagram).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the demo inside the creator profile and lets her leave it", () => {
+    const onDemoChange = jest.fn();
+    render(
+      <CreatorWeeklyCollabsGate
+        accessState="free_unused"
+        isDemo
+        onUpgrade={jest.fn()}
+        onConnectInstagram={jest.fn()}
+        onDemoChange={onDemoChange}
+      />,
+    );
+
+    expect(screen.getByText("Uma pauta, duas casas.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sair do exemplo" }));
+    expect(onDemoChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { NarrativeMapAccessState } from "@/app/dashboard/boards/videoUpload/narrativeMapAccessState";
+import type { PaywallContext } from "@/types/paywall";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
+
+export function CreatorWeeklyCollabsGate({
+  accessState,
+  isDemo,
+  onUpgrade,
+  onConnectInstagram,
+  onDemoChange,
+}: {
+  accessState: NarrativeMapAccessState;
+  isDemo: boolean;
+  onUpgrade: (context?: PaywallContext) => void;
+  onConnectInstagram: () => void;
+  onDemoChange: (demo: boolean) => void;
+}) {
+  const isProNeedsInstagram = accessState === "pro_needs_instagram";
+  const billingAttention = accessState === "payment_pending" || accessState === "payment_action_needed";
+  const changeDemo = (next: boolean) => {
+    trackMobileNarrativeEvent(
+      next ? "mobile_weekly_report_demo_opened" : "mobile_weekly_report_demo_closed",
+      {
+        route: "/dashboard/boards/mobile-strategic-profile",
+        accessState,
+        actionType: "collabs",
+      },
+    );
+    onDemoChange(next);
+  };
+
+  if (isDemo) {
+    return (
+      <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+        <header>
+          <div className="flex items-center gap-2">
+            <span className="ds-eyebrow">Collabs</span>
+            <span className="ds-badge ds-badge--neutral">Exemplo</span>
+          </div>
+          <h1 className="mt-2 text-[2rem] font-bold leading-none text-[var(--ds-color-ink)]">Uma pauta, duas casas.</h1>
+          <p className="ds-body mt-2">O exemplo mostra como o encaixe é explicado antes de qualquer convite.</p>
+        </header>
+
+        <section className="ds-editorial-panel mt-6 p-5">
+          <span className="ds-eyebrow">Por que combina</span>
+          <h2 className="mt-3 text-[1.4rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
+            Vocês falam de rotina real por ângulos diferentes.
+          </h2>
+          <p className="ds-body mt-3">Uma mostra a decisão por dentro; a outra transforma a mesma situação em passo prático.</p>
+          <div className="mt-5 border-t border-[var(--ds-color-line)] pt-4">
+            <span className="ds-eyebrow">Como gravar</span>
+            <ol className="mt-3 space-y-3 text-[14px] leading-[1.45] text-[var(--ds-color-ink)]">
+              <li className="flex gap-3"><b>1.</b><span>Cada uma grava em casa a mesma pergunta.</span></li>
+              <li className="flex gap-3"><b>2.</b><span>As respostas se alternam em cortes curtos.</span></li>
+              <li className="flex gap-3"><b>3.</b><span>A conclusão aponta o que as duas aprenderam.</span></li>
+            </ol>
+          </div>
+        </section>
+
+        <button type="button" className="ds-button ds-button--quiet ds-button--block mt-5" onClick={() => changeDemo(false)}>
+          Sair do exemplo
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+      <header>
+        <span className="ds-eyebrow">Collabs</span>
+        <h1 className="mt-2 text-[2rem] font-bold leading-none text-[var(--ds-color-ink)]">Criadores que combinam com você</h1>
+      </header>
+
+      <section className="ds-editorial-panel mt-6 p-5">
+        <span className="ds-eyebrow">Ainda não dá</span>
+        <h2 className="mt-3 text-[1.45rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
+          Para achar quem combina com você, a D2C precisa ver os seus vídeos.
+        </h2>
+        <p className="ds-body mt-3">A combinação é por assunto e jeito de gravar — não por número de seguidores.</p>
+        <button
+          type="button"
+          className="ds-button ds-button--primary mt-5"
+          onClick={isProNeedsInstagram ? onConnectInstagram : () => onUpgrade(billingAttention ? "narrative_map" : "planning")}
+        >
+          {isProNeedsInstagram ? "Conectar Instagram" : billingAttention ? "Resolver pagamento" : "Assinar Pro"}
+        </button>
+      </section>
+
+      <section className="mt-7 border-t border-[var(--ds-color-line)] pt-6">
+        <span className="ds-eyebrow">Veja por dentro</span>
+        <h2 className="mt-2 text-[1.35rem] font-bold leading-tight text-[var(--ds-color-ink)]">O exemplo também tem as collabs.</h2>
+        <p className="ds-body mt-2">Veja quem combina com quem, por quê e o passo a passo para gravar.</p>
+        <button type="button" className="ds-button ds-button--quiet mt-4" onClick={() => changeDemo(true)}>
+          Ver exemplo
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyCollabsGate.tsx
@@ -33,7 +33,7 @@ export function CreatorWeeklyCollabsGate({
 
   if (isDemo) {
     return (
-      <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+      <main className="ds-notebook-page ds-analysis-editorial">
         <header>
           <div className="flex items-center gap-2">
             <span className="ds-eyebrow">Collabs</span>
@@ -43,13 +43,13 @@ export function CreatorWeeklyCollabsGate({
           <p className="ds-body mt-2">O exemplo mostra como o encaixe é explicado antes de qualquer convite.</p>
         </header>
 
-        <section className="ds-editorial-panel mt-6 p-5">
+        <section className="ds-notebook-section mt-6">
           <span className="ds-eyebrow">Por que combina</span>
           <h2 className="mt-3 text-[1.4rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
             Vocês falam de rotina real por ângulos diferentes.
           </h2>
           <p className="ds-body mt-3">Uma mostra a decisão por dentro; a outra transforma a mesma situação em passo prático.</p>
-          <div className="mt-5 border-t border-[var(--ds-color-line)] pt-4">
+          <div className="mt-5">
             <span className="ds-eyebrow">Como gravar</span>
             <ol className="mt-3 space-y-3 text-[14px] leading-[1.45] text-[var(--ds-color-ink)]">
               <li className="flex gap-3"><b>1.</b><span>Cada uma grava em casa a mesma pergunta.</span></li>
@@ -67,13 +67,13 @@ export function CreatorWeeklyCollabsGate({
   }
 
   return (
-    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+    <main className="ds-notebook-page ds-analysis-editorial">
       <header>
         <span className="ds-eyebrow">Collabs</span>
         <h1 className="mt-2 text-[2rem] font-bold leading-none text-[var(--ds-color-ink)]">Criadores que combinam com você</h1>
       </header>
 
-      <section className="ds-editorial-panel mt-6 p-5">
+      <section className="ds-notebook-section mt-6">
         <span className="ds-eyebrow">Ainda não dá</span>
         <h2 className="mt-3 text-[1.45rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
           Para achar quem combina com você, a D2C precisa ver os seus vídeos.
@@ -88,7 +88,7 @@ export function CreatorWeeklyCollabsGate({
         </button>
       </section>
 
-      <section className="mt-7 border-t border-[var(--ds-color-line)] pt-6">
+      <section className="ds-notebook-section">
         <span className="ds-eyebrow">Veja por dentro</span>
         <h2 className="mt-2 text-[1.35rem] font-bold leading-tight text-[var(--ds-color-ink)]">O exemplo também tem as collabs.</h2>
         <p className="ds-body mt-2">Veja quem combina com quem, por quê e o passo a passo para gravar.</p>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.test.tsx
@@ -10,6 +10,7 @@ jest.mock("@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry", () => (
 const callbacks = {
   onDemoChange: jest.fn(),
   onOpenAccountMenu: jest.fn(),
+  onOpenNorte: jest.fn(),
   onOpenMediaKit: jest.fn(),
   onOpenCalculator: jest.fn(),
   onUpgrade: jest.fn(),
@@ -19,7 +20,7 @@ const callbacks = {
 describe("CreatorWeeklyProfileExperience", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("mantém identidade e mapa próprios no estado gratuito", () => {
+  it("mantém identidade e mapa próprios em uma hierarquia plana no estado gratuito", () => {
     const data = buildDiagnosticoPageDataFixture({
       accessState: "free_unused",
       instagramConnected: false,
@@ -42,7 +43,7 @@ describe("CreatorWeeklyProfileExperience", () => {
       },
     });
 
-    render(
+    const { container } = render(
       <CreatorWeeklyProfileExperience
         data={data}
         weeklyMeeting={null}
@@ -54,6 +55,21 @@ describe("CreatorWeeklyProfileExperience", () => {
     expect(screen.getByText("Ana Criadora")).toBeInTheDocument();
     expect(screen.getByText(/Uma mãe que encontra força na rotina/)).toBeInTheDocument();
     expect(screen.getByText("Faltam 2 passos")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Mídia Kit/i }).closest("section")).toHaveClass("ds-notebook-section");
+    expect(
+      screen.getByRole("heading", { name: "Veja um relatório inteiro antes de assinar." }).closest("section"),
+    ).toHaveClass("ds-notebook-section");
+    expect(screen.getByRole("heading", { name: "Toda quinta, 19h" }).closest("section")).toHaveClass("ds-notebook-section");
+    expect(container.querySelector("main")).toHaveClass("ds-notebook-page");
+    expect(container.querySelectorAll(".ds-editorial-panel")).toHaveLength(0);
+    expect(container.querySelectorAll(".ds-notebook-section .ds-notebook-section")).toHaveLength(0);
+    expect(screen.getByRole("button", { name: /Mídia Kit/i }).querySelector("svg")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Ajustar mapa" }));
+    expect(callbacks.onOpenNorte).toHaveBeenCalledTimes(1);
+    // A engrenagem migrou do header para dentro do cartão de identidade;
+    // este clique existe para o caminho não se perder numa próxima mudança.
+    fireEvent.click(screen.getByRole("button", { name: "Configurações da conta" }));
+    expect(callbacks.onOpenAccountMenu).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Ver relatório de exemplo" }));
     expect(callbacks.onDemoChange).toHaveBeenCalledWith(true);
   });
@@ -71,7 +87,7 @@ describe("CreatorWeeklyProfileExperience", () => {
       },
     });
 
-    render(
+    const { container } = render(
       <CreatorWeeklyProfileExperience
         data={data}
         weeklyMeeting={null}
@@ -81,7 +97,8 @@ describe("CreatorWeeklyProfileExperience", () => {
     );
 
     expect(screen.getByText("Ana Criadora")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "A semana por dentro" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "A semana por dentro" }).closest("section")).toHaveClass("ds-notebook-section");
+    expect(container.querySelectorAll(".ds-editorial-panel")).toHaveLength(0);
     fireEvent.click(screen.getByRole("button", { name: /Dia e horário/i }));
     expect(screen.getByRole("heading", { name: "Dia e horário" })).toBeInTheDocument();
     expect(screen.getByText("Ranking dos dias")).toBeInTheDocument();

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CREATOR_WEEKLY_REPORT_DEMO } from "@/app/lib/creatorWeeklyReport/demoReport";
+import { buildDiagnosticoPageDataFixture } from "./diagnosticoTestFixtures";
+import { CreatorWeeklyProfileExperience } from "./CreatorWeeklyProfileExperience";
+
+jest.mock("@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry", () => ({
+  trackMobileNarrativeEvent: jest.fn(),
+}));
+
+const callbacks = {
+  onDemoChange: jest.fn(),
+  onOpenAccountMenu: jest.fn(),
+  onOpenMediaKit: jest.fn(),
+  onOpenCalculator: jest.fn(),
+  onUpgrade: jest.fn(),
+  onConnectInstagram: jest.fn(),
+};
+
+describe("CreatorWeeklyProfileExperience", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("mantém identidade e mapa próprios no estado gratuito", () => {
+    const data = buildDiagnosticoPageDataFixture({
+      accessState: "free_unused",
+      instagramConnected: false,
+      userInfo: {
+        name: "Ana Criadora",
+        handle: "anacriadora",
+        imageUrl: null,
+        plan: "Free",
+      },
+      mapaSeed: {
+        narrativa_central: "Uma mãe que encontra força na rotina",
+        territorios: ["Maternidade", "Fé"],
+        temas: [],
+        narrativas_adjacentes: [],
+        assets: [],
+        tom: "",
+        formatos: [],
+        maturidade: "seed",
+        fonte: ["onboarding_declarativo"],
+      },
+    });
+
+    render(
+      <CreatorWeeklyProfileExperience
+        data={data}
+        weeklyMeeting={null}
+        isDemo={false}
+        {...callbacks}
+      />,
+    );
+
+    expect(screen.getByText("Ana Criadora")).toBeInTheDocument();
+    expect(screen.getByText(/Uma mãe que encontra força na rotina/)).toBeInTheDocument();
+    expect(screen.getByText("Faltam 2 passos")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Ver relatório de exemplo" }));
+    expect(callbacks.onDemoChange).toHaveBeenCalledWith(true);
+  });
+
+  it("abre os rankings do relatório real sem trocar a identidade", () => {
+    const data = buildDiagnosticoPageDataFixture({
+      accessState: "pro_instagram_connected",
+      instagramConnected: true,
+      creatorWeeklyReport: CREATOR_WEEKLY_REPORT_DEMO,
+      userInfo: {
+        name: "Ana Criadora",
+        handle: "anacriadora",
+        imageUrl: null,
+        plan: "Pro",
+      },
+    });
+
+    render(
+      <CreatorWeeklyProfileExperience
+        data={data}
+        weeklyMeeting={null}
+        isDemo={false}
+        {...callbacks}
+      />,
+    );
+
+    expect(screen.getByText("Ana Criadora")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "A semana por dentro" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Dia e horário/i }));
+    expect(screen.getByRole("heading", { name: "Dia e horário" })).toBeInTheDocument();
+    expect(screen.getByText("Ranking dos dias")).toBeInTheDocument();
+  });
+
+  it("nunca usa a demonstração para trocar o nome da criadora", () => {
+    const data = buildDiagnosticoPageDataFixture({
+      accessState: "free_preview_used",
+      instagramConnected: false,
+      userInfo: { name: "Ana Criadora", handle: null, imageUrl: null, plan: "Free" },
+    });
+
+    render(
+      <CreatorWeeklyProfileExperience
+        data={data}
+        weeklyMeeting={null}
+        isDemo
+        {...callbacks}
+      />,
+    );
+
+    expect(screen.getByText("Ana Criadora")).toBeInTheDocument();
+    expect(screen.getByText(/Você está vendo um exemplo/)).toBeInTheDocument();
+    expect(screen.getByText("Uma marca de bem-estar")).toBeInTheDocument();
+    expect(screen.queryByText(/Débora Broch/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.tsx
@@ -1,0 +1,623 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { COMMUNITY_WHATSAPP_URL } from "@/app/lib/communityLinks";
+import type { DiagnosticoPageData } from "@/app/dashboard/boards/videoUpload/diagnosticoPageData";
+import { CREATOR_WEEKLY_REPORT_DEMO } from "@/app/lib/creatorWeeklyReport/demoReport";
+import type {
+  CreatorWeeklyReportDetailId,
+  CreatorWeeklyReportPayload,
+  CreatorWeeklyReportVideo,
+} from "@/app/lib/creatorWeeklyReport/types";
+import type { PaywallContext } from "@/types/paywall";
+import type { WeeklyMeetingProfileData } from "./WeeklyMeetingProfileCard";
+import { CreatorWeeklyReportDetail } from "./CreatorWeeklyReportDetail";
+import { trackMobileNarrativeEvent } from "@/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry";
+
+function firstName(value: string | null | undefined) {
+  return value?.trim().split(/\s+/)[0] || "Criadora";
+}
+
+function normalizeForMatch(value: string) {
+  return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLocaleLowerCase("pt-BR");
+}
+
+function formatMetric(value: number | null) {
+  if (value === null) return "—";
+  return new Intl.NumberFormat("pt-BR", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function formatIndex(value: number | null) {
+  if (value === null) return null;
+  return `${value.toFixed(1).replace(".", ",")}× acima do seu normal`;
+}
+
+function formatMeetingDate(meeting: WeeklyMeetingProfileData) {
+  const date = new Date(meeting.startAt);
+  if (Number.isNaN(date.getTime())) return "Toda quinta, 19h";
+  const label = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function GearIcon() {
+  return (
+    <svg width="19" height="19" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33A1.65 1.65 0 0 0 14 20.83V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15 1.65 1.65 0 0 0 3.17 14H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68 1.65 1.65 0 0 0 10 3.17V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9 1.65 1.65 0 0 0 20.91 10H21a2 2 0 1 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15z" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M9 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="5" y="10" width="14" height="10" rx="2.5" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M8.5 10V7.5a3.5 3.5 0 0 1 7 0V10" stroke="currentColor" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function ProfileAvatar({ name, imageUrl }: { name: string | null; imageUrl: string | null }) {
+  const [failed, setFailed] = useState(false);
+  const initial = firstName(name).charAt(0).toUpperCase();
+  return (
+    <div className="grid h-[3.25rem] w-[3.25rem] shrink-0 place-items-center overflow-hidden rounded-full bg-[var(--ds-color-ink)] text-[16px] font-extrabold text-white">
+      {imageUrl && !failed ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={imageUrl} alt="" className="h-full w-full object-cover" onError={() => setFailed(true)} />
+      ) : initial}
+    </div>
+  );
+}
+
+function UtilityPanel({
+  isPro,
+  onOpenMediaKit,
+  onOpenCalculator,
+}: {
+  isPro: boolean;
+  onOpenMediaKit: () => void;
+  onOpenCalculator: () => void;
+}) {
+  const rows = [
+    { id: "media-kit", icon: "▤", title: "Mídia Kit", subtitle: isPro ? "Sua página para marcas" : "Sua página para marcas · incluído no Pro", action: onOpenMediaKit },
+    { id: "calculator", icon: "R$", title: "Quanto vale sua publi", subtitle: isPro ? "Calcule seu preço justo" : "Seu preço justo · incluído no Pro", action: onOpenCalculator },
+  ];
+  return (
+    <section className="overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
+      {rows.map((row) => (
+        <button
+          key={row.id}
+          type="button"
+          onClick={row.action}
+          className="grid min-h-[4.6rem] w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 border-b border-[var(--ds-color-line)] px-4 text-left last:border-b-0 active:bg-[var(--ds-color-neutral)]"
+        >
+          <span className="grid h-9 w-9 place-items-center rounded-full bg-[var(--ds-color-neutral)] text-[12px] font-extrabold text-[var(--ds-color-ink)]">{row.icon}</span>
+          <span className="min-w-0">
+            <span className="block text-[14px] font-bold text-[var(--ds-color-ink)]">{row.title}</span>
+            <span className="mt-0.5 block text-[11px] leading-[1.35] text-[var(--ds-color-text-muted)]">{row.subtitle}</span>
+          </span>
+          <span className="text-[var(--ds-color-text-muted)]">{isPro ? <ChevronIcon /> : <LockIcon />}</span>
+        </button>
+      ))}
+    </section>
+  );
+}
+
+function ActivationCard({
+  accessState,
+  onUpgrade,
+  onConnectInstagram,
+}: {
+  accessState: DiagnosticoPageData["accessState"];
+  onUpgrade: (context?: PaywallContext) => void;
+  onConnectInstagram: () => void;
+}) {
+  // Administradores compartilham o mesmo entitlement do Pro, mesmo quando o
+  // rótulo de cobrança ainda é "Free". Sem esta equivalência, a tela oferecia
+  // assinatura a quem já tinha acesso e o CTA correto de Instagram desaparecia.
+  const proNeedsInstagram = accessState === "pro_needs_instagram" || accessState === "admin";
+  const paymentPending = accessState === "payment_pending";
+  const paymentAction = accessState === "payment_action_needed";
+  const billingAttention = paymentPending || paymentAction;
+
+  if (billingAttention) {
+    return (
+      <section className="ds-editorial-panel p-5">
+        <span className="ds-eyebrow">Assinatura</span>
+        <h2 className="mt-3 text-[1.5rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
+          {paymentPending ? "Falta concluir o pagamento." : "Seu pagamento precisa ser atualizado."}
+        </h2>
+        <p className="ds-body mt-3">Seu mapa continua seguro. Resolva a cobrança para liberar novamente relatório, Collabs e ferramentas Pro.</p>
+        <button type="button" className="ds-button ds-button--primary mt-5" onClick={() => onUpgrade("narrative_map")}>
+          {paymentPending ? "Continuar pagamento" : "Atualizar pagamento"}
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="ds-editorial-panel p-5">
+      <span className="ds-eyebrow">{proNeedsInstagram ? "Falta 1 passo" : "Faltam 2 passos"}</span>
+      <h2 className="mt-3 text-[1.55rem] font-bold leading-[1.07] text-[var(--ds-color-ink)]">
+        Você já contou quem você é. Agora falta a D2C ver os seus vídeos.
+      </h2>
+      <p className="ds-body mt-3">Dia, horário, cena e assunto são calculados com os seus próprios posts.</p>
+
+      <ol className="mt-5 border-t border-[var(--ds-color-line)]">
+        <li className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-[var(--ds-color-line)] py-4">
+          <span className={`grid h-8 w-8 place-items-center rounded-full text-[12px] font-extrabold ${proNeedsInstagram ? "bg-[var(--ds-color-success-soft)] text-[var(--ds-color-success)]" : "bg-[var(--ds-color-ink)] text-white"}`}>
+            {proNeedsInstagram ? "✓" : "1"}
+          </span>
+          <div>
+            <p className="m-0 text-[14px] font-bold text-[var(--ds-color-ink)]">Assinar o Pro</p>
+            <p className="ds-caption mt-1">Libera relatório semanal, Mídia Kit, calculadora, Collabs e reunião.</p>
+            {!proNeedsInstagram ? (
+              <button type="button" className="ds-button ds-button--primary ds-button--small mt-3" onClick={() => onUpgrade("narrative_map")}>Assinar</button>
+            ) : null}
+          </div>
+        </li>
+        <li className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 py-4">
+          <span className={`grid h-8 w-8 place-items-center rounded-full text-[12px] font-extrabold ${proNeedsInstagram ? "bg-[var(--ds-color-ink)] text-white" : "bg-[var(--ds-color-neutral)] text-[var(--ds-color-text-muted)]"}`}>2</span>
+          <div>
+            <p className="m-0 text-[14px] font-bold text-[var(--ds-color-ink)]">Conectar o seu Instagram</p>
+            <p className="ds-caption mt-1">Você autoriza pelo próprio Instagram e pode desconectar quando quiser.</p>
+            {proNeedsInstagram ? (
+              <button type="button" className="ds-button ds-button--primary ds-button--small mt-3" onClick={onConnectInstagram}>Conectar Instagram</button>
+            ) : null}
+          </div>
+        </li>
+      </ol>
+
+      <div className="rounded-[16px] bg-[var(--ds-color-neutral)] px-4 py-3 text-[12px] leading-[1.5] text-[var(--ds-color-text-secondary)]">
+        <strong className="text-[var(--ds-color-ink)]">Sem uma fila depois da conexão.</strong> O relatório-base usa os posts já publicados; leituras visuais entram conforme ficam confiáveis.
+      </div>
+    </section>
+  );
+}
+
+function CreatorMap({
+  narrative,
+  territories,
+  observedSubjects,
+  hasVideoEvidence,
+  onOpenSettings,
+}: {
+  narrative: string;
+  territories: string[];
+  observedSubjects: string[];
+  hasVideoEvidence: boolean;
+  onOpenSettings: () => void;
+}) {
+  const observedNormalized = observedSubjects.map(normalizeForMatch);
+  return (
+    <section className="ds-editorial-panel p-5">
+      <span className="ds-eyebrow">Seu mapa</span>
+      <blockquote className="mt-3 text-[1.5rem] font-bold leading-[1.12] text-[var(--ds-color-ink)]">
+        “{narrative}”
+      </blockquote>
+      <div className="mt-5 border-t border-[var(--ds-color-line)] pt-4">
+        <span className="text-[10px] font-extrabold uppercase tracking-[0.09em] text-[var(--ds-color-text-muted)]">Seus assuntos</span>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {territories.length > 0 ? territories.map((territory) => {
+            const normalized = normalizeForMatch(territory);
+            const observed = observedNormalized.some((subject) => subject.includes(normalized) || normalized.includes(subject));
+            return (
+              <span key={territory} className={`ds-chip ${observed ? "ds-chip--active" : ""}`}>
+                {observed ? "✓" : null} {territory}
+              </span>
+            );
+          }) : <span className="ds-caption">Adicione os assuntos que fazem parte da sua história.</span>}
+        </div>
+        <p className="ds-caption mt-3">
+          {hasVideoEvidence
+            ? "O ✓ indica um assunto que também apareceu nos vídeos lidos."
+            : "Isso é o que você escreveu ao criar a conta. Nenhum vídeo publicado confirmou esses assuntos ainda."}
+        </p>
+        <button type="button" className="mt-3 min-h-10 text-[12px] font-bold text-[var(--ds-color-brand-strong)]" onClick={onOpenSettings}>
+          Ajustar nas configurações
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function WeeklyVideoCard({ video, isDemo }: { video: CreatorWeeklyReportVideo; isDemo: boolean }) {
+  const body = (
+    <div className="ds-editorial-panel overflow-hidden">
+      <div className="relative aspect-[16/10] bg-[var(--ds-color-ink)]">
+        {!isDemo && video.thumbnailUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={video.thumbnailUrl} alt="Capa do vídeo da semana" className="h-full w-full object-cover opacity-85" />
+        ) : (
+          <div className="grid h-full place-items-center bg-[linear-gradient(145deg,var(--ds-color-line-strong),var(--ds-color-text-muted))] text-center text-[12px] font-bold text-white/80">
+            {isDemo ? "Vídeo ocultado no exemplo" : "Capa indisponível"}
+          </div>
+        )}
+        <span className="absolute left-4 top-4 rounded-full bg-black/65 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.08em] text-white backdrop-blur-sm">Vídeo da semana</span>
+      </div>
+      <div className="p-5">
+        <div className="flex items-center gap-2">
+          <span className="ds-eyebrow">O que mais rendeu</span>
+          {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
+        </div>
+        <h2 className="mt-3 text-[1.35rem] font-bold leading-[1.12] text-[var(--ds-color-ink)]">{video.description}</h2>
+        {formatIndex(video.performanceIndex) ? <p className="mt-2 text-[13px] font-bold text-[var(--ds-color-success)]">{formatIndex(video.performanceIndex)}</p> : null}
+        <div className="mt-5 grid grid-cols-3 border-t border-[var(--ds-color-line)] pt-4">
+          <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.views)}</b><span className="ds-caption">views</span></div>
+          <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.saved)}</b><span className="ds-caption">salvos</span></div>
+          <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.shares)}</b><span className="ds-caption">envios</span></div>
+        </div>
+        {video.openingLine ? <p className="mt-4 border-l-2 border-[var(--ds-color-brand)] pl-3 text-[13px] italic leading-[1.45] text-[var(--ds-color-text-secondary)]">“{video.openingLine}”</p> : null}
+      </div>
+    </div>
+  );
+  if (!isDemo && video.postLink) {
+    return <a href={video.postLink} target="_blank" rel="noreferrer" className="block no-underline">{body}</a>;
+  }
+  return body;
+}
+
+function ReportOverview({
+  report,
+  isDemo,
+  onOpenDetail,
+}: {
+  report: CreatorWeeklyReportPayload;
+  isDemo: boolean;
+  onOpenDetail: (id: CreatorWeeklyReportDetailId) => void;
+}) {
+  return (
+    <section aria-labelledby="weekly-report-title">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="ds-eyebrow">Seu relatório</span>
+            {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
+          </div>
+          <h2 id="weekly-report-title" className="mt-2 text-[1.75rem] font-bold leading-none text-[var(--ds-color-ink)]">A semana por dentro</h2>
+        </div>
+        <span className="ds-caption shrink-0">90 dias</span>
+      </div>
+      <p className="ds-body mt-3">{report.overview.summary}</p>
+
+      <div className="mt-5 grid grid-cols-3 border-y border-[var(--ds-color-line)] py-4">
+        {report.overview.numbers.map((number) => (
+          <div key={number.label} className="border-r border-[var(--ds-color-line)] px-2 text-center first:pl-0 last:border-r-0 last:pr-0">
+            <b className="block text-[1.25rem] leading-none text-[var(--ds-color-ink)]">{number.value}</b>
+            <span className="mt-1 block text-[10px] leading-[1.2] text-[var(--ds-color-text-muted)]">{number.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {report.weeklyVideo ? <div className="mt-6"><WeeklyVideoCard video={report.weeklyVideo} isDemo={isDemo} /></div> : (
+        <div className="mt-6 rounded-[18px] bg-[var(--ds-color-neutral)] p-5">
+          <span className="ds-eyebrow">Vídeo da semana</span>
+          <h3 className="mt-2 text-[1.25rem] font-bold text-[var(--ds-color-ink)]">Nenhum post na semana encerrada.</h3>
+          <p className="ds-body mt-2">Os rankings de 90 dias continuam disponíveis abaixo.</p>
+        </div>
+      )}
+
+      <div className="mt-6 overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
+        {report.details.map((detail) => (
+          <button
+            key={detail.id}
+            type="button"
+            onClick={() => onOpenDetail(detail.id)}
+            className="grid min-h-[5.25rem] w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-[var(--ds-color-line)] px-4 py-3.5 text-left last:border-b-0 active:bg-[var(--ds-color-neutral)]"
+          >
+            <span className="min-w-0">
+              <span className="block text-[14px] font-bold text-[var(--ds-color-ink)]">{detail.title}</span>
+              <span className="mt-1 block text-[11px] leading-[1.35] text-[var(--ds-color-text-muted)]">{detail.summary}</span>
+            </span>
+            <span className="text-[var(--ds-color-brand-strong)]"><ChevronIcon /></span>
+          </button>
+        ))}
+      </div>
+      <p className="ds-caption mt-3">{report.coverage.postsWithScene} de {report.coverage.posts90d} posts têm leitura visual. Rankings sem cobertura ficam honestamente vazios.</p>
+    </section>
+  );
+}
+
+function LockedBenefits() {
+  const rows = [
+    ["O vídeo da semana", "Qual vídeo rendeu mais e o motivo"],
+    ["Dia e horário", "O melhor dia e a melhor hora para você"],
+    ["Cena, tom e câmera", "Onde gravar, como falar e como se enquadrar"],
+    ["Assuntos e aberturas", "Os temas e primeiras frases que mais rendem"],
+  ];
+  return (
+    <section className="ds-editorial-panel p-5">
+      <span className="ds-eyebrow">O que chega toda segunda</span>
+      <h2 className="mt-3 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">Depois dos dois passos</h2>
+      <div className="mt-3">
+        {rows.map(([title, subtitle]) => (
+          <div key={title} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-[var(--ds-color-line)] py-3 last:border-b-0">
+            <span><b className="block text-[13px] text-[var(--ds-color-ink)]">{title}</b><span className="ds-caption mt-1 block">{subtitle}</span></span>
+            <span className="self-center text-[var(--ds-color-text-muted)]"><LockIcon /></span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BrandMatchCard({
+  match,
+  isDemo,
+}: {
+  match: DiagnosticoPageData["brandMatches"][number] | null;
+  isDemo: boolean;
+}) {
+  if (!isDemo && !match) return null;
+
+  const brandName = isDemo ? "Uma marca de bem-estar" : match?.brandName;
+  const rationale = isDemo
+    ? "No relatório de exemplo, rotina possível e autocuidado aparecem entre os assuntos mais fortes."
+    : match?.rationale;
+
+  return (
+    <section className="ds-editorial-panel p-5">
+      <div className="flex items-center gap-2">
+        <span className="ds-eyebrow">Marca que combina com você</span>
+        {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
+      </div>
+      <h2 className="mt-3 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">{brandName}</h2>
+      {rationale ? <p className="ds-body mt-2">{rationale}</p> : null}
+      {!isDemo && match?.disclaimer ? <p className="ds-caption mt-3">{match.disclaimer}</p> : null}
+    </section>
+  );
+}
+
+function MeetingCard({
+  meeting,
+  isPro,
+  isDemo,
+  onUpgrade,
+}: {
+  meeting: WeeklyMeetingProfileData | null;
+  isPro: boolean;
+  isDemo: boolean;
+  onUpgrade: (context?: PaywallContext) => void;
+}) {
+  const cancelled = meeting?.status === "cancelled";
+  return (
+    <section className="border-t border-[var(--ds-color-line)] pt-6">
+      <span className="ds-eyebrow">Reunião da comunidade</span>
+      <h2 className="mt-2 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">
+        {cancelled ? "Esta edição foi cancelada" : meeting ? formatMeetingDate(meeting) : "Toda quinta, 19h"}
+      </h2>
+      <p className="ds-body mt-2">Os criadores abrem os relatórios e dizem o que fariam diferente. É onde você descobre o que ninguém percebe sozinho.</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {isPro && !isDemo ? (
+          <>
+            <Link href="/reuniao" className="ds-button ds-button--secondary ds-button--small no-underline">Entrar na reunião</Link>
+            <a href={COMMUNITY_WHATSAPP_URL} target="_blank" rel="noreferrer" className="ds-button ds-button--quiet ds-button--small no-underline">Grupo Pro</a>
+          </>
+        ) : (
+          <button type="button" className="ds-button ds-button--quiet ds-button--small" onClick={() => onUpgrade("mentoria")}>Participar das reuniões</button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function CreatorWeeklyProfileExperience({
+  data,
+  weeklyMeeting,
+  isDemo,
+  onDemoChange,
+  onOpenAccountMenu,
+  onOpenMediaKit,
+  onOpenCalculator,
+  onUpgrade,
+  onConnectInstagram,
+}: {
+  data: DiagnosticoPageData;
+  weeklyMeeting: WeeklyMeetingProfileData | null;
+  isDemo: boolean;
+  onDemoChange: (demo: boolean) => void;
+  onOpenAccountMenu: () => void;
+  onOpenMediaKit: () => void;
+  onOpenCalculator: () => void;
+  onUpgrade: (context?: PaywallContext) => void;
+  onConnectInstagram: () => void;
+}) {
+  const [liveReport, setLiveReport] = useState<CreatorWeeklyReportPayload | null>(data.creatorWeeklyReport ?? null);
+  const [detailId, setDetailId] = useState<CreatorWeeklyReportDetailId | null>(null);
+  const viewedRef = useRef(false);
+  const isAdmin = data.accessState === "admin";
+  const isPro = data.userInfo.plan === "Pro" || isAdmin;
+  const hasReportAccess = isPro && data.instagramConnected;
+  const report = isDemo ? CREATOR_WEEKLY_REPORT_DEMO : liveReport;
+
+  useEffect(() => {
+    const container = document.querySelector<HTMLElement>("[data-mobile-profile-scroll-container='true']");
+    if (!container) return;
+    if (typeof container.scrollTo === "function") container.scrollTo({ top: 0, behavior: "auto" });
+    else container.scrollTop = 0;
+  }, [detailId]);
+
+  useEffect(() => {
+    if (viewedRef.current) return;
+    viewedRef.current = true;
+    trackMobileNarrativeEvent("mobile_weekly_profile_viewed", {
+      route: "/dashboard/boards/mobile-strategic-profile",
+      accessState: data.accessState,
+      isPro,
+      instagramConnected: data.instagramConnected,
+      actionType: liveReport?.status ?? "without_report",
+    });
+  }, [data.accessState, data.instagramConnected, isPro, liveReport?.status]);
+
+  useEffect(() => setLiveReport(data.creatorWeeklyReport ?? null), [data.creatorWeeklyReport]);
+
+  useEffect(() => {
+    if (!hasReportAccess || (liveReport?.coverage.posts90d ?? 0) > 0) return;
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const refresh = async () => {
+      attempts += 1;
+      try {
+        const response = await fetch("/api/dashboard/mobile-strategic-profile/weekly-report", { cache: "no-store" });
+        const payload = await response.json().catch(() => null);
+        if (!cancelled && response.ok && payload?.report) {
+          setLiveReport(payload.report);
+          if ((payload.report.coverage?.posts90d ?? 0) > 0) {
+            trackMobileNarrativeEvent("mobile_weekly_report_refresh_succeeded", {
+              route: "/dashboard/boards/mobile-strategic-profile",
+              accessState: data.accessState,
+              isPro,
+              instagramConnected: data.instagramConnected,
+              actionType: payload.report.status,
+            });
+          }
+        }
+        if (!cancelled && (payload?.report?.coverage?.posts90d ?? 0) === 0 && attempts < 10) {
+          timer = setTimeout(refresh, 6000);
+        }
+      } catch {
+        if (!cancelled && attempts < 10) timer = setTimeout(refresh, 6000);
+      }
+    };
+    void refresh();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [data.accessState, data.instagramConnected, hasReportAccess, isPro, liveReport?.coverage.posts90d]);
+
+  const narrative = data.mapaSeed?.narrativa_central?.trim()
+    || data.synthesis.mainNarrative?.label?.trim()
+    || "Sua história ainda está ganhando forma";
+  const territories = useMemo(() => {
+    const fromMap = data.mapaSeed?.territorios?.filter(Boolean) ?? [];
+    if (fromMap.length > 0) return fromMap.slice(0, 8);
+    return data.synthesis.narrativeTerritories.map((territory) => territory.label).filter(Boolean).slice(0, 8);
+  }, [data.mapaSeed?.territorios, data.synthesis.narrativeTerritories]);
+  const activeDetail = detailId ? report?.details.find((detail) => detail.id === detailId) ?? null : null;
+  const handleDemoChange = (next: boolean) => {
+    trackMobileNarrativeEvent(
+      next ? "mobile_weekly_report_demo_opened" : "mobile_weekly_report_demo_closed",
+      {
+        route: "/dashboard/boards/mobile-strategic-profile",
+        accessState: data.accessState,
+        isPro,
+        instagramConnected: data.instagramConnected,
+      },
+    );
+    setDetailId(null);
+    onDemoChange(next);
+  };
+  const handleOpenDetail = (id: CreatorWeeklyReportDetailId) => {
+    trackMobileNarrativeEvent("mobile_weekly_report_detail_opened", {
+      route: "/dashboard/boards/mobile-strategic-profile",
+      accessState: data.accessState,
+      isPro,
+      instagramConnected: data.instagramConnected,
+      actionType: id,
+    });
+    setDetailId(id);
+  };
+
+  if (activeDetail) {
+    return <CreatorWeeklyReportDetail detail={activeDetail} isDemo={isDemo} onBack={() => setDetailId(null)} />;
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+      <header className="flex items-center gap-3">
+        <ProfileAvatar name={data.userInfo.name} imageUrl={data.userInfo.imageUrl} />
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-[1.05rem] font-extrabold leading-tight text-[var(--ds-color-ink)]">{data.userInfo.name || "Seu perfil"}</h1>
+          <p className="mt-1 truncate text-[11px] text-[var(--ds-color-text-muted)]">
+            {isDemo ? "Relatório de exemplo" : report ? `Semana de ${report.period.rangeLabel}` : `Olá, ${firstName(data.userInfo.name)}`}
+          </p>
+        </div>
+        <button type="button" className="ds-icon-button" aria-label="Configurações da conta" onClick={onOpenAccountMenu}><GearIcon /></button>
+      </header>
+
+      <div className="mt-6 space-y-6">
+        {!hasReportAccess && !isDemo ? (
+          <ActivationCard accessState={data.accessState} onUpgrade={onUpgrade} onConnectInstagram={onConnectInstagram} />
+        ) : null}
+
+        <UtilityPanel isPro={isPro && !isDemo} onOpenMediaKit={isDemo ? () => onUpgrade("media_kit") : onOpenMediaKit} onOpenCalculator={isDemo ? () => onUpgrade("calculator") : onOpenCalculator} />
+
+        <CreatorMap
+          narrative={narrative}
+          territories={territories}
+          observedSubjects={report?.overview.observedSubjects ?? []}
+          hasVideoEvidence={(report?.coverage.postsWithScene ?? 0) > 0 && !isDemo}
+          onOpenSettings={onOpenAccountMenu}
+        />
+
+        {isDemo ? (
+          <section className="rounded-[18px] bg-[var(--ds-color-brand-soft)] p-4 text-[13px] leading-[1.5] text-[var(--ds-color-brand-strong)]">
+            <strong>Você está vendo um exemplo.</strong> Seu nome, sua foto e seu mapa continuam sendo seus; só os números abaixo são demonstrativos.
+          </section>
+        ) : null}
+
+        {report && (hasReportAccess || isDemo) ? (
+          <ReportOverview report={report} isDemo={isDemo} onOpenDetail={handleOpenDetail} />
+        ) : hasReportAccess ? (
+          <section className="rounded-[20px] bg-[var(--ds-color-neutral)] p-5" role="status" aria-live="polite">
+            <span className="ds-eyebrow">Seu relatório</span>
+            <h2 className="mt-2 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">Seus dados já estão chegando ao Perfil.</h2>
+            <p className="ds-body mt-2">O mapa permanece disponível e esta seção se atualiza automaticamente depois da primeira sincronização.</p>
+          </section>
+        ) : (
+          <LockedBenefits />
+        )}
+
+        {report && (hasReportAccess || isDemo) ? (
+          <BrandMatchCard match={data.brandMatches[0] ?? null} isDemo={isDemo} />
+        ) : null}
+
+        {!hasReportAccess && !isDemo ? (
+          <section className="border-t border-[var(--ds-color-line)] pt-6">
+            <span className="ds-eyebrow">Veja por dentro</span>
+            <h2 className="mt-2 text-[1.5rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">Veja um relatório inteiro antes de assinar.</h2>
+            <p className="ds-body mt-2">Navegue pelos rankings, pelo vídeo da semana e pelas frases de abertura com dados sanitizados.</p>
+            <button type="button" className="ds-button ds-button--primary mt-4" onClick={() => handleDemoChange(true)}>Ver relatório de exemplo</button>
+          </section>
+        ) : null}
+
+        {isDemo ? (
+          <section className="ds-editorial-panel p-5">
+            <span className="ds-eyebrow">Fim do exemplo</span>
+            <h2 className="mt-2 text-[1.45rem] font-bold leading-tight text-[var(--ds-color-ink)]">O seu usa os seus últimos 90 dias.</h2>
+            <p className="ds-body mt-2">Depois da conexão, ele aparece aqui e se atualiza toda segunda-feira.</p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {!isPro ? <button type="button" className="ds-button ds-button--primary ds-button--small" onClick={() => onUpgrade("narrative_map")}>Assinar</button> : null}
+              <button type="button" className="ds-button ds-button--quiet ds-button--small" onClick={() => handleDemoChange(false)}>Voltar ao meu perfil</button>
+            </div>
+          </section>
+        ) : null}
+
+        <MeetingCard meeting={weeklyMeeting} isPro={isPro} isDemo={isDemo} onUpgrade={onUpgrade} />
+
+        <p className="pb-2 text-center text-[11px] leading-[1.45] text-[var(--ds-color-text-muted)]">
+          Segunda o relatório chega. Quinta a gente conversa sobre ele.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyProfileExperience.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { BriefcaseBusiness, Calculator } from "lucide-react";
 import { COMMUNITY_WHATSAPP_URL } from "@/app/lib/communityLinks";
 import type { DiagnosticoPageData } from "@/app/dashboard/boards/videoUpload/diagnosticoPageData";
 import { CREATOR_WEEKLY_REPORT_DEMO } from "@/app/lib/creatorWeeklyReport/demoReport";
@@ -64,20 +65,13 @@ function ChevronIcon() {
   );
 }
 
-function LockIcon() {
-  return (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <rect x="5" y="10" width="14" height="10" rx="2.5" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M8.5 10V7.5a3.5 3.5 0 0 1 7 0V10" stroke="currentColor" strokeWidth="1.8" />
-    </svg>
-  );
-}
-
 function ProfileAvatar({ name, imageUrl }: { name: string | null; imageUrl: string | null }) {
   const [failed, setFailed] = useState(false);
   const initial = firstName(name).charAt(0).toUpperCase();
   return (
-    <div className="grid h-[3.25rem] w-[3.25rem] shrink-0 place-items-center overflow-hidden rounded-full bg-[var(--ds-color-ink)] text-[16px] font-extrabold text-white">
+    // 72px: retrato, não chip de conta. Sem foto o círculo é bege com a letra
+    // escura — um disco preto de 72px pesaria mais do que a letra comunica.
+    <div className="grid h-[4.5rem] w-[4.5rem] shrink-0 place-items-center overflow-hidden rounded-full bg-[var(--ds-color-neutral)] text-[24px] font-extrabold text-[var(--ds-color-ink)]">
       {imageUrl && !failed ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img src={imageUrl} alt="" className="h-full w-full object-cover" onError={() => setFailed(true)} />
@@ -88,34 +82,60 @@ function ProfileAvatar({ name, imageUrl }: { name: string | null; imageUrl: stri
 
 function UtilityPanel({
   isPro,
+  calculatorPrice,
   onOpenMediaKit,
   onOpenCalculator,
 }: {
   isPro: boolean;
+  calculatorPrice: string | null;
   onOpenMediaKit: () => void;
   onOpenCalculator: () => void;
 }) {
+  // Linha de navegação, não botão: elas levam para outra tela em vez de
+  // executar algo aqui — a seta é a promessa correta, o botão prometeria demais.
   const rows = [
-    { id: "media-kit", icon: "▤", title: "Mídia Kit", subtitle: isPro ? "Sua página para marcas" : "Sua página para marcas · incluído no Pro", action: onOpenMediaKit },
-    { id: "calculator", icon: "R$", title: "Quanto vale sua publi", subtitle: isPro ? "Calcule seu preço justo" : "Seu preço justo · incluído no Pro", action: onOpenCalculator },
+    {
+      id: "media-kit",
+      icon: <BriefcaseBusiness className="h-[18px] w-[18px]" strokeWidth={1.8} />,
+      title: "Mídia Kit",
+      subtitle: "Sua página para marcas",
+      value: null as string | null,
+      action: onOpenMediaKit,
+    },
+    {
+      id: "calculator",
+      icon: <Calculator className="h-[18px] w-[18px]" strokeWidth={1.8} />,
+      title: "Quanto vale sua publi",
+      // Uma linha que devolve um número se justifica; uma que só se anuncia, não.
+      subtitle: isPro && calculatorPrice ? "Último cálculo · Reels" : "Calcule seu preço justo",
+      value: isPro ? calculatorPrice : null,
+      action: onOpenCalculator,
+    },
   ];
   return (
-    <section className="overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
-      {rows.map((row) => (
-        <button
-          key={row.id}
-          type="button"
-          onClick={row.action}
-          className="grid min-h-[4.6rem] w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 border-b border-[var(--ds-color-line)] px-4 text-left last:border-b-0 active:bg-[var(--ds-color-neutral)]"
-        >
-          <span className="grid h-9 w-9 place-items-center rounded-full bg-[var(--ds-color-neutral)] text-[12px] font-extrabold text-[var(--ds-color-ink)]">{row.icon}</span>
-          <span className="min-w-0">
-            <span className="block text-[14px] font-bold text-[var(--ds-color-ink)]">{row.title}</span>
-            <span className="mt-0.5 block text-[11px] leading-[1.35] text-[var(--ds-color-text-muted)]">{row.subtitle}</span>
-          </span>
-          <span className="text-[var(--ds-color-text-muted)]">{isPro ? <ChevronIcon /> : <LockIcon />}</span>
-        </button>
-      ))}
+    <section className="ds-notebook-section" aria-labelledby="profile-tools-title">
+      <h2 id="profile-tools-title" className="ds-notebook-label mb-1">{isPro ? "Ferramentas" : "Ferramentas incluídas no Pro"}</h2>
+      <div className="ds-notebook-divided">
+        {rows.map((row) => (
+          <button key={row.id} type="button" onClick={row.action} className="ds-notebook-row">
+            <span className="text-[var(--ds-color-text-secondary)]">{row.icon}</span>
+            <span className="min-w-0">
+              <span className="block text-[14px] font-semibold text-[var(--ds-color-ink)]">{row.title}</span>
+              <span className="mt-0.5 block text-[12px] leading-[1.35] text-[var(--ds-color-text-muted)]">{row.subtitle}</span>
+            </span>
+            {isPro ? (
+              <span className="flex items-center gap-2 text-[var(--ds-color-text-muted)]">
+                {row.value ? <b className="text-[15px] font-extrabold tabular-nums text-[var(--ds-color-ink)]">{row.value}</b> : null}
+                <ChevronIcon />
+              </span>
+            ) : (
+              // Etiqueta escrita no lugar do cadeado: um ícone de 12px em cinza
+              // lê como enfeite, a palavra comunica na hora.
+              <span className="ds-notebook-tag font-semibold text-[var(--ds-color-text-secondary)]">Pro</span>
+            )}
+          </button>
+        ))}
+      </div>
     </section>
   );
 }
@@ -139,8 +159,8 @@ function ActivationCard({
 
   if (billingAttention) {
     return (
-      <section className="ds-editorial-panel p-5">
-        <span className="ds-eyebrow">Assinatura</span>
+      <section className="ds-notebook-section">
+        <span className="ds-notebook-label">Assinatura</span>
         <h2 className="mt-3 text-[1.5rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
           {paymentPending ? "Falta concluir o pagamento." : "Seu pagamento precisa ser atualizado."}
         </h2>
@@ -153,16 +173,17 @@ function ActivationCard({
   }
 
   return (
-    <section className="ds-editorial-panel p-5">
-      <span className="ds-eyebrow">{proNeedsInstagram ? "Falta 1 passo" : "Faltam 2 passos"}</span>
-      <h2 className="mt-3 text-[1.55rem] font-bold leading-[1.07] text-[var(--ds-color-ink)]">
+    <section className="ds-notebook-section">
+      {/* A contagem diz que o caminho é curto e finito — "Próximos passos" não diz. */}
+      <span className="ds-notebook-label">{proNeedsInstagram ? "Falta 1 passo" : "Faltam 2 passos"}</span>
+      <h2 className="mt-3 text-[1.5rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">
         Você já contou quem você é. Agora falta a D2C ver os seus vídeos.
       </h2>
       <p className="ds-body mt-3">Dia, horário, cena e assunto são calculados com os seus próprios posts.</p>
 
-      <ol className="mt-5 border-t border-[var(--ds-color-line)]">
-        <li className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-[var(--ds-color-line)] py-4">
-          <span className={`grid h-8 w-8 place-items-center rounded-full text-[12px] font-extrabold ${proNeedsInstagram ? "bg-[var(--ds-color-success-soft)] text-[var(--ds-color-success)]" : "bg-[var(--ds-color-ink)] text-white"}`}>
+      <ol className="mt-5 space-y-5">
+        <li className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-3">
+          <span className={`pt-0.5 text-[13px] font-bold ${proNeedsInstagram ? "text-[var(--ds-color-text-muted)]" : "text-[var(--ds-color-ink)]"}`}>
             {proNeedsInstagram ? "✓" : "1"}
           </span>
           <div>
@@ -173,8 +194,8 @@ function ActivationCard({
             ) : null}
           </div>
         </li>
-        <li className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 py-4">
-          <span className={`grid h-8 w-8 place-items-center rounded-full text-[12px] font-extrabold ${proNeedsInstagram ? "bg-[var(--ds-color-ink)] text-white" : "bg-[var(--ds-color-neutral)] text-[var(--ds-color-text-muted)]"}`}>2</span>
+        <li className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-3">
+          <span className={`pt-0.5 text-[13px] font-bold ${proNeedsInstagram ? "text-[var(--ds-color-ink)]" : "text-[var(--ds-color-text-muted)]"}`}>2</span>
           <div>
             <p className="m-0 text-[14px] font-bold text-[var(--ds-color-ink)]">Conectar o seu Instagram</p>
             <p className="ds-caption mt-1">Você autoriza pelo próprio Instagram e pode desconectar quando quiser.</p>
@@ -185,7 +206,7 @@ function ActivationCard({
         </li>
       </ol>
 
-      <div className="rounded-[16px] bg-[var(--ds-color-neutral)] px-4 py-3 text-[12px] leading-[1.5] text-[var(--ds-color-text-secondary)]">
+      <div className="ds-notebook-note mt-1">
         <strong className="text-[var(--ds-color-ink)]">Sem uma fila depois da conexão.</strong> O relatório-base usa os posts já publicados; leituras visuais entram conforme ficam confiáveis.
       </div>
     </section>
@@ -193,33 +214,68 @@ function ActivationCard({
 }
 
 function CreatorMap({
+  userName,
+  userImageUrl,
+  headerSubtitle,
   narrative,
+  narrativeIsPlaceholder,
   territories,
   observedSubjects,
   hasVideoEvidence,
   onOpenSettings,
+  onOpenAccountMenu,
 }: {
+  userName: string | null;
+  userImageUrl: string | null;
+  headerSubtitle: string;
   narrative: string;
+  narrativeIsPlaceholder: boolean;
   territories: string[];
   observedSubjects: string[];
   hasVideoEvidence: boolean;
   onOpenSettings: () => void;
+  onOpenAccountMenu: () => void;
 }) {
   const observedNormalized = observedSubjects.map(normalizeForMatch);
   return (
-    <section className="ds-editorial-panel p-5">
-      <span className="ds-eyebrow">Seu mapa</span>
-      <blockquote className="mt-3 text-[1.5rem] font-bold leading-[1.12] text-[var(--ds-color-ink)]">
-        “{narrative}”
-      </blockquote>
-      <div className="mt-5 border-t border-[var(--ds-color-line)] pt-4">
-        <span className="text-[10px] font-extrabold uppercase tracking-[0.09em] text-[var(--ds-color-text-muted)]">Seus assuntos</span>
+    // Identidade e mapa no mesmo cartão: são a mesma pergunta — quem é você.
+    // Separados por uma fronteira de cartão, o retrato virava enfeite de topo.
+    <section className="ds-notebook-section ds-notebook-section--first" aria-labelledby="creator-map-title">
+      <div className="flex items-center gap-4">
+        <ProfileAvatar name={userName} imageUrl={userImageUrl} />
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-[1.3rem] font-extrabold leading-tight tracking-[-0.02em] text-[var(--ds-color-ink)]">
+            {userName || "Seu perfil"}
+          </h1>
+          <p className="mt-1 truncate text-[12.5px] text-[var(--ds-color-text-muted)]">{headerSubtitle}</p>
+        </div>
+        <button type="button" className="ds-icon-button shrink-0 self-start" aria-label="Configurações da conta" onClick={onOpenAccountMenu}>
+          <GearIcon />
+        </button>
+      </div>
+
+      <div className="my-5 h-px bg-[var(--ds-color-line)]" />
+
+      <span className="ds-notebook-label">Seu mapa</span>
+      {/* Vazio nunca ocupa o nível de título: promover a ausência de conteúdo
+          faz o maior texto da tela ser justamente o que não existe ainda. */}
+      {narrativeIsPlaceholder ? (
+        <p id="creator-map-title" className="mt-3 text-[15px] leading-[1.5] text-[var(--ds-color-text-muted)]">
+          {narrative}
+        </p>
+      ) : (
+        <blockquote id="creator-map-title" className="mt-3 text-[1.75rem] font-bold leading-[1.08] tracking-[-0.03em] text-[var(--ds-color-ink)]">
+          “{narrative}”
+        </blockquote>
+      )}
+      <div className="mt-5">
+        <span className="ds-notebook-label">Assuntos</span>
         <div className="mt-3 flex flex-wrap gap-2">
           {territories.length > 0 ? territories.map((territory) => {
             const normalized = normalizeForMatch(territory);
             const observed = observedNormalized.some((subject) => subject.includes(normalized) || normalized.includes(subject));
             return (
-              <span key={territory} className={`ds-chip ${observed ? "ds-chip--active" : ""}`}>
+              <span key={territory} className={`ds-notebook-tag ${observed ? "font-semibold text-[var(--ds-color-ink)]" : ""}`}>
                 {observed ? "✓" : null} {territory}
               </span>
             );
@@ -230,8 +286,9 @@ function CreatorMap({
             ? "O ✓ indica um assunto que também apareceu nos vídeos lidos."
             : "Isso é o que você escreveu ao criar a conta. Nenhum vídeo publicado confirmou esses assuntos ainda."}
         </p>
-        <button type="button" className="mt-3 min-h-10 text-[12px] font-bold text-[var(--ds-color-brand-strong)]" onClick={onOpenSettings}>
-          Ajustar nas configurações
+        <button type="button" className="ds-notebook-action mt-2" onClick={onOpenSettings}>
+          <span>Ajustar mapa</span>
+          <span className="text-[var(--ds-color-text-muted)]"><ChevronIcon /></span>
         </button>
       </div>
     </section>
@@ -240,31 +297,35 @@ function CreatorMap({
 
 function WeeklyVideoCard({ video, isDemo }: { video: CreatorWeeklyReportVideo; isDemo: boolean }) {
   const body = (
-    <div className="ds-editorial-panel overflow-hidden">
-      <div className="relative aspect-[16/10] bg-[var(--ds-color-ink)]">
-        {!isDemo && video.thumbnailUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
+    <div className="ds-notebook-media">
+      {/* Sem capa o bloco não precisa ocupar a altura de um vídeo — vira uma
+          faixa baixa, para não abrir um vazio de 400px no meio da leitura. */}
+      {!isDemo && video.thumbnailUrl ? (
+        <div className="relative aspect-[16/10] bg-[var(--ds-color-ink)]">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={video.thumbnailUrl} alt="Capa do vídeo da semana" className="h-full w-full object-cover opacity-85" />
-        ) : (
-          <div className="grid h-full place-items-center bg-[linear-gradient(145deg,var(--ds-color-line-strong),var(--ds-color-text-muted))] text-center text-[12px] font-bold text-white/80">
-            {isDemo ? "Vídeo ocultado no exemplo" : "Capa indisponível"}
-          </div>
-        )}
-        <span className="absolute left-4 top-4 rounded-full bg-black/65 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.08em] text-white backdrop-blur-sm">Vídeo da semana</span>
-      </div>
+        </div>
+      ) : (
+        <div className="grid h-[76px] place-items-center bg-[var(--ds-color-neutral)] text-center text-[12px] font-semibold text-[var(--ds-color-text-muted)]">
+          {isDemo ? "Vídeo ocultado no exemplo" : "Capa indisponível"}
+        </div>
+      )}
       <div className="p-5">
         <div className="flex items-center gap-2">
-          <span className="ds-eyebrow">O que mais rendeu</span>
+          <span className="ds-notebook-label">Vídeo da semana</span>
           {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
         </div>
-        <h2 className="mt-3 text-[1.35rem] font-bold leading-[1.12] text-[var(--ds-color-ink)]">{video.description}</h2>
-        {formatIndex(video.performanceIndex) ? <p className="mt-2 text-[13px] font-bold text-[var(--ds-color-success)]">{formatIndex(video.performanceIndex)}</p> : null}
-        <div className="mt-5 grid grid-cols-3 border-t border-[var(--ds-color-line)] pt-4">
+        {/* O veredito vem antes da manchete: é o que a pessoa veio saber. */}
+        {formatIndex(video.performanceIndex) ? (
+          <p className="mt-2 text-[1.5rem] font-extrabold leading-none tracking-[-0.02em] text-[var(--ds-color-success)]">{formatIndex(video.performanceIndex)}</p>
+        ) : null}
+        <h2 className="mt-2 text-[1.35rem] font-bold leading-[1.12] text-[var(--ds-color-ink)]">{video.description}</h2>
+        <div className="mt-5 grid grid-cols-3 pt-1">
           <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.views)}</b><span className="ds-caption">views</span></div>
           <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.saved)}</b><span className="ds-caption">salvos</span></div>
           <div><b className="block text-[16px] text-[var(--ds-color-ink)]">{formatMetric(video.shares)}</b><span className="ds-caption">envios</span></div>
         </div>
-        {video.openingLine ? <p className="mt-4 border-l-2 border-[var(--ds-color-brand)] pl-3 text-[13px] italic leading-[1.45] text-[var(--ds-color-text-secondary)]">“{video.openingLine}”</p> : null}
+        {video.openingLine ? <p className="mt-4 border-l-2 border-[var(--ds-color-line-strong)] pl-3 text-[13px] italic leading-[1.45] text-[var(--ds-color-text-secondary)]">“{video.openingLine}”</p> : null}
       </div>
     </div>
   );
@@ -284,20 +345,18 @@ function ReportOverview({
   onOpenDetail: (id: CreatorWeeklyReportDetailId) => void;
 }) {
   return (
-    <section aria-labelledby="weekly-report-title">
-      <div className="flex items-end justify-between gap-3">
-        <div>
-          <div className="flex items-center gap-2">
-            <span className="ds-eyebrow">Seu relatório</span>
-            {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
-          </div>
-          <h2 id="weekly-report-title" className="mt-2 text-[1.75rem] font-bold leading-none text-[var(--ds-color-ink)]">A semana por dentro</h2>
-        </div>
-        <span className="ds-caption shrink-0">90 dias</span>
+    <section aria-labelledby="weekly-report-title" className="ds-notebook-section">
+      <div className="flex items-center gap-2">
+        <span className="ds-notebook-label">Seu relatório</span>
+        {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
       </div>
+      <h2 id="weekly-report-title" className="mt-2 text-[1.75rem] font-bold leading-none tracking-[-0.025em] text-[var(--ds-color-ink)]">A semana por dentro</h2>
+      {/* "90 dias" colado no título contradizia a seção, que fala da semana.
+          Como linha de apoio ele explica a régua em vez de confundir. */}
       <p className="ds-body mt-3">{report.overview.summary}</p>
+      <p className="ds-caption mt-2">Tudo comparado com a sua mediana dos últimos 90 dias.</p>
 
-      <div className="mt-5 grid grid-cols-3 border-y border-[var(--ds-color-line)] py-4">
+      <div className="mt-5 grid grid-cols-3 py-2">
         {report.overview.numbers.map((number) => (
           <div key={number.label} className="border-r border-[var(--ds-color-line)] px-2 text-center first:pl-0 last:border-r-0 last:pr-0">
             <b className="block text-[1.25rem] leading-none text-[var(--ds-color-ink)]">{number.value}</b>
@@ -307,26 +366,26 @@ function ReportOverview({
       </div>
 
       {report.weeklyVideo ? <div className="mt-6"><WeeklyVideoCard video={report.weeklyVideo} isDemo={isDemo} /></div> : (
-        <div className="mt-6 rounded-[18px] bg-[var(--ds-color-neutral)] p-5">
+        <div className="mt-6 py-3">
           <span className="ds-eyebrow">Vídeo da semana</span>
           <h3 className="mt-2 text-[1.25rem] font-bold text-[var(--ds-color-ink)]">Nenhum post na semana encerrada.</h3>
           <p className="ds-body mt-2">Os rankings de 90 dias continuam disponíveis abaixo.</p>
         </div>
       )}
 
-      <div className="mt-6 overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
+      <div className="ds-notebook-divided mt-6">
         {report.details.map((detail) => (
           <button
             key={detail.id}
             type="button"
             onClick={() => onOpenDetail(detail.id)}
-            className="grid min-h-[5.25rem] w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-[var(--ds-color-line)] px-4 py-3.5 text-left last:border-b-0 active:bg-[var(--ds-color-neutral)]"
+            className="grid min-h-[5rem] w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-1 py-3 text-left active:bg-[var(--ds-color-neutral)]"
           >
             <span className="min-w-0">
               <span className="block text-[14px] font-bold text-[var(--ds-color-ink)]">{detail.title}</span>
               <span className="mt-1 block text-[11px] leading-[1.35] text-[var(--ds-color-text-muted)]">{detail.summary}</span>
             </span>
-            <span className="text-[var(--ds-color-brand-strong)]"><ChevronIcon /></span>
+            <span className="text-[var(--ds-color-text-muted)]"><ChevronIcon /></span>
           </button>
         ))}
       </div>
@@ -343,14 +402,16 @@ function LockedBenefits() {
     ["Assuntos e aberturas", "Os temas e primeiras frases que mais rendem"],
   ];
   return (
-    <section className="ds-editorial-panel p-5">
-      <span className="ds-eyebrow">O que chega toda segunda</span>
+    <section className="ds-notebook-section">
+      <span className="ds-notebook-label">O que chega toda segunda</span>
       <h2 className="mt-3 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">Depois dos dois passos</h2>
-      <div className="mt-3">
+      {/* Sem cadeado por linha: o título já diz que isso ainda vai chegar, e um
+          ícone de 12px repetido quatro vezes só adiciona ruído. */}
+      <div className="ds-notebook-divided mt-4">
         {rows.map(([title, subtitle]) => (
-          <div key={title} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-[var(--ds-color-line)] py-3 last:border-b-0">
-            <span><b className="block text-[13px] text-[var(--ds-color-ink)]">{title}</b><span className="ds-caption mt-1 block">{subtitle}</span></span>
-            <span className="self-center text-[var(--ds-color-text-muted)]"><LockIcon /></span>
+          <div key={title} className="py-3">
+            <b className="block text-[14px] text-[var(--ds-color-ink)]">{title}</b>
+            <span className="ds-caption mt-1 block">{subtitle}</span>
           </div>
         ))}
       </div>
@@ -373,7 +434,7 @@ function BrandMatchCard({
     : match?.rationale;
 
   return (
-    <section className="ds-editorial-panel p-5">
+    <section className="ds-notebook-section">
       <div className="flex items-center gap-2">
         <span className="ds-eyebrow">Marca que combina com você</span>
         {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
@@ -398,8 +459,8 @@ function MeetingCard({
 }) {
   const cancelled = meeting?.status === "cancelled";
   return (
-    <section className="border-t border-[var(--ds-color-line)] pt-6">
-      <span className="ds-eyebrow">Reunião da comunidade</span>
+    <section className="ds-notebook-section">
+      <span className="ds-notebook-label">Reunião da comunidade</span>
       <h2 className="mt-2 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">
         {cancelled ? "Esta edição foi cancelada" : meeting ? formatMeetingDate(meeting) : "Toda quinta, 19h"}
       </h2>
@@ -421,9 +482,11 @@ function MeetingCard({
 export function CreatorWeeklyProfileExperience({
   data,
   weeklyMeeting,
+  calculatorPrice = null,
   isDemo,
   onDemoChange,
   onOpenAccountMenu,
+  onOpenNorte,
   onOpenMediaKit,
   onOpenCalculator,
   onUpgrade,
@@ -431,9 +494,12 @@ export function CreatorWeeklyProfileExperience({
 }: {
   data: DiagnosticoPageData;
   weeklyMeeting: WeeklyMeetingProfileData | null;
+  /** Último cálculo de publi já formatado (ex.: "R$ 2.800"), quando existir. */
+  calculatorPrice?: string | null;
   isDemo: boolean;
   onDemoChange: (demo: boolean) => void;
   onOpenAccountMenu: () => void;
+  onOpenNorte: () => void;
   onOpenMediaKit: () => void;
   onOpenCalculator: () => void;
   onUpgrade: (context?: PaywallContext) => void;
@@ -504,9 +570,13 @@ export function CreatorWeeklyProfileExperience({
     };
   }, [data.accessState, data.instagramConnected, hasReportAccess, isPro, liveReport?.coverage.posts90d]);
 
-  const narrative = data.mapaSeed?.narrativa_central?.trim()
+  const declaredNarrative = data.mapaSeed?.narrativa_central?.trim()
     || data.synthesis.mainNarrative?.label?.trim()
-    || "Sua história ainda está ganhando forma";
+    || "";
+  const narrativeIsPlaceholder = declaredNarrative.length === 0;
+  const narrative = narrativeIsPlaceholder
+    ? "Sua história ainda está ganhando forma. Responda o Seu Norte para escrevê-la."
+    : declaredNarrative;
   const territories = useMemo(() => {
     const fromMap = data.mapaSeed?.territorios?.filter(Boolean) ?? [];
     if (fromMap.length > 0) return fromMap.slice(0, 8);
@@ -542,44 +612,47 @@ export function CreatorWeeklyProfileExperience({
   }
 
   return (
-    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
-      <header className="flex items-center gap-3">
-        <ProfileAvatar name={data.userInfo.name} imageUrl={data.userInfo.imageUrl} />
-        <div className="min-w-0 flex-1">
-          <h1 className="truncate text-[1.05rem] font-extrabold leading-tight text-[var(--ds-color-ink)]">{data.userInfo.name || "Seu perfil"}</h1>
-          <p className="mt-1 truncate text-[11px] text-[var(--ds-color-text-muted)]">
-            {isDemo ? "Relatório de exemplo" : report ? `Semana de ${report.period.rangeLabel}` : `Olá, ${firstName(data.userInfo.name)}`}
-          </p>
-        </div>
-        <button type="button" className="ds-icon-button" aria-label="Configurações da conta" onClick={onOpenAccountMenu}><GearIcon /></button>
-      </header>
+    <main className="ds-notebook-page ds-analysis-editorial">
+      <div>
+        {/* Identidade sempre primeiro: em qualquer estado ela abre o app e vê
+            o próprio perfil antes de qualquer cobrança ou relatório. */}
+        <CreatorMap
+          userName={data.userInfo.name}
+          userImageUrl={data.userInfo.imageUrl}
+          headerSubtitle={isDemo ? "Relatório de exemplo" : report ? `Semana de ${report.period.rangeLabel}` : `Olá, ${firstName(data.userInfo.name)}`}
+          narrative={narrative}
+          narrativeIsPlaceholder={narrativeIsPlaceholder}
+          territories={territories}
+          observedSubjects={report?.overview.observedSubjects ?? []}
+          hasVideoEvidence={(report?.coverage.postsWithScene ?? 0) > 0 && !isDemo}
+          onOpenSettings={onOpenNorte}
+          onOpenAccountMenu={onOpenAccountMenu}
+        />
 
-      <div className="mt-6 space-y-6">
+        {/* Depois da identidade, a ordem muda com o estado: quem já tem relatório
+            abre o app para ver a semana, então as ferramentas descem para o fim.
+            Quem ainda não tem vê nelas o valor que a assinatura libera. */}
         {!hasReportAccess && !isDemo ? (
           <ActivationCard accessState={data.accessState} onUpgrade={onUpgrade} onConnectInstagram={onConnectInstagram} />
         ) : null}
 
-        <UtilityPanel isPro={isPro && !isDemo} onOpenMediaKit={isDemo ? () => onUpgrade("media_kit") : onOpenMediaKit} onOpenCalculator={isDemo ? () => onUpgrade("calculator") : onOpenCalculator} />
-
-        <CreatorMap
-          narrative={narrative}
-          territories={territories}
-          observedSubjects={report?.overview.observedSubjects ?? []}
-          hasVideoEvidence={(report?.coverage.postsWithScene ?? 0) > 0 && !isDemo}
-          onOpenSettings={onOpenAccountMenu}
-        />
+        {!hasReportAccess || isDemo ? (
+          <UtilityPanel isPro={isPro && !isDemo} calculatorPrice={calculatorPrice} onOpenMediaKit={isDemo ? () => onUpgrade("media_kit") : onOpenMediaKit} onOpenCalculator={isDemo ? () => onUpgrade("calculator") : onOpenCalculator} />
+        ) : null}
 
         {isDemo ? (
-          <section className="rounded-[18px] bg-[var(--ds-color-brand-soft)] p-4 text-[13px] leading-[1.5] text-[var(--ds-color-brand-strong)]">
+          <section className="ds-notebook-section">
+            <p className="ds-notebook-note">
             <strong>Você está vendo um exemplo.</strong> Seu nome, sua foto e seu mapa continuam sendo seus; só os números abaixo são demonstrativos.
+            </p>
           </section>
         ) : null}
 
         {report && (hasReportAccess || isDemo) ? (
           <ReportOverview report={report} isDemo={isDemo} onOpenDetail={handleOpenDetail} />
         ) : hasReportAccess ? (
-          <section className="rounded-[20px] bg-[var(--ds-color-neutral)] p-5" role="status" aria-live="polite">
-            <span className="ds-eyebrow">Seu relatório</span>
+          <section className="ds-notebook-section" role="status" aria-live="polite">
+            <span className="ds-notebook-label">Seu relatório</span>
             <h2 className="mt-2 text-[1.4rem] font-bold leading-tight text-[var(--ds-color-ink)]">Seus dados já estão chegando ao Perfil.</h2>
             <p className="ds-body mt-2">O mapa permanece disponível e esta seção se atualiza automaticamente depois da primeira sincronização.</p>
           </section>
@@ -592,17 +665,19 @@ export function CreatorWeeklyProfileExperience({
         ) : null}
 
         {!hasReportAccess && !isDemo ? (
-          <section className="border-t border-[var(--ds-color-line)] pt-6">
-            <span className="ds-eyebrow">Veja por dentro</span>
+          <section className="ds-notebook-section">
+            <span className="ds-notebook-label">Veja por dentro</span>
             <h2 className="mt-2 text-[1.5rem] font-bold leading-[1.08] text-[var(--ds-color-ink)]">Veja um relatório inteiro antes de assinar.</h2>
             <p className="ds-body mt-2">Navegue pelos rankings, pelo vídeo da semana e pelas frases de abertura com dados sanitizados.</p>
-            <button type="button" className="ds-button ds-button--primary mt-4" onClick={() => handleDemoChange(true)}>Ver relatório de exemplo</button>
+            {/* Secundário de propósito: o vermelho da tela pertence a "Assinar".
+                Dois botões cheios na mesma rolagem anulam um ao outro. */}
+            <button type="button" className="ds-button ds-button--secondary mt-4" onClick={() => handleDemoChange(true)}>Ver relatório de exemplo</button>
           </section>
         ) : null}
 
         {isDemo ? (
-          <section className="ds-editorial-panel p-5">
-            <span className="ds-eyebrow">Fim do exemplo</span>
+          <section className="ds-notebook-section">
+            <span className="ds-notebook-label">Fim do exemplo</span>
             <h2 className="mt-2 text-[1.45rem] font-bold leading-tight text-[var(--ds-color-ink)]">O seu usa os seus últimos 90 dias.</h2>
             <p className="ds-body mt-2">Depois da conexão, ele aparece aqui e se atualiza toda segunda-feira.</p>
             <div className="mt-4 flex flex-wrap gap-2">
@@ -614,7 +689,11 @@ export function CreatorWeeklyProfileExperience({
 
         <MeetingCard meeting={weeklyMeeting} isPro={isPro} isDemo={isDemo} onUpgrade={onUpgrade} />
 
-        <p className="pb-2 text-center text-[11px] leading-[1.45] text-[var(--ds-color-text-muted)]">
+        {hasReportAccess && !isDemo ? (
+          <UtilityPanel isPro={isPro} calculatorPrice={calculatorPrice} onOpenMediaKit={onOpenMediaKit} onOpenCalculator={onOpenCalculator} />
+        ) : null}
+
+        <p className="pb-2 pt-6 text-center text-[11px] leading-[1.45] text-[var(--ds-color-text-muted)]">
           Segunda o relatório chega. Quinta a gente conversa sobre ele.
         </p>
       </div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyReportDetail.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyReportDetail.tsx
@@ -31,11 +31,11 @@ export function CreatorWeeklyReportDetail({
   onBack: () => void;
 }) {
   return (
-    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+    <main className="ds-notebook-page ds-analysis-editorial">
       <button
         type="button"
         onClick={onBack}
-        className="mb-4 inline-flex min-h-11 items-center gap-1 rounded-full bg-transparent pr-3 text-[13px] font-bold text-[var(--ds-color-brand-strong)]"
+        className="mb-4 inline-flex min-h-11 items-center gap-1 rounded-md bg-transparent pr-3 text-[13px] font-semibold text-[var(--ds-color-ink)] active:bg-[var(--ds-color-neutral)]"
       >
         <BackIcon /> Voltar
       </button>
@@ -51,14 +51,18 @@ export function CreatorWeeklyReportDetail({
         <p className="ds-body mt-2">{detail.subtitle}</p>
       </header>
 
-      <div className="mt-5 rounded-[18px] bg-[var(--ds-color-info-soft)] px-4 py-3 text-[13px] leading-[1.5] text-[var(--ds-color-info)]">
-        <strong>Quanto dá para confiar.</strong> Indício é 1 ou 2 posts; sinal é de 3 a 7; tendência é 8 ou mais.
-      </div>
+      <details className="group mt-5 rounded-xl bg-white px-4 py-2 text-[13px]">
+        <summary className="flex min-h-10 cursor-pointer list-none items-center justify-between font-semibold text-[var(--ds-color-ink)]">
+          Quanto dá para confiar
+          <span className="text-[var(--ds-color-text-muted)] transition-transform group-open:rotate-90" aria-hidden="true">›</span>
+        </summary>
+        <p className="pb-2 pr-6 leading-[1.5] text-[var(--ds-color-text-muted)]">Indício é 1 ou 2 posts; sinal é de 3 a 7; tendência é 8 ou mais.</p>
+      </details>
 
       {detail.groups.length > 0 ? (
-        <div className="mt-6 space-y-6">
+        <div className="mt-6">
           {detail.groups.map((group) => (
-            <section key={group.id} aria-labelledby={`weekly-report-group-${group.id}`}>
+            <section key={group.id} className="ds-notebook-section" aria-labelledby={`weekly-report-group-${group.id}`}>
               <div className="mb-3">
                 <h2 id={`weekly-report-group-${group.id}`} className="text-[1.25rem] font-bold leading-tight text-[var(--ds-color-ink)]">
                   {group.title}
@@ -66,20 +70,16 @@ export function CreatorWeeklyReportDetail({
                 <p className="ds-caption mt-1">{group.subtitle}</p>
               </div>
 
-              <div className="overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
+              <div className="space-y-1">
                 {group.items.map((item, index) => {
                   const positive = item.index !== null && item.index >= 1;
                   return (
                     <div
                       key={item.id}
-                      className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-2 border-b border-[var(--ds-color-line)] px-3 py-3.5 last:border-b-0"
+                      className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-2 rounded-lg py-3"
                     >
                       <span
-                        className={`grid h-7 w-7 place-items-center rounded-full text-[11px] font-extrabold ${
-                          index === 0
-                            ? "bg-[var(--ds-color-ink)] text-white"
-                            : "bg-[var(--ds-color-neutral)] text-[var(--ds-color-text-secondary)]"
-                        }`}
+                        className={`text-[12px] font-semibold ${index === 0 ? "text-[var(--ds-color-ink)]" : "text-[var(--ds-color-text-muted)]"}`}
                       >
                         {index + 1}
                       </span>
@@ -87,7 +87,7 @@ export function CreatorWeeklyReportDetail({
                         <span className="block text-[14px] font-bold leading-[1.25] text-[var(--ds-color-ink)]">
                           {item.label}
                         </span>
-                        <span className="mt-1 block text-[11px] text-[var(--ds-color-text-muted)]">
+                        <span className="mt-1 block text-[12px] text-[var(--ds-color-text-muted)]">
                           {item.nPosts} {item.nPosts === 1 ? "post" : "posts"} · {EVIDENCE_LABEL[item.evidence]}
                           {item.weeklyOccurrences > 0 ? ` · ${item.weeklyOccurrences} nesta semana` : ""}
                         </span>
@@ -111,7 +111,7 @@ export function CreatorWeeklyReportDetail({
           ))}
         </div>
       ) : (
-        <section className="mt-6 rounded-[20px] bg-[var(--ds-color-neutral)] p-5">
+        <section className="ds-notebook-section mt-6">
           <span className="ds-eyebrow">Cobertura em formação</span>
           <h2 className="mt-2 text-[1.25rem] font-bold leading-tight text-[var(--ds-color-ink)]">
             Ainda não há dados suficientes para este ranking.
@@ -120,7 +120,7 @@ export function CreatorWeeklyReportDetail({
         </section>
       )}
 
-      <section className="mt-6 border-l-2 border-[var(--ds-color-brand)] pl-4">
+      <section className="ds-notebook-section mt-6">
         <span className="ds-eyebrow">Leitura da semana</span>
         <p className="mt-2 text-[15px] leading-[1.55] text-[var(--ds-color-ink)]">
           {detail.interpretation ?? detail.summary}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyReportDetail.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/CreatorWeeklyReportDetail.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { CreatorWeeklyReportDetail as ReportDetail } from "@/app/lib/creatorWeeklyReport/types";
+
+const EVIDENCE_LABEL = {
+  indicio: "indício",
+  sinal: "sinal",
+  tendencia: "tendência",
+} as const;
+
+function formatIndex(value: number | null) {
+  if (value === null) return "—";
+  return `${value.toFixed(1).replace(".", ",")}×`;
+}
+
+function BackIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M15 5l-7 7 7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function CreatorWeeklyReportDetail({
+  detail,
+  isDemo,
+  onBack,
+}: {
+  detail: ReportDetail;
+  isDemo: boolean;
+  onBack: () => void;
+}) {
+  return (
+    <main className="mx-auto w-full max-w-[32rem] px-5 pb-8 pt-[var(--ds-safe-top)] ds-analysis-editorial">
+      <button
+        type="button"
+        onClick={onBack}
+        className="mb-4 inline-flex min-h-11 items-center gap-1 rounded-full bg-transparent pr-3 text-[13px] font-bold text-[var(--ds-color-brand-strong)]"
+      >
+        <BackIcon /> Voltar
+      </button>
+
+      <header>
+        <div className="flex items-center gap-2">
+          <span className="ds-eyebrow">Seu relatório</span>
+          {isDemo ? <span className="ds-badge ds-badge--neutral">Exemplo</span> : null}
+        </div>
+        <h1 className="mt-2 text-[2rem] font-bold leading-[1.02] text-[var(--ds-color-ink)]">
+          {detail.title}
+        </h1>
+        <p className="ds-body mt-2">{detail.subtitle}</p>
+      </header>
+
+      <div className="mt-5 rounded-[18px] bg-[var(--ds-color-info-soft)] px-4 py-3 text-[13px] leading-[1.5] text-[var(--ds-color-info)]">
+        <strong>Quanto dá para confiar.</strong> Indício é 1 ou 2 posts; sinal é de 3 a 7; tendência é 8 ou mais.
+      </div>
+
+      {detail.groups.length > 0 ? (
+        <div className="mt-6 space-y-6">
+          {detail.groups.map((group) => (
+            <section key={group.id} aria-labelledby={`weekly-report-group-${group.id}`}>
+              <div className="mb-3">
+                <h2 id={`weekly-report-group-${group.id}`} className="text-[1.25rem] font-bold leading-tight text-[var(--ds-color-ink)]">
+                  {group.title}
+                </h2>
+                <p className="ds-caption mt-1">{group.subtitle}</p>
+              </div>
+
+              <div className="overflow-hidden rounded-[20px] border border-[var(--ds-color-line)] bg-[var(--ds-color-surface)]">
+                {group.items.map((item, index) => {
+                  const positive = item.index !== null && item.index >= 1;
+                  return (
+                    <div
+                      key={item.id}
+                      className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-2 border-b border-[var(--ds-color-line)] px-3 py-3.5 last:border-b-0"
+                    >
+                      <span
+                        className={`grid h-7 w-7 place-items-center rounded-full text-[11px] font-extrabold ${
+                          index === 0
+                            ? "bg-[var(--ds-color-ink)] text-white"
+                            : "bg-[var(--ds-color-neutral)] text-[var(--ds-color-text-secondary)]"
+                        }`}
+                      >
+                        {index + 1}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block text-[14px] font-bold leading-[1.25] text-[var(--ds-color-ink)]">
+                          {item.label}
+                        </span>
+                        <span className="mt-1 block text-[11px] text-[var(--ds-color-text-muted)]">
+                          {item.nPosts} {item.nPosts === 1 ? "post" : "posts"} · {EVIDENCE_LABEL[item.evidence]}
+                          {item.weeklyOccurrences > 0 ? ` · ${item.weeklyOccurrences} nesta semana` : ""}
+                        </span>
+                      </span>
+                      <span
+                        className={`text-[15px] font-extrabold tabular-nums ${
+                          item.index === null
+                            ? "text-[var(--ds-color-text-muted)]"
+                            : positive
+                              ? "text-[var(--ds-color-success)]"
+                              : "text-[var(--ds-color-danger)]"
+                        }`}
+                      >
+                        {formatIndex(item.index)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <section className="mt-6 rounded-[20px] bg-[var(--ds-color-neutral)] p-5">
+          <span className="ds-eyebrow">Cobertura em formação</span>
+          <h2 className="mt-2 text-[1.25rem] font-bold leading-tight text-[var(--ds-color-ink)]">
+            Ainda não há dados suficientes para este ranking.
+          </h2>
+          <p className="ds-body mt-2">A seção aparece automaticamente quando os vídeos publicados recebem leitura suficiente.</p>
+        </section>
+      )}
+
+      <section className="mt-6 border-l-2 border-[var(--ds-color-brand)] pl-4">
+        <span className="ds-eyebrow">Leitura da semana</span>
+        <p className="mt-2 text-[15px] leading-[1.55] text-[var(--ds-color-ink)]">
+          {detail.interpretation ?? detail.summary}
+        </p>
+      </section>
+
+      <p className="ds-caption mt-6 text-center">{detail.coverageLabel}</p>
+    </main>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoAccountMenuSheet.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoAccountMenuSheet.tsx
@@ -35,7 +35,7 @@ interface Props {
   onSignOut: () => void;
   /** Fase 2 — abre a pesquisa de perfil para completar o mapa. */
   onOpenSurvey?: () => void;
-  /** Fase 4 — abre a tela "Meu Norte" para editar o propósito do criador. */
+  /** Abre "Seu norte" para editar o propósito e revisar o mapa do criador. */
   onOpenNorte?: () => void;
   /** Fase 4 — indica se o propósito ainda não foi declarado (ponto laranja). */
   hasPurpose?: boolean;
@@ -120,9 +120,7 @@ export function DiagnosticoAccountMenuSheet({
             ) : null}
           </div>
           <span
-            className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold ${
-              plan === "Pro" ? "bg-emerald-50 text-emerald-800" : "bg-amber-50 text-amber-800"
-            }`}
+            className="shrink-0 rounded-[4px] bg-zinc-100 px-2.5 py-1 text-[11px] font-semibold text-zinc-600"
           >
             {plan}
           </span>
@@ -147,7 +145,7 @@ export function DiagnosticoAccountMenuSheet({
           )}
           {onOpenNorte && (
             <AccountMenuAction
-              label="Meu Norte"
+              label="Seu norte"
               onClick={() => { onClose(); onOpenNorte(); }}
               icon={<Compass className="h-4 w-4" strokeWidth={1.9} />}
               statusDot={hasPurpose ? undefined : "orange"}
@@ -243,7 +241,7 @@ function AccountMenuAction({
   onClick: () => void;
   /** Optional status indicator dot rendered before the chevron. */
   statusDot?: "green" | "orange";
-  /** Primary action styling (amber accent) — used for "Assinar Pro". */
+  /** Primary action styling — used for "Assinar Pro". */
   emphasis?: boolean;
 }) {
   const iconClass = emphasis

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoNorteView.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoNorteView.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DiagnosticoNorteView } from "./DiagnosticoNorteView";
+
+describe("DiagnosticoNorteView", () => {
+  it("reúne propósito e mapa atual na mesma área de configuração", () => {
+    const onEditMap = jest.fn();
+
+    const { container } = render(
+      <DiagnosticoNorteView
+        initialPurpose="Ajudar criadores a trabalharem com mais leveza"
+        mapNarrative="Rotina criativa sem perfeccionismo"
+        mapTerritories={["Bastidores", "Produtividade leve"]}
+        onClose={jest.fn()}
+        onEditMap={onEditMap}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Ajudar criadores a trabalharem com mais leveza")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Rotina criativa sem perfeccionismo/ })).toBeInTheDocument();
+    expect(screen.getByText("Bastidores")).toBeInTheDocument();
+    expect(screen.getByText("Produtividade leve")).toBeInTheDocument();
+    expect(container.querySelectorAll(".ds-editorial-panel")).toHaveLength(0);
+    expect(container.querySelectorAll(".ds-notebook-section .ds-notebook-section")).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Ajustar respostas do mapa" }));
+    expect(onEditMap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoNorteView.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoNorteView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { DiagnosticoNavHeader } from "./DiagnosticoNavHeader";
 import { SAFE_TOP } from "./diagnosticoTokens";
 
@@ -9,7 +9,12 @@ import { SAFE_TOP } from "./diagnosticoTokens";
 interface Props {
   /** Propósito atual salvo no perfil (vindo de User.onboardingAnswers.creatorPurpose). */
   initialPurpose: string | null;
+  /** Leitura atual exibida no card "Seu mapa". */
+  mapNarrative: string | null;
+  mapTerritories: string[];
   onClose: () => void;
+  /** Abre as respostas que dão origem ao mapa. */
+  onEditMap: () => void;
   /** Chamado quando o save é bem-sucedido, com o novo valor (ou null se limpo). */
   onSaved?: (newPurpose: string | null) => void;
 }
@@ -21,7 +26,7 @@ const MAX_CHARS = 400;
 // ─── Componente ───────────────────────────────────────────────────────────────
 
 /**
- * Fase 4 — Tela "Meu Norte" nas Configurações.
+ * Tela "Seu norte" nas Configurações.
  *
  * Permite ao criador ler e editar a declaração de propósito ("para quem cria /
  * o que quer que eles sintam") que alimenta a IA do mapa narrativo.
@@ -29,16 +34,17 @@ const MAX_CHARS = 400;
  * Pattern: DiagnosticoNavHeader + paddingTop SAFE_TOP (igual a ReadingDetailView
  * e MediaKitSheet).
  */
-export function DiagnosticoNorteView({ initialPurpose, onClose, onSaved }: Props) {
+export function DiagnosticoNorteView({
+  initialPurpose,
+  mapNarrative,
+  mapTerritories,
+  onClose,
+  onEditMap,
+  onSaved,
+}: Props) {
   const [value, setValue] = useState(initialPurpose?.trim() ?? "");
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  // Foco automático no textarea ao abrir (melhora UX mobile — teclado sobe).
-  useEffect(() => {
-    const timer = setTimeout(() => textareaRef.current?.focus(), 200);
-    return () => clearTimeout(timer);
-  }, []);
 
   const isDirty = value.trim() !== (initialPurpose?.trim() ?? "");
   const isEmpty = value.trim().length === 0;
@@ -81,7 +87,7 @@ export function DiagnosticoNorteView({ initialPurpose, onClose, onSaved }: Props
       style={{ paddingTop: SAFE_TOP }}
     >
       <DiagnosticoNavHeader
-        title="Meu Norte"
+        title="Seu norte"
         onBack={onClose}
         actionSlot={
           <SaveButton
@@ -94,71 +100,90 @@ export function DiagnosticoNorteView({ initialPurpose, onClose, onSaved }: Props
 
       <div className="flex-1 overflow-y-auto overscroll-contain">
         <div className="mx-auto max-w-lg px-5 pb-16 pt-6">
-
-          {/* Cabeçalho da seção */}
-          <p className="mb-1 text-[11px] font-bold uppercase tracking-[0.12em] text-zinc-400">
-            Propósito
-          </p>
-          <h2 className="mb-2 font-display text-[1.75rem] font-bold leading-[1.05] tracking-[-0.035em] text-zinc-950">
-            Para quem você cria?
-          </h2>
-          <p className="mb-6 text-[13px] leading-relaxed text-zinc-500">
-            Em uma frase: para quem cria e o que quer que eles sintam ou façam.
-            Seu mapa usa este propósito para interpretar seus conteúdos e gerar pautas.
-          </p>
-
-          {/* Campo de texto */}
-          <div className="relative">
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={(e) => {
-                setStatus("idle");
-                setValue(e.target.value.slice(0, MAX_CHARS));
-              }}
-              placeholder="ex: quero encorajar mães sem tempo a se cuidarem"
-              rows={4}
-              className="ds-field min-h-[8rem] resize-none"
-            />
-            {/* Contador de caracteres — visível ao se aproximar do limite */}
-            {value.length >= 300 && (
-              <span className="absolute bottom-3 right-4 text-[11px] text-zinc-300">
-                {value.length}/{MAX_CHARS}
-              </span>
-            )}
-          </div>
-
-          {/* Botão limpar — só quando tem valor */}
-          {!isEmpty && (
-            <button
-              type="button"
-              onClick={handleClear}
-              className="mt-3 text-[12px] font-medium text-zinc-400 underline-offset-2 hover:underline"
-            >
-              Limpar
-            </button>
-          )}
-
-          {/* Feedback de erro */}
-          {status === "error" && (
-            <p className="mt-4 text-[13px] font-medium text-red-500">
-              Não conseguimos salvar agora. Tente de novo.
+          <section className="ds-notebook-section" aria-labelledby="norte-purpose-title">
+            <p className="ds-notebook-label mb-1">Propósito</p>
+            <h2 id="norte-purpose-title" className="mb-2 font-display text-[1.75rem] font-bold leading-[1.05] tracking-[-0.035em] text-zinc-950">
+              Para quem você cria?
+            </h2>
+            <p className="mb-5 text-[13px] leading-relaxed text-zinc-500">
+              Em uma frase: para quem cria e o que quer que eles sintam ou façam.
+              Seu mapa usa este propósito para interpretar seus conteúdos e gerar pautas.
             </p>
-          )}
 
-          {/* Indicador de impacto — âncora da feature */}
-          <div className="mt-8 rounded-2xl border border-zinc-100 bg-zinc-50 p-4">
-            <div className="mb-2 flex items-center gap-2">
-              <span className="h-1.5 w-1.5 rounded-full bg-zinc-400" aria-hidden="true" />
-              <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
-                Como é usado
-              </p>
+            <div className="relative rounded-lg bg-[var(--ds-color-neutral)] px-3">
+              <textarea
+                ref={textareaRef}
+                value={value}
+                onChange={(e) => {
+                  setStatus("idle");
+                  setValue(e.target.value.slice(0, MAX_CHARS));
+                }}
+                placeholder="ex: quero encorajar mães sem tempo a se cuidarem"
+                rows={4}
+                className="min-h-[8rem] w-full resize-none border-0 bg-transparent px-0 py-3 text-[15px] leading-relaxed text-[var(--ds-color-ink)] outline-none placeholder:text-[var(--ds-color-text-muted)] focus:ring-0"
+              />
+              {value.length >= 300 && (
+                <span className="absolute bottom-3 right-4 text-[11px] text-zinc-300">
+                  {value.length}/{MAX_CHARS}
+                </span>
+              )}
             </div>
-            <p className="text-[13px] leading-relaxed text-zinc-500">
+
+            {!isEmpty && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="mt-3 text-[12px] font-medium text-zinc-400 underline-offset-2 hover:underline"
+              >
+                Limpar
+              </button>
+            )}
+
+            {status === "error" && (
+              <p className="mt-4 text-[13px] font-medium text-red-500">
+                Não conseguimos salvar agora. Tente de novo.
+              </p>
+            )}
+          </section>
+
+          <section className="ds-notebook-section" aria-labelledby="norte-map-title">
+            <p className="ds-notebook-label">Seu mapa</p>
+            <h2
+              id="norte-map-title"
+              className="mt-3 font-display text-[1.45rem] font-bold leading-[1.12] tracking-[-0.035em] text-[var(--ds-color-ink)]"
+            >
+              “{mapNarrative || "Sua história ainda está ganhando forma"}”
+            </h2>
+
+            <div className="mt-5">
+              <p className="ds-notebook-label">Seus assuntos</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {mapTerritories.length > 0 ? mapTerritories.map((territory) => (
+                  <span key={territory} className="ds-notebook-tag">{territory}</span>
+                )) : (
+                  <span className="ds-caption">Responda algumas perguntas para formar os primeiros assuntos do seu mapa.</span>
+                )}
+              </div>
+              <p className="ds-caption mt-3">
+                O mapa nasce das suas respostas e fica mais preciso conforme a D2C lê seus vídeos.
+              </p>
+              <button type="button" className="ds-notebook-action mt-3" onClick={onEditMap}>
+                <span>Ajustar respostas do mapa</span>
+                <span className="text-[var(--ds-color-text-muted)]" aria-hidden="true">›</span>
+              </button>
+            </div>
+          </section>
+
+          <details className="group rounded-xl bg-white px-4 py-2">
+            <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between text-[13px] font-semibold text-[var(--ds-color-ink)]">
+              Como é usado
+              <span className="text-[var(--ds-color-text-muted)] transition-transform group-open:rotate-90" aria-hidden="true">›</span>
+            </summary>
+            <p className="pb-2 pr-6 text-[13px] leading-relaxed text-[var(--ds-color-text-muted)]">
               Quando você cria pautas ou analisa vídeos, a IA considera este propósito
               para filtrar o que é coerente com quem você é e para quem cria.
             </p>
-          </div>
+          </details>
 
           {/* Empty state — convite quando não há propósito */}
           {isEmpty && (
@@ -200,7 +225,7 @@ function SaveButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded-full bg-zinc-950 px-4 py-2 text-[13px] font-semibold text-white transition-opacity disabled:opacity-30 active:opacity-70"
+      className="min-h-11 rounded-md bg-[var(--ds-color-ink)] px-3 text-[13px] font-semibold text-white transition-colors disabled:bg-transparent disabled:text-[var(--ds-color-text-muted)] active:bg-[#37352f]"
     >
       {status === "saving" ? "Salvando…" : "Salvar"}
     </button>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.test.tsx
@@ -130,6 +130,34 @@ describe("DiagnosticoRealShellClient", () => {
     expect(mockDiagnosticoPageRender).not.toHaveBeenCalled();
   });
 
+  it("abre Seu norte diretamente pelo card do mapa", async () => {
+    render(
+      <DiagnosticoRealShellClient
+        data={buildDiagnosticoPageDataFixture({
+          creatorWeeklyProfileExperienceEnabled: true,
+          mapaSeed: {
+            narrativa_central: "Criatividade que cabe na rotina",
+            territorios: ["Bastidores", "Processo criativo"],
+            temas: [],
+            narrativas_adjacentes: [],
+            assets: [],
+            tom: "",
+            formatos: [],
+            maturidade: "seed",
+            fonte: ["onboarding_declarativo"],
+          },
+        })}
+        onAnalyzeAction={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Ajustar mapa" }));
+
+    expect(await screen.findByText("Seu norte")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Criatividade que cabe na rotina/ })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Conta e preferências" })).not.toBeInTheDocument();
+  });
+
   it("lets an admin with a Free billing label use premium mobile actions", async () => {
     const fetchSpy = jest.spyOn(global, "fetch").mockImplementation((input: RequestInfo | URL) => {
       if (String(input) === "/api/calculator/latest") {

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.test.tsx
@@ -109,6 +109,107 @@ describe("DiagnosticoRealShellClient", () => {
     });
   });
 
+  it("renders the weekly profile and its new tab navigation when enabled", () => {
+    render(
+      <DiagnosticoRealShellClient
+        data={buildDiagnosticoPageDataFixture({
+          creatorWeeklyProfileExperienceEnabled: true,
+          userInfo: {
+            ...buildDiagnosticoPageDataFixture().userInfo,
+            name: "Ana Criadora",
+          },
+        })}
+        onAnalyzeAction={null}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Ana Criadora" })).toBeInTheDocument();
+    expect(screen.getByText("Faltam 2 passos")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Analisar conteúdo" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collabs" })).toBeInTheDocument();
+    expect(mockDiagnosticoPageRender).not.toHaveBeenCalled();
+  });
+
+  it("lets an admin with a Free billing label use premium mobile actions", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      if (String(input) === "/api/calculator/latest") {
+        return Promise.resolve(new Response(JSON.stringify({ error: "Nenhum cálculo encontrado." }), { status: 404 }));
+      }
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const base = buildDiagnosticoPageDataFixture();
+
+    render(
+      <DiagnosticoRealShellClient
+        data={buildDiagnosticoPageDataFixture({
+          accessState: "admin",
+          creatorWeeklyProfileExperienceEnabled: true,
+          instagramConnected: false,
+          userInfo: { ...base.userInfo, plan: "Free" },
+        })}
+        onAnalyzeAction={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Configurações da conta" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Conectar Instagram" }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/dashboard/instagram/connect?next=narrative-map",
+    );
+    expect(openPaywallModal).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Quanto vale sua publi/i }));
+    expect(await screen.findByRole("dialog", { name: "Resultado sugerido" })).toBeInTheDocument();
+    expect(openPaywallModal).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("chains Instagram after upgrade only when the account is not connected", () => {
+    const base = buildDiagnosticoPageDataFixture();
+    const { unmount } = render(
+      <DiagnosticoRealShellClient
+        data={buildDiagnosticoPageDataFixture({
+          accessState: "free_unused",
+          creatorWeeklyProfileExperienceEnabled: true,
+          instagramConnected: false,
+          userInfo: { ...base.userInfo, plan: "Free" },
+        })}
+        onAnalyzeAction={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Assinar" }));
+    expect(openPaywallModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        returnTo: "/dashboard/boards/mobile-strategic-profile",
+        postCheckoutIntent: "connect_instagram",
+      }),
+    );
+
+    unmount();
+    jest.clearAllMocks();
+
+    render(
+      <DiagnosticoRealShellClient
+        data={buildDiagnosticoPageDataFixture({
+          accessState: "free_unused",
+          creatorWeeklyProfileExperienceEnabled: true,
+          instagramConnected: true,
+          userInfo: { ...base.userInfo, plan: "Free" },
+        })}
+        onAnalyzeAction={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Assinar" }));
+    expect(openPaywallModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        returnTo: "/dashboard/boards/mobile-strategic-profile",
+        postCheckoutIntent: undefined,
+      }),
+    );
+  });
+
   it("does not render an internal floating tab bar", () => {
     render(<DiagnosticoRealShellClient data={buildDiagnosticoPageDataFixture()} onAnalyzeAction={null} />);
     expect(screen.queryByRole("navigation", { name: /navegação do diagnóstico/i })).not.toBeInTheDocument();
@@ -138,7 +239,7 @@ describe("DiagnosticoRealShellClient", () => {
     expect(screen.getByRole("button", { name: "Conectar Instagram" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Assinar Pro" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Suporte por email" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Programa de Afiliados" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Afiliados" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Excluir minha conta" })).toBeInTheDocument();
   });
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
@@ -32,6 +32,8 @@ import { fetchAnalysisConfirmationDataFromReading } from "./mobileStrategicProfi
 import { DiagnosticoPage } from "./DiagnosticoPage";
 import type { WeeklyMeetingProfileData } from "./WeeklyMeetingProfileCard";
 import { DiagnosticoTabBar, type DiagnosticoTab } from "./DiagnosticoTabBar";
+import { CreatorWeeklyProfileExperience } from "./CreatorWeeklyProfileExperience";
+import { CreatorWeeklyCollabsGate } from "./CreatorWeeklyCollabsGate";
 import type {
   CollabsBootstrapStatus,
   PautaActionKind,
@@ -236,6 +238,14 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
   // Aba ativa da tab bar mobile (Perfil/Collabs). "+" não é aba — abre o upload.
   // Default "perfil": usuário novo/sem mapa cai no Perfil.
   const [activeTab, setActiveTab] = useState<DiagnosticoTab>("perfil");
+  const [weeklyReportDemo, setWeeklyReportDemo] = useState(false);
+  const weeklyProfileExperienceEnabled = data.creatorWeeklyProfileExperienceEnabled === true;
+  const hasProAccess = data.userInfo.plan === "Pro" || data.accessState === "admin";
+  const weeklyCollabsUnlocked =
+    hasProAccess &&
+    data.instagramConnected &&
+    data.accessState !== "payment_pending" &&
+    data.accessState !== "payment_action_needed";
   const [accessMessage, setAccessMessage] = useState<string | null>(null);
   const [localThumbnails, setLocalThumbnails] = useState<Record<string, string>>({});
   const [showInstagramConnectedNotice, setShowInstagramConnectedNotice] = useState(false);
@@ -251,7 +261,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     } else {
       container.scrollTop = 0;
     }
-  }, [activeTab]);
+  }, [activeTab, weeklyReportDemo]);
   // True quando a página foi carregada após a conexão do Instagram (via ?instagramLinked=true).
   // Usado para mostrar estado "processando" no card de pautas enquanto o enriquecimento
   // assíncrono ainda não terminou. Inicializa do URL para capturar o hard-reload.
@@ -283,7 +293,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     controller: AbortController;
   } | null>(null);
   const loadLatestCalculation = useCallback(() => {
-    if (data.userInfo.plan !== "Pro") return Promise.resolve(null);
+    if (!hasProAccess) return Promise.resolve(null);
     if (latestCalculationRequestRef.current) return latestCalculationRequestRef.current.promise;
 
     const controller = new AbortController();
@@ -302,7 +312,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       });
     latestCalculationRequestRef.current = { promise: request, controller };
     return request;
-  }, [data.userInfo.plan]);
+  }, [hasProAccess]);
   const [openIdeaId, setOpenIdeaId] = useState<string | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(data.needsOnboarding);
   // O3: step de retomada após conectar Instagram durante o onboarding.
@@ -461,6 +471,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
 
   useEffect(() => {
     if (activeTab !== "collabs") return;
+    if (weeklyProfileExperienceEnabled && (!weeklyCollabsUnlocked || weeklyReportDemo)) return;
     if (collabsReadySignatureRef.current === collabsInputSignature) return;
 
     const requestId = ++collabsBootstrapRequestRef.current;
@@ -487,7 +498,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
 
     // Free não consulta identidades reais, mas ainda respeita a transição única
     // loading → ready para não hidratar decisões locais depois do primeiro card.
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       commitLocalDecisions();
       setPautaCollabs(new Map());
       setCollabDecisions(new Map());
@@ -596,8 +607,11 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     collabsInputSignature,
     collabsNarrativeLabel,
     collabsPautas,
-    data.userInfo.plan,
+    hasProAccess,
     localPautaDecisionStorageKey,
+    weeklyCollabsUnlocked,
+    weeklyProfileExperienceEnabled,
+    weeklyReportDemo,
   ]);
 
   const handleRetryCollabsBootstrap = useCallback(() => {
@@ -701,7 +715,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
   }, [findCurrentPauta, pautaCollabs]);
 
   const handleConnectInstagram = useCallback(() => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "narrative_map",
         source: "mobile_profile_instagram_connect",
@@ -711,10 +725,10 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       return;
     }
     router.push(MOBILE_INSTAGRAM_CONNECT_ROUTE);
-  }, [data.userInfo.plan, router]);
+  }, [hasProAccess, router]);
 
   const handleOpenMediaKit = useCallback(() => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "media_kit",
         source: "mobile_profile_media_kit",
@@ -732,7 +746,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     } else {
       router.push(MOBILE_MEDIA_KIT_ROUTE);
     }
-  }, [data.userInfo.plan, data.instagramConnected, data.userInfo.mediaKitSlug, router]);
+  }, [hasProAccess, data.instagramConnected, data.userInfo.mediaKitSlug, router]);
 
   const handleOpenCreatorMediaKit = useCallback((slug: string) => {
     setMediaKitSheetSlug(slug);
@@ -745,7 +759,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     handleOpenMediaKit();
   }, [handleOpenMediaKit]);
   const handleOpenCalculator = useCallback(() => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "calculator",
         source: "mobile_profile_calculator",
@@ -756,12 +770,12 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     }
     void loadLatestCalculation();
     setCalculatorWizardOpen(true);
-  }, [data.instagramConnected, data.userInfo.plan, loadLatestCalculation]);
+  }, [data.instagramConnected, hasProAccess, loadLatestCalculation]);
 
   // Abrir a pauta (roteiro completo + por que o criador é ideal pra collab) é Pro.
   // Free vê o card (título + direcional) como teaser; o tap abre o paywall.
   const handleOpenIdea = useCallback((id: string) => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "planning",
         source: "mobile_idea_open",
@@ -771,7 +785,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       return;
     }
     setOpenIdeaId(id);
-  }, [data.instagramConnected, data.userInfo.plan]);
+  }, [data.instagramConnected, hasProAccess]);
 
   const beginPautaAction = useCallback((id: string) => {
     if (pautaActionInFlightRef.current.has(id)) return false;
@@ -786,7 +800,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
   // Salvar explicitamente: usado no deck. Falha não recoloca a pauta no deck;
   // ela fica na estante da sessão como "não sincronizada" com retry.
   const handleSavePauta = useCallback((id: string) => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "planning",
         source: "mobile_idea_save",
@@ -818,7 +832,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     beginPautaAction,
     clearPautaAction,
     data.instagramConnected,
-    data.userInfo.plan,
+    hasProAccess,
     finishPautaAction,
     localPautaDecisionStorageKey,
     persistPautaStatus,
@@ -880,7 +894,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
   ]);
 
   const handleAcceptCollabPauta = useCallback((id: string) => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       openPaywallModal({
         context: "narrative_map",
         source: "mobile_collabs_accept",
@@ -928,7 +942,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     beginPautaAction,
     clearPautaAction,
     data.instagramConnected,
-    data.userInfo.plan,
+    hasProAccess,
     findCurrentPauta,
     finishPautaAction,
     localPautaDecisionStorageKey,
@@ -1038,7 +1052,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
   }, []);
 
   useEffect(() => {
-    if (data.userInfo.plan !== "Pro") {
+    if (!hasProAccess) {
       latestCalculationRequestRef.current?.controller.abort();
       setLatestCalculation(null);
       latestCalculationRequestRef.current = null;
@@ -1052,7 +1066,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       latestCalculationRequestRef.current?.controller.abort();
       latestCalculationRequestRef.current = null;
     };
-  }, [data.userInfo.plan, loadLatestCalculation]);
+  }, [hasProAccess, loadLatestCalculation]);
 
   // Extracted so the user can also retry manually from the card.
   // `focusedTerritory` (opcional) semeia a geração a partir de um território —
@@ -1452,7 +1466,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
         context: "narrative_map",
         source: "mobile_profile_free_used",
         returnTo: MOBILE_PROFILE_ROUTE,
-        postCheckoutIntent: "connect_instagram",
+        postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
       });
       return;
     }
@@ -1465,7 +1479,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
         context: "narrative_map",
         source: "mobile_profile",
         returnTo: MOBILE_PROFILE_ROUTE,
-        postCheckoutIntent: "connect_instagram",
+        postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
       });
       return;
     }
@@ -1474,9 +1488,9 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       context: "narrative_map",
       source: "mobile_profile",
       returnTo: MOBILE_PROFILE_ROUTE,
-      postCheckoutIntent: "connect_instagram",
+      postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
     });
-  }, [data.accessState]);
+  }, [data.accessState, data.instagramConnected]);
 
   const handleOpenReading = useCallback(
     (diagnosisId: string) => {
@@ -1670,9 +1684,9 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       context: "narrative_map",
       source: "mobile_profile_free_completion",
       returnTo: MOBILE_PROFILE_ROUTE,
-      postCheckoutIntent: "connect_instagram",
+      postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
     });
-  }, []);
+  }, [data.instagramConnected]);
 
   const handleCleanupUpload = useCallback(
     async (payload: {
@@ -1890,9 +1904,29 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       context: typeof context === "string" ? context : "narrative_map",
       source: typeof context === "string" ? `mobile_profile_${context}` : "mobile_profile_empty_state",
       returnTo: MOBILE_PROFILE_ROUTE,
-      postCheckoutIntent: "connect_instagram",
+      postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
     });
-  }, []);
+  }, [data.instagramConnected]);
+  const handleSelectProfileTab = useCallback(() => {
+    trackMobileNarrativeEvent("mobile_profile_tab_selected", {
+      route: MOBILE_PROFILE_ROUTE,
+      accessState: data.accessState,
+      isPro: data.userInfo.plan === "Pro" || data.accessState === "admin",
+      instagramConnected: data.instagramConnected,
+      actionType: "perfil",
+    });
+    setActiveTab("perfil");
+  }, [data.accessState, data.instagramConnected, data.userInfo.plan]);
+  const handleSelectCollabsTab = useCallback(() => {
+    trackMobileNarrativeEvent("mobile_profile_tab_selected", {
+      route: MOBILE_PROFILE_ROUTE,
+      accessState: data.accessState,
+      isPro: data.userInfo.plan === "Pro" || data.accessState === "admin",
+      instagramConnected: data.instagramConnected,
+      actionType: "collabs",
+    });
+    setActiveTab("collabs");
+  }, [data.accessState, data.instagramConnected, data.userInfo.plan]);
   const handleOpenAccountMenu = useCallback(() => setAccountMenuOpen(true), []);
   const handleOpenSurvey = useCallback(() => setSurveyOpen(true), []);
   const handleOpenNorte = useCallback(() => setNorteOpen(true), []);
@@ -1913,6 +1947,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     >
       <div
         ref={tabScrollContainerRef}
+        data-mobile-profile-scroll-container="true"
         className="flex-1 overflow-y-auto overscroll-contain"
         style={{
           paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 5.5rem)",
@@ -1928,9 +1963,18 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
         }}
       >
         {activeTab === "collabs" ? (
+          weeklyProfileExperienceEnabled && (!weeklyCollabsUnlocked || weeklyReportDemo) ? (
+            <CreatorWeeklyCollabsGate
+              accessState={hydratedData.accessState}
+              isDemo={weeklyReportDemo}
+              onUpgrade={handleProfileUpgrade}
+              onConnectInstagram={handleConnectInstagram}
+              onDemoChange={setWeeklyReportDemo}
+            />
+          ) : (
           <DiagnosticoCollabsFeed
             pautas={effectiveContentIdeas}
-            isPro={hydratedData.userInfo.plan === "Pro"}
+            isPro={hasProAccess}
             whatsappLinked={hydratedData.userInfo.whatsappLinked ?? false}
             isGeneratingIdeas={isGeneratingIdeas}
             ideaGenerationBlocker={ideaGenerationBlocker}
@@ -1954,10 +1998,24 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
               context: typeof ctx === "string" ? ctx : "narrative_map",
               source: typeof ctx === "string" ? `mobile_collabs_${ctx}` : "mobile_collabs",
               returnTo: MOBILE_PROFILE_ROUTE,
-              postCheckoutIntent: "connect_instagram",
+              postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
             })}
             onGenerate={triggerGenerateIdeas}
             onBackToPerfil={() => setActiveTab("perfil")}
+          />
+          )
+        ) : (
+        weeklyProfileExperienceEnabled ? (
+          <CreatorWeeklyProfileExperience
+            data={hydratedData}
+            weeklyMeeting={weeklyMeeting}
+            isDemo={weeklyReportDemo}
+            onDemoChange={setWeeklyReportDemo}
+            onOpenAccountMenu={handleOpenAccountMenu}
+            onOpenMediaKit={handleOpenMediaKit}
+            onOpenCalculator={handleOpenCalculator}
+            onUpgrade={handleProfileUpgrade}
+            onConnectInstagram={handleConnectInstagram}
           />
         ) : (
         <DiagnosticoPage
@@ -1996,6 +2054,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
           onOpenCalculator={handleOpenCalculator}
           weeklyMeeting={weeklyMeeting}
         />
+        )
         )}
       </div>
 
@@ -2003,9 +2062,11 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
           abre o upload via handleNewReading (mesma lógica de acesso do card). */}
       <DiagnosticoTabBar
         activeTab={activeTab}
-        onSelectPerfil={() => setActiveTab("perfil")}
-        onSelectCollabs={() => setActiveTab("collabs")}
-        onPressPlus={handleNewReading}
+        onSelectPerfil={handleSelectProfileTab}
+        onSelectCollabs={handleSelectCollabsTab}
+        onPressPlus={weeklyReportDemo
+          ? () => setAccessMessage("No relatório de exemplo, a análise de vídeo fica desativada.")
+          : handleNewReading}
       />
 
       {openIdeaId && (() => {
@@ -2020,7 +2081,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
           <DiagnosticoIdeaDetailSheet
             idea={idea}
             collab={ideaCollab}
-            isPro={hydratedData.userInfo.plan === "Pro"}
+            isPro={hasProAccess}
             decisionPending={Boolean(ideaCollab) && !ideaDecision && !ideaMatched}
             onDecide={(decision) => {
               if (decision === "interested") {
@@ -2036,7 +2097,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
               context: "narrative_map",
               source: "mobile_idea_collab",
               returnTo: MOBILE_PROFILE_ROUTE,
-              postCheckoutIntent: "connect_instagram",
+              postCheckoutIntent: data.instagramConnected ? undefined : "connect_instagram",
             })}
             onClose={() => setOpenIdeaId(null)}
           />
@@ -2075,7 +2136,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       {accountMenuOpen ? (
         <DiagnosticoAccountMenuSheet
           userInfo={hydratedData.userInfo}
-          isPro={hydratedData.userInfo.plan === "Pro"}
+          isPro={hasProAccess}
           instagramConnected={hydratedData.instagramConnected}
           onClose={closeAccountMenu}
           onOpenMediaKit={handleOpenAccountMediaKit}
@@ -2213,7 +2274,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       {openCategory === "community" && (
         <DiagnosticoCommunityDetailView
           creatorDirectory={creatorDirectory}
-          isPro={hydratedData.userInfo.plan === "Pro"}
+          isPro={hasProAccess}
           onUpgrade={() => openPaywallModal({
             context: "narrative_map",
             source: "community_join_upsell",

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoRealShellClient.tsx
@@ -18,7 +18,6 @@ import {
   MOBILE_INSTAGRAM_CONNECT_ROUTE,
   MOBILE_MEDIA_KIT_ROUTE,
   MOBILE_PROFILE_ROUTE,
-  MOBILE_WHATSAPP_CONNECT_ROUTE,
 } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes";
 import { requestUploadSession } from "./mobileStrategicProfileUploadSessionClient";
 import { uploadVideoToTemporarySignedUrl } from "./mobileStrategicProfileDirectUploadClient";
@@ -313,6 +312,18 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
     latestCalculationRequestRef.current = { promise: request, controller };
     return request;
   }, [hasProAccess]);
+  // Valor da última publi já formatado para a linha de ferramentas do Perfil.
+  // Usa o cálculo que já é carregado após a primeira pintura — sem requisição nova.
+  const weeklyProfileCalculatorPrice = useMemo(() => {
+    const justo = latestCalculation?.justo;
+    if (typeof justo !== "number" || !Number.isFinite(justo)) return null;
+    return new Intl.NumberFormat("pt-BR", {
+      style: "currency",
+      currency: "BRL",
+      maximumFractionDigits: 0,
+    }).format(justo);
+  }, [latestCalculation?.justo]);
+
   const [openIdeaId, setOpenIdeaId] = useState<string | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(data.needsOnboarding);
   // O3: step de retomada após conectar Instagram durante o onboarding.
@@ -590,7 +601,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
             body: JSON.stringify({ celebratedPautaIds }),
           }).catch(() => {});
         }
-      } catch (error) {
+      } catch {
         if (controller.signal.aborted || collabsBootstrapRequestRef.current !== requestId) return;
         setCollabsBootstrap({
           status: "error",
@@ -1940,9 +1951,9 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
 
   return (
     <div
-      className={`d2c-mobile-app fixed inset-0 flex flex-col overflow-hidden ${d2cFontVariables}`}
+      className={`d2c-mobile-app ds-notebook fixed inset-0 flex flex-col overflow-hidden ${d2cFontVariables}`}
       style={{
-        background: "var(--ds-color-paper)",
+        background: "var(--ds-color-neutral)",
       }}
     >
       <div
@@ -1959,7 +1970,7 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
           // gradiente mudar (parar mais peachy, por mais tempo), essa faixa
           // reaparece com a cor errada, sem nenhum aviso. Fundo explícito
           // remove essa dependência — a faixa é sempre branca, ponto.
-          background: "var(--ds-color-paper)",
+          background: "var(--ds-color-neutral)",
         }}
       >
         {activeTab === "collabs" ? (
@@ -2009,9 +2020,11 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
           <CreatorWeeklyProfileExperience
             data={hydratedData}
             weeklyMeeting={weeklyMeeting}
+            calculatorPrice={weeklyProfileCalculatorPrice}
             isDemo={weeklyReportDemo}
             onDemoChange={setWeeklyReportDemo}
             onOpenAccountMenu={handleOpenAccountMenu}
+            onOpenNorte={handleOpenNorte}
             onOpenMediaKit={handleOpenMediaKit}
             onOpenCalculator={handleOpenCalculator}
             onUpgrade={handleProfileUpgrade}
@@ -2167,7 +2180,18 @@ export function DiagnosticoRealShellClient({ data, weeklyMeeting = null }: Props
       {norteOpen && (
         <DiagnosticoNorteView
           initialPurpose={localPurpose}
+          mapNarrative={hydratedData.mapaSeed?.narrativa_central?.trim()
+            || hydratedData.synthesis.mainNarrative?.label?.trim()
+            || null}
+          mapTerritories={(hydratedData.mapaSeed?.territorios?.filter(Boolean).length
+            ? hydratedData.mapaSeed.territorios.filter(Boolean)
+            : hydratedData.synthesis.narrativeTerritories.map((territory) => territory.label).filter(Boolean)
+          ).slice(0, 8)}
           onClose={() => setNorteOpen(false)}
+          onEditMap={() => {
+            setNorteOpen(false);
+            setSurveyOpen(true);
+          }}
           onSaved={(newPurpose) => {
             setLocalPurpose(newPurpose);
             // Declarar o propósito SEMEIA o MapaSeed no servidor (seedMapaSeedFromPurpose,

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.test.tsx
@@ -18,11 +18,11 @@ describe("DiagnosticoTabBar", () => {
 
     expect(screen.getByRole("button", { name: "Collabs" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("button", { name: "Perfil" })).not.toHaveAttribute("aria-current");
-    expect(screen.getByText("Escanear")).toBeVisible();
+    expect(screen.queryByText("Escanear")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Perfil" }));
     fireEvent.click(screen.getByRole("button", { name: "Collabs" }));
-    fireEvent.click(screen.getByRole("button", { name: "Escanear novo vídeo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analisar conteúdo" }));
 
     expect(onSelectPerfil).toHaveBeenCalledTimes(1);
     expect(onSelectCollabs).toHaveBeenCalledTimes(1);

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.test.tsx
@@ -7,7 +7,7 @@ describe("DiagnosticoTabBar", () => {
     const onSelectCollabs = jest.fn();
     const onPressPlus = jest.fn();
 
-    render(
+    const { container } = render(
       <DiagnosticoTabBar
         activeTab="collabs"
         onSelectPerfil={onSelectPerfil}
@@ -19,6 +19,8 @@ describe("DiagnosticoTabBar", () => {
     expect(screen.getByRole("button", { name: "Collabs" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("button", { name: "Perfil" })).not.toHaveAttribute("aria-current");
     expect(screen.queryByText("Escanear")).not.toBeInTheDocument();
+    expect(container.querySelector("nav")).toHaveClass("bg-white");
+    expect(container.querySelector("nav")).not.toHaveClass("shadow-lg");
 
     fireEvent.click(screen.getByRole("button", { name: "Perfil" }));
     fireEvent.click(screen.getByRole("button", { name: "Collabs" }));

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-// Tab bar mobile do "Seu Mapa" — 3 slots: Perfil · Scan · Collabs.
+// Tab bar mobile do Perfil — 3 slots: Perfil · ação "+" · Collabs.
 // Apresentacional: o shell (DiagnosticoRealShellClient) dona o estado da aba e a
 // ação do "+". Fica em z-40 — acima do conteúdo da página e ABAIXO dos overlays
 // de detalhe (z-50), que devem cobri-la quando abertos.
@@ -91,12 +91,12 @@ export function DiagnosticoTabBar({
         <PerfilIcon active={activeTab === "perfil"} />
       </TabButton>
 
-      {/* Centro Scan — ação de leitura, não é uma aba. Elevado e destacado. */}
+      {/* O centro é uma ação, não uma terceira aba. O rótulo permanece no aria. */}
       <div className="flex min-w-[64px] flex-1 flex-col items-center">
         <button
           type="button"
           onClick={onPressPlus}
-          aria-label="Escanear novo vídeo"
+          aria-label="Analisar conteúdo"
           className="active:scale-[0.94] focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-[rgba(250,22,91,0.3)]"
           style={{
             marginTop: -22,
@@ -114,23 +114,9 @@ export function DiagnosticoTabBar({
           }}
         >
           <svg width="27" height="27" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M8 4H5a1 1 0 0 0-1 1v3M16 4h3a1 1 0 0 1 1 1v3M20 16v3a1 1 0 0 1-1 1h-3M8 20H5a1 1 0 0 1-1-1v-3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            <path d="M7 12h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            <circle cx="12" cy="12" r="2.4" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
           </svg>
         </button>
-        <span
-          aria-hidden="true"
-          style={{
-            marginTop: 3,
-            color: color.brandStrong,
-            fontSize: 11,
-            fontWeight: 750,
-            letterSpacing: -0.1,
-          }}
-        >
-          Escanear
-        </span>
       </div>
 
       <TabButton label="Collabs" active={activeTab === "collabs"} onClick={onSelectCollabs}>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/DiagnosticoTabBar.tsx
@@ -5,28 +5,24 @@
 // ação do "+". Fica em z-40 — acima do conteúdo da página e ABAIXO dos overlays
 // de detalhe (z-50), que devem cobri-la quando abertos.
 
-import { color } from "@/design-system";
-
 export type DiagnosticoTab = "perfil" | "collabs";
 
-function PerfilIcon({ active }: { active: boolean }) {
-  const c = active ? color.brand : color.textMuted;
+function PerfilIcon() {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <circle cx="12" cy="8" r="3.4" stroke={c} strokeWidth="1.8" />
-      <path d="M5.5 19.5c0-3.3 2.9-5.5 6.5-5.5s6.5 2.2 6.5 5.5" stroke={c} strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="12" cy="8" r="3.4" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M5.5 19.5c0-3.3 2.9-5.5 6.5-5.5s6.5 2.2 6.5 5.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
     </svg>
   );
 }
 
-function CollabsIcon({ active }: { active: boolean }) {
-  const c = active ? color.brand : color.textMuted;
+function CollabsIcon() {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <circle cx="8.5" cy="8" r="3" stroke={c} strokeWidth="1.8" />
-      <circle cx="16" cy="9.5" r="2.4" stroke={c} strokeWidth="1.8" />
-      <path d="M3 19c0-2.8 2.5-4.7 5.5-4.7 1.6 0 3 .55 4 1.45" stroke={c} strokeWidth="1.8" strokeLinecap="round" />
-      <path d="M14 18.8c.3-2.2 2.1-3.6 4.4-3.6 1.5 0 2.8.6 3.6 1.6" stroke={c} strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="8.5" cy="8" r="3" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="16" cy="9.5" r="2.4" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M3 19c0-2.8 2.5-4.7 5.5-4.7 1.6 0 3 .55 4 1.45" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M14 18.8c.3-2.2 2.1-3.6 4.4-3.6 1.5 0 2.8.6 3.6 1.6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
     </svg>
   );
 }
@@ -47,17 +43,10 @@ function TabButton({
       type="button"
       onClick={onClick}
       aria-current={active ? "page" : undefined}
-      className="relative flex min-h-[3.25rem] min-w-[64px] flex-1 flex-col items-center justify-start gap-1.5 rounded-xl border-0 bg-transparent pt-0.5 transition-transform active:scale-95"
+      className={`relative flex min-h-[3.25rem] min-w-[64px] flex-1 flex-col items-center justify-start gap-1.5 rounded-md border-0 bg-transparent pt-0.5 transition-transform active:scale-[0.97] ${active ? "text-[var(--ds-color-brand-strong)]" : "text-[var(--ds-color-text-muted)]"}`}
     >
       {children}
-      <span
-        style={{
-          fontSize: 11,
-          fontWeight: active ? 750 : 620,
-          letterSpacing: -0.1,
-          color: active ? color.brandStrong : color.textMuted,
-        }}
-      >
+      <span className={`text-[11px] tracking-[-0.1px] ${active ? "font-semibold" : "font-medium"}`}>
         {label}
       </span>
     </button>
@@ -79,16 +68,13 @@ export function DiagnosticoTabBar({
   return (
     <nav
       data-diagnostico-tab-bar="true"
-      className="fixed bottom-0 left-0 right-0 z-40 flex h-[var(--ds-tab-bar-height)] items-start justify-center border-t px-5 pb-[var(--ds-safe-bottom)] pt-2.5 lg:hidden"
+      className="fixed bottom-0 left-0 right-0 z-40 flex h-[var(--ds-tab-bar-height)] items-start justify-center border-t border-[var(--ds-color-line)] bg-white px-5 pb-[var(--ds-safe-bottom)] pt-2.5 lg:hidden"
       style={{
-        background: "color-mix(in srgb, var(--ds-color-paper) 94%, transparent)",
-        borderColor: color.line,
-        boxShadow: "0 -12px 36px rgba(18,16,20,0.08)",
-        backdropFilter: "blur(18px)",
+        background: "var(--ds-color-paper)",
       }}
     >
       <TabButton label="Perfil" active={activeTab === "perfil"} onClick={onSelectPerfil}>
-        <PerfilIcon active={activeTab === "perfil"} />
+        <PerfilIcon />
       </TabButton>
 
       {/* O centro é uma ação, não uma terceira aba. O rótulo permanece no aria. */}
@@ -97,20 +83,11 @@ export function DiagnosticoTabBar({
           type="button"
           onClick={onPressPlus}
           aria-label="Analisar conteúdo"
-          className="active:scale-[0.94] focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-[rgba(250,22,91,0.3)]"
+          className="grid place-items-center rounded-full border-2 border-white bg-[var(--ds-color-brand)] text-white transition-transform active:scale-[0.95] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ds-color-brand-strong)]"
           style={{
-            marginTop: -22,
-            width: 56,
-            height: 56,
-            borderRadius: 9999,
-            background: color.brand,
-            color: "var(--ds-color-on-brand)",
-            display: "grid",
-            placeItems: "center",
-            border: `3px solid ${color.paper}`,
-            boxShadow: "0 8px 24px rgba(250,22,91,0.28)",
-            cursor: "pointer",
-            transition: "transform var(--ds-motion-fast) var(--ds-ease-standard)",
+            marginTop: -18,
+            width: 52,
+            height: 52,
           }}
         >
           <svg width="27" height="27" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -120,7 +97,7 @@ export function DiagnosticoTabBar({
       </div>
 
       <TabButton label="Collabs" active={activeTab === "collabs"} onClick={onSelectCollabs}>
-        <CollabsIcon active={activeTab === "collabs"} />
+        <CollabsIcon />
       </TabButton>
     </nav>
   );

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.test.tsx
@@ -137,7 +137,7 @@ describe("MobileStrategicProfilePage Rota Real", () => {
     });
 
     const jsx = await MobileStrategicProfilePage({
-      searchParams: { state: "instagram_optimized" },
+      searchParams: Promise.resolve({ state: "instagram_optimized" }),
     });
     render(jsx);
 

--- a/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile/page.tsx
@@ -35,10 +35,13 @@ import { normalizePlanStatus } from "@/utils/planStatus";
 import type { MobileStrategicProfileSnapshotPayload } from "../videoUpload/mobileStrategicProfileSnapshotTypes";
 import { getWeeklyMeetingExperience } from "@/app/lib/community/weeklyMeetingService";
 import type { WeeklyMeetingProfileData } from "../components/videoUpload/appPreview/WeeklyMeetingProfileCard";
+import { isCreatorWeeklyProfileExperienceEnabled } from "../videoUpload/creatorWeeklyProfileFeatureFlag";
+import { getOrGenerateCreatorWeeklyReport } from "@/app/lib/creatorWeeklyReport/service";
 
 export const dynamic = "force-dynamic";
 
 const DIAGNOSTICO_V2_ENABLED = process.env.DIAGNOSTICO_V2_ENABLED === "1";
+const CREATOR_WEEKLY_PROFILE_ENABLED = isCreatorWeeklyProfileExperienceEnabled();
 const PERF_LOGGING_ENABLED =
   process.env.MOBILE_STRATEGIC_PROFILE_PERF_LOGGING_ENABLED === "1";
 
@@ -68,7 +71,10 @@ if (process.env.NODE_ENV === "production") {
   const REQUIRED_PROD_FLAGS = [
     "DIAGNOSTICO_V2_ENABLED",
     "VIDEO_NARRATIVE_GEMINI_PROVIDER_ENABLED",
-    "VIDEO_NARRATIVE_REAL_ANALYSIS_ALLOW_PREMIUM_BETA",
+    "VIDEO_NARRATIVE_TEMP_UPLOAD_SESSION_ENABLED",
+    "VIDEO_NARRATIVE_REAL_UPLOAD_ENABLED",
+    "VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED",
+    "NEXT_PUBLIC_VIDEO_NARRATIVE_REAL_ANALYSIS_E2E_ENABLED",
   ] as const;
   for (const flag of REQUIRED_PROD_FLAGS) {
     const val = process.env[flag];
@@ -82,10 +88,10 @@ if (process.env.NODE_ENV === "production") {
 }
 
 type MobileStrategicProfilePageProps = {
-  searchParams?: {
+  searchParams?: Promise<{
     state?: string | string[];
     affiliate?: string | string[];
-  };
+  }>;
 };
 
 export default async function MobileStrategicProfilePage({
@@ -93,6 +99,7 @@ export default async function MobileStrategicProfilePage({
 }: MobileStrategicProfilePageProps) {
   const requestStartedAt = serverNow();
   const serverTimings: ServerTimingMeasurements = {};
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
 
   if (!isMobileStrategicProfileEnabled()) {
     notFound();
@@ -289,6 +296,21 @@ export default async function MobileStrategicProfilePage({
             confirmations,
           ).catch(() => ({ matches: selector.brandMatches ?? [], confirmedMap: false }));
         });
+        const creatorWeeklyReportPromise = measureServerOperation(
+          serverTimings,
+          "creatorWeeklyReport",
+          async () => {
+            if (!CREATOR_WEEKLY_PROFILE_ENABLED || !isInstagramConnected || (!hasPremiumAccess && !isInternalAdmin)) {
+              return null;
+            }
+            return getOrGenerateCreatorWeeklyReport(userId)
+              .then((snapshot) => snapshot.report)
+              .catch((error) => {
+                console.error("[mobile-strategic-profile] relatório semanal indisponível:", error);
+                return null;
+              });
+          },
+        );
 
         const [
           selectorResult,
@@ -302,6 +324,7 @@ export default async function MobileStrategicProfilePage({
           fullMapaSeedDoc,
           resolvedAvatarUrl,
           brandMatchResult,
+          creatorWeeklyReport,
         ] = await Promise.all([
           selectorPromise,
           instagramMetricsPromise,
@@ -314,6 +337,7 @@ export default async function MobileStrategicProfilePage({
           fullMapaSeedPromise,
           avatarPromise,
           brandMatchesPromise,
+          creatorWeeklyReportPromise,
         ]);
         initialNarrativeMapViewModel = selectorResult.viewModel;
         initialNarrativeMapPresentation = selectorResult.currentPresentation;
@@ -403,6 +427,8 @@ export default async function MobileStrategicProfilePage({
           contentIdeasMapStale,
           audienceInsights: audienceInsights ?? null,
           mapaSeed: fullMapaSeedDoc,
+          creatorWeeklyReport,
+          creatorWeeklyProfileExperienceEnabled: CREATOR_WEEKLY_PROFILE_ENABLED,
           userInfo: (() => {
             const profile = (effectiveUserForAccess as any).creatorProfileExtended ?? {};
             const hasNiches = Array.isArray(profile.niches) && profile.niches.length > 0;
@@ -467,8 +493,9 @@ export default async function MobileStrategicProfilePage({
     });
   }
 
-  const stateQuery = typeof searchParams?.state === "string" ? searchParams.state : null;
-  const initialAffiliateView = searchParams?.affiliate === "1";
+  const stateQuery =
+    typeof resolvedSearchParams?.state === "string" ? resolvedSearchParams.state : null;
+  const initialAffiliateView = resolvedSearchParams?.affiliate === "1";
 
   if (DIAGNOSTICO_V2_ENABLED && diagnosticoPageData) {
     return (

--- a/src/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag.test.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag.test.ts
@@ -1,0 +1,9 @@
+import { isCreatorWeeklyProfileExperienceEnabled } from "./creatorWeeklyProfileFeatureFlag";
+
+describe("isCreatorWeeklyProfileExperienceEnabled", () => {
+  it("fica ativo por padrão e aceita rollback explícito", () => {
+    expect(isCreatorWeeklyProfileExperienceEnabled({})).toBe(true);
+    expect(isCreatorWeeklyProfileExperienceEnabled({ MOBILE_PROFILE_WEEKLY_REPORT_EXPERIENCE_ENABLED: "1" })).toBe(true);
+    expect(isCreatorWeeklyProfileExperienceEnabled({ MOBILE_PROFILE_WEEKLY_REPORT_EXPERIENCE_ENABLED: "0" })).toBe(false);
+  });
+});

--- a/src/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag.ts
+++ b/src/app/dashboard/boards/videoUpload/creatorWeeklyProfileFeatureFlag.ts
@@ -1,0 +1,5 @@
+export function isCreatorWeeklyProfileExperienceEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  return env.MOBILE_PROFILE_WEEKLY_REPORT_EXPERIENCE_ENABLED !== "0";
+}

--- a/src/app/dashboard/boards/videoUpload/diagnosticoPageData.ts
+++ b/src/app/dashboard/boards/videoUpload/diagnosticoPageData.ts
@@ -11,6 +11,7 @@ import type { MapEvolutionStatus } from "./mapEvolutionStatusResolver";
 import type { ContentIdeaListItem } from "./contentIdeasReadService";
 import type { ContentIdeasReadiness } from "./contentIdeasReadinessGate";
 import type { AudienceInsights } from "./audienceInsightsService";
+import type { CreatorWeeklyReportPayload } from "@/app/lib/creatorWeeklyReport/types";
 
 export interface DiagnosticoUserInfo {
   name: string | null;
@@ -200,4 +201,8 @@ export interface DiagnosticoPageData {
    * by the creator (via onboarding + enrichment). Null when no seed exists yet.
    */
   mapaSeed?: IMapaData | null;
+  /** Relatório individual da última semana fechada, comparado aos 90 dias da conta. */
+  creatorWeeklyReport?: CreatorWeeklyReportPayload | null;
+  /** Permite rollback instantâneo para o Perfil anterior sem mudar a rota. */
+  creatorWeeklyProfileExperienceEnabled?: boolean;
 }

--- a/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.ts
+++ b/src/app/dashboard/boards/videoUpload/mobileNarrativeTelemetry.ts
@@ -29,7 +29,13 @@ export type MobileNarrativeTelemetryEventName =
   | "mobile_scan_adjustment_marked"
   | "mobile_scan_rescan_started"
   | "mobile_scan_feedback_submitted"
-  | "mobile_scan_publish_decision";
+  | "mobile_scan_publish_decision"
+  | "mobile_weekly_profile_viewed"
+  | "mobile_profile_tab_selected"
+  | "mobile_weekly_report_demo_opened"
+  | "mobile_weekly_report_demo_closed"
+  | "mobile_weekly_report_detail_opened"
+  | "mobile_weekly_report_refresh_succeeded";
 
 export type MobileNarrativeAnalysisMode = "mock" | "real_gated";
 export type MobileNarrativeGateResult = "allowed" | "blocked";

--- a/src/app/dashboard/instagram/connecting/page.tsx
+++ b/src/app/dashboard/instagram/connecting/page.tsx
@@ -369,6 +369,19 @@ export default function InstagramConnectingPage() {
     [router],
   );
 
+  const prepareNarrativeMapReport = useCallback(async () => {
+    if ((nextTarget || "").toLowerCase() !== "narrative-map") return;
+    setMessage("Organizando os seus últimos 90 dias…");
+    // O refresh do Instagram continua no worker. Esta chamada materializa já o
+    // que estiver disponível e evita que contas com histórico sincronizado
+    // cheguem ao Perfil sem o primeiro relatório.
+    await fetch("/api/dashboard/mobile-strategic-profile/weekly-report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ force: true }),
+    }).catch(() => null);
+  }, [nextTarget]);
+
   const finalizeSelectedAccount = useCallback(
     async (selection: AvailableIgAccount) => {
       const instagramAccountId = selection.igAccountId;
@@ -411,6 +424,7 @@ export default function InstagramConnectingPage() {
         }
 
         await update();
+        await prepareNarrativeMapReport();
         track("ig_account_connected", {
           source: "instagram_connecting_page",
           next: nextTarget || "chat",
@@ -438,7 +452,7 @@ export default function InstagramConnectingPage() {
         setIsFinalizingSelection(false);
       }
     },
-    [nextTarget, scheduleRedirectWithSuccess, update],
+    [nextTarget, prepareNarrativeMapReport, scheduleRedirectWithSuccess, update],
   );
 
   useEffect(() => {
@@ -483,6 +497,7 @@ export default function InstagramConnectingPage() {
         }
 
         if (u.instagramConnected) {
+          await prepareNarrativeMapReport();
           scheduleRedirectWithSuccess(
             buildNextUrl(nextTarget),
             nextTarget === "post-creation"
@@ -556,6 +571,7 @@ export default function InstagramConnectingPage() {
     nextTarget,
     sp,
     finalizeSelectedAccount,
+    prepareNarrativeMapReport,
     scheduleRedirectWithSuccess,
   ]);
 

--- a/src/app/dashboard/settings/BillingMobileShell.tsx
+++ b/src/app/dashboard/settings/BillingMobileShell.tsx
@@ -185,14 +185,16 @@ export function BillingMobileShell() {
   const isUnpaid = status === "unpaid";
   const isCanceled = status === "canceled";
   const isInactive = status === "inactive" || status === "expired";
+  const billingManagedByStripe = subscription?.billingManagedByStripe !== false;
 
   const showReactivate = isNonRenewing && subscription?.cancelAtPeriodEnd === true;
-  const canCancel = (isActive || isTrialing) && !subscription?.cancelAtPeriodEnd;
+  const canCancel = billingManagedByStripe && (isActive || isTrialing) && !subscription?.cancelAtPeriodEnd;
   const canResumeCheckout = isPending;
   const canAbortCheckout = isPending || isIncompleteExpired;
   const showSubscribeAgain = isCanceled || isInactive || isIncompleteExpired;
-  const canChangePlan = isActive;
+  const canChangePlan = billingManagedByStripe && isActive;
   const showPortal =
+    billingManagedByStripe &&
     (isActive || isTrialing || isNonRenewing || isPastDue || isUnpaid) &&
     !isPending &&
     !isIncompleteExpired;
@@ -230,6 +232,9 @@ export function BillingMobileShell() {
 
   // ── Calm status subtitle (1 fact per state) ───────────────────────────────
   const statusSubtitle = (() => {
+    if (isPro && !billingManagedByStripe) {
+      return "Seu acesso Pro está ativo. Não há cobrança recorrente vinculada a esta conta.";
+    }
     if (isTrialing && amount && trialEndLabel !== "—") {
       return `Próxima cobrança de ${amount} em ${nextInvoiceDateLabel !== "—" ? nextInvoiceDateLabel : trialEndLabel}.`;
     }

--- a/src/app/lib/billing/syncTaxIdToStripe.ts
+++ b/src/app/lib/billing/syncTaxIdToStripe.ts
@@ -1,0 +1,50 @@
+import { stripe } from "@/app/lib/stripe";
+import { logger } from "@/app/lib/logger";
+import { STRIPE_TAX_ID_TYPE, type TaxId } from "@/app/lib/billing/taxId";
+
+/**
+ * Espelha o documento no cliente do Stripe.
+ *
+ * Guardamos no nosso banco porque é dali que a emissão da nota vai ler. Mandar
+ * para o Stripe também serve a outro propósito: o documento aparece na fatura
+ * e no recibo que ele emite, e fica visível no painel quando alguém for
+ * conferir uma cobrança.
+ *
+ * Nunca lança: falhar aqui não pode derrubar um cadastro ou um pagamento — o
+ * dado que importa para a nota já está salvo do nosso lado.
+ */
+export async function syncTaxIdToStripe(
+  customerId: string | null | undefined,
+  taxId: TaxId,
+): Promise<boolean> {
+  if (!customerId) return false;
+
+  try {
+    const existing = await stripe.customers.listTaxIds(customerId, { limit: 20 });
+
+    const alreadyThere = existing.data.find((entry) => entry.value === taxId.value);
+    if (alreadyThere) return true;
+
+    // Um cliente só tem um documento: os antigos saem para não sobrar dois
+    // números diferentes na mesma fatura.
+    await Promise.allSettled(
+      existing.data
+        .filter((entry) => entry.type === "br_cpf" || entry.type === "br_cnpj")
+        .map((entry) => stripe.customers.deleteTaxId(customerId, entry.id)),
+    );
+
+    await stripe.customers.createTaxId(customerId, {
+      type: STRIPE_TAX_ID_TYPE[taxId.type],
+      value: taxId.value,
+    });
+
+    return true;
+  } catch (error) {
+    logger.warn("billing_tax_id_stripe_sync_failed", {
+      customerId,
+      taxIdType: taxId.type,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/src/app/lib/billing/taxId.test.ts
+++ b/src/app/lib/billing/taxId.test.ts
@@ -1,0 +1,83 @@
+import {
+  formatTaxId,
+  isValidCnpj,
+  isValidCpf,
+  maskTaxIdInput,
+  parseTaxId,
+  stripTaxIdFormatting,
+} from "./taxId";
+
+// Documentos sinteticamente válidos (dígito verificador fecha), não são de
+// pessoas ou empresas reais.
+const CPF = "52998224725";
+const CNPJ = "11222333000181";
+
+describe("isValidCpf", () => {
+  it("accepts a CPF whose check digits close", () => {
+    expect(isValidCpf(CPF)).toBe(true);
+    expect(isValidCpf("529.982.247-25")).toBe(true);
+  });
+
+  it("rejects a CPF with the right length but wrong check digits", () => {
+    expect(isValidCpf("52998224726")).toBe(false);
+  });
+
+  it("rejects repeated digits, which pass the naive check", () => {
+    expect(isValidCpf("11111111111")).toBe(false);
+    expect(isValidCpf("00000000000")).toBe(false);
+  });
+
+  it("rejects the wrong length", () => {
+    expect(isValidCpf("5299822472")).toBe(false);
+    expect(isValidCpf("")).toBe(false);
+  });
+});
+
+describe("isValidCnpj", () => {
+  it("accepts a CNPJ whose check digits close", () => {
+    expect(isValidCnpj(CNPJ)).toBe(true);
+    expect(isValidCnpj("11.222.333/0001-81")).toBe(true);
+  });
+
+  it("rejects wrong check digits and repeated digits", () => {
+    expect(isValidCnpj("11222333000182")).toBe(false);
+    expect(isValidCnpj("11111111111111")).toBe(false);
+  });
+});
+
+describe("parseTaxId", () => {
+  it("infers the type from the length, so nobody has to choose", () => {
+    expect(parseTaxId("529.982.247-25")).toEqual({ value: CPF, type: "cpf" });
+    expect(parseTaxId("11.222.333/0001-81")).toEqual({ value: CNPJ, type: "cnpj" });
+  });
+
+  it("returns null for anything that would be refused by the city", () => {
+    expect(parseTaxId("12345678900")).toBeNull();
+    expect(parseTaxId("123")).toBeNull();
+    expect(parseTaxId(null)).toBeNull();
+    expect(parseTaxId(undefined)).toBeNull();
+    expect(parseTaxId(12345678900 as unknown)).toBeNull();
+  });
+});
+
+describe("formatting", () => {
+  it("strips every non-digit", () => {
+    expect(stripTaxIdFormatting("529.982.247-25")).toBe(CPF);
+  });
+
+  it("formats for display", () => {
+    expect(formatTaxId(CPF)).toBe("529.982.247-25");
+    expect(formatTaxId(CNPJ)).toBe("11.222.333/0001-81");
+  });
+
+  it("masks progressively while typing", () => {
+    expect(maskTaxIdInput("529")).toBe("529");
+    expect(maskTaxIdInput("5299")).toBe("529.9");
+    expect(maskTaxIdInput("52998224725")).toBe("529.982.247-25");
+    expect(maskTaxIdInput("11222333000181")).toBe("11.222.333/0001-81");
+  });
+
+  it("never lets the field grow past a CNPJ", () => {
+    expect(stripTaxIdFormatting(maskTaxIdInput("112223330001819999"))).toHaveLength(14);
+  });
+});

--- a/src/app/lib/billing/taxId.ts
+++ b/src/app/lib/billing/taxId.ts
@@ -1,0 +1,111 @@
+/**
+ * CPF/CNPJ do cliente.
+ *
+ * A nota fiscal de serviço precisa identificar quem recebeu o serviço, então
+ * sem documento não há nota. Validamos o dígito verificador aqui em vez de só
+ * conferir o tamanho: um número com 11 dígitos que não fecha a conta é rejeitado
+ * pela prefeitura na hora de emitir — e aí o erro aparece um mês depois, longe
+ * da pessoa que poderia corrigir.
+ */
+
+export type TaxIdType = "cpf" | "cnpj";
+
+export type TaxId = {
+  /** Só dígitos — é assim que guardamos e mandamos para o Stripe. */
+  value: string;
+  type: TaxIdType;
+};
+
+/** Tipos de tax ID do Stripe correspondentes. */
+export const STRIPE_TAX_ID_TYPE: Record<TaxIdType, "br_cpf" | "br_cnpj"> = {
+  cpf: "br_cpf",
+  cnpj: "br_cnpj",
+};
+
+export function stripTaxIdFormatting(value: unknown): string {
+  return typeof value === "string" ? value.replace(/\D/g, "") : "";
+}
+
+function hasRepeatedDigits(digits: string): boolean {
+  return /^(\d)\1+$/.test(digits);
+}
+
+export function isValidCpf(input: unknown): boolean {
+  const digits = stripTaxIdFormatting(input);
+  if (digits.length !== 11 || hasRepeatedDigits(digits)) return false;
+
+  for (const [length, position] of [[9, 10], [10, 11]] as const) {
+    let sum = 0;
+    for (let i = 0; i < length; i++) {
+      sum += Number(digits[i]) * (position - i);
+    }
+    const remainder = (sum * 10) % 11;
+    const check = remainder === 10 || remainder === 11 ? 0 : remainder;
+    if (check !== Number(digits[length])) return false;
+  }
+
+  return true;
+}
+
+export function isValidCnpj(input: unknown): boolean {
+  const digits = stripTaxIdFormatting(input);
+  if (digits.length !== 14 || hasRepeatedDigits(digits)) return false;
+
+  const check = (length: number) => {
+    let sum = 0;
+    let weight = length - 7;
+    for (let i = 0; i < length; i++) {
+      sum += Number(digits[i]) * weight;
+      weight = weight - 1 < 2 ? 9 : weight - 1;
+    }
+    const remainder = sum % 11;
+    return remainder < 2 ? 0 : 11 - remainder;
+  };
+
+  return check(12) === Number(digits[12]) && check(13) === Number(digits[13]);
+}
+
+/**
+ * Devolve o documento normalizado, ou null se não for um CPF nem um CNPJ
+ * válido. O tipo é inferido pelo tamanho — quem digita não precisa escolher.
+ */
+export function parseTaxId(input: unknown): TaxId | null {
+  const digits = stripTaxIdFormatting(input);
+  if (digits.length === 11) {
+    return isValidCpf(digits) ? { value: digits, type: "cpf" } : null;
+  }
+  if (digits.length === 14) {
+    return isValidCnpj(digits) ? { value: digits, type: "cnpj" } : null;
+  }
+  return null;
+}
+
+/** 123.456.789-09 / 12.345.678/0001-95 — só para exibir. */
+export function formatTaxId(input: unknown): string {
+  const digits = stripTaxIdFormatting(input);
+  if (digits.length === 11) {
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+  }
+  if (digits.length === 14) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5");
+  }
+  return digits;
+}
+
+/** Máscara progressiva, para o campo formatar enquanto a pessoa digita. */
+export function maskTaxIdInput(input: unknown): string {
+  const digits = stripTaxIdFormatting(input).slice(0, 14);
+  if (digits.length <= 11) {
+    return digits
+      .replace(/^(\d{3})(\d)/, "$1.$2")
+      .replace(/^(\d{3})\.(\d{3})(\d)/, "$1.$2.$3")
+      .replace(/^(\d{3})\.(\d{3})\.(\d{3})(\d)/, "$1.$2.$3-$4");
+  }
+  return digits
+    .replace(/^(\d{2})(\d)/, "$1.$2")
+    .replace(/^(\d{2})\.(\d{3})(\d)/, "$1.$2.$3")
+    .replace(/^(\d{2})\.(\d{3})\.(\d{3})(\d)/, "$1.$2.$3/$4")
+    .replace(/^(\d{2})\.(\d{3})\.(\d{3})\/(\d{4})(\d)/, "$1.$2.$3/$4-$5");
+}
+
+export const TAX_ID_INVALID_MESSAGE = "Informe um CPF ou CNPJ válido.";

--- a/src/app/lib/creatorWeeklyReport/demoReport.ts
+++ b/src/app/lib/creatorWeeklyReport/demoReport.ts
@@ -1,0 +1,157 @@
+import {
+  CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+  type CreatorWeeklyReportPayload,
+  type CreatorWeeklyReportRankGroup,
+} from "./types";
+
+function group(
+  id: string,
+  title: string,
+  subtitle: string,
+  rows: Array<[string, string, number, number, "indicio" | "sinal" | "tendencia", number?]>,
+): CreatorWeeklyReportRankGroup {
+  return {
+    id,
+    title,
+    subtitle,
+    items: rows.map(([rowId, label, nPosts, index, evidence, weeklyOccurrences = 0]) => ({
+      id: rowId,
+      label,
+      nPosts,
+      index,
+      evidence,
+      weeklyOccurrences,
+    })),
+  };
+}
+
+/**
+ * Fixture deliberadamente sem identidade, links ou mídia de uma pessoa real.
+ * Nome, foto e mapa vêm sempre do usuário logado; este objeto fornece só números.
+ */
+export const CREATOR_WEEKLY_REPORT_DEMO: CreatorWeeklyReportPayload = {
+  schemaVersion: CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+  weekKey: "demo",
+  period: {
+    startsAt: "2026-08-03T03:00:00.000Z",
+    endsAt: "2026-08-10T02:59:59.999Z",
+    rangeLabel: "4 a 10 de agosto",
+  },
+  status: "ready",
+  generatedAt: "2026-08-10T11:00:00.000Z",
+  sourceMetricsUpdatedAt: null,
+  coverage: {
+    posts90d: 84,
+    postsWeek: 6,
+    postsWithScene: 71,
+    scenePercent: 85,
+  },
+  overview: {
+    summary: "Seis conteúdos mostraram um padrão claro: rotina vivida rende mais quando a conclusão vem logo na abertura.",
+    numbers: [
+      { value: "6", label: "posts" },
+      { value: "440", label: "salvamentos" },
+      { value: "317", label: "compartilhamentos" },
+    ],
+    observedSubjects: ["Maternidade", "Fé", "Bem-estar"],
+  },
+  weeklyVideo: {
+    postId: null,
+    postLink: null,
+    thumbnailUrl: null,
+    publishedAt: "2026-08-07T09:00:00.000Z",
+    description: "Uma rotina simples virou uma história completa porque começou pelo conflito, não pela explicação.",
+    views: 48200,
+    saved: 184,
+    shares: 126,
+    performanceIndex: 4.8,
+    openingLine: "Eu achei que precisava dar conta de tudo sozinha.",
+    subject: "Maternidade sem idealização",
+    place: "Sala",
+  },
+  details: [
+    {
+      id: "timing",
+      title: "Dia e horário",
+      subtitle: "Comparado com o normal dos últimos 90 dias.",
+      summary: "Quinta, entre 4h e 8h, é a combinação mais consistente.",
+      interpretation: "Nesta semana houve quatro posts na melhor faixa, mas nenhum no melhor dia.",
+      coverageLabel: "84 posts nos últimos 90 dias",
+      groups: [
+        group("weekday", "Ranking dos dias", "Resultado contra a mediana da conta.", [
+          ["thu", "Quinta", 14, 2.5, "tendencia"],
+          ["mon", "Segunda", 15, 1.5, "tendencia"],
+          ["sun", "Domingo", 11, 0.4, "tendencia"],
+          ["wed", "Quarta", 14, 0.3, "tendencia", 2],
+        ]),
+        group("time", "Ranking dos horários", "Faixas de quatro horas.", [
+          ["4-8", "Das 4h às 8h", 7, 3.2, "sinal", 4],
+          ["20-24", "Das 20h às 24h", 8, 1.5, "tendencia"],
+          ["8-12", "Das 8h às 12h", 31, 0.8, "tendencia"],
+          ["12-16", "Das 12h às 16h", 15, 0.6, "tendencia"],
+        ]),
+      ],
+    },
+    {
+      id: "scene",
+      title: "Cena, tom e câmera",
+      subtitle: "Onde gravar, como falar e como se enquadrar.",
+      summary: "Sala com fala direta é o padrão mais repetível.",
+      interpretation: "Natureza aparece no topo com um único post; trate como indício, não como regra.",
+      coverageLabel: "71 de 84 posts com leitura visual",
+      groups: [
+        group("place", "Onde você grava", "Cenários identificados nos vídeos.", [
+          ["nature", "Natureza", 1, 7.5, "indicio"],
+          ["living", "Sala", 7, 2.5, "sinal", 2],
+          ["car", "Carro", 6, 1.7, "sinal"],
+          ["store", "Loja ou restaurante", 2, 0.4, "indicio"],
+        ]),
+        group("tone", "Seu jeito de falar", "Tom percebido na fala.", [
+          ["direct", "Direto e acolhedor", 18, 2.1, "tendencia", 3],
+          ["humor", "Humor cotidiano", 9, 1.4, "tendencia"],
+          ["explain", "Explicativo", 20, 0.7, "tendencia"],
+        ]),
+        group("framing", "Como a câmera te mostra", "Enquadramentos recorrentes.", [
+          ["close", "Plano próximo", 24, 1.9, "tendencia", 4],
+          ["fixed", "Câmera fixa", 17, 1.2, "tendencia"],
+          ["wide", "Plano aberto", 8, 0.6, "tendencia"],
+        ]),
+      ],
+    },
+    {
+      id: "subjects",
+      title: "Assuntos",
+      subtitle: "Os temas específicos que a audiência mais compartilha.",
+      summary: "Maternidade sem idealização rendeu 3,6× do normal.",
+      interpretation: "O melhor tema combina experiência vivida com uma conclusão que serve para outra mãe.",
+      coverageLabel: "71 de 84 posts com leitura visual",
+      groups: [
+        group("subjects", "Assuntos mais fortes", "Tema exato de cada vídeo.", [
+          ["mother", "Maternidade sem idealização", 8, 3.6, "tendencia", 2],
+          ["faith", "Fé nas decisões difíceis", 5, 2.1, "sinal", 1],
+          ["care", "Cuidado possível na rotina", 6, 1.7, "sinal"],
+          ["tips", "Dica genérica de bem-estar", 9, 0.5, "tendencia"],
+        ]),
+      ],
+    },
+    {
+      id: "openings",
+      title: "Frases de abertura",
+      subtitle: "As primeiras frases que mais e menos renderam.",
+      summary: "Começar pelo conflito pessoal supera começar por uma explicação.",
+      interpretation: "Cada frase isolada é um indício; o padrão confiável é a estrutura em comum.",
+      coverageLabel: "63 aberturas identificadas",
+      groups: [
+        group("best", "Aberturas mais fortes", "Texto falado ou escrito no início.", [
+          ["a", "Eu achei que precisava dar conta de tudo sozinha.", 1, 5.2, "indicio"],
+          ["b", "Ninguém me contou isso quando eu virei mãe.", 1, 4.1, "indicio"],
+          ["c", "Hoje eu fiz diferente — e foi por isso.", 1, 3.3, "indicio"],
+        ]),
+        group("weak", "Aberturas que renderam menos", "Use como contraste.", [
+          ["d", "Três dicas para melhorar sua rotina.", 1, 0.6, "indicio"],
+          ["e", "Vim mostrar um pouco do meu dia.", 1, 0.4, "indicio"],
+        ]),
+      ],
+    },
+  ],
+};

--- a/src/app/lib/creatorWeeklyReport/engine.test.ts
+++ b/src/app/lib/creatorWeeklyReport/engine.test.ts
@@ -1,0 +1,67 @@
+import { lastClosedWeek } from "@/app/lib/relatorio/weekWindow";
+import { buildCreatorWeeklyReport } from "./engine";
+
+function metric(params: {
+  date: string;
+  shares: number;
+  saved?: number;
+  views?: number;
+  subject?: string;
+  opening?: string;
+}) {
+  return {
+    instagramMediaId: params.date,
+    postDate: new Date(params.date),
+    updatedAt: new Date("2026-08-10T10:00:00Z"),
+    stats: {
+      shares: params.shares,
+      saved: params.saved ?? params.shares * 2,
+      views: params.views ?? params.shares * 100,
+    },
+    sceneElements: params.subject
+      ? {
+          version: "v1",
+          subjects: [params.subject],
+          openingLine: params.opening ?? null,
+          toneIds: [],
+          framingIds: [],
+        }
+      : null,
+  };
+}
+
+describe("buildCreatorWeeklyReport", () => {
+  const week = lastClosedWeek(new Date("2026-08-10T12:00:00Z"));
+
+  it("compara padrões com a mediana da própria conta e registra cobertura", () => {
+    const report = buildCreatorWeeklyReport({
+      week,
+      generatedAt: new Date("2026-08-10T12:00:00Z"),
+      metrics: [
+        metric({ date: "2026-08-03T09:00:00Z", shares: 10, subject: "Rotina real", opening: "Hoje deu tudo errado." }),
+        metric({ date: "2026-08-04T09:00:00Z", shares: 20, subject: "Rotina real", opening: "Eu não esperava por isso." }),
+        metric({ date: "2026-08-05T21:00:00Z", shares: 5, subject: "Autocuidado", opening: "Três dicas rápidas." }),
+        metric({ date: "2026-07-20T09:00:00Z", shares: 5 }),
+      ],
+    });
+
+    expect(report.weekKey).toBe("2026-W32");
+    expect(report.coverage).toEqual(expect.objectContaining({ posts90d: 4, postsWeek: 3, postsWithScene: 3 }));
+    expect(report.weeklyVideo?.shares).toBe(20);
+    expect(report.details.find((detail) => detail.id === "subjects")?.groups[0]?.items[0]).toEqual(
+      expect.objectContaining({ label: "Rotina real", nPosts: 2 }),
+    );
+  });
+
+  it("não inventa rankings visuais quando não existe leitura de cena", () => {
+    const report = buildCreatorWeeklyReport({
+      week,
+      metrics: [metric({ date: "2026-08-04T10:00:00Z", shares: 3 })],
+    });
+
+    expect(report.status).toBe("partial");
+    expect(report.coverage.postsWithScene).toBe(0);
+    expect(report.details.find((detail) => detail.id === "scene")?.groups).toEqual([]);
+    expect(report.details.find((detail) => detail.id === "openings")?.groups).toEqual([]);
+  });
+});

--- a/src/app/lib/creatorWeeklyReport/engine.ts
+++ b/src/app/lib/creatorWeeklyReport/engine.ts
@@ -1,0 +1,493 @@
+import {
+  canonicalFramingById,
+  canonicalPlaceById,
+  canonicalToneById,
+} from "@/app/lib/relatorio/mapRegistry";
+import {
+  gridPosition,
+  SLOT_LABELS,
+  WEEKDAY_LABELS_SHORT,
+  type WeekWindow,
+} from "@/app/lib/relatorio/weekWindow";
+import {
+  CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+  type CreatorWeeklyReportDetail,
+  type CreatorWeeklyReportEvidence,
+  type CreatorWeeklyReportPayload,
+  type CreatorWeeklyReportRankGroup,
+  type CreatorWeeklyReportRankItem,
+  type CreatorWeeklyReportVideo,
+} from "./types";
+
+type MetricStats = Record<string, unknown>;
+
+export interface CreatorWeeklyReportMetricInput {
+  instagramMediaId?: string | null;
+  postLink?: string | null;
+  postDate: Date | string;
+  description?: string | null;
+  thumbnailUrl?: string | null;
+  coverUrl?: string | null;
+  stats?: MetricStats | null;
+  updatedAt?: Date | string | null;
+  sceneElements?: {
+    subjects?: unknown;
+    subjectIds?: unknown;
+    objects?: unknown;
+    placeId?: unknown;
+    toneIds?: unknown;
+    framingIds?: unknown;
+    openingLine?: unknown;
+    version?: unknown;
+  } | null;
+}
+
+type PreparedMetric = Omit<CreatorWeeklyReportMetricInput, "postDate"> & {
+  postDate: Date;
+  views: number | null;
+  saved: number | null;
+  shares: number | null;
+};
+
+type ExtractedItem = { id: string; label: string };
+
+const MAX_RANK_ITEMS = 10;
+const EVIDENCE_K = 5;
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function metricValue(stats: MetricStats | null | undefined, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = finiteNumber(stats?.[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function median(values: Array<number | null>): number | null {
+  const usable = values
+    .filter((value): value is number => value !== null && Number.isFinite(value))
+    .sort((a, b) => a - b);
+  if (usable.length === 0) return null;
+  const middle = Math.floor(usable.length / 2);
+  return usable.length % 2 === 0
+    ? ((usable[middle - 1] as number) + (usable[middle] as number)) / 2
+    : (usable[middle] as number);
+}
+
+function indexAgainst(value: number | null, baseline: number | null): number | null {
+  if (value === null || baseline === null || baseline <= 0) return null;
+  return value / baseline;
+}
+
+function evidenceFor(nPosts: number): CreatorWeeklyReportEvidence {
+  const confidence = nPosts <= 0 ? 0 : nPosts / (nPosts + EVIDENCE_K);
+  if (confidence < 0.35) return "indicio";
+  if (confidence < 0.6) return "sinal";
+  return "tendencia";
+}
+
+function rankStrength(index: number | null, nPosts: number): number {
+  if (index === null || !Number.isFinite(index)) return 0;
+  return 1 + (index - 1) * (nPosts / (nPosts + EVIDENCE_K));
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim().replace(/\s+/g, " ");
+  return text || null;
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    const text = normalizeText(item);
+    if (!text) continue;
+    const key = text.toLocaleLowerCase("pt-BR");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(text);
+  }
+  return result;
+}
+
+function bestPerformanceIndex(
+  metrics: Pick<PreparedMetric, "shares" | "saved" | "views">,
+  baseline: { shares: number | null; saved: number | null; views: number | null },
+): number | null {
+  return (
+    indexAgainst(metrics.shares, baseline.shares) ??
+    indexAgainst(metrics.saved, baseline.saved) ??
+    indexAgainst(metrics.views, baseline.views)
+  );
+}
+
+function prepareMetrics(metrics: CreatorWeeklyReportMetricInput[]): PreparedMetric[] {
+  return metrics
+    .map((metric) => {
+      const postDate = metric.postDate instanceof Date ? metric.postDate : new Date(metric.postDate);
+      if (Number.isNaN(postDate.getTime())) return null;
+      return {
+        ...metric,
+        postDate,
+        views: metricValue(metric.stats, "views", "video_views", "impressions"),
+        saved: metricValue(metric.stats, "saved"),
+        shares: metricValue(metric.stats, "shares"),
+      } satisfies PreparedMetric;
+    })
+    .filter((metric): metric is PreparedMetric => metric !== null);
+}
+
+function buildRankGroup(params: {
+  id: string;
+  title: string;
+  subtitle: string;
+  metrics: PreparedMetric[];
+  weekStartsAt: Date;
+  baseline: { shares: number | null; saved: number | null; views: number | null };
+  extract: (metric: PreparedMetric) => ExtractedItem[];
+  minimumPosts?: number;
+}): CreatorWeeklyReportRankGroup {
+  const groups = new Map<string, { label: string; metrics: PreparedMetric[] }>();
+  for (const metric of params.metrics) {
+    for (const item of params.extract(metric)) {
+      const current = groups.get(item.id) ?? { label: item.label, metrics: [] };
+      current.metrics.push(metric);
+      groups.set(item.id, current);
+    }
+  }
+
+  const items: CreatorWeeklyReportRankItem[] = [];
+  for (const [id, group] of groups) {
+    if (group.metrics.length < (params.minimumPosts ?? 1)) continue;
+    const aggregate = {
+      shares: median(group.metrics.map((metric) => metric.shares)),
+      saved: median(group.metrics.map((metric) => metric.saved)),
+      views: median(group.metrics.map((metric) => metric.views)),
+    };
+    items.push({
+      id,
+      label: group.label,
+      nPosts: group.metrics.length,
+      index: bestPerformanceIndex(aggregate, params.baseline),
+      evidence: evidenceFor(group.metrics.length),
+      weeklyOccurrences: group.metrics.filter((metric) => metric.postDate >= params.weekStartsAt).length,
+    });
+  }
+
+  items.sort((a, b) => rankStrength(b.index, b.nPosts) - rankStrength(a.index, a.nPosts));
+
+  return {
+    id: params.id,
+    title: params.title,
+    subtitle: params.subtitle,
+    items: items.slice(0, MAX_RANK_ITEMS),
+  };
+}
+
+function buildTextExtremesGroup(params: {
+  id: string;
+  title: string;
+  subtitle: string;
+  metrics: PreparedMetric[];
+  weekStartsAt: Date;
+  baseline: { shares: number | null; saved: number | null; views: number | null };
+  extract: (metric: PreparedMetric) => string | null;
+  ascending?: boolean;
+}): CreatorWeeklyReportRankGroup {
+  const items = params.metrics
+    .map<CreatorWeeklyReportRankItem | null>((metric) => {
+      const label = params.extract(metric);
+      if (!label) return null;
+      return {
+        id: `${params.id}-${metric.instagramMediaId ?? metric.postDate.toISOString()}`,
+        label,
+        nPosts: 1,
+        index: bestPerformanceIndex(metric, params.baseline),
+        evidence: "indicio" as const,
+        weeklyOccurrences: metric.postDate >= params.weekStartsAt ? 1 : 0,
+      };
+    })
+    .filter((item): item is CreatorWeeklyReportRankItem => item !== null && item.index !== null)
+    .sort((a, b) => (params.ascending ? 1 : -1) * ((a.index ?? 0) - (b.index ?? 0)))
+    .slice(0, 6);
+
+  return { id: params.id, title: params.title, subtitle: params.subtitle, items };
+}
+
+function formatCompactNumber(value: number | null): string {
+  if (value === null) return "—";
+  return new Intl.NumberFormat("pt-BR", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function truncateDescription(value: string | null | undefined): string {
+  const text = normalizeText(value);
+  if (!text) return "O conteúdo que mais se destacou na semana.";
+  const sentence = text.split(/(?<=[.!?])\s+/)[0] ?? text;
+  return sentence.length > 150 ? `${sentence.slice(0, 147).trim()}…` : sentence;
+}
+
+function buildWeeklyVideo(
+  weekMetrics: PreparedMetric[],
+  baseline: { shares: number | null; saved: number | null; views: number | null },
+): CreatorWeeklyReportVideo | null {
+  const sorted = [...weekMetrics].sort((a, b) => {
+    const aIndex = bestPerformanceIndex(a, baseline);
+    const bIndex = bestPerformanceIndex(b, baseline);
+    if (aIndex !== null || bIndex !== null) return (bIndex ?? -1) - (aIndex ?? -1);
+    return (b.shares ?? 0) + (b.saved ?? 0) - ((a.shares ?? 0) + (a.saved ?? 0));
+  });
+  const metric = sorted[0];
+  if (!metric) return null;
+  const subjects = stringList(metric.sceneElements?.subjects);
+  const placeId = normalizeText(metric.sceneElements?.placeId);
+  return {
+    postId: metric.instagramMediaId ?? null,
+    postLink: normalizeText(metric.postLink),
+    thumbnailUrl: normalizeText(metric.thumbnailUrl) ?? normalizeText(metric.coverUrl),
+    publishedAt: metric.postDate.toISOString(),
+    description: truncateDescription(metric.description),
+    views: metric.views,
+    saved: metric.saved,
+    shares: metric.shares,
+    performanceIndex: bestPerformanceIndex(metric, baseline),
+    openingLine: normalizeText(metric.sceneElements?.openingLine),
+    subject: subjects[0] ?? null,
+    place: placeId ? canonicalPlaceById(placeId)?.label ?? null : null,
+  };
+}
+
+function detailSummary(groups: CreatorWeeklyReportRankGroup[], fallback: string): string {
+  const best = groups.flatMap((group) => group.items).find((item) => item.index !== null);
+  if (!best) return fallback;
+  const index = best.index ? `${best.index.toFixed(1).replace(".", ",")}×` : "acima do normal";
+  return `${best.label} chegou a ${index} do seu normal.`;
+}
+
+export function buildCreatorWeeklyReport(params: {
+  metrics: CreatorWeeklyReportMetricInput[];
+  week: WeekWindow;
+  generatedAt?: Date;
+}): CreatorWeeklyReportPayload {
+  const generatedAt = params.generatedAt ?? new Date();
+  const metrics = prepareMetrics(params.metrics).filter(
+    (metric) => metric.postDate >= params.week.windowStartsAt && metric.postDate <= params.week.endsAt,
+  );
+  const weekMetrics = metrics.filter(
+    (metric) => metric.postDate >= params.week.startsAt && metric.postDate <= params.week.endsAt,
+  );
+  const sceneMetrics = metrics.filter((metric) => Boolean(metric.sceneElements?.version));
+  const baseline = {
+    shares: median(metrics.map((metric) => metric.shares)),
+    saved: median(metrics.map((metric) => metric.saved)),
+    views: median(metrics.map((metric) => metric.views)),
+  };
+
+  const timingGroups = [
+    buildRankGroup({
+      id: "weekday",
+      title: "Ranking dos dias",
+      subtitle: "Comparado com o seu normal dos últimos 90 dias.",
+      metrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => {
+        const { dayOfWeek } = gridPosition(metric.postDate);
+        return [{ id: `day-${dayOfWeek}`, label: WEEKDAY_LABELS_SHORT[dayOfWeek] ?? "Dia" }];
+      },
+    }),
+    buildRankGroup({
+      id: "time-slot",
+      title: "Ranking dos horários",
+      subtitle: "Faixas de quatro horas no fuso de São Paulo.",
+      metrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => {
+        const { slot } = gridPosition(metric.postDate);
+        return [{ id: `slot-${slot}`, label: SLOT_LABELS[slot] ?? "Horário" }];
+      },
+    }),
+  ];
+
+  const sceneGroups = [
+    buildRankGroup({
+      id: "place",
+      title: "Onde você grava",
+      subtitle: "Cenários identificados nos seus vídeos.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => {
+        const id = normalizeText(metric.sceneElements?.placeId);
+        const label = id ? canonicalPlaceById(id)?.label : null;
+        return id && label ? [{ id, label }] : [];
+      },
+    }),
+    buildRankGroup({
+      id: "tone",
+      title: "Seu jeito de falar",
+      subtitle: "Tons que mais se repetem em cena.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => stringList(metric.sceneElements?.toneIds)
+        .map((id) => ({ id, label: canonicalToneById(id)?.label ?? id })),
+    }),
+    buildRankGroup({
+      id: "framing",
+      title: "Como a câmera te mostra",
+      subtitle: "Enquadramentos usados nos últimos 90 dias.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => stringList(metric.sceneElements?.framingIds)
+        .map((id) => ({ id, label: canonicalFramingById(id)?.label ?? id })),
+    }),
+  ].filter((group) => group.items.length > 0);
+
+  const subjectGroups = [
+    buildRankGroup({
+      id: "subjects-repeated",
+      title: "Assuntos que você repetiu",
+      subtitle: "Temas específicos que apareceram em mais de um vídeo.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      minimumPosts: 2,
+      extract: (metric) => stringList(metric.sceneElements?.subjects)
+        .map((label) => ({ id: label.toLocaleLowerCase("pt-BR"), label })),
+    }),
+    buildTextExtremesGroup({
+      id: "subjects-best",
+      title: "Assuntos mais fortes",
+      subtitle: "O tema exato de cada vídeo que mais rendeu.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => stringList(metric.sceneElements?.subjects).join(" · ") || null,
+    }),
+  ].filter((group) => group.items.length > 0);
+
+  const openingGroups = [
+    buildTextExtremesGroup({
+      id: "openings-best",
+      title: "Aberturas mais fortes",
+      subtitle: "As primeiras frases dos vídeos que mais renderam.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      extract: (metric) => normalizeText(metric.sceneElements?.openingLine),
+    }),
+    buildTextExtremesGroup({
+      id: "openings-weak",
+      title: "Aberturas que renderam menos",
+      subtitle: "Use como contraste, não como regra definitiva.",
+      metrics: sceneMetrics,
+      weekStartsAt: params.week.startsAt,
+      baseline,
+      ascending: true,
+      extract: (metric) => normalizeText(metric.sceneElements?.openingLine),
+    }),
+  ].filter((group) => group.items.length > 0);
+
+  const scenePercent = metrics.length > 0 ? Math.round((sceneMetrics.length / metrics.length) * 100) : 0;
+  const coverageLabel = `${sceneMetrics.length} de ${metrics.length} posts com leitura visual`;
+  const details: CreatorWeeklyReportDetail[] = [
+    {
+      id: "timing",
+      title: "Dia e horário",
+      subtitle: "Quando seus posts rendem acima ou abaixo do seu próprio normal.",
+      summary: detailSummary(timingGroups, "Ainda não há posts suficientes para comparar dias e horários."),
+      interpretation: weekMetrics.length > 0
+        ? `Você publicou ${weekMetrics.length} ${weekMetrics.length === 1 ? "vez" : "vezes"} na semana encerrada.`
+        : "Você não publicou na semana encerrada; o ranking continua usando os últimos 90 dias.",
+      coverageLabel: `${metrics.length} posts nos últimos 90 dias`,
+      groups: timingGroups.filter((group) => group.items.length > 0),
+    },
+    {
+      id: "scene",
+      title: "Cena, tom e câmera",
+      subtitle: "Onde gravar, como falar e como se enquadrar.",
+      summary: detailSummary(sceneGroups, "A leitura visual ainda não tem cobertura suficiente."),
+      interpretation: sceneGroups.length > 0
+        ? "Compare resultado e amostra antes de transformar um achado em regra."
+        : "Esta seção aparece assim que os vídeos publicados recebem leitura visual.",
+      coverageLabel,
+      groups: sceneGroups,
+    },
+    {
+      id: "subjects",
+      title: "Assuntos",
+      subtitle: "O que você fala e quais temas a audiência mais compartilha.",
+      summary: detailSummary(subjectGroups, "Ainda não há assuntos classificados o bastante para comparar."),
+      interpretation: subjectGroups.length > 0
+        ? "Assuntos específicos mostram melhor a demanda do que categorias genéricas."
+        : "Os assuntos entram aqui depois da leitura visual dos vídeos.",
+      coverageLabel,
+      groups: subjectGroups,
+    },
+    {
+      id: "openings",
+      title: "Frases de abertura",
+      subtitle: "As primeiras frases que mais e menos renderam.",
+      summary: detailSummary(openingGroups, "Ainda não há aberturas classificadas para comparar."),
+      interpretation: openingGroups.length > 0
+        ? "Uma frase é um indício; procure construções que se repetem entre as melhores."
+        : "As frases entram aqui quando a abertura falada ou escrita é identificada.",
+      coverageLabel,
+      groups: openingGroups,
+    },
+  ];
+
+  const observedSubjects = Array.from(
+    new Set(sceneMetrics.flatMap((metric) => stringList(metric.sceneElements?.subjects))),
+  ).slice(0, 12);
+  const weeklySaved = weekMetrics.reduce((total, metric) => total + (metric.saved ?? 0), 0);
+  const weeklyShares = weekMetrics.reduce((total, metric) => total + (metric.shares ?? 0), 0);
+  const newestMetric = [...metrics].sort((a, b) => {
+    const aUpdated = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+    const bUpdated = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+    return bUpdated - aUpdated;
+  })[0];
+
+  return {
+    schemaVersion: CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+    weekKey: params.week.weekKey,
+    period: {
+      startsAt: params.week.startsAt.toISOString(),
+      endsAt: params.week.endsAt.toISOString(),
+      rangeLabel: params.week.rangeLabel,
+    },
+    status: metrics.length > 0 && scenePercent >= 40 ? "ready" : "partial",
+    generatedAt: generatedAt.toISOString(),
+    sourceMetricsUpdatedAt: newestMetric?.updatedAt
+      ? new Date(newestMetric.updatedAt).toISOString()
+      : null,
+    coverage: {
+      posts90d: metrics.length,
+      postsWeek: weekMetrics.length,
+      postsWithScene: sceneMetrics.length,
+      scenePercent,
+    },
+    overview: {
+      summary: weekMetrics.length === 0
+        ? "Você não publicou na semana encerrada. Seus padrões de 90 dias continuam disponíveis."
+        : weekMetrics.length === 1
+          ? "Você publicou um conteúdo na semana. Veja o que ele confirma — e o que ainda é só indício."
+          : `Você publicou ${weekMetrics.length} conteúdos na semana. O relatório compara cada padrão com o seu próprio normal.`,
+      numbers: [
+        { value: String(weekMetrics.length), label: weekMetrics.length === 1 ? "post" : "posts" },
+        { value: formatCompactNumber(weeklySaved), label: "salvamentos" },
+        { value: formatCompactNumber(weeklyShares), label: "compartilhamentos" },
+      ],
+      observedSubjects,
+    },
+    weeklyVideo: buildWeeklyVideo(weekMetrics, baseline),
+    details,
+  };
+}

--- a/src/app/lib/creatorWeeklyReport/service.ts
+++ b/src/app/lib/creatorWeeklyReport/service.ts
@@ -1,0 +1,112 @@
+import mongoose from "mongoose";
+import { connectToDatabase } from "@/app/lib/mongoose";
+import Metric from "@/app/models/Metric";
+import CreatorWeeklyReport from "@/app/models/CreatorWeeklyReport";
+import { lastClosedWeek, type WeekWindow } from "@/app/lib/relatorio/weekWindow";
+import { buildCreatorWeeklyReport, type CreatorWeeklyReportMetricInput } from "./engine";
+import {
+  CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+  type CreatorWeeklyReportDocumentSnapshot,
+  type CreatorWeeklyReportPayload,
+} from "./types";
+
+function assertUserId(userId: string) {
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    throw new Error("creator_weekly_report_invalid_user_id");
+  }
+}
+
+function serializeReport(document: any): CreatorWeeklyReportDocumentSnapshot {
+  return {
+    id: String(document._id),
+    userId: String(document.userId),
+    report: document.payload as CreatorWeeklyReportPayload,
+    createdAt: new Date(document.createdAt).toISOString(),
+    updatedAt: new Date(document.updatedAt).toISOString(),
+  };
+}
+
+export async function getLatestCreatorWeeklyReport(
+  userId: string,
+): Promise<CreatorWeeklyReportDocumentSnapshot | null> {
+  assertUserId(userId);
+  await connectToDatabase();
+  const document = await CreatorWeeklyReport.findOne({ userId })
+    .sort({ periodEndsAt: -1 })
+    .lean();
+  return document ? serializeReport(document) : null;
+}
+
+export async function generateCreatorWeeklyReport(params: {
+  userId: string;
+  week?: WeekWindow;
+  force?: boolean;
+  now?: Date;
+}): Promise<CreatorWeeklyReportDocumentSnapshot> {
+  assertUserId(params.userId);
+  await connectToDatabase();
+
+  const now = params.now ?? new Date();
+  const week = params.week ?? lastClosedWeek(now);
+  const userObjectId = new mongoose.Types.ObjectId(params.userId);
+  const metrics = await Metric.find({
+    user: userObjectId,
+    postDate: { $gte: week.windowStartsAt, $lte: week.endsAt },
+  })
+    .select(
+      "instagramMediaId postLink postDate description thumbnailUrl coverUrl stats sceneElements updatedAt",
+    )
+    .sort({ postDate: 1 })
+    .lean<CreatorWeeklyReportMetricInput[]>();
+
+  const newestMetricUpdatedAt = metrics.reduce<Date | null>((latest, metric) => {
+    if (!metric.updatedAt) return latest;
+    const updatedAt = new Date(metric.updatedAt);
+    return !latest || updatedAt > latest ? updatedAt : latest;
+  }, null);
+
+  if (!params.force) {
+    const existing = await CreatorWeeklyReport.findOne({
+      userId: userObjectId,
+      weekKey: week.weekKey,
+      schemaVersion: CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+      status: { $in: ["ready", "partial"] },
+    }).lean();
+    const existingSource = existing?.sourceMetricsUpdatedAt
+      ? new Date(existing.sourceMetricsUpdatedAt).getTime()
+      : null;
+    const currentSource = newestMetricUpdatedAt?.getTime() ?? null;
+    if (existing && existingSource === currentSource) {
+      return serializeReport(existing);
+    }
+  }
+
+  const payload = buildCreatorWeeklyReport({ metrics, week, generatedAt: now });
+  const document = await CreatorWeeklyReport.findOneAndUpdate(
+    { userId: userObjectId, weekKey: week.weekKey },
+    {
+      $set: {
+        status: payload.status,
+        schemaVersion: CREATOR_WEEKLY_REPORT_SCHEMA_VERSION,
+        periodStartsAt: week.startsAt,
+        periodEndsAt: week.endsAt,
+        generatedAt: now,
+        sourceMetricsUpdatedAt: newestMetricUpdatedAt,
+        coverage: payload.coverage,
+        payload,
+        safeErrorCode: null,
+      },
+      $inc: { attempts: 1 },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  ).lean();
+
+  if (!document) throw new Error("creator_weekly_report_write_failed");
+  return serializeReport(document);
+}
+
+export async function getOrGenerateCreatorWeeklyReport(
+  userId: string,
+): Promise<CreatorWeeklyReportDocumentSnapshot> {
+  return generateCreatorWeeklyReport({ userId });
+}

--- a/src/app/lib/creatorWeeklyReport/types.ts
+++ b/src/app/lib/creatorWeeklyReport/types.ts
@@ -1,0 +1,97 @@
+export const CREATOR_WEEKLY_REPORT_SCHEMA_VERSION = 1;
+
+export type CreatorWeeklyReportStatus =
+  | "queued"
+  | "generating"
+  | "ready"
+  | "partial"
+  | "failed";
+
+export type CreatorWeeklyReportEvidence = "indicio" | "sinal" | "tendencia";
+
+export type CreatorWeeklyReportDetailId =
+  | "timing"
+  | "scene"
+  | "subjects"
+  | "openings";
+
+export interface CreatorWeeklyReportRankItem {
+  id: string;
+  label: string;
+  nPosts: number;
+  index: number | null;
+  evidence: CreatorWeeklyReportEvidence;
+  weeklyOccurrences: number;
+}
+
+export interface CreatorWeeklyReportRankGroup {
+  id: string;
+  title: string;
+  subtitle: string;
+  items: CreatorWeeklyReportRankItem[];
+}
+
+export interface CreatorWeeklyReportDetail {
+  id: CreatorWeeklyReportDetailId;
+  title: string;
+  subtitle: string;
+  summary: string;
+  interpretation: string | null;
+  coverageLabel: string;
+  groups: CreatorWeeklyReportRankGroup[];
+}
+
+export interface CreatorWeeklyReportVideo {
+  postId: string | null;
+  postLink: string | null;
+  thumbnailUrl: string | null;
+  publishedAt: string;
+  description: string;
+  views: number | null;
+  saved: number | null;
+  shares: number | null;
+  performanceIndex: number | null;
+  openingLine: string | null;
+  subject: string | null;
+  place: string | null;
+}
+
+export interface CreatorWeeklyReportPayload {
+  schemaVersion: number;
+  weekKey: string;
+  period: {
+    startsAt: string;
+    endsAt: string;
+    rangeLabel: string;
+  };
+  status: CreatorWeeklyReportStatus;
+  generatedAt: string;
+  sourceMetricsUpdatedAt: string | null;
+  coverage: {
+    posts90d: number;
+    postsWeek: number;
+    postsWithScene: number;
+    scenePercent: number;
+  };
+  overview: {
+    summary: string;
+    numbers: Array<{ value: string; label: string }>;
+    observedSubjects: string[];
+  };
+  weeklyVideo: CreatorWeeklyReportVideo | null;
+  details: CreatorWeeklyReportDetail[];
+}
+
+export interface CreatorWeeklyReportDocumentSnapshot {
+  id: string;
+  userId: string;
+  report: CreatorWeeklyReportPayload;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function isCreatorWeeklyReportReady(
+  report: CreatorWeeklyReportPayload | null | undefined,
+): report is CreatorWeeklyReportPayload {
+  return report?.status === "ready" || report?.status === "partial";
+}

--- a/src/app/models/CreatorWeeklyReport.ts
+++ b/src/app/models/CreatorWeeklyReport.ts
@@ -1,0 +1,63 @@
+import mongoose, { Document, Model, Schema, Types } from "mongoose";
+import type {
+  CreatorWeeklyReportPayload,
+  CreatorWeeklyReportStatus,
+} from "@/app/lib/creatorWeeklyReport/types";
+
+export interface ICreatorWeeklyReport extends Document {
+  userId: Types.ObjectId;
+  weekKey: string;
+  status: CreatorWeeklyReportStatus;
+  schemaVersion: number;
+  periodStartsAt: Date;
+  periodEndsAt: Date;
+  generatedAt: Date;
+  sourceMetricsUpdatedAt: Date | null;
+  coverage: CreatorWeeklyReportPayload["coverage"];
+  payload: CreatorWeeklyReportPayload;
+  safeErrorCode: string | null;
+  attempts: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const creatorWeeklyReportSchema = new Schema<ICreatorWeeklyReport>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    weekKey: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ["queued", "generating", "ready", "partial", "failed"],
+      required: true,
+      default: "queued",
+    },
+    schemaVersion: { type: Number, required: true },
+    periodStartsAt: { type: Date, required: true },
+    periodEndsAt: { type: Date, required: true },
+    generatedAt: { type: Date, required: true },
+    sourceMetricsUpdatedAt: { type: Date, default: null },
+    coverage: { type: Schema.Types.Mixed, required: true },
+    payload: { type: Schema.Types.Mixed, required: true },
+    safeErrorCode: { type: String, default: null },
+    attempts: { type: Number, default: 0 },
+  },
+  {
+    timestamps: true,
+    collection: "creatorweeklyreports",
+  },
+);
+
+creatorWeeklyReportSchema.index({ userId: 1, weekKey: 1 }, { unique: true });
+creatorWeeklyReportSchema.index({ userId: 1, periodEndsAt: -1 });
+creatorWeeklyReportSchema.index({ status: 1, updatedAt: 1 });
+
+const CreatorWeeklyReport: Model<ICreatorWeeklyReport> =
+  (mongoose.models.CreatorWeeklyReport as Model<ICreatorWeeklyReport>) ||
+  mongoose.model<ICreatorWeeklyReport>("CreatorWeeklyReport", creatorWeeklyReportSchema);
+
+export default CreatorWeeklyReport;

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -373,6 +373,10 @@ export interface IUser extends Document {
    */
   pendingCheckoutSessionId?: string | null;
   pendingCheckoutExpiresAt?: Date | null;
+  /** CPF/CNPJ do assinante, só dígitos. Obrigatório para emitir NFS-e. */
+  taxId?: string | null;
+  taxIdType?: 'cpf' | 'cnpj' | null;
+  taxIdUpdatedAt?: Date | null;
   planExpiresAt?: Date | null;
   autoRenewConsentAt?: Date | null;
   proTrialStatus?: ProTrialState;
@@ -646,6 +650,9 @@ const userSchema = new Schema<IUser>(
     lastSubscriptionEventId: { type: String, default: null },
     pendingCheckoutSessionId: { type: String, default: null },
     pendingCheckoutExpiresAt: { type: Date, default: null },
+    taxId: { type: String, default: null },
+    taxIdType: { type: String, enum: ['cpf', 'cnpj', null], default: null },
+    taxIdUpdatedAt: { type: Date, default: null },
 
     inferredExpertiseLevel: {
       type: String,

--- a/src/design-system/tokens.css
+++ b/src/design-system/tokens.css
@@ -160,6 +160,220 @@
   padding-block: 1rem;
 }
 
+/*
+ * Notebook workspace
+ * ------------------
+ * A monochrome, document-first layer for the mobile creator experience. It is
+ * deliberately scoped so the rest of the product keeps the existing brand
+ * system. Hierarchy comes from type, spacing and dividers; surfaces are the
+ * exception and are reserved for media or overlays.
+ */
+.ds-notebook {
+  /* Vermelho da landing pública (#e90f4f). A variante forte existe para texto
+     pequeno, onde o tom cheio não alcança contraste AA. */
+  --ds-color-brand: #e90f4f;
+  --ds-color-brand-strong: #c70a42;
+  --ds-color-brand-soft: #fdecf1;
+  /* Escala neutra própria, de viés quente — parente do creme do deck da
+     reunião. Substitui os cinzas frios usados na primeira versão. */
+  --ds-color-ink: #17140f;
+  --ds-color-paper: #ffffff;
+  --ds-color-surface: #ffffff;
+  --ds-color-neutral: #efe9e0;
+  --ds-color-text: #17140f;
+  --ds-color-text-secondary: #423b33;
+  --ds-color-text-muted: #6b6157; /* 5.9:1 no branco — o #787774 anterior ficava em 4.5 */
+  --ds-color-line: #e7e1d8;
+  --ds-color-line-strong: #d6cec2;
+  --ds-shadow-raised: none;
+  --ds-shadow-floating: none;
+  /* A página é mais escura que o cartão de propósito: cartão só existe se tiver
+     sobre o que repousar. Branco sobre quase-branco é o pior dos dois mundos. */
+  background: #f1ebe1;
+}
+
+.d2c-mobile-app.ds-notebook {
+  background: #f1ebe1;
+}
+
+/* A fonte de display já cobre h1/h2/h3 via `.d2c-mobile-app`; a narrativa do
+   mapa é um blockquote e ficava de fora, saindo na fonte de corpo. */
+.ds-notebook :where(blockquote) {
+  font-family: var(--ds-font-display);
+}
+
+.ds-notebook-page {
+  width: 100%;
+  max-width: 32rem;
+  margin-inline: auto;
+  /* O primeiro elemento é um cartão com borda visível, não texto solto: encostar
+     a 12px do notch aperta. 16px dá o respiro que a aresta do cartão pede. */
+  padding: calc(env(safe-area-inset-top, 0px) + 1rem) 1.25rem 2rem;
+}
+
+/* Dois níveis de separação, sem ambiguidade: o cartão separa assuntos
+   diferentes; a linha fina (.ds-notebook-divided) separa irmãos dentro do
+   mesmo assunto. Antes os dois usavam a mesma linha e o leitor não conseguia
+   distinguir fronteira de divisão. */
+.ds-notebook-section {
+  margin-bottom: 0.75rem;
+  border: 0;
+  border-radius: 1rem;
+  background: var(--ds-color-surface);
+  padding: 1.25rem;
+}
+
+.ds-notebook-section--first {
+  padding-top: 1.25rem;
+}
+
+/* Irmãos dentro de um bloco. */
+.ds-notebook-divided > * + * {
+  border-top: 1px solid var(--ds-color-line);
+}
+
+.ds-notebook-label {
+  color: var(--ds-color-text-secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.ds-notebook-row {
+  display: grid;
+  min-height: 3.5rem;
+  width: 100%;
+  grid-template-columns: 1.5rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0.7rem 0.25rem;
+  color: var(--ds-color-ink);
+  text-align: left;
+  transition: background var(--ds-motion-fast) var(--ds-ease-standard);
+}
+
+.ds-notebook-row + .ds-notebook-row { margin-top: 0.15rem; }
+.ds-notebook-row:active { background: var(--ds-color-neutral); }
+
+.ds-notebook-tag {
+  display: inline-flex;
+  min-height: 1.65rem;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 0.375rem;
+  background: var(--ds-color-neutral);
+  color: var(--ds-color-text-secondary);
+  padding: 0.3rem 0.55rem;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  line-height: 1.1;
+}
+
+.ds-notebook-action {
+  display: flex;
+  min-height: 2.75rem;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--ds-color-ink);
+  padding: 0.55rem 0;
+  font-size: 0.82rem;
+  font-weight: 650;
+  text-align: left;
+  transition: background var(--ds-motion-fast) var(--ds-ease-standard), padding var(--ds-motion-fast) var(--ds-ease-standard);
+}
+
+.ds-notebook-action:active {
+  background: var(--ds-color-neutral);
+  padding-inline: 0.5rem;
+}
+
+.ds-notebook-media {
+  overflow: hidden;
+  border: 1px solid var(--ds-color-line);
+  border-radius: 0.625rem;
+  background: var(--ds-color-surface);
+}
+
+.ds-notebook-note {
+  border-left: 2px solid var(--ds-color-line-strong);
+  padding-left: 0.9rem;
+  color: var(--ds-color-text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+/* Flatten legacy panels that still render inside this scoped experience. */
+.ds-notebook .ds-editorial-panel {
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.ds-notebook .ds-eyebrow {
+  color: var(--ds-color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.ds-notebook .ds-chip {
+  min-height: 1.65rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background: var(--ds-color-neutral);
+  color: var(--ds-color-text-secondary);
+  padding: 0.3rem 0.55rem;
+  font-weight: 550;
+}
+
+.ds-notebook .ds-chip--active {
+  border: 0;
+  background: var(--ds-color-line-strong);
+  color: var(--ds-color-ink);
+}
+
+.ds-notebook .ds-button {
+  min-height: 2.75rem;
+  border-radius: 0.5rem;
+  box-shadow: none;
+}
+
+/* A ação principal é um dos quatro únicos lugares com cor na tela. */
+.ds-notebook .ds-button--primary {
+  background: var(--ds-color-brand);
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.ds-notebook .ds-button--secondary {
+  background: var(--ds-color-ink);
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.ds-notebook .ds-button--quiet {
+  background: var(--ds-color-neutral);
+  color: var(--ds-color-ink);
+}
+
+.ds-notebook .ds-icon-button {
+  border-radius: 0.5rem;
+  background: transparent;
+}
+
+.ds-notebook .ds-icon-button:active { background: var(--ds-color-neutral); }
+
 .ds-chip {
   display: inline-flex;
   min-height: 2rem;

--- a/src/hooks/billing/useSubscription.test.ts
+++ b/src/hooks/billing/useSubscription.test.ts
@@ -1,0 +1,25 @@
+import { subscriptionFallbackFromPlanStatus } from "./useSubscription";
+
+describe("subscriptionFallbackFromPlanStatus", () => {
+  it("keeps manual and internal Pro access coherent without Stripe billing", () => {
+    expect(subscriptionFallbackFromPlanStatus({
+      ok: true,
+      status: "active",
+      planExpiresAt: null,
+      cancelAtPeriodEnd: false,
+      extras: { normalizedStatus: "active", hasPremiumAccess: true },
+    })).toMatchObject({
+      planName: "Pro",
+      status: "active",
+      billingManagedByStripe: false,
+    });
+  });
+
+  it("does not invent a subscription for a Free account", () => {
+    expect(subscriptionFallbackFromPlanStatus({
+      ok: true,
+      status: "inactive",
+      extras: { normalizedStatus: "inactive", hasPremiumAccess: false },
+    })).toBeNull();
+  });
+});

--- a/src/hooks/billing/useSubscription.ts
+++ b/src/hooks/billing/useSubscription.ts
@@ -11,14 +11,52 @@ export type SubResp = {
   paymentMethodLast4?: string | null;
   defaultPaymentMethodBrand?: string | null;
   trialEnd?: string | null;
+  /** false para acessos Pro internos/manuais sem assinatura recorrente na Stripe. */
+  billingManagedByStripe?: boolean;
 };
 
-const fetcher = (u: string) =>
-  fetch(u, { cache: 'no-store' }).then(async r => {
-    if (r.status === 204) return null;
-    if (!r.ok) throw new Error('fail');
-    return r.json();
-  });
+export function subscriptionFallbackFromPlanStatus(payload: any): SubResp | null {
+  if (!payload?.ok) return null;
+  const normalizedStatus = String(payload?.extras?.normalizedStatus ?? payload?.status ?? "").toLowerCase();
+  const hasPremiumAccess = Boolean(payload?.extras?.hasPremiumAccess);
+  if (!hasPremiumAccess) return null;
+
+  const status =
+    normalizedStatus === "non_renewing"
+      ? "non_renewing"
+      : normalizedStatus === "active" || normalizedStatus === "trialing"
+        ? normalizedStatus
+        : "active";
+
+  return {
+    planName: "Pro",
+    currency: "BRL",
+    nextInvoiceAmountCents: 0,
+    nextInvoiceDate: payload?.planExpiresAt ?? null,
+    currentPeriodEnd: payload?.planExpiresAt ?? null,
+    status,
+    cancelAtPeriodEnd: Boolean(payload?.cancelAtPeriodEnd),
+    paymentMethodLast4: null,
+    defaultPaymentMethodBrand: null,
+    trialEnd: payload?.trial?.expiresAt ?? null,
+    billingManagedByStripe: false,
+  };
+}
+
+async function fetchPlanStatusFallback(): Promise<SubResp | null> {
+  const response = await fetch("/api/plan/status", { cache: "no-store", credentials: "include" });
+  if (!response.ok) return null;
+  return subscriptionFallbackFromPlanStatus(await response.json().catch(() => null));
+}
+
+const fetcher = async (u: string): Promise<SubResp | null> => {
+  const response = await fetch(u, { cache: "no-store", credentials: "include" });
+  if (response.status === 204 || response.status === 404) {
+    return fetchPlanStatusFallback();
+  }
+  if (!response.ok) throw new Error("fail");
+  return { ...(await response.json()), billingManagedByStripe: true } as SubResp;
+};
 
 export function useSubscription() {
   const { data, error, isLoading, mutate } = useSWR<SubResp | null>(

--- a/src/scripts/scheduleCrons.ts
+++ b/src/scripts/scheduleCrons.ts
@@ -120,6 +120,13 @@ const CRONS = [
     method: 'POST',
     body: '[RELATORIO_SEMANAL] Congelar o snapshot da semana por território',
   },
+  {
+    id: 'creator-weekly-reports',
+    destination: 'https://data2content.ai/api/cron/creator-weekly-reports',
+    cron: '15 4 * * 1', // Segunda 01:15 BRT — após o fechamento das métricas.
+    method: 'POST',
+    body: '[CREATOR_WEEKLY_REPORT] Materializar os relatórios individuais da semana',
+  },
 ] as const;
 
 async function createCrons() {
@@ -131,9 +138,43 @@ async function createCrons() {
     throw new Error('Missing ADMIN_TOKEN environment variable.');
   }
 
-  for (const task of CRONS) {
-    console.log(`Creating QStash schedule: ${task.id}`);
+  const requestedIds = new Set(
+    process.argv
+      .slice(2)
+      .flatMap((value) => value.split(','))
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  const unknownIds = [...requestedIds].filter(
+    (id) => !CRONS.some((task) => task.id === id),
+  );
+  if (unknownIds.length > 0) {
+    throw new Error(`Unknown schedule id(s): ${unknownIds.join(', ')}`);
+  }
+
+  const selectedCrons = requestedIds.size > 0
+    ? CRONS.filter((task) => requestedIds.has(task.id))
+    : CRONS;
+  const existingSchedules = await qstash.schedules.list();
+  const duplicateDestinations: string[] = [];
+
+  for (const task of selectedCrons) {
+    const existingForDestination = existingSchedules.filter(
+      (schedule) => schedule.destination === task.destination,
+    );
+    if (existingForDestination.length > 1) {
+      duplicateDestinations.push(task.destination);
+      console.error(
+        `Skipping ${task.id}: ${existingForDestination.length} schedules already target ${task.destination}. ` +
+        'Deduplicate them explicitly before reconciling this destination.',
+      );
+      continue;
+    }
+
+    const scheduleId = existingForDestination[0]?.scheduleId ?? task.id;
+    console.log(`${existingForDestination.length === 0 ? 'Creating' : 'Updating'} QStash schedule: ${task.id}`);
     await qstash.schedules.create({
+      scheduleId,
       destination: task.destination,
       cron: task.cron,
       body: task.body,
@@ -145,7 +186,13 @@ async function createCrons() {
     });
   }
 
-  console.log('✅ All scheduled jobs created successfully.');
+  if (duplicateDestinations.length > 0) {
+    throw new Error(
+      `Duplicate QStash destinations require manual cleanup: ${duplicateDestinations.join(', ')}`,
+    );
+  }
+
+  console.log(`✅ ${selectedCrons.length} scheduled job(s) reconciled successfully.`);
 }
 
 createCrons().catch((error) => {


### PR DESCRIPTION
## What changed

- launches the new mobile weekly profile for Free, Pro, admin and demo states
- adds the Perfil / Analisar conteúdo / Collabs tab experience
- materializes weekly creator reports through API, cron and QStash worker
- connects Instagram refresh/connection to report generation
- fixes Stripe checkout return URLs and subscription state reconciliation
- adds CPF/CNPJ collection and Stripe tax ID synchronization
- makes QStash schedule reconciliation idempotent and selectable by schedule id

## Why

The mobile prototype needed to become a complete production flow, with navigation, entitlements, billing, Instagram data and weekly reports connected end to end.

## Validation

- 169 focused tests passed
- ESLint passed
- TypeScript passed
- mobile design-system audit passed
- Next.js production build passed
- mobile browser QA completed for Pro and Free profiles at 390×844
- live Stripe prices and webhook configuration verified read-only

Generated reports, slide decks, videos and local Playwright captures were intentionally excluded from this PR.