### PR TITLE
Biblioteca de gravações no celular + tela de processamento da análise

### DIFF
--- a/src/app/(dashboard)/reunioes-gravadas/page.tsx
+++ b/src/app/(dashboard)/reunioes-gravadas/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { Film } from "lucide-react";
+import Link from "next/link";
+import { ArrowLeft, Film } from "lucide-react";
 
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import RecordedMeetingsLibrary from "@/app/dashboard/recorded-meetings/RecordedMeetingsLibrary";
@@ -11,6 +12,7 @@ import {
   type RecordedMeetingsResult,
 } from "@/app/lib/community/recordedMeetingsService";
 import { RECORDED_MEETINGS_ROUTE } from "@/constants/routes";
+import { MOBILE_PROFILE_ROUTE } from "@/app/dashboard/boards/videoUpload/mobileStrategicProfileRoutes";
 
 export const dynamic = "force-dynamic";
 
@@ -44,21 +46,37 @@ export default async function RecordedMeetingsPage() {
   }
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto bg-[#f7f7f5] text-zinc-950">
-      <div className="mx-auto w-full max-w-[1480px] px-4 pb-16 pt-6 sm:px-6 sm:pt-8 lg:px-10 lg:pb-10">
-        <header className="mb-8 flex flex-col justify-between gap-5 border-b border-zinc-200 pb-7 sm:flex-row sm:items-end">
+    // Fundo bege quente e vermelho da marca: vindo do Perfil, a pessoa continua
+    // dentro do mesmo produto. Antes era cinza frio com destaques em roxo.
+    <div
+      className="h-full min-h-0 overflow-y-auto bg-[#f1ebe1] text-[#17140f]"
+      style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
+    >
+      <div className="mx-auto w-full max-w-[1480px] px-4 pb-16 pt-4 sm:px-6 sm:pt-8 lg:px-10 lg:pb-10">
+        {/* Esta rota vive fora da casca do app mobile, que tem barra de abas.
+            Sem este link, quem chega do Perfil fica sem caminho de volta. */}
+        <Link
+          href={MOBILE_PROFILE_ROUTE}
+          className="-ml-1 inline-flex min-h-11 items-center gap-1.5 rounded-lg px-1 text-sm font-semibold text-[#6b6157] transition active:bg-black/5 hover:text-[#17140f]"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Voltar ao perfil
+        </Link>
+
+        <header className="mb-6 mt-3 flex flex-col justify-between gap-4 border-b border-[#e7e1d8] pb-5 sm:mb-8 sm:flex-row sm:items-end sm:pb-7">
           <div>
-            <p className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.2em] text-violet-700">
+            <p className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.18em] text-[#c70a42]">
               <Film className="h-3.5 w-3.5" /> Arquivo dos assinantes
             </p>
-            <h1 className="mt-3 text-3xl font-bold tracking-[-0.04em] sm:text-5xl">
+            <h1 className="mt-2 text-[2rem] font-bold tracking-[-0.04em] sm:mt-3 sm:text-5xl">
               Reuniões gravadas
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-600 sm:text-base">
+            {/* O subtítulo explicativo custava 170px no celular para dizer o que
+                a pessoa acabou de ler no botão. Some no telefone. */}
+            <p className="mt-3 hidden max-w-2xl text-sm leading-6 text-[#423b33] sm:block sm:text-base">
               Reveja análises, referências e direcionamentos das reuniões semanais.
             </p>
           </div>
-          <span className="w-fit rounded-full border border-violet-200 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-800">
+          <span className="hidden w-fit rounded-full border border-[#e7e1d8] bg-white px-3 py-1.5 text-xs font-semibold text-[#423b33] sm:inline-flex">
             Acesso D2C Pro
           </span>
         </header>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/AnalysisProcessingExperience.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/AnalysisProcessingExperience.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ANALYSIS_PROGRESS_STAGES, useAnalysisProgress } from "./useAnalysisProgress";
+
+export function AnalysisProcessingExperience({
+  thumbnailSrc,
+  active,
+  complete,
+  resetKey,
+  errorMessage,
+}: {
+  thumbnailSrc?: string | null;
+  active: boolean;
+  complete: boolean;
+  resetKey?: number | string;
+  errorMessage?: string | null;
+}) {
+  const reduceMotion = useReducedMotion();
+  const { progress, stageIndex } = useAnalysisProgress({ active, complete, resetKey });
+  const currentStage = ANALYSIS_PROGRESS_STAGES[stageIndex] ?? ANALYSIS_PROGRESS_STAGES[0]!;
+  const completedStages = ANALYSIS_PROGRESS_STAGES
+    .slice(0, Math.min(stageIndex, ANALYSIS_PROGRESS_STAGES.length - 1))
+    .slice(-3);
+  const completed = progress >= 100;
+
+  return (
+    <div className="pb-1">
+      <motion.figure
+        layoutId={thumbnailSrc ? "content-analysis-thumbnail" : undefined}
+        transition={{ duration: reduceMotion ? 0 : 0.45, ease: [0.22, 1, 0.36, 1] }}
+        className="relative -mx-5 -mt-1 aspect-[16/10] overflow-hidden bg-zinc-950"
+      >
+        {thumbnailSrc ? (
+          <motion.img
+            src={thumbnailSrc}
+            alt="Capa do vídeo em análise"
+            className="h-full w-full object-cover opacity-70"
+            initial={false}
+            animate={reduceMotion ? undefined : { scale: [1.015, 1.055, 1.015] }}
+            transition={{ duration: 7, ease: "easeInOut", repeat: Infinity }}
+          />
+        ) : (
+          <div className="absolute inset-0 grid place-items-center" aria-hidden="true">
+            <svg width="42" height="42" viewBox="0 0 42 42" fill="none" className="text-white/45">
+              <path d="M13 8H8v5M29 8h5v5M34 29v5h-5M13 34H8v-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <path d="M15 21h12M21 15v12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </div>
+        )}
+
+        <div className="absolute inset-0 bg-black/20" aria-hidden="true" />
+        <span className="absolute left-4 top-4 h-5 w-5 border-l border-t border-white/80" aria-hidden="true" />
+        <span className="absolute right-4 top-4 h-5 w-5 border-r border-t border-white/80" aria-hidden="true" />
+        <span className="absolute bottom-4 left-4 h-5 w-5 border-b border-l border-white/80" aria-hidden="true" />
+        <span className="absolute bottom-4 right-4 h-5 w-5 border-b border-r border-white/80" aria-hidden="true" />
+
+        {!errorMessage && !completed ? (
+          <motion.span
+            className="absolute left-4 right-4 z-10 h-px bg-white/90 shadow-[0_0_16px_3px_rgba(255,255,255,0.35)]"
+            initial={false}
+            animate={reduceMotion ? { top: "50%" } : { top: ["14%", "84%", "14%"] }}
+            transition={{ duration: 3.1, ease: "easeInOut", repeat: Infinity }}
+            aria-hidden="true"
+          />
+        ) : null}
+
+        <figcaption className="absolute bottom-4 left-5 right-5 z-20 flex items-center justify-between gap-3 text-[10px] font-semibold uppercase tracking-[0.13em] text-white/70">
+          <span>{completed ? "Leitura concluída" : errorMessage ? "Leitura interrompida" : "Conteúdo em análise"}</span>
+          <span>Vídeo temporário</span>
+        </figcaption>
+      </motion.figure>
+
+      {errorMessage ? (
+        <motion.div
+          initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="pt-6"
+          role="alert"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-[0.13em] text-zinc-400">Análise interrompida</p>
+          <h3 className="mt-2 font-display text-[1.55rem] font-bold leading-[1.02] tracking-[-0.04em] text-zinc-950">
+            Não foi possível concluir agora.
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-zinc-600">{errorMessage}</p>
+        </motion.div>
+      ) : (
+        <div className="pt-6">
+          <div className="flex items-end justify-between gap-4">
+            <p className="font-display text-[3.1rem] font-bold leading-none tracking-[-0.065em] text-zinc-950 tabular-nums">
+              {progress}<span className="ml-0.5 text-[1.25rem] tracking-[-0.03em] text-zinc-400">%</span>
+            </p>
+            <p className="pb-1 text-[11px] font-medium text-zinc-400">
+              {completed ? "Concluído" : "Pode levar alguns instantes"}
+            </p>
+          </div>
+
+          <div
+            className="mt-4 h-1.5 overflow-hidden rounded-full bg-zinc-100"
+            role="progressbar"
+            aria-label="Progresso da análise do vídeo"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progress}
+          >
+            <motion.div
+              className="h-full rounded-full bg-zinc-950"
+              initial={false}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: reduceMotion ? 0 : 0.25, ease: "easeOut" }}
+            />
+          </div>
+
+          <div className="min-h-[6.7rem] pt-6" aria-live="polite" aria-atomic="true">
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={currentStage.threshold}
+                initial={reduceMotion ? false : { opacity: 0, y: 7 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduceMotion ? undefined : { opacity: 0, y: -5 }}
+                transition={{ duration: reduceMotion ? 0 : 0.22 }}
+              >
+                <p className="font-display text-[1.25rem] font-bold leading-tight tracking-[-0.035em] text-zinc-950">
+                  {currentStage.label}
+                </p>
+                <p className="mt-1.5 max-w-[34ch] text-sm leading-5 text-zinc-500">{currentStage.detail}</p>
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {completedStages.length > 0 ? (
+            <div className="mt-1 space-y-2.5 border-t border-zinc-100 pt-4" aria-label="Etapas concluídas">
+              {completedStages.map((stage) => (
+                <div key={stage.threshold} className="flex items-center gap-2.5 text-xs text-zinc-400">
+                  <span className="grid h-4 w-4 place-items-center rounded-full bg-zinc-950 text-white" aria-hidden="true">
+                    <svg width="9" height="9" viewBox="0 0 10 10" fill="none">
+                      <path d="M2 5.3 4.1 7.4 8.2 2.8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </span>
+                  <span>{stage.label}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/ContentAnalysisReport.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/ContentAnalysisReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { motion, useReducedMotion } from "framer-motion";
 import type { MobileStrategicProfileAnalyzeConfirmationData } from "./MobileStrategicProfileAnalyzeFlow";
 import type {
   VideoNarrativeContentPotentialScan,
@@ -59,31 +60,22 @@ function basisText(scan: VideoNarrativeContentPotentialScan): string {
   return `Comparação com ${count} ${count === 1 ? "conteúdo publicado" : "conteúdos publicados"}.`;
 }
 
-function Signal({
-  label,
-  status,
-  evidence,
+function Comparison({
+  item,
+  index,
+  reduceMotion,
 }: {
-  label: string;
-  status: VideoNarrativePotentialDimensionStatus;
-  evidence: string;
+  item: VideoNarrativePersonalComparison;
+  index: number;
+  reduceMotion: boolean;
 }) {
   return (
-    <div className="flex items-start gap-3 py-3">
-      <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${STATUS_DOT[status]}`} aria-hidden="true" />
-      <div className="min-w-0">
-        <p className="text-sm font-semibold text-zinc-950">
-          {label} <span className="font-medium text-zinc-400">· {STATUS_LABEL[status]}</span>
-        </p>
-        <p className="mt-1 text-sm leading-5 text-zinc-600">{evidence}</p>
-      </div>
-    </div>
-  );
-}
-
-function Comparison({ item }: { item: VideoNarrativePersonalComparison }) {
-  return (
-    <article className="rounded-2xl bg-zinc-50 px-4 py-4">
+    <motion.article
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: reduceMotion ? 0 : 0.28, delay: reduceMotion ? 0 : index * 0.045 }}
+      className="rounded-2xl bg-zinc-50 px-4 py-4"
+    >
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-bold text-zinc-950">{item.label}</h3>
         <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-zinc-400">
@@ -101,7 +93,7 @@ function Comparison({ item }: { item: VideoNarrativePersonalComparison }) {
         </div>
       </dl>
       <p className="mt-3 text-xs leading-5 text-zinc-500">{item.reading}</p>
-    </article>
+    </motion.article>
   );
 }
 
@@ -116,6 +108,7 @@ export function ContentAnalysisReport({
   analyzedAt?: string | null;
   onCopySuggestion?: (scan: VideoNarrativeContentPotentialScan) => void;
 }) {
+  const reduceMotion = Boolean(useReducedMotion());
   const scan = data?.contentPotentialScan ?? null;
 
   if (!scan) {
@@ -137,17 +130,27 @@ export function ContentAnalysisReport({
   const confidence = potential?.confidence ?? scan.confidence;
   const comparisons = scan.personalComparisons ?? [];
   const signalDimensions = [
-    ["Gancho e abertura", scan.dimensions.openingClarity],
-    ["Cenas e progressão", scan.dimensions.attentionArchitecture],
-    ["Vontade de compartilhar", scan.dimensions.shareImpulse],
-    ["Entrega da promessa", scan.dimensions.promiseDelivery],
-    ["Assunto e narrativa", scan.dimensions.narrativeFit],
+    { key: "opening", label: "Gancho e abertura", dimension: scan.dimensions.openingClarity },
+    { key: "scenes", label: "Cenas e progressão", dimension: scan.dimensions.attentionArchitecture },
+    { key: "sharing", label: "Vontade de compartilhar", dimension: scan.dimensions.shareImpulse },
+    { key: "promise", label: "Entrega da promessa", dimension: scan.dimensions.promiseDelivery },
+    { key: "narrative", label: "Assunto e narrativa", dimension: scan.dimensions.narrativeFit },
   ] as const;
+  const strongestSignal = signalDimensions.find(({ dimension }) => dimension.status === "strong")
+    ?? signalDimensions.find(({ dimension }) => dimension.status === "mixed")
+    ?? signalDimensions[0];
+  const limitingSignal = signalDimensions.find(({ dimension }) => dimension.status === "weak")
+    ?? signalDimensions.find(({ dimension, key }) => dimension.status === "mixed" && key !== strongestSignal.key)
+    ?? null;
 
   return (
     <article className="ds-analysis-editorial pb-2">
       {thumbnailSrc ? (
-        <figure className="relative -mx-5 -mt-1 mb-6 aspect-[16/10] overflow-hidden bg-zinc-100">
+        <motion.figure
+          layoutId="content-analysis-thumbnail"
+          transition={{ duration: reduceMotion ? 0 : 0.45, ease: [0.22, 1, 0.36, 1] }}
+          className="relative -mx-5 -mt-1 mb-6 aspect-[4/3] overflow-hidden bg-zinc-100"
+        >
           <Image
             src={thumbnailSrc}
             alt="Capa do conteúdo analisado"
@@ -160,10 +163,14 @@ export function ContentAnalysisReport({
           <figcaption className="absolute bottom-3 left-3 rounded-full bg-black/65 px-3 py-1.5 text-[10px] font-semibold text-white backdrop-blur-sm">
             Conteúdo analisado
           </figcaption>
-        </figure>
+        </motion.figure>
       ) : null}
 
-      <header className="ds-enter-sheet">
+      <motion.header
+        initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.3, delay: reduceMotion ? 0 : 0.08 }}
+      >
         <div className="flex items-center justify-between gap-3">
           <p className="text-[10px] font-bold uppercase tracking-[0.13em] text-zinc-500">
             Potencial de engajamento
@@ -179,16 +186,39 @@ export function ContentAnalysisReport({
         <p className="mt-3 text-[11px] font-semibold text-zinc-500">
           Confiança {confidence === "high" ? "alta" : confidence === "medium" ? "média" : "baixa"} · {basisText(scan)}
         </p>
-      </header>
+      </motion.header>
 
       <section className="mt-7" aria-labelledby="analysis-summary-title">
         <h3 id="analysis-summary-title" className="text-[11px] font-bold uppercase tracking-[0.12em] text-zinc-400">
-          Em resumo
+          Leitura rápida
         </h3>
-        <div className="mt-2 space-y-1">
-          {signalDimensions.map(([label, dimension]) => (
-            <Signal key={label} label={label} status={dimension.status} evidence={dimension.evidence} />
-          ))}
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <motion.article
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.28, delay: reduceMotion ? 0 : 0.12 }}
+            className="rounded-2xl bg-zinc-950 p-4 text-white"
+          >
+            <p className="text-[10px] font-bold uppercase tracking-[0.11em] text-white/45">O que sustenta</p>
+            <p className="mt-3 text-sm font-bold leading-5">{strongestSignal.label}</p>
+            <p className="mt-1.5 text-xs leading-5 text-white/65">{strongestSignal.dimension.evidence}</p>
+          </motion.article>
+          <motion.article
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.28, delay: reduceMotion ? 0 : 0.17 }}
+            className="rounded-2xl bg-zinc-100 p-4 text-zinc-950"
+          >
+            <p className="text-[10px] font-bold uppercase tracking-[0.11em] text-zinc-400">
+              {limitingSignal ? "O que pode limitar" : "Próximo ganho"}
+            </p>
+            <p className="mt-3 text-sm font-bold leading-5">
+              {limitingSignal?.label ?? "Ajuste de maior impacto"}
+            </p>
+            <p className="mt-1.5 text-xs leading-5 text-zinc-600">
+              {limitingSignal?.dimension.evidence ?? scan.highestImpactAdjustment}
+            </p>
+          </motion.article>
         </div>
       </section>
 
@@ -201,7 +231,9 @@ export function ContentAnalysisReport({
             O que aparece agora e o que tende a acompanhar seus conteúdos de maior interação.
           </p>
           <div className="mt-4 space-y-3">
-            {comparisons.map((item) => <Comparison key={item.dimension} item={item} />)}
+            {comparisons.map((item, index) => (
+              <Comparison key={item.dimension} item={item} index={index} reduceMotion={reduceMotion} />
+            ))}
           </div>
         </section>
       ) : null}
@@ -211,33 +243,39 @@ export function ContentAnalysisReport({
           <h3 id="moments-title" className="font-display text-[1.3rem] font-bold tracking-[-0.035em] text-zinc-950">
             Como o vídeo se desenvolve
           </h3>
-          <div className="mt-4">
+          <div className="-mx-5 mt-4 flex snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             {scan.watchedMoments.map((moment, index) => (
-              <div key={`${moment.moment}-${index}`} className="grid grid-cols-[12px_1fr] gap-3">
-                <div className="flex flex-col items-center">
-                  <span className="mt-1.5 h-2 w-2 rounded-full bg-zinc-950" />
-                  {index < scan.watchedMoments!.length - 1 ? <span className="my-1 w-px flex-1 bg-zinc-200" /> : null}
-                </div>
-                <div className="pb-5">
+              <motion.article
+                key={`${moment.moment}-${index}`}
+                initial={reduceMotion ? false : { opacity: 0, x: 10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: reduceMotion ? 0 : 0.28, delay: reduceMotion ? 0 : index * 0.05 }}
+                className="min-w-[82%] snap-center rounded-2xl bg-zinc-50 p-4"
+              >
+                <div className="flex items-center justify-between gap-3">
                   <p className="text-[10px] font-bold uppercase tracking-[0.11em] text-zinc-400">{MOMENT_LABEL[moment.moment]}</p>
-                  <p className="mt-1 text-sm font-semibold leading-5 text-zinc-900">{moment.observation}</p>
-                  <p className="mt-1 text-sm leading-5 text-zinc-500">{moment.impact}</p>
+                  <span className="font-display text-lg font-bold text-zinc-300">{String(index + 1).padStart(2, "0")}</span>
                 </div>
-              </div>
+                <p className="mt-4 text-sm font-semibold leading-5 text-zinc-900">{moment.observation}</p>
+                <p className="mt-2 text-sm leading-5 text-zinc-500">{moment.impact}</p>
+              </motion.article>
             ))}
           </div>
         </section>
       ) : null}
 
-      <section className="mt-3" aria-labelledby="full-analysis-title">
+      <section className="mt-7" aria-labelledby="full-analysis-title">
         <h3 id="full-analysis-title" className="font-display text-[1.3rem] font-bold tracking-[-0.035em] text-zinc-950">
-          Análise completa
+          Análise por dimensão
         </h3>
         <div className="mt-3 space-y-2">
-          {signalDimensions.map(([label, dimension]) => (
-            <details key={label} className="group rounded-xl bg-zinc-50 px-4 py-1">
+          {signalDimensions.map(({ key, label, dimension }) => (
+            <details key={key} className="group rounded-xl bg-zinc-50 px-4 py-1">
               <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-zinc-900">
-                <span>{label}</span>
+                <span className="flex items-center gap-2.5">
+                  <span className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT[dimension.status]}`} aria-hidden="true" />
+                  {label}
+                </span>
                 <span className="flex items-center gap-2 text-xs font-medium text-zinc-400">
                   {STATUS_LABEL[dimension.status]}
                   <span className="transition-transform group-open:rotate-90">›</span>
@@ -254,14 +292,20 @@ export function ContentAnalysisReport({
         </div>
       </section>
 
-      <section className="mt-7 rounded-[1.4rem] bg-zinc-950 p-5 text-white" aria-labelledby="impact-adjustment-title">
+      <motion.section
+        initial={reduceMotion ? false : { opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.3 }}
+        className="mt-7 rounded-[1.4rem] bg-zinc-950 p-5 text-white"
+        aria-labelledby="impact-adjustment-title"
+      >
         <p className="text-[10px] font-bold uppercase tracking-[0.13em] text-white/50">Ajuste de maior impacto</p>
         <h3 id="impact-adjustment-title" className="mt-2 font-display text-[1.35rem] font-bold leading-[1.05] tracking-[-0.035em]">
           {scan.practicalDirection?.title ?? scan.highestImpactAdjustment}
         </h3>
         {scan.practicalDirection?.action ? <p className="mt-2 text-sm leading-5 text-white/70">{scan.practicalDirection.action}</p> : null}
         {scan.practicalDirection?.example ? (
-          <blockquote className="mt-4 rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold leading-5">
+          <blockquote className="mt-4 border-l border-white/30 pl-4 text-sm font-semibold leading-5 text-white/90">
             “{scan.practicalDirection.example}”
           </blockquote>
         ) : null}
@@ -270,9 +314,9 @@ export function ContentAnalysisReport({
             Copiar sugestão
           </button>
         ) : null}
-      </section>
+      </motion.section>
 
-      <details className="mt-5 rounded-xl bg-zinc-50 px-4 py-1 text-xs text-zinc-500">
+      <details className="mt-5 border-t border-zinc-100 py-1 text-xs text-zinc-500">
         <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between font-semibold text-zinc-700">
           Sobre esta leitura <span aria-hidden="true">›</span>
         </summary>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.test.tsx
@@ -87,6 +87,9 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     // O antigo passo "O que você quer ler neste vídeo?" não existe mais.
     expect(screen.queryByText("O que você quer ler neste vídeo?")).not.toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "Escaneando seu vídeo" })).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Progresso da análise do vídeo" })).toHaveAttribute("aria-valuemax", "100");
+    expect(screen.getByText("Preparando o vídeo")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Continuar" })).not.toBeInTheDocument();
   });
 
   it("abre o resultado no topo mesmo quando o upload estava rolado", async () => {
@@ -126,7 +129,9 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     });
 
     expect(screen.getByText("Pode engajar após um ajuste.")).toBeInTheDocument();
-    expect(screen.getByText("Em resumo")).toBeInTheDocument();
+    expect(screen.getByText("Leitura rápida")).toBeInTheDocument();
+    expect(screen.getByText("O que sustenta")).toBeInTheDocument();
+    expect(screen.getByText("O que pode limitar")).toBeInTheDocument();
     expect(screen.getByText("Como o vídeo se desenvolve")).toBeInTheDocument();
     expect(screen.getByText("Abertura")).toBeInTheDocument();
     expect(screen.getByText("Você apresenta a dúvida principal na fala, mas ela não aparece em texto.")).toBeInTheDocument();
@@ -242,7 +247,7 @@ describe("MobileStrategicProfileAnalyzeFlow", () => {
     continueFlow(); // upload -> processing
 
     await waitFor(() => {
-      expect(screen.getByText("Erro na análise")).toBeInTheDocument();
+      expect(screen.getByText("Análise interrompida")).toBeInTheDocument();
       expect(screen.getByText("Erro de conexão simulado.")).toBeInTheDocument();
     });
 

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfileAnalyzeFlow.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { LayoutGroup } from "framer-motion";
 import {
   buildUploadSessionPayloadFromFile,
   type UploadSessionPayload,
@@ -10,6 +11,7 @@ import type {
 } from "./mobileStrategicProfileDirectUploadClient";
 import type { VideoNarrativeContentPotentialScan } from "@/app/dashboard/boards/videoUpload/videoNarrativeContentPotentialScan";
 import { ContentAnalysisReport } from "./ContentAnalysisReport";
+import { AnalysisProcessingExperience } from "./AnalysisProcessingExperience";
 
 const STEPS = [
   "upload",
@@ -138,6 +140,8 @@ type MobileStrategicProfileAnalyzeFlowProps = {
     /** Limite do plano (free: 1; pro: 10). */
     limit: number;
   } | null;
+  /** Capa controlada usada apenas por previews internos sem upload real. */
+  initialThumbnailSrc?: string | null;
 };
 
 function nextStep(current: AnalyzeFlowStep): AnalyzeFlowStep {
@@ -273,6 +277,7 @@ export function MobileStrategicProfileAnalyzeFlow({
   onReportInteraction,
   completionSecondaryAction = "another_video",
   onCompletionUpgrade,
+  initialThumbnailSrc = null,
 }: MobileStrategicProfileAnalyzeFlowProps) {
   const sheetRef = useRef<HTMLElement | null>(null);
   const [step, setStep] = useState<AnalyzeFlowStep>("upload");
@@ -284,12 +289,11 @@ export function MobileStrategicProfileAnalyzeFlow({
   const [submitAttempt, setSubmitAttempt] = useState(0);
   const [savedDiagnosisId, setSavedDiagnosisId] = useState<string | null>(null);
   const [confirmationData, setConfirmationData] = useState<MobileStrategicProfileAnalyzeConfirmationData | null>(null);
-  // Animated scan stage: 0..3, aligned with the work the server performs.
-  const [processingStage, setProcessingStage] = useState(0);
+  const [processingComplete, setProcessingComplete] = useState(false);
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [videoDurationSeconds, setVideoDurationSeconds] = useState<number | null>(null);
-  const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(null);
+  const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(initialThumbnailSrc);
   const [validationStatus, setValidationStatus] = useState<"idle" | "validating" | "uploading" | "validated" | "uploaded" | "error">("idle");
   const [fileValidationError, setFileValidationError] = useState<string | null>(null);
   const [uploadSessionValidated, setUploadSessionValidated] = useState(false);
@@ -325,30 +329,24 @@ export function MobileStrategicProfileAnalyzeFlow({
       setIsSubmitting(false);
       setSelectedFile(null);
       setVideoDurationSeconds(null);
-      setThumbnailDataUrl(null);
+      setThumbnailDataUrl(initialThumbnailSrc);
       setValidationStatus("idle");
       setFileValidationError(null);
       setUploadSessionValidated(false);
       setTemporaryUploadForCleanup(null);
       setTemporaryUploadForAnalysis(null);
-      setProcessingStage(0);
+      setProcessingComplete(false);
       setConfirmationData(null);
     }
-  }, [open]);
+  }, [initialThumbnailSrc, open]);
 
   useEffect(() => {
     if (open && sheetRef.current) sheetRef.current.scrollTop = 0;
   }, [open, step]);
 
-  // Animate processing stage labels progressively while waiting for server
   useEffect(() => {
-    if (step !== "processing" || errorMsg) return;
-    setProcessingStage(0);
-    const t1 = setTimeout(() => setProcessingStage(1), 3000);
-    const t2 = setTimeout(() => setProcessingStage(2), 7000);
-    const t3 = setTimeout(() => setProcessingStage(3), 11000);
-    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
-  }, [step, errorMsg, submitAttempt]);
+    if (step === "processing" && !errorMsg) setProcessingComplete(false);
+  }, [step, submitAttempt, errorMsg]);
 
   useEffect(() => {
     if (step !== "processing") return;
@@ -392,6 +390,9 @@ export function MobileStrategicProfileAnalyzeFlow({
             if (result?.confirmationData) {
               setConfirmationData(result.confirmationData);
             }
+            setProcessingComplete(true);
+            await new Promise((resolve) => setTimeout(resolve, 560));
+            if (!active) return;
             setIsSubmitting(false);
             setStep("confirmation");
           }
@@ -407,6 +408,7 @@ export function MobileStrategicProfileAnalyzeFlow({
             }
           }
           if (active) {
+            setProcessingComplete(false);
             setIsSubmitting(false);
             setErrorRetryable(err?.retryable !== false);
             setErrorMsg(err.message || "Ocorreu um erro no processamento do diagnóstico.");
@@ -419,7 +421,10 @@ export function MobileStrategicProfileAnalyzeFlow({
       } else {
         fallbackTimer = setTimeout(() => {
           if (active) {
-            setStep("confirmation");
+            setProcessingComplete(true);
+            fallbackTimer = setTimeout(() => {
+              if (active) setStep("confirmation");
+            }, 560);
           }
         }, 1000);
       }
@@ -553,10 +558,10 @@ export function MobileStrategicProfileAnalyzeFlow({
     setUploadSessionValidated(false);
     setTemporaryUploadForCleanup(null);
     setTemporaryUploadForAnalysis(null);
-    setThumbnailDataUrl(null);
+    setThumbnailDataUrl(initialThumbnailSrc);
     setSavedDiagnosisId(null);
     setConfirmationData(null);
-    setProcessingStage(0);
+    setProcessingComplete(false);
   };
 
   const close = () => {
@@ -597,6 +602,7 @@ export function MobileStrategicProfileAnalyzeFlow({
     setTemporaryUploadForAnalysis(null);
     setSavedDiagnosisId(null);
     setConfirmationData(null);
+    setProcessingComplete(false);
   };
 
   const copyPracticalSuggestion = async (scan: VideoNarrativeContentPotentialScan) => {
@@ -662,18 +668,17 @@ export function MobileStrategicProfileAnalyzeFlow({
         </button>
         </div>
 
-        <div className="mt-4 grid grid-cols-2 gap-1" aria-hidden="true">
+        {step !== "processing" ? <div className="mt-4 grid grid-cols-2 gap-1" aria-hidden="true">
           {VISIBLE_STEPS.map((item, index) => {
             const vIdx = visibleStepIndex(step);
-            // Durante o processing (entre os dois passos visíveis), mantém só o
-            // primeiro preenchido; na confirmação, ambos.
-            const filled = step === "processing" ? index === 0 : index <= vIdx;
+            const filled = index <= vIdx;
             return (
-              <span key={item} className={filled ? "h-1.5 rounded-full bg-[var(--ds-color-brand)]" : "h-1.5 rounded-full bg-zinc-200"} />
+              <span key={item} className={filled ? "h-1.5 rounded-full bg-zinc-950" : "h-1.5 rounded-full bg-zinc-200"} />
             );
           })}
-        </div>
+        </div> : null}
 
+        <LayoutGroup id="content-analysis-flow">
         <div className="mt-4">
 
         {step === "upload" ? (
@@ -692,7 +697,7 @@ export function MobileStrategicProfileAnalyzeFlow({
                     setUploadSessionValidated(false);
                     setTemporaryUploadForCleanup(null);
                     setTemporaryUploadForAnalysis(null);
-                    setThumbnailDataUrl(null);
+    setThumbnailDataUrl(initialThumbnailSrc);
                     setVideoDurationSeconds(null);
                     if (file.size > MAX_VIDEO_FILE_SIZE_BYTES) {
                       setValidationStatus("error");
@@ -717,9 +722,9 @@ export function MobileStrategicProfileAnalyzeFlow({
               />
 
               {!selectedFile ? (
-                <label htmlFor="video-file-picker" className="ds-upload-dropzone">
+                <label htmlFor="video-file-picker" className="ds-upload-dropzone hover:!border-zinc-950 hover:!bg-zinc-50">
                   <span>
-                    <span className="ds-upload-dropzone__icon" aria-hidden="true">
+                    <span className="ds-upload-dropzone__icon !bg-zinc-950 !shadow-none" aria-hidden="true">
                       <svg width="25" height="25" viewBox="0 0 24 24" fill="none">
                         <path d="M8 4H5a1 1 0 0 0-1 1v3M16 4h3a1 1 0 0 1 1 1v3M20 16v3a1 1 0 0 1-1 1h-3M8 20H5a1 1 0 0 1-1-1v-3M7 12h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                         <circle cx="12" cy="12" r="2.25" stroke="currentColor" strokeWidth="1.5" />
@@ -799,55 +804,13 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         {step === "processing" ? (
-            <div className="rounded-[1.5rem] bg-zinc-950 p-5 text-white transition-all">
-            {errorMsg ? (
-              <div>
-                <p className="text-sm font-semibold text-red-400">Erro na análise</p>
-                <p className="mt-2 text-sm leading-6 text-red-300">{errorMsg}</p>
-              </div>
-            ) : (
-              <div>
-                {thumbnailDataUrl ? (
-                  <div className="ds-scan-frame mb-5 h-28">
-                    <img src={thumbnailDataUrl} alt="" className="h-full w-full object-cover opacity-55" aria-hidden="true" />
-                    <span className="ds-scan-beam" aria-hidden="true" />
-                  </div>
-                ) : null}
-                <div className="grid gap-3">
-                  {(
-                    [
-                      { label: "Lendo cenas, fala e enquadramento", threshold: 0 },
-                      { label: "Mapeando gancho, ritmo e entrega", threshold: 1 },
-                      { label: "Consultando seus conteúdos publicados", threshold: 2 },
-                      { label: "Estimando o potencial de engajamento", threshold: 3 },
-                    ] as const
-                  ).map((stage, idx) => {
-                    const isDone = processingStage > stage.threshold;
-                    const isActive = processingStage === stage.threshold;
-                    return (
-                      <div key={stage.label} className="flex items-center gap-3">
-                        {isDone ? (
-                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500">
-                            <svg width="10" height="10" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-                              <path d="M3 7.5l3 3 5-6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
-                            </svg>
-                          </span>
-                        ) : isActive ? (
-                          <span className="mx-1.5 h-2 w-2 shrink-0 animate-pulse rounded-full bg-white" />
-                        ) : (
-                          <span className="mx-1.5 h-2 w-2 shrink-0 rounded-full bg-white/25" />
-                        )}
-                        <span className={`text-sm transition-opacity ${!isDone && !isActive ? "text-white/40" : "text-white"}`}>
-                          {stage.label}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-                <p className="mt-4 text-[11px] text-white/30">Isso pode levar até 30 segundos</p>
-              </div>
-            )}
-          </div>
+          <AnalysisProcessingExperience
+            thumbnailSrc={thumbnailDataUrl}
+            active={step === "processing" && !errorMsg}
+            complete={processingComplete}
+            resetKey={submitAttempt}
+            errorMessage={errorMsg}
+          />
         ) : null}
 
         {step === "confirmation" ? (
@@ -859,13 +822,14 @@ export function MobileStrategicProfileAnalyzeFlow({
         ) : null}
 
         </div>
+        </LayoutGroup>
 
         <div className="mt-5 flex gap-2">
         {step === "confirmation" ? (
           <div className="flex w-full flex-col gap-2">
             <button
               type="button"
-              className="ds-button ds-button--primary ds-button--block"
+              className="ds-button ds-button--primary ds-button--block !bg-zinc-950 !text-white !shadow-none hover:!bg-zinc-800"
               onClick={complete}
             >
               Concluir
@@ -900,7 +864,7 @@ export function MobileStrategicProfileAnalyzeFlow({
               </button>
               <button
                 type="button"
-                className="ds-button ds-button--primary w-1/2"
+                className="ds-button ds-button--primary w-1/2 !bg-zinc-950 !text-white !shadow-none hover:!bg-zinc-800"
                 onClick={() => {
                   setErrorMsg(null);
                   setErrorRetryable(true);
@@ -918,16 +882,16 @@ export function MobileStrategicProfileAnalyzeFlow({
           ) : (
             <button
               type="button"
-              className="ds-button ds-button--primary ds-button--block"
+              className="ds-button ds-button--primary ds-button--block !bg-zinc-950 !text-white !shadow-none hover:!bg-zinc-800"
               onClick={close}
             >
               Fechar
             </button>
           )
-        ) : (
+        ) : step === "processing" ? null : (
           <button
             type="button"
-            className="ds-button ds-button--primary ds-button--block"
+            className="ds-button ds-button--primary ds-button--block !bg-zinc-950 !text-white !shadow-none hover:!bg-zinc-800"
             onClick={handleContinue}
             disabled={isContinueDisabled}
           >

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/MobileStrategicProfilePreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import type {
   MobileStrategicProfile,
   MobileStrategicProfileAction,
@@ -73,6 +73,10 @@ type MobileStrategicProfilePreviewProps = {
     diagnosisId: string;
     answer: { questionId: string; questionText: string; answerId: string; answerValue: string };
   }) => Promise<void>;
+  /** Resultado serializável do harness interno; nunca é usado no shell real. */
+  analysisPreviewResult?: MobileStrategicProfileAnalyzeResult | null;
+  analysisPreviewDelayMs?: number;
+  analysisPreviewThumbnailSrc?: string | null;
 };
 
 const CARD_TONE: Record<MobileStrategicProfileSectionCard["tone"], string> = {
@@ -456,6 +460,9 @@ export function MobileStrategicProfilePreview({
   readingQuota,
   onCleanupTemporaryUpload,
   onSubmitConfirmationAnswer,
+  analysisPreviewResult = null,
+  analysisPreviewDelayMs = 6500,
+  analysisPreviewThumbnailSrc = null,
 }: MobileStrategicProfilePreviewProps) {
   const [mediaKitModalOpen, setMediaKitModalOpen] = useState(false);
   const [analyzeFlowOpen, setAnalyzeFlowOpen] = useState(false);
@@ -464,6 +471,13 @@ export function MobileStrategicProfilePreview({
   const [accessMessage, setAccessMessage] = useState<string | null>(null);
   const accessState = accessStateProp ?? inferAccessStateFromProfile(profile);
   const normalizedQuota = normalizeNarrativeMapReadingQuotaSnapshot(readingQuota);
+
+  const submitPreviewAnalysis = useCallback(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, analysisPreviewDelayMs));
+    return analysisPreviewResult ?? undefined;
+  }, [analysisPreviewDelayMs, analysisPreviewResult]);
+  const resolvedSubmitAnalysis = onSubmitAnalysis
+    ?? (analysisPreviewResult ? submitPreviewAnalysis : undefined);
 
   if (profile.authGate.visible) return <AuthGate profile={profile} isRealShell={isRealShell} />;
 
@@ -622,12 +636,13 @@ export function MobileStrategicProfilePreview({
               open={analyzeFlowOpen}
               onClose={() => setAnalyzeFlowOpen(false)}
               onComplete={handleAnalyzeComplete}
-              onSubmitAnalysis={onSubmitAnalysis}
+              onSubmitAnalysis={resolvedSubmitAnalysis}
               onCreateUploadSession={onCreateUploadSession}
               onUploadToTemporarySignedUrl={onUploadToTemporarySignedUrl}
               enableRealAnalysis={enableRealAnalysis}
               onCleanupTemporaryUpload={onCleanupTemporaryUpload}
               onSubmitConfirmationAnswer={onSubmitConfirmationAnswer}
+              initialThumbnailSrc={analysisPreviewThumbnailSrc}
             />
           </div>
         </div>

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/buildContentAnalysisPreviewResult.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/buildContentAnalysisPreviewResult.ts
@@ -1,0 +1,116 @@
+import type { MobileStrategicProfileAnalyzeResult } from "./MobileStrategicProfileAnalyzeFlow";
+
+/**
+ * Dados controlados usados somente pelo preview interno de UX. Eles permitem
+ * revisar o relatório completo sem upload, chamada de IA ou persistência.
+ */
+export function buildContentAnalysisPreviewResult(): MobileStrategicProfileAnalyzeResult {
+  return {
+    savedDiagnosisId: "internal-content-analysis-preview",
+    confirmationData: {
+      diagnosisSummary: "O vídeo tem uma estrutura clara, mas a promessa precisa aparecer antes.",
+      directAnswer: "O conteúdo pode engajar melhor com um ajuste na abertura.",
+      contentPotentialScan: {
+        band: "promising_with_adjustment",
+        confidence: "high",
+        basis: "creator_history",
+        objective: "complete_reading",
+        historyPostsAnalyzed: 18,
+        engagementPotential: {
+          verdict: "promising_with_adjustment",
+          confidence: "high",
+          basis: "creator_history",
+          summary:
+            "A progressão visual e o assunto combinam com seus conteúdos de melhor resposta. O principal risco está no gancho: a promessa fica clara tarde demais.",
+          postsCompared: 18,
+          historicalWindowDays: 90,
+        },
+        personalComparisons: [
+          {
+            dimension: "hook",
+            label: "Gancho",
+            current: "A rotina começa antes de revelar o ganho para quem assiste.",
+            historical: "Seus conteúdos mais fortes mostram a transformação já nos primeiros segundos.",
+            impact: "limiting",
+            reading: "A entrada atual exige mais paciência do que o seu padrão de melhor desempenho.",
+            evidenceCount: 8,
+          },
+          {
+            dimension: "framing",
+            label: "Enquadramento",
+            current: "Rosto, gesto e produto permanecem legíveis no mesmo plano.",
+            historical: "Planos próximos e demonstrações manuais acompanham seus melhores resultados.",
+            impact: "positive",
+            reading: "O enquadramento preserva a proximidade que costuma funcionar para você.",
+            evidenceCount: 11,
+          },
+          {
+            dimension: "subject",
+            label: "Assunto",
+            current: "A rotina de autocuidado entrega uma aplicação prática.",
+            historical: "Conteúdos de rotina com utilidade concreta concentram mais compartilhamentos.",
+            impact: "positive",
+            reading: "O tema está dentro de um território já validado pelo seu público.",
+            evidenceCount: 13,
+          },
+        ],
+        dimensions: {
+          openingClarity: {
+            status: "weak",
+            evidence: "A primeira cena mostra o ritual, mas ainda não revela qual ganho será entregue.",
+            adjustment: "Antecipar a transformação e escrevê-la no primeiro frame.",
+            window: "0-3s",
+          },
+          attentionArchitecture: {
+            status: "strong",
+            evidence: "A alternância entre rosto, produto e aplicação cria progressão visual fácil de acompanhar.",
+            adjustment: null,
+            window: "0-10s",
+          },
+          shareImpulse: {
+            status: "mixed",
+            evidence: "A dica é útil, mas o fechamento ainda não a transforma numa síntese fácil de enviar.",
+            adjustment: "Encerrar com uma regra curta que a audiência queira guardar ou compartilhar.",
+            window: "full_video",
+          },
+          promiseDelivery: {
+            status: "strong",
+            evidence: "O vídeo demonstra o ritual anunciado e chega a uma conclusão prática.",
+            adjustment: null,
+            window: "full_video",
+          },
+          narrativeFit: {
+            status: "strong",
+            evidence: "Autocuidado aplicado à rotina é um território recorrente entre seus conteúdos mais consistentes.",
+            adjustment: null,
+            window: "creator_history",
+          },
+        },
+        watchedMoments: [
+          {
+            moment: "opening",
+            observation: "Você aparece com o produto em mãos, mas a transformação ainda não é nomeada.",
+            impact: "A cena chama atenção visualmente, porém demora a explicar por que vale continuar.",
+          },
+          {
+            moment: "development",
+            observation: "A aplicação do produto acompanha a explicação sem disputar atenção com a fala.",
+            impact: "O gesto confirma a mensagem e sustenta o ritmo no trecho central.",
+          },
+          {
+            moment: "closing",
+            observation: "O resultado aparece, mas a principal aprendizagem permanece apenas na fala.",
+            impact: "A conclusão funciona, porém poderia gerar mais salvamentos com uma síntese visível.",
+          },
+        ],
+        practicalDirection: {
+          title: "Mostre o resultado antes de começar a rotina",
+          action: "Abra com a transformação e use a rotina como prova nos segundos seguintes.",
+          example: "O passo que fez minha pele parar de repuxar pela manhã",
+        },
+        highestImpactAdjustment: "Antecipar a transformação e torná-la legível no primeiro frame.",
+        disclaimer: "Leitura estrutural comparada ao histórico disponível — não é garantia de alcance.",
+      },
+    },
+  };
+}

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/useAnalysisProgress.test.tsx
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/useAnalysisProgress.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  analysisProgressStageIndex,
+  estimatedAnalysisProgress,
+  useAnalysisProgress,
+} from "./useAnalysisProgress";
+
+describe("analysis progress", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("cresce de forma monotônica e nunca ultrapassa 94 enquanto aguarda o backend", () => {
+    expect(estimatedAnalysisProgress(0)).toBe(0);
+    expect(estimatedAnalysisProgress(1_600)).toBe(14);
+    expect(estimatedAnalysisProgress(10_400)).toBe(58);
+    expect(estimatedAnalysisProgress(60_000)).toBe(94);
+  });
+
+  it("mapeia o percentual para a etapa editorial correta", () => {
+    expect(analysisProgressStageIndex(0)).toBe(0);
+    expect(analysisProgressStageIndex(38)).toBe(2);
+    expect(analysisProgressStageIndex(89)).toBe(4);
+    expect(analysisProgressStageIndex(94)).toBe(5);
+    expect(analysisProgressStageIndex(100)).toBe(6);
+  });
+
+  it("só alcança 100 depois que a análise foi concluída", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-10T12:00:00.000Z"));
+    const { result, rerender } = renderHook(
+      ({ complete }) => useAnalysisProgress({ active: true, complete, resetKey: 1 }),
+      { initialProps: { complete: false } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+    expect(result.current.progress).toBe(94);
+
+    rerender({ complete: true });
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+    expect(result.current.progress).toBe(100);
+  });
+});

--- a/src/app/dashboard/boards/components/videoUpload/appPreview/useAnalysisProgress.ts
+++ b/src/app/dashboard/boards/components/videoUpload/appPreview/useAnalysisProgress.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+
+export type AnalysisProgressStage = {
+  threshold: number;
+  label: string;
+  detail: string;
+};
+
+export const ANALYSIS_PROGRESS_STAGES: readonly AnalysisProgressStage[] = [
+  {
+    threshold: 0,
+    label: "Preparando o vídeo",
+    detail: "Organizando os sinais visuais e sonoros.",
+  },
+  {
+    threshold: 14,
+    label: "Observando cenas e enquadramento",
+    detail: "Identificando composição, presença e mudanças de cena.",
+  },
+  {
+    threshold: 38,
+    label: "Lendo gancho, ritmo e entrega",
+    detail: "Avaliando como o conteúdo abre, progride e conclui.",
+  },
+  {
+    threshold: 58,
+    label: "Cruzando com seus conteúdos publicados",
+    detail: "Comparando este vídeo com os padrões do seu histórico.",
+  },
+  {
+    threshold: 78,
+    label: "Estimando o potencial de engajamento",
+    detail: "Reunindo os sinais que podem sustentar ou limitar a interação.",
+  },
+  {
+    threshold: 90,
+    label: "Finalizando seu relatório",
+    detail: "Transformando a leitura em uma direção prática.",
+  },
+  {
+    threshold: 100,
+    label: "Relatório pronto",
+    detail: "Sua leitura está pronta para abrir.",
+  },
+] as const;
+
+const ESTIMATED_PROGRESS_POINTS = [
+  { elapsedMs: 0, progress: 0 },
+  { elapsedMs: 1_600, progress: 14 },
+  { elapsedMs: 5_400, progress: 38 },
+  { elapsedMs: 10_400, progress: 58 },
+  { elapsedMs: 17_500, progress: 78 },
+  { elapsedMs: 27_000, progress: 90 },
+  { elapsedMs: 45_000, progress: 94 },
+] as const;
+
+export function estimatedAnalysisProgress(elapsedMs: number): number {
+  const elapsed = Math.max(0, elapsedMs);
+  for (let index = 1; index < ESTIMATED_PROGRESS_POINTS.length; index += 1) {
+    const previous = ESTIMATED_PROGRESS_POINTS[index - 1]!;
+    const next = ESTIMATED_PROGRESS_POINTS[index]!;
+    if (elapsed <= next.elapsedMs) {
+      const segmentProgress = (elapsed - previous.elapsedMs) / (next.elapsedMs - previous.elapsedMs);
+      return Math.min(94, Math.round(previous.progress + (next.progress - previous.progress) * segmentProgress));
+    }
+  }
+  return 94;
+}
+
+export function analysisProgressStageIndex(progress: number): number {
+  let currentIndex = 0;
+  for (let index = 0; index < ANALYSIS_PROGRESS_STAGES.length; index += 1) {
+    if (progress >= ANALYSIS_PROGRESS_STAGES[index]!.threshold) currentIndex = index;
+  }
+  return currentIndex;
+}
+
+export function useAnalysisProgress({
+  active,
+  complete,
+  resetKey,
+}: {
+  active: boolean;
+  complete: boolean;
+  resetKey?: number | string;
+}) {
+  const [progress, setProgress] = useState(0);
+  const startedAtRef = useRef(0);
+
+  useEffect(() => {
+    if (!active) return;
+    startedAtRef.current = Date.now();
+    setProgress(0);
+  }, [active, resetKey]);
+
+  useEffect(() => {
+    if (!active || complete) return;
+    const update = () => {
+      const estimate = estimatedAnalysisProgress(Date.now() - startedAtRef.current);
+      setProgress((current) => Math.max(current, estimate));
+    };
+    update();
+    const interval = setInterval(update, 120);
+    return () => clearInterval(interval);
+  }, [active, complete, resetKey]);
+
+  useEffect(() => {
+    if (!active || !complete) return;
+    const interval = setInterval(() => {
+      setProgress((current) => {
+        if (current >= 100) return 100;
+        return Math.min(100, current + Math.max(1, Math.ceil((100 - current) / 3)));
+      });
+    }, 45);
+    return () => clearInterval(interval);
+  }, [active, complete]);
+
+  return {
+    progress,
+    stageIndex: analysisProgressStageIndex(progress),
+    stage: ANALYSIS_PROGRESS_STAGES[analysisProgressStageIndex(progress)]!,
+  };
+}

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.test.tsx
@@ -3,6 +3,10 @@ import path from "path";
 import { render, screen } from "@testing-library/react";
 import MobileStrategicProfilePreviewPage from "./page";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
 const originalFlag = process.env.NEXT_PUBLIC_MOBILE_STRATEGIC_PROFILE_PREVIEW_ENABLED;
 const adminViewer = { role: "admin" };
 const commonViewer = { role: "user" };
@@ -74,8 +78,8 @@ describe("MobileStrategicProfilePreviewPage", () => {
     );
 
     expect(screen.getByText("Preview interno — Mapa narrativo")).toBeInTheDocument();
-    expect(screen.getByText("Seu mapa narrativo")).toBeInTheDocument();
-    expect(screen.getByText("Ler diagnóstico completo")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Leituras em capítulos" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Estados do mapa narrativo" })).toBeInTheDocument();
   });
 
   it("does not import forbidden integrations or real UI surfaces", () => {

--- a/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
+++ b/src/app/dashboard/boards/mobile-strategic-profile-preview/page.tsx
@@ -1,6 +1,7 @@
 import { MobileStrategicProfilePreview } from "../components/videoUpload/appPreview/MobileStrategicProfilePreview";
 import { buildMobileStrategicProfilePreviewFixture } from "../components/videoUpload/appPreview/buildMobileStrategicProfilePreviewFixture";
 import { NarrativeMapReadingPreview } from "../components/videoUpload/appPreview/NarrativeMapReadingPreview";
+import { buildContentAnalysisPreviewResult } from "../components/videoUpload/appPreview/buildContentAnalysisPreviewResult";
 import {
   buildNarrativeMapReadingPreviewFixture,
   isNarrativeMapReadingPreviewState,
@@ -15,7 +16,9 @@ import { isMobileStrategicProfilePreviewEnabled } from "../videoUpload/mobileStr
 type MobileStrategicProfilePreviewPageProps = {
   searchParams?: {
     state?: string | string[];
-  };
+  } | Promise<{
+    state?: string | string[];
+  }>;
   viewer?: InternalPreviewUser | null;
 };
 
@@ -48,11 +51,22 @@ export default async function MobileStrategicProfilePreviewPage({
     return <BlockedInternalPreview reason="permission" />;
   }
 
-  if (isNarrativeMapReadingPreviewState(searchParams?.state)) {
-    const fixture = buildNarrativeMapReadingPreviewFixture({ state: searchParams?.state });
+  const resolvedSearchParams = await searchParams;
+
+  if (isNarrativeMapReadingPreviewState(resolvedSearchParams?.state)) {
+    const fixture = buildNarrativeMapReadingPreviewFixture({ state: resolvedSearchParams?.state });
     return <NarrativeMapReadingPreview fixture={fixture} />;
   }
 
-  const fixture = buildMobileStrategicProfilePreviewFixture({ state: searchParams?.state });
-  return <MobileStrategicProfilePreview profile={fixture.profile} activeState={fixture.id} showSmokeHarness />;
+  const fixture = buildMobileStrategicProfilePreviewFixture({ state: resolvedSearchParams?.state });
+  return (
+    <MobileStrategicProfilePreview
+      profile={fixture.profile}
+      activeState={fixture.id}
+      showSmokeHarness
+      analysisPreviewResult={buildContentAnalysisPreviewResult()}
+      analysisPreviewDelayMs={6500}
+      analysisPreviewThumbnailSrc="/images/mulher_se_maquiando.png"
+    />
+  );
 }

--- a/src/app/dashboard/recorded-meetings/RecordedMeetingPlayerDialog.tsx
+++ b/src/app/dashboard/recorded-meetings/RecordedMeetingPlayerDialog.tsx
@@ -7,7 +7,7 @@ import { CalendarDays, X } from "lucide-react";
 import type { RecordedMeeting } from "@/app/lib/community/recordedMeetingsService";
 
 const DATE_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
-  day: "2-digit",
+  day: "numeric",
   month: "long",
   year: "numeric",
   timeZone: "America/Sao_Paulo",
@@ -26,68 +26,107 @@ export default function RecordedMeetingPlayerDialog({
   meeting: RecordedMeeting | null;
   onClose: () => void;
 }) {
+  const dialogRef = React.useRef<HTMLElement | null>(null);
+  const closeButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const previouslyFocusedRef = React.useRef<HTMLElement | null>(null);
+
   React.useEffect(() => {
     if (!meeting) return undefined;
 
     const previousOverflow = document.body.style.overflow;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
+    // Sem prender o foco, quem navega por teclado continuava andando pela
+    // página atrás do vídeo, sem saber onde estava.
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], iframe, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusables || focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
 
     document.body.style.overflow = "hidden";
     window.addEventListener("keydown", handleKeyDown);
+    closeButtonRef.current?.focus();
 
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedRef.current?.focus?.();
     };
   }, [meeting, onClose]);
 
   if (!meeting || typeof document === "undefined") return null;
 
   return createPortal(
+    // No celular o vídeo ficava com 24% da altura da tela, flutuando no meio do
+    // preto. Aqui ele encosta nas bordas e sobe para o topo; a moldura de
+    // diálogo centralizado volta só a partir do desktop.
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/90 p-3 backdrop-blur-sm sm:p-6"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/95 backdrop-blur-sm sm:p-6"
       onMouseDown={(event) => {
         if (event.currentTarget === event.target) onClose();
       }}
     >
+      {/* Fora do fluxo: assim o conjunto vídeo + título fica centrado na tela
+          em vez de encostar no topo com um vazio embaixo. */}
+      <button
+        ref={closeButtonRef}
+        type="button"
+        onClick={onClose}
+        className="absolute right-3 z-10 flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white sm:right-9 sm:top-9"
+        style={{ top: "calc(env(safe-area-inset-top, 0px) + 0.75rem)" }}
+        aria-label="Fechar vídeo"
+      >
+        <X className="h-5 w-5" aria-hidden="true" />
+      </button>
+
       <section
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label={`Assistir ${meeting.title}`}
-        className="w-full max-w-6xl overflow-hidden rounded-2xl bg-zinc-950 text-white shadow-2xl sm:rounded-[28px]"
+        className="w-full bg-zinc-950 text-white sm:max-w-6xl sm:overflow-hidden sm:rounded-[28px] sm:shadow-2xl"
       >
-        <header className="flex items-start justify-between gap-4 border-b border-white/10 px-4 py-4 sm:px-6">
-          <div className="min-w-0">
-            <p className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-violet-300">
-              <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-              {formatMeetingDate(meeting.publishedAt)}
-            </p>
-            <h2 className="mt-1.5 line-clamp-2 text-base font-semibold leading-6 sm:text-xl">
-              {meeting.title}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300"
-            aria-label="Fechar vídeo"
-          >
-            <X className="h-5 w-5" aria-hidden="true" />
-          </button>
-        </header>
-
         <iframe
           key={meeting.youtubeVideoId}
           className="block w-full bg-black"
           style={{ aspectRatio: "16 / 9" }}
-          src={`https://www.youtube.com/embed/${meeting.youtubeVideoId}?autoplay=1&rel=0&modestbranding=1`}
+          // playsinline evita que o iPhone assuma o player nativo em tela cheia
+          // sem a pessoa pedir.
+          src={`https://www.youtube.com/embed/${meeting.youtubeVideoId}?autoplay=1&playsinline=1&rel=0&modestbranding=1`}
           title={meeting.title}
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           referrerPolicy="strict-origin-when-cross-origin"
           allowFullScreen
         />
+
+        {/* Título abaixo do vídeo: no celular ele deixa de disputar o topo com a
+            imagem, que é o que a pessoa veio ver. */}
+        <div className="min-w-0 px-4 pb-6 pt-4 sm:px-6">
+          <p className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-zinc-400">
+            <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+            {formatMeetingDate(meeting.publishedAt)}
+          </p>
+          <h2 className="mt-2 text-[17px] font-semibold leading-[1.35] sm:text-xl">{meeting.title}</h2>
+        </div>
       </section>
     </div>,
     document.body,

--- a/src/app/dashboard/recorded-meetings/RecordedMeetingsLibrary.test.tsx
+++ b/src/app/dashboard/recorded-meetings/RecordedMeetingsLibrary.test.tsx
@@ -30,17 +30,35 @@ const meetings: RecordedMeeting[] = [
   },
 ];
 
+/** Lista longa o bastante para a busca aparecer. */
+function manyMeetings(): RecordedMeeting[] {
+  return Array.from({ length: 8 }, (_, index) => ({
+    ...(meetings[index % meetings.length] as RecordedMeeting),
+    id: `meeting-${index}`,
+    youtubeVideoId: `video-${index}`,
+  }));
+}
+
 describe("RecordedMeetingsLibrary", () => {
   it("apresenta destaque e catálogo com capas 16:9 em alta resolução", () => {
     render(<RecordedMeetingsLibrary meetings={meetings} />);
 
     expect(screen.getByRole("heading", { name: "Raio X de Conteúdo" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Todos os episódios" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Todas as reuniões" })).toBeInTheDocument();
     expect(screen.getAllByAltText("Capa da reunião Raio X de Conteúdo")[0]).toHaveAttribute(
       "src",
       "https://img.youtube.com/vi/video-1/maxresdefault.jpg",
     );
-    expect(screen.getByText("2 episódios")).toBeInTheDocument();
+    expect(screen.getByText("2 reuniões")).toBeInTheDocument();
+  });
+
+  it("só mostra a busca quando a lista deixa de caber na rolagem", () => {
+    const { unmount } = render(<RecordedMeetingsLibrary meetings={meetings} />);
+    expect(screen.queryByRole("searchbox", { name: "Buscar reunião" })).not.toBeInTheDocument();
+    unmount();
+
+    render(<RecordedMeetingsLibrary meetings={manyMeetings()} />);
+    expect(screen.getByRole("searchbox", { name: "Buscar reunião" })).toBeInTheDocument();
   });
 
   it("abre e fecha o player sem sair da biblioteca", () => {
@@ -59,13 +77,14 @@ describe("RecordedMeetingsLibrary", () => {
   });
 
   it("filtra o catálogo por título", () => {
-    render(<RecordedMeetingsLibrary meetings={meetings} />);
+    render(<RecordedMeetingsLibrary meetings={manyMeetings()} />);
 
     fireEvent.change(screen.getByRole("searchbox", { name: "Buscar reunião" }), {
       target: { value: "narrativas" },
     });
 
-    expect(screen.getByRole("button", { name: "Assistir Narrativas que vendem" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Assistir Narrativas que vendem" }).length).toBeGreaterThan(0);
+    // Sobra só o destaque, que fica fora do filtro.
     expect(screen.getAllByRole("button", { name: "Assistir Raio X de Conteúdo" })).toHaveLength(1);
   });
 });

--- a/src/app/dashboard/recorded-meetings/RecordedMeetingsLibrary.tsx
+++ b/src/app/dashboard/recorded-meetings/RecordedMeetingsLibrary.tsx
@@ -19,16 +19,25 @@ import RecordedMeetingPlayerDialog from "@/app/dashboard/recorded-meetings/Recor
 import RecordedMeetingThumbnail from "@/app/dashboard/recorded-meetings/RecordedMeetingThumbnail";
 
 const DATE_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
-  day: "2-digit",
+  day: "numeric",
+  month: "long",
+  timeZone: "America/Sao_Paulo",
+});
+
+const DATE_FORMATTER_WITH_YEAR = new Intl.DateTimeFormat("pt-BR", {
+  day: "numeric",
   month: "long",
   year: "numeric",
   timeZone: "America/Sao_Paulo",
 });
 
+/** "6 de agosto" no ano corrente; o ano só entra quando muda de fato o sentido. */
 function formatMeetingDate(value: string) {
   if (!value) return "Data não informada";
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "Data não informada" : DATE_FORMATTER.format(date);
+  if (Number.isNaN(date.getTime())) return "Data não informada";
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return (sameYear ? DATE_FORMATTER : DATE_FORMATTER_WITH_YEAR).format(date);
 }
 
 function getMeetingSummary(description: string) {
@@ -72,26 +81,25 @@ export default function RecordedMeetingsLibrary({
   if (!featuredMeeting) {
     const unavailable = status === "unavailable" || status === "unconfigured";
     return (
-      <section className="grid min-h-[430px] overflow-hidden rounded-[28px] border border-zinc-200/80 bg-white shadow-[0_18px_50px_rgba(24,24,27,0.045)] lg:grid-cols-[minmax(0,1fr)_22rem]">
-        <div className="flex flex-col items-center justify-center px-8 py-14 text-center">
-          <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-violet-50 text-violet-700 ring-1 ring-violet-100">
+      // Vazio não precisa de vitrine: a lista lateral com três "recursos da
+      // biblioteca" virava uma coluna de texto que ninguém lê no celular.
+      <section className="overflow-hidden rounded-[24px] border border-[#e7e1d8] bg-white lg:grid lg:min-h-[430px] lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="flex flex-col items-center justify-center px-6 py-12 text-center sm:px-8 sm:py-14">
+          <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[#fdecf1] text-[#c70a42]">
             <Video className="h-6 w-6" aria-hidden="true" />
           </span>
-          <p className="mt-6 text-[10px] font-bold uppercase tracking-[0.18em] text-violet-700">
-            {unavailable ? "Biblioteca indisponível" : "Nenhuma gravação publicada"}
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-zinc-950">
-            {unavailable ? "Não foi possível carregar as gravações" : "A biblioteca está sendo preparada"}
+          <h2 className="mt-5 text-[1.4rem] font-semibold leading-tight tracking-[-0.03em] text-[#17140f] sm:text-2xl">
+            {unavailable ? "Não foi possível carregar as gravações" : "A primeira gravação ainda não saiu"}
           </h2>
-          <p className="mt-3 max-w-md text-sm leading-6 text-zinc-500">
+          <p className="mt-3 max-w-md text-sm leading-6 text-[#423b33]">
             {unavailable
-              ? "Estamos ajustando o acesso ao acervo. Tente novamente em alguns minutos."
-              : "Assim que a primeira reunião for publicada, ela aparecerá aqui pronta para assistir."}
+              ? "Tente novamente em alguns minutos."
+              : "Assim que uma reunião for publicada, ela aparece aqui."}
           </p>
         </div>
 
-        <aside className="border-t border-zinc-200/80 bg-zinc-50/70 px-7 py-9 lg:border-l lg:border-t-0" aria-label="Recursos da biblioteca">
-          <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-zinc-400">
+        <aside className="hidden border-zinc-200/80 bg-[#f7f3ed] px-7 py-9 lg:block lg:border-l" aria-label="Recursos da biblioteca">
+          <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-[#6b6157]">
             Nesta biblioteca
           </p>
           <ul className="mt-6 space-y-6">
@@ -116,9 +124,15 @@ export default function RecordedMeetingsLibrary({
     );
   }
 
+  // A busca só ganha espaço quando a lista deixa de caber na rolagem.
+  const showSearch = meetings.length >= 8;
+
   return (
     <div className="min-w-0">
-      <section className="grid overflow-hidden rounded-[28px] bg-zinc-950 text-white shadow-[0_24px_70px_rgba(24,24,27,0.18)] lg:grid-cols-[minmax(20rem,0.85fr)_minmax(0,1.4fr)]">
+      {/* O destaque repetia a reunião mais recente, que aparece logo abaixo como
+          primeiro item com o selo "mais recente" — 590px da primeira dobra do
+          celular gastos duas vezes com a mesma coisa. No desktop ele cabe. */}
+      <section className="hidden overflow-hidden rounded-[28px] bg-zinc-950 text-white shadow-[0_24px_70px_rgba(24,24,27,0.18)] lg:grid lg:grid-cols-[minmax(20rem,0.85fr)_minmax(0,1.4fr)]">
         <div className="flex flex-col justify-center px-6 py-8 sm:px-9 sm:py-10 lg:px-12">
           <p className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.2em] text-violet-300">
             <Sparkles className="h-3.5 w-3.5" aria-hidden="true" /> Última reunião
@@ -134,7 +148,7 @@ export default function RecordedMeetingsLibrary({
               <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
               {formatMeetingDate(featuredMeeting.publishedAt)}
             </span>
-            <span>{meetings.length} {meetings.length === 1 ? "episódio" : "episódios"}</span>
+            <span>{meetings.length} {meetings.length === 1 ? "reunião" : "reuniões"}</span>
           </div>
           <button
             type="button"
@@ -167,27 +181,33 @@ export default function RecordedMeetingsLibrary({
         </button>
       </section>
 
-      <section className="mt-10" aria-labelledby="recorded-meetings-catalog-title">
-        <div className="flex flex-col justify-between gap-4 border-b border-zinc-200 pb-5 sm:flex-row sm:items-end">
-          <div>
-            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-violet-700">
+      <section className="lg:mt-10" aria-labelledby="recorded-meetings-catalog-title">
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end lg:border-b lg:border-[#e7e1d8] lg:pb-5">
+          {/* Sem o destaque acima, este par de títulos repetia o cabeçalho da
+              página: "Reuniões gravadas" seguido de "Todas as reuniões". No
+              desktop ele separa o destaque da lista e continua fazendo sentido. */}
+          <div className="hidden lg:block">
+            <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-[#c70a42]">
               Catálogo
             </p>
-            <h2 id="recorded-meetings-catalog-title" className="mt-1 text-2xl font-bold tracking-[-0.03em] text-zinc-950">
-              Todos os episódios
+            <h2 id="recorded-meetings-catalog-title" className="mt-1 text-2xl font-bold tracking-[-0.03em] text-[#17140f]">
+              {/* "Episódios" virava podcast; o produto inteiro chama de reunião. */}
+              Todas as reuniões
             </h2>
           </div>
-          <label className="flex min-h-11 w-full items-center gap-2 rounded-full border border-zinc-200 bg-white px-4 text-zinc-500 transition focus-within:border-violet-300 focus-within:ring-2 focus-within:ring-violet-100 sm:w-72">
-            <Search className="h-4 w-4 shrink-0" aria-hidden="true" />
-            <span className="sr-only">Buscar reunião</span>
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Buscar reunião"
-              className="w-full border-0 bg-transparent p-0 text-sm text-zinc-900 outline-none ring-0 placeholder:text-zinc-400 focus:ring-0"
-            />
-          </label>
+          {showSearch ? (
+            <label className="flex min-h-11 w-full items-center gap-2 rounded-full border border-[#e7e1d8] bg-white px-4 text-[#6b6157] transition focus-within:border-[#c70a42] focus-within:ring-2 focus-within:ring-[#fdecf1] sm:w-72">
+              <Search className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="sr-only">Buscar reunião</span>
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Buscar reunião"
+                className="w-full border-0 bg-transparent p-0 text-sm text-[#17140f] outline-none ring-0 placeholder:text-[#6b6157] focus:ring-0"
+              />
+            </label>
+          ) : null}
         </div>
 
         {filteredMeetings.length > 0 ? (
@@ -197,11 +217,13 @@ export default function RecordedMeetingsLibrary({
                 key={meeting.id}
                 type="button"
                 onClick={() => setPlayingMeeting(meeting)}
-                className="group min-w-0 text-left focus-visible:outline-none"
+                // active: existia só no mouse — no celular o toque não devolvia
+                // sinal nenhum e a pessoa tocava duas vezes.
+                className="group min-w-0 text-left transition duration-150 active:scale-[0.985] active:opacity-90 focus-visible:outline-none"
                 aria-label={`Assistir ${meeting.title}`}
               >
                 <span
-                  className="relative block w-full overflow-hidden rounded-2xl bg-zinc-900 shadow-[0_12px_32px_rgba(24,24,27,0.1)] ring-1 ring-black/5 transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[0_18px_42px_rgba(24,24,27,0.18)] group-focus-visible:ring-2 group-focus-visible:ring-violet-500"
+                  className="relative block w-full overflow-hidden rounded-2xl bg-zinc-900 shadow-[0_12px_32px_rgba(24,24,27,0.1)] ring-1 ring-black/5 transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[0_18px_42px_rgba(24,24,27,0.18)] group-focus-visible:ring-2 group-focus-visible:ring-[#c70a42]"
                   style={{ aspectRatio: "16 / 9" }}
                 >
                   <RecordedMeetingThumbnail
@@ -209,38 +231,40 @@ export default function RecordedMeetingsLibrary({
                     sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
                     className="transition duration-500 group-hover:scale-[1.035]"
                   />
-                  <span className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/5 to-transparent" />
+                  {/* O gradiente escurecia a capa sem ter texto para contrastar. */}
                   <span className="absolute bottom-4 left-4 flex h-11 w-11 items-center justify-center rounded-full bg-white text-zinc-950 shadow-lg transition group-hover:scale-110">
                     <Play className="ml-0.5 h-4 w-4 fill-current" aria-hidden="true" />
                   </span>
                   {index === 0 ? (
-                    <span className="absolute right-3 top-3 rounded-full bg-zinc-950/80 px-3 py-1.5 text-[9px] font-bold uppercase tracking-[0.14em] text-white backdrop-blur">
+                    <span className="absolute right-3 top-3 rounded-full bg-zinc-950/80 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.1em] text-white backdrop-blur">
                       Mais recente
                     </span>
                   ) : null}
                 </span>
-                <span className="mt-4 flex items-start justify-between gap-4">
+                <span className="mt-3 flex items-start justify-between gap-3">
                   <span className="min-w-0">
-                    <span className="line-clamp-2 text-base font-semibold leading-5 text-zinc-900 transition group-hover:text-violet-800">
+                    {/* Três linhas: o título é a única pista do assunto — cortá-lo
+                        em duas deixava só a data. */}
+                    <span className="line-clamp-3 text-[15px] font-semibold leading-[1.35] text-[#17140f] transition group-hover:text-[#c70a42]">
                       {meeting.title}
                     </span>
-                    <span className="mt-2 block text-xs font-medium text-zinc-500">
+                    <span className="mt-1.5 block text-xs font-medium text-[#6b6157]">
                       {formatMeetingDate(meeting.publishedAt)}
                     </span>
                   </span>
-                  <ChevronRight className="mt-0.5 h-5 w-5 shrink-0 text-zinc-300 transition group-hover:translate-x-0.5 group-hover:text-violet-700" aria-hidden="true" />
+                  <ChevronRight className="mt-0.5 h-5 w-5 shrink-0 text-[#d6cec2] transition group-hover:translate-x-0.5 group-hover:text-[#c70a42]" aria-hidden="true" />
                 </span>
               </button>
             ))}
           </div>
         ) : (
           <div className="py-16 text-center">
-            <Search className="mx-auto h-6 w-6 text-zinc-300" aria-hidden="true" />
-            <p className="mt-3 text-sm font-medium text-zinc-600">Nenhuma reunião encontrada.</p>
+            <Search className="mx-auto h-6 w-6 text-[#d6cec2]" aria-hidden="true" />
+            <p className="mt-3 text-sm font-medium text-[#423b33]">Nenhuma reunião encontrada.</p>
             <button
               type="button"
               onClick={() => setQuery("")}
-              className="mt-3 text-sm font-bold text-violet-800"
+              className="mt-3 min-h-11 px-3 text-sm font-bold text-[#c70a42] transition active:opacity-70"
             >
               Limpar busca
             </button>


### PR DESCRIPTION
Duas entregas em cima do que já foi para a main no #891.

## Biblioteca de reuniões gravadas, pensada para o celular

A tela nasceu para o desktop e agora recebe gente vinda do card da reunião no Perfil.

**Lista**
- O destaque repetia a reunião mais recente, que aparecia logo abaixo como primeiro item do catálogo — 590px da primeira dobra gastos duas vezes com a mesma coisa. Fica só no desktop. **Altura da página: 2276px → 1477px.**
- **Estados de toque.** Havia sete efeitos de "passar o mouse" e nenhum de toque: no celular a tela não devolvia sinal de que registrou o toque.
- Título em três linhas (era a única pista do assunto e vinha cortado em duas) e data curta, sem o ano corrente.
- Fora o gradiente sobre as capas: escurecia a imagem sem ter texto para contrastar.
- "Reuniões" no lugar de "episódios", que é como o resto do produto fala.
- Busca só a partir de 8 gravações.
- Paleta do Perfil no lugar do cinza frio com roxo.
- **"Voltar ao perfil"** — a rota vive fora da casca do app mobile e não tinha saída.

**Player**
- No celular ocupava 366×206 flutuando no meio do preto. Agora é tela cheia, centralizado, vídeo na largura toda.
- `playsinline`: sem ele o iPhone não iniciava e a pessoa tocava no play uma segunda vez.
- Foco preso enquanto aberto e devolvido ao fechar.

## Tela de processamento da análise de vídeo

Trabalho local do Codex, incluído a pedido: experiência de processamento, hook de progresso e preview do resultado. Não foi escrito nem revisado nesta sessão.

## Verificação
- `npm run build` passa.
- Suíte `appPreview` + `recorded-meetings`: as mesmas 16 suítes com falha pré-existente, sem regressão.
- Testes novos fixam a regra da busca (não aparece com 4 gravações, aparece com 8) e o vocabulário.
- Antes e depois capturados em 390px, em `output/playwright/gravacoes-mobile/`.

## Não verificado
As capturas usam gravações de exemplo numa rota temporária já removida. As reais vêm de uma playlist do YouTube — títulos e capas podem ter proporções diferentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)